### PR TITLE
docs(readme): user-focused rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,61 +2,83 @@
 
 A polyglot, agent-native build system. Bazel's ambitions, none of its mistakes.
 
-> Status: pre-alpha. Walking skeleton. Not yet usable for real builds.
-
-See [docs/design.md](docs/design.md) for the v0 design and
-[docs/roadmap.md](docs/roadmap.md) for the phased execution plan.
+> 🚧 **Pre-alpha.** Not yet usable for real builds. The CLI runs and the cache works, but
+> there is no language plugin yet (it's the next phase). See the
+> [roadmap](docs/roadmap.md) for what lands when.
 
 ## Install
 
-Once the first release lands, fabrik will be installable via mise's
-ubi backend:
+The recommended path is [mise](https://mise.jdx.dev) with the GitHub backend:
 
 ```sh
-mise use --global ubi:tuist/fabrik@latest
+mise use --global github:tuist/fabrik@latest
 fabrik --version
 ```
 
-Releases are produced automatically from `main` on every push that
-contains conventional commits (`feat:`, `fix:`, `perf:`, `refactor:`).
-See [.github/workflows/release.yml](.github/workflows/release.yml).
+Pin to a specific release if you want reproducibility:
+
+```sh
+mise use --global github:tuist/fabrik@0.1.0
+```
+
+Or download a prebuilt archive directly from
+[releases](https://github.com/tuist/fabrik/releases). Each release ships
+binaries for:
+
+- 🐧 Linux x86_64
+- 🍎 macOS x86_64 and arm64
+- 🪟 Windows x86_64
+
+## Quick taste
+
+```sh
+# Run a command through the action cache.
+fabrik run -e PATH=/usr/bin:/bin -- /bin/sh -c 'echo hello'
+
+# A second identical invocation replays the cached stdout/stderr/exit
+# without re-running the command.
+fabrik run -e PATH=/usr/bin:/bin -- /bin/sh -c 'echo hello'
+
+# Cache stats.
+fabrik cache stats
+```
+
+The cache lives under `<workspace>/.fabrik/`. Use `-C <dir>` to point at
+a different workspace, the same way `make -C` works.
+
+## What the design promises
+
+- **One build system for the whole polyglot stack.** Rust, Go, C/C++,
+  TypeScript, Python, Java/Kotlin, Elixir, Swift, Android, iOS.
+- **Trustworthy, content-addressed caching** that's shareable across
+  machines via the Bazel REAPI protocol.
+- **Honest boundaries.** When fidelity has to drop (Gradle, Vite, Mix),
+  Fabrik says so out loud rather than pretending.
+- **Agent-native.** The build graph is a typed, queryable data
+  structure. Humans and AI agents talk to the same gRPC API.
+- **OpenTelemetry-native** with build-specific semantic conventions.
+
+The full picture is in [docs/design.md](docs/design.md).
+
+## Project status
+
+Phase 0 (walking skeleton: CAS, action executor, CLI) shipped in 0.1.0.
+The next phase brings the Rust language plugin so Fabrik can build
+itself. Track progress in the [roadmap](docs/roadmap.md).
 
 ## Build from source
 
 ```sh
-mise install              # installs the pinned Rust + shellspec + git-cliff toolchain
-cargo build --release     # builds the workspace
-cargo test                # unit tests
-mise exec -- shellspec    # end-to-end CLI tests
-cargo clippy --workspace --all-targets -- -D warnings
-cargo fmt --check
+mise install
+cargo build --release
+cargo test
+mise exec -- shellspec
 ```
 
-## What works today
+CI runs lint, tests, and a Windows compile check on every PR. See
+[.github/workflows/ci.yml](.github/workflows/ci.yml) and
+[CONTRIBUTING](docs/contributing.md) (coming soon).
 
-```sh
-# Run a command through the action cache.
-cargo run -- run -e PATH=/usr/bin:/bin -- /bin/sh -c 'echo hello'
+## License
 
-# Cache it under a workspace-relative cwd; second run replays from cache.
-cargo run -- -C /tmp/ws run --cwd subdir -e PATH=/usr/bin:/bin -- /bin/sh -c 'pwd'
-
-# Per-action timeout (child is killed via kill_on_drop).
-cargo run -- run --timeout-ms 1000 -e PATH=/usr/bin:/bin -- /bin/sh -c 'sleep 5'
-
-# Cache stats.
-cargo run -- cache stats
-
-# Verbose tracing (or set RUST_LOG=debug).
-cargo run -- -vv run -e PATH=/usr/bin:/bin -- /bin/sh -c 'echo hi'
-```
-
-`fabrik run` executes a command and caches its `(stdout, stderr, exit code)`
-keyed by argv + env + cwd + timeout. The cache lives in `<workspace>/.fabrik/`.
-Failures are not cached unless you pass `--cache-failures`.
-
-## Layout
-
-- `crates/fabrik-cas` — async content-addressed store with streaming put.
-- `crates/fabrik-core` — `Action`, `Runner` (semaphore-bounded), executor.
-- `crates/fabrik-cli` — the `fabrik` binary.
+[MIT](LICENSE).


### PR DESCRIPTION
Leads with install via mise (github backend, since ubi is deprecated
and gets removed in mise 2027.1.0), shows a quick-taste workflow,
summarizes the design promise, and pushes build-from-source to the
bottom for contributors. Drops em dashes throughout, adds a few
platform emojis on the release-target list.

Verified install path:
\`\`\`
$ mise x github:tuist/fabrik@latest -- fabrik --version
fabrik 0.1.0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)