### PR TITLE
feat(rust): fabrik cargo cached cargo wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +193,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +255,7 @@ dependencies = [
  "clap",
  "fabrik-cas",
  "fabrik-core",
+ "fabrik-rust",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -233,6 +269,21 @@ dependencies = [
  "fabrik-cas",
  "serde",
  "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fabrik-rust"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "fabrik-cas",
+ "fabrik-core",
+ "ignore",
  "tempfile",
  "thiserror",
  "tokio",
@@ -271,6 +322,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +366,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -513,6 +593,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -784,6 +873,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +938,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/fabrik-cli",
     "crates/fabrik-core",
     "crates/fabrik-cas",
+    "crates/fabrik-rust",
 ]
 
 [workspace.package]
@@ -16,11 +17,13 @@ repository = "https://github.com/tuist/fabrik"
 [workspace.dependencies]
 fabrik-core = { path = "crates/fabrik-core" }
 fabrik-cas = { path = "crates/fabrik-cas" }
+fabrik-rust = { path = "crates/fabrik-rust" }
 
 anyhow = "1"
 blake3 = "1"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
+ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/fabrik-cli/src/main.rs
+++ b/crates/fabrik-cli/src/main.rs
@@ -76,6 +76,30 @@ enum Cmd {
         argv: Vec<String>,
     },
 
+    /// Run `cargo` against the workspace through the action cache.
+    ///
+    /// First invocation runs cargo end-to-end and captures the result.
+    /// Subsequent invocations with the same workspace source digest,
+    /// rust+cargo versions, and arguments replay the cached
+    /// stdout/stderr/exit instead of re-running.
+    ///
+    /// This is opaque-mode integration: cargo runs as one unit. cargo's
+    /// own incremental compilation still applies on a cache miss.
+    /// Future phases will replace this with per-crate `rustc`
+    /// invocations driven by `cargo metadata`.
+    Cargo {
+        /// Cache cargo failures the same way successes are cached. Off
+        /// by default so a transient `cargo build` failure doesn't
+        /// pin a red state.
+        #[arg(long)]
+        cache_failures: bool,
+
+        /// Arguments forwarded to cargo. Use `--` to separate from
+        /// fabrik flags, e.g. `fabrik cargo -- build --release -p foo`.
+        #[arg(trailing_var_arg = true, required = true)]
+        args: Vec<String>,
+    },
+
     /// Cache management.
     Cache {
         #[command(subcommand)]
@@ -143,10 +167,50 @@ async fn dispatch(cli: Cli) -> Result<ExitCode> {
             cache_failures,
             argv,
         } => run_command(&workspace, &cas, env, cwd, timeout_ms, cache_failures, argv).await,
+        Cmd::Cargo {
+            cache_failures,
+            args,
+        } => cargo_command(&workspace, &cas, cache_failures, args).await,
         Cmd::Cache {
             cmd: CacheCmd::Stats,
         } => print_stats(&cas).await.map(|()| ExitCode::SUCCESS),
     }
+}
+
+async fn cargo_command(
+    workspace: &std::path::Path,
+    cas: &Cas,
+    cache_failures: bool,
+    args: Vec<String>,
+) -> Result<ExitCode> {
+    let toolchain = fabrik_rust::Toolchain::detect().context("probing rust toolchain")?;
+    let action =
+        fabrik_rust::cargo_action(workspace, &args, &toolchain).context("building cargo action")?;
+    let opts = RunOpts { cache_failures };
+    let outcome = fabrik_core::run(&action, workspace, cas, opts)
+        .await
+        .context("executing cargo action")?;
+
+    let stdout = cas.get_blob(&outcome.result.stdout).await?;
+    let stderr = cas.get_blob(&outcome.result.stderr).await?;
+    let mut out = tokio::io::stdout();
+    out.write_all(&stdout).await?;
+    out.flush().await?;
+    let mut err = tokio::io::stderr();
+    err.write_all(&stderr).await?;
+
+    let tag = match outcome.cache {
+        CacheState::Hit => "hit",
+        CacheState::Miss => "miss",
+    };
+    let trailer = format!(
+        "fabrik: cargo cache {tag} action={} exit={}\n",
+        outcome.action, outcome.result.exit_code
+    );
+    err.write_all(trailer.as_bytes()).await?;
+    err.flush().await?;
+
+    Ok(exit_from(outcome.result.exit_code))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/fabrik-rust/Cargo.toml
+++ b/crates/fabrik-rust/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name = "fabrik-cli"
+name = "fabrik-rust"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
-[[bin]]
-name = "fabrik"
-path = "src/main.rs"
-
 [dependencies]
 fabrik-cas.workspace = true
 fabrik-core.workspace = true
-fabrik-rust.workspace = true
 
 anyhow.workspace = true
-clap.workspace = true
+blake3.workspace = true
+ignore.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/fabrik-rust/src/lib.rs
+++ b/crates/fabrik-rust/src/lib.rs
@@ -1,0 +1,386 @@
+//! Rust language integration for Fabrik.
+//!
+//! Currently exposes one capability: build a `RunCommand` action that
+//! invokes `cargo` against a Rust workspace, with the workspace's
+//! source tree and toolchain versions folded into the action's cache
+//! key. A second invocation with no source change is a cache hit.
+//!
+//! This is opaque-mode integration: cargo runs end-to-end, and Fabrik
+//! caches the (stdout, stderr, exit) tuple. Subsequent phases will
+//! replace this with cooperative resolution (`cargo metadata`) and
+//! reimplemented per-crate `rustc` actions.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use fabrik_cas::Digest;
+use fabrik_core::Action;
+use ignore::WalkBuilder;
+use tracing::instrument;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("not a Rust workspace: {0:?} has no Cargo.toml")]
+    NotARustWorkspace(PathBuf),
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to run `{program} {arg}`: {source}")]
+    ToolProbe {
+        program: String,
+        arg: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Snapshot of the Rust toolchain a cargo invocation will see.
+///
+/// Captured by shelling out to `cargo --version` and `rustc --version`
+/// before constructing the action so the cache key reflects toolchain
+/// drift, not just source drift.
+#[derive(Debug, Clone)]
+pub struct Toolchain {
+    pub cargo_version: String,
+    pub rustc_version: String,
+}
+
+impl Toolchain {
+    /// Probe the toolchain on `PATH`.
+    pub fn detect() -> Result<Self> {
+        Ok(Self {
+            cargo_version: probe("cargo", "--version")?,
+            rustc_version: probe("rustc", "--version")?,
+        })
+    }
+
+    fn fingerprint(&self) -> String {
+        format!("cargo={}|rustc={}", self.cargo_version, self.rustc_version)
+    }
+}
+
+fn probe(program: &str, arg: &str) -> Result<String> {
+    let output = Command::new(program)
+        .arg(arg)
+        .output()
+        .map_err(|source| Error::ToolProbe {
+            program: program.into(),
+            arg: arg.into(),
+            source,
+        })?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Compute a deterministic digest of the workspace's Rust source.
+///
+/// Includes `Cargo.toml`, `Cargo.lock`, and every `*.rs` file the
+/// `ignore` crate considers visible (respects `.gitignore`,
+/// `.ignore`, hidden-file rules). Files are sorted by their
+/// workspace-relative path before hashing, so the digest is stable
+/// across machines and filesystems with different directory-walk
+/// orders.
+///
+/// Specifically excludes `target/` because cargo writes there and we
+/// don't want a successful build to invalidate its own cache key.
+#[instrument(skip(workspace))]
+pub fn workspace_digest(workspace: &Path) -> Result<Digest> {
+    let cargo_toml = workspace.join("Cargo.toml");
+    if !cargo_toml.exists() {
+        return Err(Error::NotARustWorkspace(workspace.to_path_buf()));
+    }
+
+    let mut entries: Vec<(String, Digest)> = Vec::new();
+    let walker = WalkBuilder::new(workspace)
+        .standard_filters(true)
+        // Honor .gitignore even when the workspace isn't a git repo
+        // (e.g. fixtures, tarballed sources). Without this, the ignore
+        // crate skips .gitignore entirely outside a repo.
+        .require_git(false)
+        .filter_entry(|entry| {
+            // Always traverse the root.
+            if entry.depth() == 0 {
+                return true;
+            }
+            // Drop target/ at any depth — cargo's output directory.
+            entry.file_name() != "target"
+        })
+        .build();
+
+    for result in walker {
+        let entry = result.map_err(|e| Error::Io {
+            path: workspace.to_path_buf(),
+            source: std::io::Error::other(e.to_string()),
+        })?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if !is_rust_source(path) {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(workspace)
+            .expect("walked path is under workspace");
+        // Forward-slash path string so digests match across Windows
+        // and unix.
+        let rel_str = rel
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join("/");
+        let bytes = std::fs::read(path).map_err(|source| Error::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        entries.push((rel_str, Digest::of_bytes(&bytes)));
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"fabrik.rust.workspace_digest.v1\0");
+    for (rel, digest) in &entries {
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(digest.as_bytes());
+        hasher.update(b"\n");
+    }
+    Ok(Digest::from_bytes(*hasher.finalize().as_bytes()))
+}
+
+fn is_rust_source(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if name == "Cargo.toml" || name == "Cargo.lock" {
+        return true;
+    }
+    matches!(path.extension().and_then(|e| e.to_str()), Some("rs"))
+}
+
+/// Build a `RunCommand` action that runs `cargo <args>` against
+/// `workspace`, with the workspace source digest and toolchain
+/// fingerprint folded into the cache key.
+///
+/// The action runs with `cwd = workspace_root` (the executor will
+/// resolve `None` to it). The environment is the minimum cargo
+/// expects: `PATH`, `HOME`, plus opt-in passthrough of `RUSTUP_HOME`,
+/// `CARGO_HOME`, `CARGO_TARGET_DIR`, `USER`, `TERM` when the parent
+/// has them set. A synthetic `FABRIK_CARGO_KEY` env var carries the
+/// source digest + toolchain fingerprint so any change to either
+/// invalidates the cache without affecting cargo's behavior.
+pub fn cargo_action(workspace: &Path, args: &[String], toolchain: &Toolchain) -> Result<Action> {
+    let digest = workspace_digest(workspace)?;
+    let key = format!(
+        "src={src}|tool={tool}",
+        src = digest,
+        tool = toolchain.fingerprint(),
+    );
+
+    let mut env: BTreeMap<String, String> = BTreeMap::new();
+    env.insert("FABRIK_CARGO_KEY".into(), key);
+    // Always-required env. Without PATH cargo can't find rustc; without
+    // HOME it can't locate ~/.cargo.
+    for k in ["PATH", "HOME"] {
+        if let Ok(v) = env::var(k) {
+            env.insert(k.into(), v);
+        }
+    }
+    // Best-effort passthrough — included in the cache key so changes
+    // to e.g. CARGO_TARGET_DIR force a rebuild.
+    for k in [
+        "RUSTUP_HOME",
+        "RUSTUP_TOOLCHAIN",
+        "CARGO_HOME",
+        "CARGO_TARGET_DIR",
+        "USER",
+        "TERM",
+    ] {
+        if let Ok(v) = env::var(k) {
+            env.insert(k.into(), v);
+        }
+    }
+
+    let mut argument_vec = vec!["cargo".to_string()];
+    argument_vec.extend(args.iter().cloned());
+
+    Ok(Action::RunCommand {
+        argv: argument_vec,
+        env,
+        cwd: None,
+        timeout_ms: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn fixture() -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        write(
+            &tmp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = []\n",
+        );
+        write(&tmp.path().join("Cargo.lock"), "# locked\n");
+        write(&tmp.path().join("src/main.rs"), "fn main() {}\n");
+        tmp
+    }
+
+    #[test]
+    fn workspace_digest_is_stable_across_calls() {
+        let tmp = fixture();
+        let a = workspace_digest(tmp.path()).unwrap();
+        let b = workspace_digest(tmp.path()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn workspace_digest_rejects_non_rust_workspace() {
+        let tmp = TempDir::new().unwrap();
+        let err = workspace_digest(tmp.path()).unwrap_err();
+        assert!(matches!(err, Error::NotARustWorkspace(_)));
+    }
+
+    #[test]
+    fn workspace_digest_changes_when_a_source_file_changes() {
+        let tmp = fixture();
+        let before = workspace_digest(tmp.path()).unwrap();
+        write(
+            &tmp.path().join("src/main.rs"),
+            "fn main() { println!(\"hi\"); }\n",
+        );
+        let after = workspace_digest(tmp.path()).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn workspace_digest_changes_when_cargo_toml_changes() {
+        let tmp = fixture();
+        let before = workspace_digest(tmp.path()).unwrap();
+        write(
+            &tmp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"foo\"]\n",
+        );
+        let after = workspace_digest(tmp.path()).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn workspace_digest_ignores_target_dir() {
+        let tmp = fixture();
+        let before = workspace_digest(tmp.path()).unwrap();
+        // Drop a fake build artifact in target/ — must not affect digest.
+        write(
+            &tmp.path().join("target/release/fabrik-cli"),
+            "\x7fELF... pretend",
+        );
+        write(&tmp.path().join("target/release/.rs"), "noise");
+        write(
+            &tmp.path().join("target/debug/build/foo-1234/output.rs"),
+            "fn unrelated() {}",
+        );
+        let after = workspace_digest(tmp.path()).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn workspace_digest_respects_gitignore() {
+        let tmp = fixture();
+        // Put a file the user has ignored — should not affect digest.
+        write(&tmp.path().join(".gitignore"), "ignored.rs\n");
+        let before = workspace_digest(tmp.path()).unwrap();
+        write(&tmp.path().join("ignored.rs"), "fn ignored() {}");
+        let after = workspace_digest(tmp.path()).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn workspace_digest_changes_when_a_new_rs_file_is_added() {
+        let tmp = fixture();
+        let before = workspace_digest(tmp.path()).unwrap();
+        write(&tmp.path().join("src/lib.rs"), "pub fn lib() {}\n");
+        let after = workspace_digest(tmp.path()).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn cargo_action_includes_synthetic_key_in_env() {
+        let tmp = fixture();
+        let toolchain = Toolchain {
+            cargo_version: "cargo 1.86.0".into(),
+            rustc_version: "rustc 1.86.0".into(),
+        };
+        let action = cargo_action(
+            tmp.path(),
+            &["build".to_string(), "--release".to_string()],
+            &toolchain,
+        )
+        .unwrap();
+        let Action::RunCommand { argv, env, .. } = action;
+        assert_eq!(argv, vec!["cargo", "build", "--release"]);
+        let key = env.get("FABRIK_CARGO_KEY").expect("synthetic key set");
+        assert!(key.starts_with("src="), "{key}");
+        assert!(key.contains("tool=cargo=cargo 1.86.0"), "{key}");
+    }
+
+    #[test]
+    fn cargo_action_changes_digest_when_source_changes() {
+        let tmp = fixture();
+        let toolchain = Toolchain {
+            cargo_version: "cargo 1.86.0".into(),
+            rustc_version: "rustc 1.86.0".into(),
+        };
+        let a = cargo_action(tmp.path(), &["build".into()], &toolchain).unwrap();
+        write(
+            &tmp.path().join("src/main.rs"),
+            "fn main() { /* edit */ }\n",
+        );
+        let b = cargo_action(tmp.path(), &["build".into()], &toolchain).unwrap();
+        assert_ne!(a.digest(), b.digest());
+    }
+
+    #[test]
+    fn cargo_action_changes_digest_when_toolchain_changes() {
+        let tmp = fixture();
+        let t1 = Toolchain {
+            cargo_version: "cargo 1.86.0".into(),
+            rustc_version: "rustc 1.86.0".into(),
+        };
+        let t2 = Toolchain {
+            cargo_version: "cargo 1.87.0".into(),
+            rustc_version: "rustc 1.87.0".into(),
+        };
+        let a = cargo_action(tmp.path(), &["build".into()], &t1).unwrap();
+        let b = cargo_action(tmp.path(), &["build".into()], &t2).unwrap();
+        assert_ne!(a.digest(), b.digest());
+    }
+
+    #[test]
+    fn cargo_action_changes_digest_when_args_change() {
+        let tmp = fixture();
+        let toolchain = Toolchain {
+            cargo_version: "cargo 1.86.0".into(),
+            rustc_version: "rustc 1.86.0".into(),
+        };
+        let a = cargo_action(tmp.path(), &["build".into()], &toolchain).unwrap();
+        let b = cargo_action(tmp.path(), &["test".into()], &toolchain).unwrap();
+        assert_ne!(a.digest(), b.digest());
+    }
+}

--- a/spec/cargo_spec.sh
+++ b/spec/cargo_spec.sh
@@ -1,0 +1,38 @@
+#shellcheck shell=bash
+# Surface checks for the `fabrik cargo` subcommand. End-to-end caching
+# behavior is covered by Rust unit tests in fabrik-rust where the
+# assertion can inspect the action digest directly.
+
+Describe 'fabrik cargo --help'
+  It 'documents the subcommand and the cache-failures flag'
+    When call "$FABRIK_BIN" cargo --help
+    The status should be success
+    The stdout should include 'cargo'
+    The stdout should include '--cache-failures'
+  End
+End
+
+Describe 'fabrik cargo without args'
+  It 'errors instead of running cargo with no arguments'
+    When call "$FABRIK_BIN" cargo
+    The status should not equal 0
+    The stderr should include 'required'
+  End
+End
+
+Describe 'fabrik cargo against a non-rust workspace'
+  setup() {
+    fresh="$(mktemp -d -t fabrik-cargo-spec.XXXXXX)"
+  }
+  cleanup() {
+    rm -rf "$fresh"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'errors clearly when the workspace has no Cargo.toml'
+    When call "$FABRIK_BIN" -C "$fresh" cargo -- check
+    The status should not equal 0
+    The stderr should include 'not a Rust workspace'
+  End
+End


### PR DESCRIPTION
## Summary
First tangible step of the Rust language plugin: a `fabrik cargo` subcommand that runs cargo against the workspace through the action cache.

End state of this PR: you can `fabrik cargo check -p fabrik-cas` on the Fabrik repo itself and a second invocation hits the cache instead of re-running cargo. Dogfooding-shaped, just at coarse granularity (one action per cargo invocation).

## Verified locally on this very repo

\`\`\`
$ fabrik cargo -- check -p fabrik-cas
fabrik: cargo cache miss action=157998bb...  exit=0   real 2.03s
$ fabrik cargo -- check -p fabrik-cas
fabrik: cargo cache hit  action=157998bb...  exit=0   real 0.04s
\`\`\`

50x speedup. Touch a source file → digest changes → cache misses → cargo runs again.

## Pieces

- **\`crates/fabrik-rust\`** (new):
  - \`workspace_digest\`: deterministic BLAKE3 over \`Cargo.toml\`, \`Cargo.lock\`, every visible \`*.rs\` file. Walks via \`ignore\` (.gitignore-aware), forward-slash paths so digests are portable across Windows and unix, \`target/\` explicitly excluded.
  - \`Toolchain::detect\`: shells out to \`cargo --version\` and \`rustc --version\` so toolchain drift invalidates the cache.
  - \`cargo_action\`: builds a \`RunCommand\` action with \`PATH\` + \`HOME\` required, opt-in passthrough of \`CARGO_*\`/\`RUSTUP_*\`/\`USER\`/\`TERM\`, and a synthetic \`FABRIK_CARGO_KEY\` env var carrying \`src=<digest>|tool=...\` so source/toolchain changes drive the cache key without affecting cargo's behavior.
- **\`crates/fabrik-cli\`**: new \`Cargo\` subcommand routes through \`fabrik_core::run\` with \`cache_failures\` defaulting off.
- **\`spec/cargo_spec.sh\`**: \`--help\`, missing-args error, non-rust workspace error.

## What's deliberately NOT here (next PRs in this phase)

- **Per-crate granularity.** This wraps the whole \`cargo\` invocation as one action. Next: drive a graph from \`cargo metadata\` so each crate is its own action.
- **Direct \`rustc\`.** Cargo still does the actual compilation. Next-after-next: emit per-crate \`rustc\` actions directly.
- **Build script tracing.** Currently passes through cargo's behavior. Next: traced-mode sandboxing for build.rs.

## Coverage

- 11 unit tests in fabrik-rust pinning digest stability + sensitivity to source/toolchain/args/.gitignore/\`target/\`.
- 3 new shellspec examples.
- Total Rust suite: 69 tests; shellspec: 31 examples.

## Why draft

Putting up so the cache-key shape (synthetic \`FABRIK_CARGO_KEY\` env var) and the env-passthrough list can be reviewed before later PRs build on them. The synthetic-key trick is the load-bearing decision here.

## Test plan
- [ ] CI green (lint + test ubuntu/macos + windows compile)
- [ ] \`fabrik cargo check\` cache miss-then-hit on the Fabrik repo
- [ ] Source change invalidates the cache
- [ ] Toolchain change (e.g. \`rustup default\`) invalidates the cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)