### PR TITLE
docs: design spec and execution roadmap

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,518 @@
+# Fabrik: Design Specification (v0 draft)
+
+A polyglot, agent-native build system. Bazel's ambitions, none of its mistakes.
+
+## 0. Goals and non-goals
+
+### Goals
+
+- One build system for the entire polyglot stack: C, C++, Rust, Go, Elixir, Java/Kotlin, Python, TypeScript/JavaScript, Swift/Objective-C. No language is a second-class citizen long-term.
+- Trustworthy, content-addressed, remote-shareable caching for every action, with honest boundaries where fidelity must degrade.
+- The build graph is a typed, queryable data structure. Agents and humans interact with the same API.
+- Causal, structured errors. Agents can act on errors programmatically; humans get useful messages.
+- Hermetic execution by default, with explicit, visible escape hatches when hermeticity isn't achievable.
+- Rust-first to enable dogfooding from day one, but the architecture is language-agnostic from the start.
+
+### Non-goals
+
+- Replacing every native build tool. We coordinate with cargo, mix, gradle, xcodebuild, vite where reimplementation is worse than cooperation.
+- A novel programming language for build files. We learned from Starlark.
+- Shipping a UI in v0. The OTel ecosystem already has them.
+- Compatibility with Bazel BUILD files. We learn from Bazel; we don't carry its baggage.
+
+### What success looks like
+
+- Fabrik builds itself (Rust + some C dependencies) faster and more reproducibly than `cargo build` within 6 months.
+- An agent can answer "why did this rebuild?" and "what would change if I removed this dep?" without reading source code.
+- A polyglot backend monorepo (Rust + Go + TypeScript + Python + protobuf) can adopt Fabrik in a week and see remote cache hits across all languages.
+- iOS, Android, and complex Gradle setups have a clear, honest story — not as good as Bazel-with-`rules_apple` on day one, on a credible path to parity.
+
+## 1. The mistakes we are not repeating
+
+This section exists because every architectural decision below is a reaction to a specific Bazel pain point. Naming them up front keeps us honest.
+
+| Bazel mistake | Our response |
+|---|---|
+| Starlark: Python-shaped, non-Turing-complete, neither human-friendly nor LLM-friendly | Typed declarative core (Pkl-influenced) + WASM plugins for computation |
+| Four overlapping extension mechanisms (macros, rules, aspects, repository rules) | One concept: plugins emit typed subgraphs |
+| BUILD files require manual enumeration of every source and dep | Globs and language-aware discovery are first-class, with deterministic resolution |
+| WORKSPACE → MODULE.bazel migration, still ongoing | One module file from day one. Versioned. Stable. |
+| `rules_*` ecosystem perpetually lags upstream language toolchains | Cooperative integration with native tools is the default; reimplementation is opt-in |
+| Untyped providers, schema-by-convention | Typed plugin contracts validated at the boundary |
+| Hermeticity is aspirational; cache poisoning is silent | Hermeticity level is per-target, declared, stored in cache, queryable |
+| Error messages span Starlark/generated code/execution; root cause is buried | Structured errors with full provenance; "why" is queryable |
+| `bazel query` is bolted on, action graph is internal | Query API is the primary interface; CLI is a thin client |
+| `--config` flag combinatorics produce non-deterministic caching | Configuration profiles are typed, named, part of the cache key namespace |
+| Long-running dev servers shoehorned into build target model (`ibazel`) | `service` targets are a separate first-class concept |
+| iOS/Android support is heroic third-party effort | First-party plugin teams for hard ecosystems, planned and resourced |
+| Remote execution requires Bazel; protocol is Bazel-shaped | REAPI-compatible at the wire level; we benefit from existing remote backends |
+| Build telemetry is BEP, proprietary tooling on top | OTel-native with build-specific semantic conventions |
+
+## 2. Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Frontend                                                        │
+│   • Build definition language (typed, declarative)               │
+│   • Plugin host (WASM)                                           │
+├──────────────────────────────────────────────────────────────────┤
+│  Coordinator                                                     │
+│   • Graph model (typed, persistent, queryable)                   │
+│   • Scheduler (local + remote workers)                           │
+│   • Query API (gRPC, primary interface)                          │
+│   • Telemetry router (OTel + structured event log)               │
+│   • Error provenance store                                       │
+├──────────────────────────────────────────────────────────────────┤
+│  Substrate                                                       │
+│   • Content-addressed storage (CAS), REAPI-compatible            │
+│   • Sandbox (strict / traced / loose)                            │
+│   • Action execution (local + remote)                            │
+│   • Action cache with provenance metadata                        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Three layers, clean interfaces, each independently testable. The coordinator is the brain; the substrate is the muscle; the frontend is the interface.
+
+### 2.1 Substrate
+
+REAPI-compatible at the wire level so we inherit BuildBuddy, Buildbarn, NativeLink, EngFlow as remote backends. Internally we add:
+
+- **Provenance metadata on every cache entry**: producing plugin name+version, hermeticity level, platform, timestamp, action key inputs.
+- **Predicate-based invalidation**: `fabrik cache invalidate --plugin=rust@1.2.3 --platform=linux/arm64`. Bazel's "wipe everything" is not the only option.
+- **Three sandbox modes**:
+  - `strict`: declared inputs only, no network, hermetic env. Default for reimplemented plugins.
+  - `traced`: syscall tracing (FUSE on Linux, EndpointSecurity on macOS, ETW on Windows) discovers actual inputs on first run; subsequent runs use that as the cache key. Default for cooperative plugins.
+  - `loose`: runs in workspace, trusts user-declared inputs. Required acknowledgment in target definition. Required for most opaque-mode targets.
+- **User-defined cache keys**: the substrate stores and retrieves by digest; the plugin owns what goes into the digest. This is critical — cargo wants `Cargo.lock + features + rustc version`; vite wants `package-lock.json + vite.config + source digest`. One-size-fits-all keys are why Bazel struggles to integrate with native tools.
+
+### 2.2 Coordinator
+
+Stateless service. Build graph state lives in the workspace (`.fabrik/`); action results live in the substrate. The coordinator is rebuilt from these on every invocation.
+
+Owns:
+- The typed action graph (protobuf schema).
+- The scheduler (topological order, parallelism, remote dispatch).
+- The query API (see §6).
+- The telemetry router (OTel exporter + structured event log).
+- The error provenance store (queryable history of failures).
+
+### 2.3 Frontend
+
+The build definition language and plugin host. Build definitions are pure typed data. Plugins are WASM modules that emit graph fragments. There is no other way to extend Fabrik.
+
+## 3. Build definition language
+
+### 3.1 Core
+
+Typed declarative DSL. Reference points: Pkl (Apple), Cue. Looks like:
+
+```fabrik
+target "api" {
+  kind = "rust_binary"
+  srcs = glob("src/**/*.rs")
+  deps = [
+    "//lib/core",
+    "//lib/proto:rust",
+    "@crates//tokio",
+  ]
+  visibility = ["//services/..."]
+}
+
+target "api_test" {
+  kind = "rust_test"
+  srcs = glob("tests/**/*.rs")
+  deps = [":api", "@crates//tokio-test"]
+}
+```
+
+Everything you write at the top level is data. The language has:
+- Strong static typing (every target type has a schema declared by its plugin).
+- Imports (`load("//build/macros.fabrik", "...")`).
+- Pure functions for data transformation (`glob`, `select`, `map`, `filter`).
+- No I/O, no side effects, no recursion at the language level.
+
+### 3.2 Computation: WASM plugins
+
+When you need real computation — generating N targets from a manifest, polyglot stitching, conditional logic beyond what `select` covers — you write a plugin. Plugins are WASM modules that emit graph fragments as typed data.
+
+Plugins can be written in any language that targets WASM. The plugin contract is a typed gRPC-over-WASI interface; the host validates inputs and outputs against the plugin's declared schema.
+
+This replaces Bazel's macros, rules, aspects, and repository rules with **one concept**.
+
+### 3.3 Configuration profiles
+
+```fabrik
+profile "release_linux_x64" {
+  platform = "linux/x86_64"
+  rust = { toolchain = "stable-1.78", opt_level = 3, lto = "thin" }
+  c = { toolchain = "clang-18", opt_level = 3, sanitizers = [] }
+}
+
+profile "debug_macos_arm64" {
+  platform = "macos/aarch64"
+  rust = { toolchain = "stable-1.78", opt_level = 0, debug = true }
+}
+```
+
+A profile is a typed bundle of toolchain selections, build settings, and platform constraints. Replaces Bazel's `--config` sprawl, transitions, toolchains, and platforms with one concept.
+
+Cache namespaces are partitioned by profile. Same inputs + same profile → same output, always. Different profile → different cache entry, no collision.
+
+## 4. Plugin model
+
+Every plugin declares per target type:
+
+```fabrik
+plugin "rust" {
+  version = "1.0.0"
+  target_types = ["rust_binary", "rust_library", "rust_test", "rust_proc_macro"]
+
+  # How to discover the dependency graph
+  resolution {
+    mode = "cooperative"
+    tool = "cargo"
+    inputs = ["Cargo.toml", "Cargo.lock"]
+    output_schema = "rust.resolved_graph.v1"
+  }
+
+  # How to execute individual actions
+  execution {
+    mode = "reimplemented"
+    sandbox = "strict"
+    cache_key_inputs = ["srcs", "deps", "rustc_version", "features", "profile.rust"]
+  }
+
+  # What the plugin can answer about its targets
+  queries = [
+    "transitive_crates",
+    "feature_set",
+    "build_script_outputs",
+  ]
+}
+```
+
+### 4.1 The three integration modes
+
+These are not aspirational labels; they are typed contracts that determine cache fidelity, query depth, error structure, and sandbox defaults.
+
+**`reimplemented`**: plugin emits explicit actions with declared inputs and outputs. Maximum cache fidelity. Used where the compilation unit maps cleanly to a single tool invocation: rustc per crate, gcc/clang per .c/.cpp, javac per source set, swiftc per module.
+
+**`cooperative`**: plugin uses the native tool to *discover* the graph but executes via the substrate. The plugin runs `cargo metadata` or `go list -json` or `mix xref` to get a structured dep graph, then translates it into Fabrik targets. Execution can be either reimplemented (we call rustc directly) or opaque (we run `mix compile`).
+
+**`opaque`**: one target = one tool invocation. Cache key is the input digest + tool version + flags. Fine-grained queries past this boundary return `{"boundary": "opaque", "tool": "...", "reason": "..."}`. Used where reimplementation is hopeless: Vite production builds, Gradle projects, Mix applications, xcodebuild.
+
+### 4.2 Honest boundaries
+
+The integration mode is **visible to users and agents**, surfaced in:
+- The build definition (`kind = "gradle_project"` is implicitly opaque; we make this loud).
+- The query API (`fabrik introspect //app/android` returns the boundary type).
+- Marketing materials and docs (we don't pretend Gradle gets the same treatment as Rust).
+- Cache statistics (`fabrik stats --by-mode` shows hit rates broken down by integration mode).
+
+This is the single biggest cultural difference from Bazel. Bazel claims total knowledge; we explicitly mark where knowledge ends.
+
+### 4.3 Plugin versioning
+
+- Plugin API has semver. Workspaces declare plugin versions. Breakage is detected, not silent.
+- Plugins are WASM modules distributed via a registry (or pinned by URL+digest).
+- Plugin schemas (target types, providers, query methods) are versioned independently of plugin code.
+- A target compiled with plugin v1.2 can be cache-shared with a target compiled with plugin v1.3 only if the plugin declares schema compatibility. Otherwise, separate cache namespaces.
+
+## 5. Caching and hermeticity
+
+### 5.1 Hermeticity is per-target, declared, queryable
+
+```fabrik
+target "build_with_system_lib" {
+  kind = "c_binary"
+  srcs = ["main.c"]
+  hermeticity = "loose"  # explicitly opted in; we link against /usr/lib/libfoo
+}
+```
+
+Every cache entry stores its hermeticity level. `fabrik why-cached //x` tells you whether the result came from a `strict`, `traced`, or `loose` cache hit. Agents can filter cache hits by hermeticity for high-reliability operations.
+
+### 5.2 Traced mode mechanics
+
+For `cooperative` plugins where pre-declaring inputs is impossible, the substrate runs the action in a sandbox that records every file read, syscall, and environment variable access. The recorded set becomes the action's effective input set; the cache key is computed from it.
+
+- Linux: FUSE-based sandbox, fallback to bpftrace.
+- macOS: EndpointSecurity framework (requires entitlement), fallback to dtrace.
+- Windows: ETW-based monitoring.
+
+Traced mode has a real cost: ~10-30% overhead on first build, near-zero on cache hits. Worth it for cargo's build scripts, mix's macro expansion, vite's dynamic import resolution.
+
+### 5.3 Cache provenance and recovery
+
+Every cache entry is annotated with: producing plugin name+version, hermeticity level, platform, action key inputs hash, timestamp, build invocation ID.
+
+Operators can:
+- Invalidate by predicate (plugin, version range, platform, age).
+- Audit cache hits (`fabrik cache audit //x` shows the chain of inputs).
+- Pin specific results as known-good or known-bad.
+
+## 6. Introspection: the agent-native interface
+
+This is the load-bearing differentiator. The query API is **not** a debugging tool bolted on at the end. It is the primary interface; the CLI is a thin client over it.
+
+### 6.1 Query API
+
+gRPC service exposed by the coordinator. Stable, versioned, typed. Examples:
+
+```
+GraphService.GetTarget(label) → Target with full metadata
+GraphService.GetTransitiveDeps(label, depth) → DAG fragment
+GraphService.GetReverseDeps(label) → which targets depend on this
+GraphService.GetActionsForTarget(label) → action list with cache state
+GraphService.WhyRebuild(label) → causal trace
+GraphService.Impact(file_path) → affected targets with reasons
+GraphService.Diff(build_id_1, build_id_2) → action-level diff between builds
+GraphService.ExplainCacheMiss(action_id) → structured reason
+GraphService.GetErrorHistory(label, time_range) → past failures with provenance
+GraphService.PredictRebuildCost(file_changes) → estimated wall time + actions
+```
+
+Plugin-extensible: the Rust plugin registers `RustPluginService.GetTransitiveCrates(label)`, the Go plugin registers `GoPluginService.GetModulePath(label)`, etc. Plugins extend the query surface, never the CLI surface directly.
+
+### 6.2 Designed for agents
+
+What makes this agent-native rather than human-native with an API afterthought:
+
+- **Every response is structured.** No "scrape stderr" paths.
+- **Every response includes provenance.** The agent always knows where data came from, when, with what plugin version.
+- **Queries are composable.** `Impact(file) → ExplainCacheMiss(action)` is a normal usage pattern, not a hack.
+- **Streaming where appropriate.** Long-running queries (full graph dump) stream; the agent can process incrementally.
+- **Predictive queries.** `PredictRebuildCost` lets an agent decide whether to make a speculative change without actually building.
+- **Read-only by default.** Agents query without side effects. Mutations (cache invalidation, pinning) are separate, audited operations.
+
+### 6.3 Agent-driven graph optimization
+
+The query API is rich enough that an agent can:
+- Identify hot paths (targets that rebuild frequently).
+- Find redundant deps (targets that depend on libraries they don't use, via cross-referencing query results with source analysis).
+- Suggest target splits (a target that's frequently partially invalidated could become two targets).
+- Detect non-determinism (cache misses that should be hits, traced via input diffing).
+- Recommend hermeticity upgrades (loose → traced → strict) based on observed input sets.
+
+These are not features Fabrik ships; they are **uses of the API that agents naturally perform**. The bet: if the API is good enough, agent-driven optimization emerges.
+
+## 7. Errors
+
+Structured first, formatted second. Every error is a typed object:
+
+```json
+{
+  "kind": "compile_error",
+  "target": "//api:server",
+  "action_id": "act_8a3f...",
+  "build_id": "build_2026_04_28_001",
+  "command": ["rustc", "--edition=2021", "..."],
+  "exit_code": 1,
+  "stderr": "...",
+  "diagnostic": {
+    "file": "src/main.rs",
+    "line": 42,
+    "column": 8,
+    "code": "E0308",
+    "message": "mismatched types"
+  },
+  "provenance": {
+    "plugin": "rust@1.2.3",
+    "hermeticity": "strict",
+    "platform": "linux/x86_64",
+    "profile": "debug_linux_x64",
+    "invocation_args": ["build", "//api:server"]
+  },
+  "related_actions": ["act_7b2c...", "act_9d4e..."]
+}
+```
+
+Plugins parse tool output into this structure where they can. Where they can't (opaque mode for Gradle), the structure still exists with raw stderr; the shape is consistent for agents.
+
+The CLI renders these as human-readable; agents consume the JSON directly.
+
+## 8. Long-running processes
+
+Dev servers are not builds. They are supervised processes with their own incremental logic. Modeling them as `service` targets:
+
+```fabrik
+service "frontend_dev" {
+  kind = "vite_dev"
+  workspace = "//apps/web"
+  watches = glob("apps/web/src/**")
+  port = 5173
+  depends_on_build = ["//apps/web:assets"]
+}
+```
+
+The coordinator launches and supervises; it does not own the dev tool's incremental graph. Vite owns its own world inside the service; we own the supervision and the cross-language deps that feed it.
+
+## 9. Per-language plans
+
+This section is honest about variance. Same architecture; different fidelities.
+
+### 9.1 Rust (v0, dogfood from day one)
+
+- **Resolution**: cooperative via `cargo metadata`. Reuse cargo's resolver, feature unification, registry.
+- **Execution**: reimplemented. We invoke `rustc` directly with `--extern` flags per dep.
+- **Build scripts**: traced mode. The first run records the build script's actual inputs (env vars, probed files); subsequent runs use that as the cache key.
+- **Proc macros**: configuration profile transition (host vs target).
+- **Workspace ↔ Fabrik integration**: `Cargo.toml` is the source of truth for crate metadata; Fabrik reads it. We don't duplicate.
+- **Why first**: we're writing Fabrik in Rust, so we get to dogfood from week one. The Rust ecosystem is also unusually well-suited to this (clean resolver output, well-behaved compiler, mature toolchain).
+
+### 9.2 C and C++
+
+- **Resolution**: explicit. C/C++ has no canonical metadata format; we ask users to declare deps. Compile commands, include paths, and link order are first-class typed fields.
+- **Execution**: reimplemented. Direct `clang`/`gcc` invocations.
+- **Header dependencies**: discovered via compiler depfile output (`-MD`), folded into the cache key. This is what every serious C build system does.
+- **System libraries**: `loose` hermeticity for unavoidable system-lib linking. Hermetic toolchain bundles (LLVM + sysroot) available as a profile option for stricter builds.
+- **CMake integration**: opaque-mode plugin for projects that can't migrate. `cmake --build` runs in a sandbox; outputs cached.
+- **Why early**: many serious C/C++ shops are exactly the audience that wants Bazel-quality caching but bounces off Bazel's complexity. This is a strong fit.
+
+### 9.3 Go
+
+- **Resolution**: cooperative via `go list -json`. Maps cleanly to Fabrik targets.
+- **Execution**: reimplemented. Direct `go tool compile` invocations, or `go build` per package in cooperative mode for simplicity.
+- **CGo**: traced mode for the C portion.
+- **Build tags**: configuration profiles handle this.
+- **Confidence**: high. Go's build model is simpler than Rust's; this should Just Work.
+
+### 9.4 TypeScript / JavaScript
+
+- **Resolution**: cooperative via `package-lock.json` / `pnpm-lock.yaml`. Plugin generates targets per package.
+- **Execution**: depends on the tool.
+  - `tsc` compilation: reimplemented.
+  - `vite build`, `webpack`, `esbuild` bundles: opaque, by tool invocation.
+  - `vite` dev server: `service` target.
+- **Honest limitation**: bundlers are not amenable to fine-grained caching by us. We cache at the bundler-invocation level. That's still a win over no caching.
+
+### 9.5 Java / Kotlin
+
+- **Direct compilation (small projects)**: reimplemented via `javac` / `kotlinc`. Target = compilation unit.
+- **Gradle projects**: opaque. `gradle build` runs in a sandbox; outputs cached at the project level. Gradle stays in charge of its world; Fabrik handles cross-tool deps.
+- **Gradle Tooling API integration**: planned for v2 — finer-grained discovery without reimplementation. Research-grade.
+- **Honest limitation**: Gradle users opting in to Fabrik for Gradle-specific gains will be disappointed in v0–v1. The win is *cross-language*: their Gradle project depending on protobuf generated from a different language, all coherent in one cache.
+
+### 9.6 Python
+
+- **Resolution**: cooperative via `pyproject.toml` + lockfile (uv, poetry, pip-tools).
+- **Execution**: largely opaque. Python doesn't compile in a meaningful way; we cache the *resolved virtualenv* and the outputs of test/lint/typecheck runs.
+- **`py_test`, `py_lint`, `py_typecheck`**: reimplemented as discrete actions with their own cache keys.
+
+### 9.7 Elixir
+
+- **Resolution**: cooperative via `mix xref` for cross-application graphs.
+- **Execution**: opaque per OTP application. One application = one `mix compile`.
+- **Why opaque**: Mix's incremental compilation is sophisticated and macro-aware in ways no external tool reproduces. Reimplementation is a multi-year project that nobody has finished. Opaque mode at the application boundary is honest and useful.
+- **What users get**: cross-application caching (touched app rebuilds; untouched apps reuse cache), cross-language deps (Elixir app depends on protobuf from Go service), uniform telemetry. *Not* finer-grained than mix already provides.
+
+### 9.8 Swift / iOS / macOS
+
+This is the hard one and we're not pretending otherwise.
+
+- **Library targets (no signing, no asset compilation)**: reimplemented via direct `swiftc`. Works for Swift Package Manager-style libraries.
+- **Application targets**: opaque via `xcodebuild`. Cache by workspace digest + xcodebuild args + Xcode version.
+- **Code signing**: explicitly out of cache. Signed artifacts are not cacheable across machines (different certificates, profiles). Signing happens as a post-cache step.
+- **Asset compilation, plist processing, Storyboard/XIB compilation**: reimplemented per-tool over time, as the team gains capacity.
+- **First-party `apple` plugin team**: required, multi-engineer, multi-year. This is a `rules_apple`-equivalent effort; we're not understating it.
+- **v0 reality**: opaque mode only. Maybe 30% of what Bazel-with-`rules_apple` provides. Honest about it.
+- **v2+ trajectory**: meaningful reimplementation, parity-class with `rules_apple` on a 2-3 year horizon if we resource it. Earlier if we partner with an existing iOS-on-Bazel team.
+
+### 9.9 Android
+
+- **Pure JVM modules**: same as Java/Kotlin above.
+- **Android resource compilation, dexing, packaging**: opaque via Gradle in v0–v1. Reimplemented in v2+ behind a first-party `android` plugin.
+- **Same honest framing as iOS**: hard ecosystem, multi-year effort to fully embrace, opaque mode is the v0 story.
+
+## 10. Telemetry
+
+OTel as the wire format, with build-specific semantic conventions on top. (Conventions defined in §10.2.)
+
+### 10.1 What gets emitted
+
+- **Action spans**: digest, input root digest, output digests, cache state, exit code, plugin name+version, hermeticity level, platform.
+- **Build invocation root span**: command, args, profile, total wall time, cache hit rate, action counts.
+- **Cache hits**: not spans (would inflate counts catastrophically) — counters and attributes on the consuming span.
+- **Plugin internal spans**: plugins can emit their own spans within their actions (compile, link, codegen sub-steps).
+- **Structured event log**: alongside OTel, a separate log carries the full graph and result data — the BEP-equivalent. Spans are for performance; the event log is for correctness/lineage. Cross-referenced by IDs.
+
+### 10.2 Fabrik semantic conventions for OTel
+
+We define and publish OTel semantic conventions for build events. (Once we have working code, push these upstream as a `build` semantic convention working group.)
+
+Key attribute namespaces: `fabrik.action.*`, `fabrik.target.*`, `fabrik.cache.*`, `fabrik.plugin.*`, `fabrik.hermeticity.*`.
+
+### 10.3 Sharding
+
+One trace per build invocation will exceed backend limits for any non-trivial build. Default behavior:
+- Root span per invocation.
+- Per-target sub-traces linked to the root.
+- Per-action spans within target traces.
+- Configurable thresholds for further sharding.
+
+## 11. What we explicitly will not do
+
+- Reimplement Vite, Webpack, esbuild. We integrate opaquely.
+- Reimplement Gradle. We integrate opaquely with cooperative discovery in v2.
+- Provide our own remote-execution backend. We use existing REAPI servers (BuildBuddy, Buildbarn, NativeLink).
+- Ship a UI in v0–v1. The OTel ecosystem provides this.
+- Bazel BUILD compatibility. We learn from Bazel; we don't import its surface area.
+
+## 12. Open questions
+
+These need resolution before we cut v0. I have leanings on each but want them debated.
+
+1. **Build definition language: bespoke (Pkl-influenced) or typed TypeScript subset?** Bespoke gives us full control and a clear story; TypeScript gives us instant editor support and a familiar surface for plugin authors. Lean: bespoke, with first-class LSP. Worth prototyping both.
+
+2. **WASI version and capability model for plugins.** WASI Preview 2 is the right target but the ecosystem isn't fully there. We may need to ship with a constrained subset and grow.
+
+3. **Workspace persistence format.** SQLite for the local graph index, flat files for the cache, content-addressed blobs in the substrate. But details (schema versioning, cross-machine sync of local index) need work.
+
+4. **First non-Rust dogfooding language.** C/C++ is the strategic choice (large addressable audience, fits architecture well). Go is the easy choice (cleanest cooperative integration). Pick one for v0.5 focus.
+
+5. **Should `service` targets exist at all?** Process supervision is its own world (systemd, pm2, mprocs, overmind). We might be better off integrating with one of these rather than building our own. Lean: build our own thin supervisor in v0, plan integration with external supervisors in v1.
+
+6. **Agent-native query API surface.** §6 is a starting point, not exhaustive. We need to dogfood with real agents (including the one we're talking to right now) to find what's missing. v0 should ship a deliberately narrow API and grow it from observed need.
+
+7. **Plugin distribution.** Registry vs URL-pinned vs vendored. Lean: URL+digest pinning in v0 (simple, secure), registry in v1.
+
+## 13. Why this works
+
+The bet is structural:
+
+- **Cooperative-first means we ship per-language support fast.** No more `rules_*` death march.
+- **WASM plugins mean polyglot extensibility without a new language.** Plugin authors use what they know.
+- **Honest boundaries mean users know what they're getting.** No silent cache poisoning, no surprise gaps.
+- **REAPI compatibility means we inherit infrastructure.** We don't build a remote-exec backend.
+- **Agent-native query API means we ride the wave.** As agents become real consumers of build telemetry — which they will, in this project's lifetime — we have the surface they need. Bazel doesn't.
+- **Rust-first dogfooding means we feel every paper cut.** No build system has ever been good without its authors using it daily.
+
+The risk is also structural: ambitious scope, multi-year arc, requires sustained investment in the hard ecosystems (iOS, Android, Gradle) that won't pay off for years. We mitigate by sequencing — backend polyglot first, hard mobile/Gradle ecosystems after we've earned the right to attempt them.
+
+---
+
+## Appendix A: Glossary
+
+- **Action**: a single executable unit with declared inputs, outputs, and command. The substrate caches at this level.
+- **Target**: a user-facing unit defined in build files. Compiles to one or more actions.
+- **Plugin**: a WASM module that defines target types and translates them to actions.
+- **Profile**: a typed bundle of toolchain selections, build settings, and platform constraints.
+- **Hermeticity level**: `strict` / `traced` / `loose`, declared per target, stored on cache entries.
+- **Integration mode**: `reimplemented` / `cooperative` / `opaque`, declared per plugin per target type.
+- **Substrate**: the bottom architectural layer (CAS, sandbox, action exec, cache).
+- **Coordinator**: the middle architectural layer (graph, scheduler, query, telemetry).
+- **Frontend**: the top architectural layer (definition language, plugin host).
+- **REAPI**: Bazel's Remote Execution API. We are wire-compatible.
+- **OTel**: OpenTelemetry. Our telemetry wire format.
+
+## Appendix B: References and prior art
+
+- Bazel — what we learn from and react against.
+- Buck2 (Meta) — the closest existing system in spirit; Rust-implemented, sound type system, action graph as data.
+- Pants — REAPI client, good Python/JVM story.
+- BuildStream — non-Bazel REAPI client, good design references.
+- Pkl (Apple), Cue — typed configuration language references for the build definition surface.
+- Nix — content-addressed everything; reference for hermeticity and reproducibility.
+- Turborepo, Nx — what cooperative-mode caching looks like for JS; what *not* to do (silent input mis-declaration).
+- `rules_rust`, `rules_go`, `rules_apple` — cooperative-resolution-plus-reimplemented-execution exemplars.
+- Gradle Develocity — what good build telemetry looks like at scale.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,172 @@
+# Fabrik: Execution Roadmap
+
+A phased plan optimized for **shortest path to self-hosting**. The design spec ([design.md](design.md)) describes the destination; this document sequences how we get there.
+
+## Sequencing principles
+
+1. **Self-hosting is the forcing function.** Every phase is judged by how much closer it gets us to "Fabrik builds Fabrik faster than cargo." Architectural elegance that doesn't move that needle waits.
+2. **Defer architectural complexity until the system works.** WASM plugins, the DSL, REAPI, and the query API are all in the v1 design — but each blocks self-hosting if we build them first. We bring them in once we have a working concrete system to extract them from.
+3. **Every phase ships a working artifact.** No phase is "refactor with no user-visible change." If a phase doesn't produce something runnable that's better than the prior phase, the phase is wrong.
+4. **In-process before out-of-process.** Plugins start as Rust modules linked into the binary. The plugin *contract* (typed interface) gets designed early; the plugin *isolation* (WASM) comes later. This lets us iterate on the contract against real code.
+5. **Hardcode before generalize.** The Rust language support is hardcoded at first. We generalize once a second language exists to triangulate against.
+
+## Phase 0 — Walking skeleton (week 1–2)
+
+**Goal:** `fabrik run "echo hello"` executes, caches the result by command digest, and returns cached output on second invocation.
+
+- Cargo workspace: `fabrik-cli`, `fabrik-core`, `fabrik-cas`.
+- Local content-addressed store: blobs in `.fabrik/cas/`, action results in `.fabrik/actions/`.
+- One action type: `RunCommand { argv, env, cwd }`.
+- Subprocess execution, no sandbox.
+- CLI: `fabrik run <cmd>`, `fabrik cache stats`.
+
+**Exit criterion:** running the same command twice — second run is a cache hit, < 10ms.
+
+**Explicitly deferred:** sandbox, DSL, plugins, graph, telemetry, remote.
+
+## Phase 1 — Single-crate Rust build (week 3–5)
+
+**Goal:** `fabrik build` produces the same binary as `cargo build` for a hello-world Rust crate, byte-identical or close to it.
+
+- New crate `fabrik-rust` (in-process, linked into CLI).
+- Reads `Cargo.toml` directly. No DSL yet.
+- Invokes `cargo metadata` to get the crate graph.
+- Generates one action per crate: `rustc --crate-name foo --edition 2021 ...`.
+- Links Phase 0's CAS for caching.
+- Inputs to cache key: source files (globbed by cargo metadata's `targets[].src_path` + a recursive glob), rustc version, feature set.
+
+**Exit criterion:** clean cache → `fabrik build` produces a working binary. Touch a `.rs` file → only that crate's rustc runs. No edits → 100% cache hit.
+
+**Risks:** rustc has many implicit inputs (env vars, lockfile, target dir layout). Expect to discover them by diffing cargo's behavior. Worth keeping a `loose` mode escape hatch from day one to unblock progress.
+
+## Phase 2 — Multi-crate parallel build (week 6–8)
+
+**Goal:** Build a multi-crate workspace (Fabrik's own) with parallelism, dependency ordering, and incremental rebuilds.
+
+- Action graph in `fabrik-core`: typed nodes, edges from declared deps.
+- Scheduler: topological order, N-way parallel (default = num CPUs).
+- Build script support via **traced mode** — Linux-first using `bpftrace` or `LD_PRELOAD` shim. macOS via `dtrace` (best-effort) or fall back to `loose` mode. This is the highest-risk item in the early plan; budget time accordingly.
+- Proc macro support: separate host-platform compilation pass (no profile transitions yet — just a hardcoded host build).
+- Error structure: capture `rustc --error-format=json` and surface it as the typed error from §7 of the design spec.
+
+**Exit criterion:** `fabrik build` builds Fabrik's own workspace end-to-end. Wall-clock time on a clean cache is within 2× of `cargo build`. Incremental rebuild on a 1-line change to a leaf crate is faster than `cargo build`.
+
+## Phase 3 — Self-hosting milestone (week 9–10)
+
+**Goal:** Fabrik builds Fabrik *and* we use it daily.
+
+- CI builds Fabrik with Fabrik (alongside `cargo build` as a check).
+- Local dev workflow uses `fabrik build` and `fabrik test`.
+- `fabrik test` added: wraps `rust_test` targets, runs binaries, captures structured output.
+- Bug-fix sprint: whatever breaks during dogfooding gets fixed before moving on.
+
+**Exit criterion:** the Fabrik team uses `fabrik build` instead of `cargo build` for at least a week without falling back. Wall-clock time on a warm cache is **better** than cargo, not just comparable.
+
+This is the dogfood gate. Don't proceed past Phase 3 until it's met.
+
+## Phase 4 — Extract the plugin contract (week 11–13)
+
+**Goal:** Refactor `fabrik-rust` to live behind a typed plugin interface, still in-process. No user-visible change.
+
+- Define `Plugin` trait + protobuf schema for: target type registration, resolution (graph fragment emission), execution (action emission), queries.
+- `fabrik-rust` becomes the first implementation of this trait.
+- Add a stub `fabrik-command` plugin (generic `command` target type) so we have a second implementation to triangulate on.
+- The trait is the contract that WASM plugins will eventually implement. Designing it against two real implementations protects us from a contract that only fits one.
+
+**Exit criterion:** zero user-visible regression, `fabrik-rust` compiled out cleanly works only through the trait, and the trait is stable enough to publish as an internal-but-reviewable API.
+
+## Phase 5 — Build definition language (week 14–18)
+
+**Goal:** Replace hardcoded `Cargo.toml` reading with `.fabrik` files. Cargo.toml becomes one *input* to the rust plugin, not the source of build truth.
+
+- DSL parser, type checker, schema registry (every plugin contributes its target schemas).
+- Bootstrap migration: the rust plugin reads `Cargo.toml` automatically when the `.fabrik` file says `kind = "rust_workspace"` — i.e., we don't make users hand-write target stanzas for Rust crates immediately.
+- LSP server (basic completion + diagnostics) — agents and humans both benefit.
+- Profiles: implement `profile` blocks, partition cache namespaces by profile.
+
+**Exit criterion:** Fabrik's own build is described in `.fabrik` files; `Cargo.toml` is read by the rust plugin but no longer the build entry point. Two profiles (`debug`, `release`) work cleanly.
+
+**Open question to resolve in this phase:** bespoke DSL vs typed-TS subset (open question #1 in the design). Prototype both early in this phase and decide.
+
+## Phase 6 — WASM plugin host (week 19–22)
+
+**Goal:** Move the rust plugin to WASM. Prove the contract works across the WASM boundary.
+
+- WASI runtime (Wasmtime) integrated as `fabrik-plugin-host`.
+- `fabrik-rust` compiled to a `.wasm` artifact, distributed alongside the binary.
+- Plugin manifest: declared capabilities (filesystem reads, subprocess spawning), pinned digest.
+- Capability negotiation: the host grants narrow filesystem and subprocess access based on the manifest, refuses everything else.
+
+**Exit criterion:** `fabrik build` of Fabrik works with the rust plugin loaded as WASM. Performance overhead < 5% (plugin runs are dwarfed by rustc time anyway).
+
+**Risk:** WASI Preview 2 ecosystem maturity (open question #2). May need a constrained interface that grows with the ecosystem. Have a documented fallback to in-process plugins if a specific plugin needs capabilities WASI doesn't yet expose.
+
+## Phase 7 — REAPI substrate + remote cache (week 23–28)
+
+**Goal:** Swap local-only CAS for a REAPI client. Connect to a remote cache. Cache hits across machines.
+
+- REAPI client in `fabrik-cas`, replacing direct disk store (disk store stays as the local tier).
+- Compatibility tested against BuildBuddy and NativeLink.
+- Provenance metadata extension to REAPI action results (custom fields).
+- Predicate-based invalidation: `fabrik cache invalidate --plugin=rust@1.x`.
+- CI publishes cache; developers consume it. Cold-start `fabrik build` on a fresh checkout should hit cache for everything CI built.
+
+**Exit criterion:** new contributor's first `fabrik build` of Fabrik completes in under 30 seconds via remote cache hits.
+
+## Phase 8 — Query API + OTel telemetry (week 29–32)
+
+**Goal:** The introspection layer that makes Fabrik agent-native.
+
+- gRPC `GraphService` exposed by the coordinator (subset of the §6.1 API: `GetTarget`, `GetTransitiveDeps`, `Impact`, `WhyRebuild`, `ExplainCacheMiss`).
+- OTel emission with the `fabrik.*` semantic conventions defined in §10.2.
+- Structured event log alongside OTel for the lineage data that's too high-volume for traces.
+- CLI commands (`fabrik query`, `fabrik impact`, `fabrik why-rebuild`) become thin clients over the gRPC API.
+- Dogfood with Claude/agents: have them use the query API to answer questions about the Fabrik build itself. File API gaps as we find them.
+
+**Exit criterion:** an agent can answer "what would change if I removed crate X?" and "why did action Y rebuild?" using only the query API, no source reading.
+
+## Phase 9 — Second language (week 33–40)
+
+**Goal:** Prove the plugin model with a non-Rust language. Choice: C/C++ or Go (open question #4).
+
+**Recommended: Go first.** Cleaner cooperative integration (`go list -json` is excellent), simpler build model, faster path to a working second plugin. C/C++ second — it's strategically more important but technically harder (depfile handling, system libraries, hermetic toolchain bundles).
+
+- New `fabrik-go` plugin (WASM from day one, since the host exists now).
+- Cooperative resolution via `go list -json`.
+- Reimplemented execution: `go tool compile` per package.
+- Cross-language proof: a small Go service in the Fabrik repo that depends on a Rust-generated artifact. End-to-end caching across the language boundary.
+
+**Exit criterion:** the cross-language sample works end-to-end, with the integration mode visible in query results, and adding Go to a Fabrik workspace requires < 50 lines of `.fabrik` config.
+
+## Phase 10+ — Beyond v0
+
+After Phase 9 we have what the design spec calls v0.5: self-hosting Rust + a second language + REAPI + agent-queryable. The remaining roadmap follows the design spec's §11.3 onward — TypeScript, Python, Java/Kotlin, Elixir, Windows traced mode, then the hard mobile ecosystems. Detailed sequencing for those phases gets written when we get there; planning beyond a 6-month horizon for a project this novel is fiction.
+
+## Cross-cutting workstreams
+
+These run in parallel with the phased work, not as separate phases:
+
+- **Test infrastructure**: integration tests that build a real-but-small workspace end-to-end. Set up in Phase 0, expanded every phase. Without this we cannot dogfood safely.
+- **Benchmarks**: wall-clock comparison vs `cargo build` on a fixed corpus. Tracked in CI from Phase 1. The self-hosting milestone (Phase 3) requires this to even exist.
+- **Documentation**: keep [design.md](design.md) in sync with what's actually shipped. Mark unbuilt sections explicitly. Avoids the "specs as fiction" drift.
+- **Error structure**: the typed error contract from §7 of the design gets implemented incrementally — Phase 1 ships a stub, every plugin tightens its parsing as it matures.
+
+## Decision log: open questions and when they get answered
+
+| # | Question | Phase to decide |
+|---|---|---|
+| 1 | DSL: bespoke vs typed-TS subset | Phase 5 (prototype both early in the phase) |
+| 2 | WASI version + capability model | Phase 6 |
+| 3 | Workspace persistence format | Phase 2 (when the graph store starts mattering) |
+| 4 | First non-Rust language | Phase 9 (recommended: Go) |
+| 5 | `service` targets — own supervisor or integrate? | Defer to v0.5+ |
+| 6 | Query API surface | Phase 8 (deliberately narrow start, grow from agent dogfooding) |
+| 7 | Plugin distribution | Phase 6 (URL+digest pinning sufficient for v0; registry later) |
+
+## What gates progress
+
+Three gates that must hold for the plan to stay on track:
+
+- **Phase 3 (self-hosting)**: if we can't dogfood Fabrik on Fabrik by week 10, the architecture is wrong and we re-plan rather than push forward.
+- **Phase 6 (WASM)**: if the WASI Preview 2 ecosystem isn't ready and our fallback constraints are too painful, we ship v0 with in-process plugins and move WASM to v1. The plugin *contract* still exists.
+- **Phase 8 (query API + agent dogfooding)**: if agents can't usefully answer real questions via the API, the API is wrong and we redesign it. This is the agent-native bet; it has to be tested with real agents on real builds.


### PR DESCRIPTION
## Summary
- Adds `docs/design.md`: v0 design spec — three-layer architecture (substrate / coordinator / frontend), plugin model with three integration modes (`reimplemented` / `cooperative` / `opaque`), per-target hermeticity, agent-native query API, OTel-native telemetry, per-language plans.
- Adds `docs/roadmap.md`: 10-phase execution plan optimized for shortest path to self-hosting (Phase 3, ~week 10). Defers WASM, DSL, and REAPI until after the system works concretely.

## Test plan
- [ ] Read both docs end-to-end
- [ ] Confirm Phase 0–3 sequencing makes sense as the dogfood path

🤖 Generated with [Claude Code](https://claude.com/claude-code)