### PR TITLE
Promote shared plugin scaffolding into fabrik-core

### DIFF
--- a/crates/fabrik-apple/src/compile.rs
+++ b/crates/fabrik-apple/src/compile.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use fabrik_cas::Digest;
-use fabrik_core::{Action, PlanNode, ResourceRequest, WorkspacePath};
+use fabrik_core::{
+    tool_env as core_tool_env, Action, InputDigestBuilder, PlanNode, ResourceRequest, WorkspacePath,
+};
 use fabrik_frontend::Target;
 
 use crate::artifact::app_bundle_path;
@@ -248,16 +250,15 @@ fn source_paths(target: &Target) -> Result<Vec<String>, AppleError> {
         .srcs
         .iter()
         .map(|src| {
-            let rel = if target.package.is_empty() {
-                src.clone()
-            } else {
-                format!("{}/{src}", target.package)
-            };
-            WorkspacePath::try_from(rel.as_str())
+            WorkspacePath::from_package_relative(&target.package, src)
                 .map(|p| p.as_str().to_string())
                 .map_err(|source| AppleError::InvalidPath {
                     label: target.id(),
-                    path: rel,
+                    path: if target.package.is_empty() {
+                        src.clone()
+                    } else {
+                        format!("{}/{src}", target.package)
+                    },
                     source,
                 })
         })
@@ -270,34 +271,27 @@ fn build_input_digest(
     bundle_id: &str,
     minimum_os: &str,
 ) -> Result<Digest, AppleError> {
-    let mut buf = Vec::new();
-    buf.extend_from_slice(b"fabrik.apple.ios_app.input.v1\0");
-    buf.extend_from_slice(bundle_id.as_bytes());
-    buf.push(0);
-    buf.extend_from_slice(minimum_os.as_bytes());
-    buf.push(0);
+    let mut builder = InputDigestBuilder::new(b"fabrik.apple.ios_app.input.v1\0");
+    builder.push_bytes(bundle_id.as_bytes());
+    builder.push_bytes(minimum_os.as_bytes());
 
     let mut srcs = source_paths(target)?;
     srcs.sort();
     for src in srcs {
-        let abs = workspace_root.join(&src);
-        let bytes = std::fs::read(&abs).map_err(|source| AppleError::ReadSource {
-            label: target.id(),
-            path: src.clone(),
-            source,
-        })?;
-        let digest = Digest::of_bytes(&bytes);
-        buf.extend_from_slice(src.as_bytes());
-        buf.push(0);
-        buf.extend_from_slice(digest.as_bytes());
-        buf.push(0);
+        builder
+            .push_source(workspace_root, &src)
+            .map_err(|source| AppleError::ReadSource {
+                label: target.id(),
+                path: src.clone(),
+                source,
+            })?;
     }
     if let Ok(developer_dir) = std::env::var("DEVELOPER_DIR") {
-        buf.extend_from_slice(b"developer_dir:");
-        buf.extend_from_slice(developer_dir.as_bytes());
-        buf.push(0);
+        let mut tag = b"developer_dir:".to_vec();
+        tag.extend_from_slice(developer_dir.as_bytes());
+        builder.push_bytes(&tag);
     }
-    Ok(Digest::of_bytes(&buf))
+    Ok(builder.finish())
 }
 
 fn uncached_launch_digest(target: &Target, bundle_id: &str) -> Digest {
@@ -316,18 +310,11 @@ fn uncached_launch_digest(target: &Target, bundle_id: &str) -> Digest {
 }
 
 fn tool_env(mode: Mode) -> BTreeMap<String, String> {
-    let mut env = BTreeMap::new();
-    for key in ["PATH", "HOME", "DEVELOPER_DIR", "SDKROOT", "TOOLCHAINS"] {
-        if let Ok(value) = std::env::var(key) {
-            env.insert(key.into(), value);
-        }
-    }
+    let mut keys: Vec<&'static str> = vec!["DEVELOPER_DIR", "SDKROOT", "TOOLCHAINS"];
     if matches!(mode, Mode::Launch) {
-        if let Ok(value) = std::env::var("FABRIK_IOS_SIMULATOR") {
-            env.insert("FABRIK_IOS_SIMULATOR".into(), value);
-        }
+        keys.push("FABRIK_IOS_SIMULATOR");
     }
-    env
+    core_tool_env(&keys)
 }
 
 fn sh_quote(value: &str) -> String {

--- a/crates/fabrik-apple/src/lib.rs
+++ b/crates/fabrik-apple/src/lib.rs
@@ -13,5 +13,5 @@ mod swift;
 
 pub use artifact::app_bundle_path;
 pub use compile::{compile_ios_app, launch_ios_app, AppleAction, AppleError};
-pub use plan::{build_plan, supports_kind, BuiltPlan, NodeInfo, PlanBuildError};
+pub use plan::{build_plan, supports_kind, PlanBuildError};
 pub use swift::{compile_swift_target, SwiftError};

--- a/crates/fabrik-apple/src/plan.rs
+++ b/crates/fabrik-apple/src/plan.rs
@@ -1,27 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 
-use fabrik_core::Plan;
+use fabrik_core::{BuiltPlan, NodeInfo, Plan};
 use fabrik_frontend::Target;
 
 use crate::artifact::{AppleKind, SwiftArtifact};
 use crate::compile::{compile_ios_app, AppleError};
 use crate::swift::{compile_swift_target, SwiftError, TargetDepMode};
-
-#[derive(Debug, Clone)]
-pub struct BuiltPlan {
-    pub plan: Plan,
-    pub root_index: usize,
-    pub root_id: String,
-    pub output: String,
-    pub nodes: Vec<NodeInfo>,
-}
-
-#[derive(Debug, Clone)]
-pub struct NodeInfo {
-    pub label: String,
-    pub kind: String,
-}
 
 #[derive(Debug, thiserror::Error)]
 pub enum PlanBuildError {

--- a/crates/fabrik-cli/src/commands/build.rs
+++ b/crates/fabrik-cli/src/commands/build.rs
@@ -13,11 +13,12 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use fabrik_cas::Cas;
-use fabrik_core::{CacheState, Plan, RunOpts, Runner};
+use fabrik_core::{BuiltPlan, CacheState, RunOpts, Runner};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::cli::Format;
+use crate::commands::util::cache_tag;
 use crate::render;
 
 #[derive(Serialize)]
@@ -60,6 +61,7 @@ pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) ->
             let mut err = tokio::io::stderr();
             for o in &outcomes {
                 let info = &built.nodes[o.index];
+                // Right-pad single-letter "hit" so columns line up.
                 let tag = match o.outcome.cache {
                     CacheState::Hit => "hit ",
                     CacheState::Miss => "miss",
@@ -85,14 +87,10 @@ pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) ->
             let mut err = tokio::io::stderr();
             for o in &outcomes {
                 let info = &built.nodes[o.index];
-                let cache_tag = match o.outcome.cache {
-                    CacheState::Hit => "hit",
-                    CacheState::Miss => "miss",
-                };
                 let record = NodeRecord {
                     label: &o.label,
                     kind: &info.kind,
-                    cache: cache_tag,
+                    cache: cache_tag(o.outcome.cache),
                     action_digest: o.outcome.action.to_string(),
                 };
                 let line = serde_json::to_string(&record)? + "\n";
@@ -116,54 +114,22 @@ pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) ->
     Ok(ExitCode::SUCCESS)
 }
 
-struct BuiltCliPlan {
-    plan: Plan,
-    nodes: Vec<NodeInfo>,
-    output: String,
-}
-
-struct NodeInfo {
-    kind: String,
-}
-
+/// Dispatch to the matching plugin's planner. Adding a new plugin is
+/// one extra arm here; the CLI rendering and execution paths above
+/// stay plugin-agnostic because every plugin returns the unified
+/// [`BuiltPlan`] shape.
 fn build_plan(
     targets: &[fabrik_frontend::Target],
     target_id: &str,
     workspace: &Path,
-) -> Result<BuiltCliPlan> {
+) -> Result<BuiltPlan> {
     let target = targets
         .iter()
         .find(|t| t.id() == target_id)
         .ok_or_else(|| anyhow::anyhow!("no target matches `{target_id}`"))?;
     if fabrik_apple::supports_kind(&target.kind) {
-        let built = fabrik_apple::build_plan(targets, target_id, workspace)?;
-        Ok(BuiltCliPlan {
-            plan: built.plan,
-            nodes: built
-                .nodes
-                .into_iter()
-                .map(|n| NodeInfo { kind: n.kind })
-                .collect(),
-            output: built.output,
-        })
+        Ok(fabrik_apple::build_plan(targets, target_id, workspace)?)
     } else {
-        let built = fabrik_rust::build_plan(targets, target_id, workspace)?;
-        let fabrik_core::Action::RunCommand { outputs, .. } =
-            &built.plan.nodes[built.root_index].action;
-        let output = outputs
-            .first()
-            .map(|p| p.as_str().to_string())
-            .unwrap_or_default();
-        Ok(BuiltCliPlan {
-            plan: built.plan,
-            nodes: built
-                .nodes
-                .into_iter()
-                .map(|n| NodeInfo {
-                    kind: n.kind.as_str().to_string(),
-                })
-                .collect(),
-            output,
-        })
+        Ok(fabrik_rust::build_plan(targets, target_id, workspace)?)
     }
 }

--- a/crates/fabrik-cli/src/commands/exec.rs
+++ b/crates/fabrik-cli/src/commands/exec.rs
@@ -17,11 +17,12 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use fabrik_cas::Cas;
-use fabrik_core::{Action, CacheState, ResourceRequest, RunOpts, WorkspacePath};
+use fabrik_core::{Action, ResourceRequest, RunOpts, WorkspacePath};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::cli::{exit_from, Format};
+use crate::commands::util::cache_tag;
 use crate::render;
 
 #[derive(Serialize)]
@@ -76,18 +77,15 @@ pub async fn exec(workspace: &Path, cas: &Cas, args: ExecArgs, format: Format) -
     let mut err = tokio::io::stderr();
     err.write_all(&stderr).await?;
 
-    let cache_tag = match outcome.cache {
-        CacheState::Hit => "hit",
-        CacheState::Miss => "miss",
-    };
+    let tag = cache_tag(outcome.cache);
     let trailer = ExecTrailer {
         action_digest: outcome.action.to_string(),
-        cache: cache_tag,
+        cache: tag,
         exit_code: outcome.result.exit_code,
     };
     let trailer = match format {
         Format::Human => format!(
-            "fabrik: cache {cache_tag} action={} exit={}\n",
+            "fabrik: cache {tag} action={} exit={}\n",
             outcome.action, outcome.result.exit_code
         ),
         Format::Json | Format::Toon => render::structured(format, &trailer)?,

--- a/crates/fabrik-cli/src/commands/mod.rs
+++ b/crates/fabrik-cli/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod exec;
 pub mod run;
 pub mod targets;
 pub mod test;
+pub mod util;
 pub mod vendor;

--- a/crates/fabrik-cli/src/commands/run.rs
+++ b/crates/fabrik-cli/src/commands/run.rs
@@ -11,11 +11,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use fabrik_cas::{Cas, Digest};
-use fabrik_core::{Action, CacheState, ResourceRequest, RunOpts, Runner, WorkspacePath};
+use fabrik_core::{
+    tool_env as core_tool_env, Action, InputDigestBuilder, ResourceRequest, RunOpts, Runner,
+    WorkspacePath,
+};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::cli::{exit_from, Format, CACHE_DIR};
+use crate::commands::util::{cache_tag, find_target};
 use crate::render;
 
 #[derive(Serialize)]
@@ -35,11 +39,8 @@ struct ActionPlan {
 }
 
 pub async fn run(workspace: &Path, cas: &Cas, target_id: &str, format: Format) -> Result<ExitCode> {
-    let targets = fabrik_frontend::load_workspace(workspace).context("loading workspace")?;
-    let target = targets
-        .iter()
-        .find(|t| t.id() == target_id)
-        .ok_or_else(|| anyhow::anyhow!("no target matches `{target_id}`"))?;
+    let (targets, idx) = find_target(workspace, target_id)?;
+    let target = &targets[idx];
 
     if target.kind == "apple_ios_app" {
         return run_apple_ios_app(workspace, cas, target_id, &targets, target, format).await;
@@ -95,15 +96,12 @@ async fn render_run_output(
 ) -> Result<()> {
     let stdout_blob = cas.get_blob(&outcome.result.stdout).await?;
     let stderr_blob = cas.get_blob(&outcome.result.stderr).await?;
-    let cache_tag = match outcome.cache {
-        CacheState::Hit => "hit",
-        CacheState::Miss => "miss",
-    };
+    let tag = cache_tag(outcome.cache);
     let record = RunRecord {
         target: target_id,
         kind: &target.kind,
         action_digest: outcome.action.to_string(),
-        cache: cache_tag,
+        cache: tag,
         exit_code: outcome.result.exit_code,
         output: output.to_string(),
     };
@@ -116,7 +114,7 @@ async fn render_run_output(
             let mut err = tokio::io::stderr();
             err.write_all(&stderr_blob).await?;
             let trailer = format!(
-                "fabrik: ran {target_id} (cache {cache_tag}, exit={})\n",
+                "fabrik: ran {target_id} (cache {tag}, exit={})\n",
                 outcome.result.exit_code
             );
             err.write_all(trailer.as_bytes()).await?;
@@ -285,12 +283,7 @@ fn task_action(workspace: &Path, target: &fabrik_frontend::Target) -> Result<Act
 }
 
 fn source_path(target: &fabrik_frontend::Target, src: &str) -> Result<WorkspacePath> {
-    let rel = if target.package.is_empty() {
-        src.to_string()
-    } else {
-        format!("{}/{src}", target.package)
-    };
-    WorkspacePath::try_from(rel.as_str())
+    WorkspacePath::from_package_relative(&target.package, src)
         .with_context(|| format!("invalid source path `{src}` in {}", target.id()))
 }
 
@@ -328,11 +321,11 @@ fn uncached_task_digest(target: &fabrik_frontend::Target) -> Digest {
 /// source paths or on any source's contents get different digests, so
 /// the action cache invalidates correctly.
 ///
-/// Encoding (per source, after sorting by workspace path):
-/// `path_bytes || 0x00 || file_digest || 0x00`. Sorting before hashing
-/// makes the result stable across iteration orders. The terminator
-/// guards against ambiguity even though declared paths never contain
-/// NULs in practice.
+/// The encoding is the empty domain prefix followed by sorted
+/// `(workspace_path, file_digest)` pairs. The empty domain matches the
+/// historical wire format from when this verb predated the granular
+/// rust planner; bumping it would invalidate every adopted-mode cache
+/// slot in the wild.
 fn input_digest(workspace: &Path, target: &fabrik_frontend::Target) -> Result<Option<Digest>> {
     if target.srcs.is_empty() {
         return Ok(None);
@@ -345,42 +338,17 @@ fn input_digest(workspace: &Path, target: &fabrik_frontend::Target) -> Result<Op
         .collect::<Result<_>>()?;
     paths.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 
-    let mut buf = Vec::new();
+    let mut builder = InputDigestBuilder::new(b"");
     for path in paths {
-        let file = std::fs::File::open(path.resolve(workspace))
-            .with_context(|| format!("reading source input `{path}`"))?;
-        let digest = Digest::of_reader(std::io::BufReader::new(file))
+        builder
+            .push_source(workspace, path.as_str())
             .with_context(|| format!("hashing source input `{path}`"))?;
-        buf.extend_from_slice(path.as_str().as_bytes());
-        buf.push(0);
-        buf.extend_from_slice(digest.as_bytes());
-        buf.push(0);
     }
-    Ok(Some(Digest::of_bytes(&buf)))
+    Ok(Some(builder.finish()))
 }
-
-/// Environment variables forwarded verbatim to spawned tool actions
-/// (rustc, cargo, ...). Anything not on this list is dropped: actions
-/// must declare every variable they depend on, or the cache key lies.
-const FORWARDED_TOOL_ENV: &[&str] = &[
-    "PATH",
-    "HOME",
-    "CARGO_HOME",
-    "RUSTUP_HOME",
-    "RUSTUP_TOOLCHAIN",
-];
 
 fn tool_env() -> BTreeMap<String, String> {
-    select_tool_env(std::env::vars())
-}
-
-fn select_tool_env<I>(vars: I) -> BTreeMap<String, String>
-where
-    I: IntoIterator<Item = (String, String)>,
-{
-    vars.into_iter()
-        .filter(|(k, _)| FORWARDED_TOOL_ENV.contains(&k.as_str()))
-        .collect()
+    core_tool_env(&["CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"])
 }
 
 #[cfg(test)]
@@ -398,27 +366,6 @@ mod tests {
             deps: vec![],
             attrs: BTreeMap::new(),
         }
-    }
-
-    #[test]
-    fn select_tool_env_keeps_only_allowlisted_keys() {
-        let env = select_tool_env([
-            ("PATH".into(), "/usr/bin".into()),
-            ("CARGO_HOME".into(), "/cargo".into()),
-            ("RUSTUP_TOOLCHAIN".into(), "1.86.0".into()),
-            ("TOOL_PRIVATE".into(), "leaked".into()),
-            ("UNRELATED".into(), "leaked".into()),
-            ("FABRIK_PROBE".into(), "leaked".into()),
-        ]);
-        assert_eq!(env.get("PATH").map(String::as_str), Some("/usr/bin"));
-        assert_eq!(env.get("CARGO_HOME").map(String::as_str), Some("/cargo"));
-        assert_eq!(
-            env.get("RUSTUP_TOOLCHAIN").map(String::as_str),
-            Some("1.86.0")
-        );
-        assert!(!env.contains_key("TOOL_PRIVATE"));
-        assert!(!env.contains_key("UNRELATED"));
-        assert!(!env.contains_key("FABRIK_PROBE"));
     }
 
     #[test]

--- a/crates/fabrik-cli/src/commands/test.rs
+++ b/crates/fabrik-cli/src/commands/test.rs
@@ -6,11 +6,14 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use fabrik_cas::Cas;
-use fabrik_core::{Action, CacheState, ResourceRequest, RunOpts, Runner};
+use fabrik_core::{
+    tool_env as core_tool_env, Action, CacheState, ResourceRequest, RunOpts, Runner,
+};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::cli::{exit_from, Format};
+use crate::commands::util::{cache_tag, find_target};
 use crate::render;
 
 #[derive(Serialize)]
@@ -32,11 +35,8 @@ pub async fn test(
     test_args: Vec<String>,
     format: Format,
 ) -> Result<ExitCode> {
-    let targets = fabrik_frontend::load_workspace(workspace).context("loading workspace")?;
-    let target = targets
-        .iter()
-        .find(|t| t.id() == target_id)
-        .ok_or_else(|| anyhow::anyhow!("no target matches `{target_id}`"))?;
+    let (targets, idx) = find_target(workspace, target_id)?;
+    let target = &targets[idx];
     if target.kind != "rust_test" {
         anyhow::bail!(
             "target {target_id} has kind `{}`; expected rust_test",
@@ -70,13 +70,13 @@ pub async fn test(
         .filter(|o| o.outcome.cache == CacheState::Hit)
         .count();
     let build_misses = build_outcomes.len() - build_hits;
-    let test_cache = cache_tag(test_outcome.cache);
+    let test_cache_tag = cache_tag(test_outcome.cache);
     let summary = TestSummary {
         target: target_id,
         build_nodes: build_outcomes.len(),
         build_cache_hits: build_hits,
         build_cache_misses: build_misses,
-        test_cache,
+        test_cache: test_cache_tag,
         exit_code: test_outcome.result.exit_code,
         binary,
         test_action_digest: test_outcome.action.to_string(),
@@ -86,13 +86,15 @@ pub async fn test(
     Ok(exit_from(test_outcome.result.exit_code))
 }
 
-fn test_binary_path(built: &fabrik_rust::BuiltPlan) -> Result<String> {
-    let fabrik_core::Action::RunCommand { outputs, .. } =
-        &built.plan.nodes[built.root_index].action;
-    outputs
-        .first()
-        .map(|p| p.as_str().to_string())
-        .ok_or_else(|| anyhow::anyhow!("rust_test {} has no declared output", built.root_id))
+fn test_binary_path(built: &fabrik_core::BuiltPlan) -> Result<String> {
+    if built.output.is_empty() {
+        Err(anyhow::anyhow!(
+            "rust_test {} has no declared output",
+            built.root_id
+        ))
+    } else {
+        Ok(built.output.clone())
+    }
 }
 
 fn test_action(binary: &str, test_args: Vec<String>, input_digest: fabrik_cas::Digest) -> Action {
@@ -152,19 +154,6 @@ async fn render_output(
     Ok(())
 }
 
-fn cache_tag(cache: CacheState) -> &'static str {
-    match cache {
-        CacheState::Hit => "hit",
-        CacheState::Miss => "miss",
-    }
-}
-
 fn test_env() -> BTreeMap<String, String> {
-    let mut env = BTreeMap::new();
-    for key in ["PATH", "HOME", "RUST_BACKTRACE", "RUST_LOG"] {
-        if let Ok(value) = std::env::var(key) {
-            env.insert(key.into(), value);
-        }
-    }
-    env
+    core_tool_env(&["RUST_BACKTRACE", "RUST_LOG"])
 }

--- a/crates/fabrik-cli/src/commands/util.rs
+++ b/crates/fabrik-cli/src/commands/util.rs
@@ -1,0 +1,35 @@
+//! Cross-verb helpers: workspace target lookup and cache-state
+//! rendering. These are tiny on their own; the value is forcing every
+//! verb through one shape so adding a new verb (or a new build-system
+//! plugin's verb) doesn't reinvent the same boilerplate slightly
+//! differently.
+
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use fabrik_core::CacheState;
+use fabrik_frontend::Target;
+
+/// Load every target declared in the workspace and pick the one whose
+/// id matches `target_id`. Returns an error if the workspace fails to
+/// load or no target has the requested id. Verbs that operate on a
+/// single target funnel through this so the error wording is uniform.
+pub fn find_target(workspace: &Path, target_id: &str) -> Result<(Vec<Target>, usize)> {
+    let targets = fabrik_frontend::load_workspace(workspace).context("loading workspace")?;
+    let idx = targets
+        .iter()
+        .position(|t| t.id() == target_id)
+        .ok_or_else(|| anyhow!("no target matches `{target_id}`"))?;
+    Ok((targets, idx))
+}
+
+/// The short string Fabrik prints for a [`CacheState`]. Repeated
+/// in every verb that emits structured output, so it lives here to
+/// keep the spelling uniform (`hit` / `miss`, no trailing space).
+#[must_use]
+pub fn cache_tag(cache: CacheState) -> &'static str {
+    match cache {
+        CacheState::Hit => "hit",
+        CacheState::Miss => "miss",
+    }
+}

--- a/crates/fabrik-core/src/env.rs
+++ b/crates/fabrik-core/src/env.rs
@@ -1,0 +1,120 @@
+//! Tool-environment selection.
+//!
+//! Cache keys are only honest if every environment variable an action
+//! observes is part of the [`Action`](crate::Action). Plugins therefore
+//! pick a small allowlist of variables to forward instead of inheriting
+//! the parent environment wholesale. Doing the selection in one place
+//! keeps the policy uniform across plugins: the same baseline keys,
+//! with each plugin adding only the keys its toolchain genuinely needs.
+
+use std::collections::BTreeMap;
+use std::env;
+
+/// Variables every spawned tool action wants regardless of toolchain.
+/// `PATH` and `HOME` are universal; adding more here would silently
+/// expand every plugin's cache key, so the list is kept deliberately
+/// small.
+const BASE_KEYS: &[&str] = &["PATH", "HOME"];
+
+/// Build a tool environment for a spawned action.
+///
+/// Returns a deterministic map containing `PATH`, `HOME`, and every
+/// `extra_keys` entry that is set in the parent environment. Pass
+/// plugin-specific keys (e.g. `RUSTUP_TOOLCHAIN`, `DEVELOPER_DIR`)
+/// through `extra_keys`. Duplicates between `BASE_KEYS` and
+/// `extra_keys` are harmless.
+pub fn tool_env(extra_keys: &[&str]) -> BTreeMap<String, String> {
+    select_tool_env(env::vars(), extra_keys)
+}
+
+/// Pure selector used by [`tool_env`]; exposed so callers (and tests)
+/// can drive the policy with an arbitrary iterator instead of the live
+/// process environment.
+pub fn select_tool_env<I>(vars: I, extra_keys: &[&str]) -> BTreeMap<String, String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut allowed: Vec<&str> = BASE_KEYS.to_vec();
+    allowed.extend(extra_keys.iter().copied());
+    vars.into_iter()
+        .filter(|(k, _)| allowed.contains(&k.as_str()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forwards_base_keys() {
+        let env = select_tool_env(
+            [
+                ("PATH".into(), "/usr/bin".into()),
+                ("HOME".into(), "/h".into()),
+                ("UNRELATED".into(), "leak".into()),
+            ],
+            &[],
+        );
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/usr/bin"));
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/h"));
+        assert!(!env.contains_key("UNRELATED"));
+    }
+
+    #[test]
+    fn extra_keys_are_admitted_when_present() {
+        let env = select_tool_env(
+            [
+                ("PATH".into(), "/usr/bin".into()),
+                ("RUSTUP_TOOLCHAIN".into(), "1.86.0".into()),
+                ("CARGO_HOME".into(), "/c".into()),
+                ("UNRELATED".into(), "leak".into()),
+            ],
+            &["RUSTUP_TOOLCHAIN", "CARGO_HOME"],
+        );
+        assert_eq!(
+            env.get("RUSTUP_TOOLCHAIN").map(String::as_str),
+            Some("1.86.0")
+        );
+        assert_eq!(env.get("CARGO_HOME").map(String::as_str), Some("/c"));
+        assert!(!env.contains_key("UNRELATED"));
+    }
+
+    #[test]
+    fn missing_extras_are_silently_dropped() {
+        // An extra key is "include if set" - it is not an error for the
+        // parent env to lack it.
+        let env = select_tool_env(
+            [("PATH".into(), "/usr/bin".into())],
+            &["RUSTUP_TOOLCHAIN", "DEVELOPER_DIR"],
+        );
+        assert_eq!(env.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_extras_do_not_double_emit() {
+        let env = select_tool_env(
+            [
+                ("PATH".into(), "/usr/bin".into()),
+                ("HOME".into(), "/h".into()),
+            ],
+            &["PATH", "HOME"],
+        );
+        assert_eq!(env.len(), 2);
+    }
+
+    #[test]
+    fn arbitrary_prefixed_keys_are_not_admitted() {
+        // Earlier policy forwarded `MISE_*` verbatim; today actions
+        // must declare every variable they depend on, no prefix
+        // passthrough. This test pins the contract.
+        let env = select_tool_env(
+            [
+                ("PATH".into(), "/usr/bin".into()),
+                ("MISE_TRUSTED_CONFIG_PATHS".into(), "/ws".into()),
+            ],
+            &[],
+        );
+        assert_eq!(env.len(), 1);
+        assert!(!env.contains_key("MISE_TRUSTED_CONFIG_PATHS"));
+    }
+}

--- a/crates/fabrik-core/src/input_digest.rs
+++ b/crates/fabrik-core/src/input_digest.rs
@@ -1,0 +1,144 @@
+//! Streaming builder for action `input_digest` values.
+//!
+//! Plugins all need the same shape: a domain-separation prefix, a
+//! deterministic concatenation of `(label, content_digest)` pairs, and
+//! a small set of plugin-specific tail values (toolchain identity,
+//! Apple SDK env, dep action digests). Open-coding it in every plugin
+//! invites subtle drift: a missed sort, a forgotten NUL terminator, a
+//! domain prefix that collides across two plugins. This builder is the
+//! one canonical implementation.
+
+use std::path::Path;
+
+use fabrik_cas::Digest;
+
+#[derive(Debug)]
+/// Build an input digest piece by piece.
+///
+/// The encoding is `domain || (label || 0 || digest_bytes || 0)*` plus
+/// any caller-appended tail bytes. NUL terminators delimit fields so
+/// that two distinct `(label, digest)` sequences can never collide
+/// after concatenation. Sources should be added in sorted order; the
+/// builder does not sort on the caller's behalf because some plugins
+/// (the Rust compiler, for example) need to mix sources, dep digests,
+/// and tail keys in a specific order that's part of their cache-key
+/// contract.
+#[must_use]
+pub struct InputDigestBuilder {
+    buf: Vec<u8>,
+}
+
+impl InputDigestBuilder {
+    /// Begin a new digest with `domain` as the leading prefix. Bumping
+    /// the domain (e.g. from `fabrik.rust.input.v1` to `...v2`) is the
+    /// portable way to invalidate an entire plugin's cache namespace
+    /// when its encoding changes.
+    pub fn new(domain: &[u8]) -> Self {
+        let mut buf = Vec::with_capacity(domain.len() + 64);
+        buf.extend_from_slice(domain);
+        Self { buf }
+    }
+
+    /// Append a `(label, digest)` pair. Most plugins use this for
+    /// source files (label = workspace path) and for dep records
+    /// (label = `dep:<label>` or similar prefix).
+    pub fn push_keyed(&mut self, label: &[u8], digest: &Digest) -> &mut Self {
+        self.buf.extend_from_slice(label);
+        self.buf.push(0);
+        self.buf.extend_from_slice(digest.as_bytes());
+        self.buf.push(0);
+        self
+    }
+
+    /// Append arbitrary bytes (e.g. a toolchain identifier).
+    pub fn push_bytes(&mut self, bytes: &[u8]) -> &mut Self {
+        self.buf.extend_from_slice(bytes);
+        self.buf.push(0);
+        self
+    }
+
+    /// Hash a workspace-relative source file and append the result
+    /// keyed by the workspace-relative path. Streams the file through
+    /// [`Digest::of_reader`] so multi-megabyte sources never sit in
+    /// memory.
+    pub fn push_source<P: AsRef<Path>>(
+        &mut self,
+        workspace_root: P,
+        ws_rel: &str,
+    ) -> std::io::Result<&mut Self> {
+        let abs = workspace_root.as_ref().join(ws_rel);
+        let file = std::fs::File::open(&abs)?;
+        let digest = Digest::of_reader(std::io::BufReader::new(file))?;
+        Ok(self.push_keyed(ws_rel.as_bytes(), &digest))
+    }
+
+    /// Finalise the buffer into a [`Digest`].
+    pub fn finish(self) -> Digest {
+        Digest::of_bytes(&self.buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn empty_digest_only_hashes_the_domain() {
+        let a = InputDigestBuilder::new(b"d").finish();
+        let b = InputDigestBuilder::new(b"d").finish();
+        assert_eq!(a, b, "deterministic for the same domain");
+        let c = InputDigestBuilder::new(b"d2").finish();
+        assert_ne!(a, c, "domain bump partitions cache slots");
+    }
+
+    #[test]
+    fn pushed_pairs_change_the_digest() {
+        let one = {
+            let mut b = InputDigestBuilder::new(b"d");
+            b.push_keyed(b"path", &Digest::of_bytes(b"X"));
+            b.finish()
+        };
+        let two = {
+            let mut b = InputDigestBuilder::new(b"d");
+            b.push_keyed(b"path", &Digest::of_bytes(b"Y"));
+            b.finish()
+        };
+        assert_ne!(one, two);
+    }
+
+    #[test]
+    fn push_source_hashes_file_contents() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
+        std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() {}").unwrap();
+
+        let first = {
+            let mut b = InputDigestBuilder::new(b"test.input.v1");
+            b.push_source(tmp.path(), "pkg/main.rs").unwrap();
+            b.finish()
+        };
+        let second = {
+            let mut b = InputDigestBuilder::new(b"test.input.v1");
+            b.push_source(tmp.path(), "pkg/main.rs").unwrap();
+            b.finish()
+        };
+        assert_eq!(first, second, "stable for identical content");
+
+        std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() { /*!*/ }").unwrap();
+        let third = {
+            let mut b = InputDigestBuilder::new(b"test.input.v1");
+            b.push_source(tmp.path(), "pkg/main.rs").unwrap();
+            b.finish()
+        };
+        assert_ne!(first, third, "content change invalidates the digest");
+    }
+
+    #[test]
+    fn push_source_propagates_io_errors() {
+        let tmp = TempDir::new().unwrap();
+        let mut b = InputDigestBuilder::new(b"d");
+        let err = b.push_source(tmp.path(), "missing.rs").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+}

--- a/crates/fabrik-core/src/lib.rs
+++ b/crates/fabrik-core/src/lib.rs
@@ -17,12 +17,16 @@ use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, instrument};
 
+mod env;
+mod input_digest;
 mod path;
 mod plan;
 mod resources;
 
+pub use env::{select_tool_env, tool_env};
+pub use input_digest::InputDigestBuilder;
 pub use path::{WorkspacePath, WorkspacePathError};
-pub use plan::{Plan, PlanError, PlanNode, PlanOutcome};
+pub use plan::{BuiltPlan, NodeInfo, Plan, PlanError, PlanNode, PlanOutcome};
 pub use resources::{ResourceLimits, ResourcePool, ResourceRequest};
 
 /// Domain-separation prefix for action digests. Bump the version when

--- a/crates/fabrik-core/src/path.rs
+++ b/crates/fabrik-core/src/path.rs
@@ -48,6 +48,23 @@ impl WorkspacePath {
             workspace.join(&self.0)
         }
     }
+
+    /// Build a workspace path from a package directory and a
+    /// package-relative source path. Mirrors the ad-hoc string joins
+    /// every plugin used to do by hand and routes the result through
+    /// the same validation as [`WorkspacePath::try_from`], so a `..`
+    /// in the declared source still surfaces as a structured error.
+    pub fn from_package_relative(
+        package: &str,
+        src: &str,
+    ) -> std::result::Result<Self, WorkspacePathError> {
+        let joined = if package.is_empty() {
+            src.to_string()
+        } else {
+            format!("{package}/{src}")
+        };
+        Self::try_from(joined)
+    }
 }
 
 impl TryFrom<String> for WorkspacePath {
@@ -144,5 +161,22 @@ mod tests {
             p.resolve(Path::new("/ws")),
             Path::new("/ws/crates/fabrik-cli")
         );
+    }
+
+    #[test]
+    fn from_package_relative_joins_and_validates() {
+        let inside = WorkspacePath::from_package_relative("crates/foo", "src/main.rs").unwrap();
+        assert_eq!(inside.as_str(), "crates/foo/src/main.rs");
+        let root = WorkspacePath::from_package_relative("", "main.rs").unwrap();
+        assert_eq!(root.as_str(), "main.rs");
+    }
+
+    #[test]
+    fn from_package_relative_rejects_escapes() {
+        // The frontend collects whatever the user wrote in a `srcs`
+        // entry; preventing the join from escaping the package is a
+        // workspace-path concern, not a per-plugin one.
+        let err = WorkspacePath::from_package_relative("pkg", "../escape.rs").unwrap_err();
+        assert!(matches!(err, WorkspacePathError::Escape(_)));
     }
 }

--- a/crates/fabrik-core/src/plan.rs
+++ b/crates/fabrik-core/src/plan.rs
@@ -42,6 +42,39 @@ pub struct PlanOutcome {
     pub outcome: Outcome,
 }
 
+/// Per-node metadata that travels alongside a [`Plan`] for telemetry
+/// and CLI rendering. The `kind` is the originating target kind
+/// (`rust_library`, `apple_ios_app`, ...), kept as a string so the
+/// shape is uniform across plugins. Plugin-internal enum
+/// representations stay inside the plugin.
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    /// Project-root-relative id of the source target, e.g.
+    /// `crates/fabrik-cas/fabrik-cas`. Named `label` for historical
+    /// continuity with [`PlanNode::label`] and [`PlanOutcome::label`].
+    pub label: String,
+    pub kind: String,
+}
+
+/// A plugin's compiled build description. Every plugin's `build_plan`
+/// returns this shape so the CLI dispatches on `target.kind`, then
+/// drives a plugin-agnostic execution and rendering pipeline. Adding a
+/// new plugin (Go, C++, ...) is a matter of producing a `BuiltPlan`,
+/// not extending the CLI's bridge structs.
+#[derive(Debug, Clone)]
+pub struct BuiltPlan {
+    pub plan: Plan,
+    pub root_index: usize,
+    /// Project-root-relative id of the root target.
+    pub root_id: String,
+    /// Workspace-relative path to the canonical output of the root
+    /// target. Empty for plugins that do not declare a primary output
+    /// (e.g. `task` targets).
+    pub output: String,
+    /// Per-node metadata, indexed in `plan.nodes` order.
+    pub nodes: Vec<NodeInfo>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum PlanError {
     #[error("plan dependency cycle detected")]

--- a/crates/fabrik-rust/src/build_script.rs
+++ b/crates/fabrik-rust/src/build_script.rs
@@ -16,7 +16,9 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use fabrik_cas::Digest;
-use fabrik_core::{Action, PlanNode, ResourceRequest, WorkspacePath};
+use fabrik_core::{
+    tool_env as core_tool_env, Action, InputDigestBuilder, PlanNode, ResourceRequest, WorkspacePath,
+};
 use fabrik_frontend::Target;
 
 use crate::artifact::{build_script_outputs_path, out_dir};
@@ -169,8 +171,7 @@ impl BuildScriptOutputs {
 }
 
 fn build_input_digest(target: &Target, workspace_root: &Path) -> Result<Digest, CompileError> {
-    let mut buf = Vec::new();
-    buf.extend_from_slice(b"fabrik.cargo_build_script.input.v1\0");
+    let mut builder = InputDigestBuilder::new(b"fabrik.cargo_build_script.input.v1\0");
     let mut srcs: Vec<&String> = target.srcs.iter().collect();
     srcs.sort();
     for src in srcs {
@@ -179,39 +180,23 @@ fn build_input_digest(target: &Target, workspace_root: &Path) -> Result<Digest, 
         } else {
             format!("{}/{}", target.package, src)
         };
-        let abs = workspace_root.join(&ws_rel);
-        let bytes = std::fs::read(&abs).map_err(|source| CompileError::ReadSource {
-            label: target.id(),
-            path: ws_rel.clone(),
-            source,
-        })?;
-        let digest = Digest::of_bytes(&bytes);
-        buf.extend_from_slice(ws_rel.as_bytes());
-        buf.push(0);
-        buf.extend_from_slice(digest.as_bytes());
-        buf.push(0);
+        builder
+            .push_source(workspace_root, &ws_rel)
+            .map_err(|source| CompileError::ReadSource {
+                label: target.id(),
+                path: ws_rel.clone(),
+                source,
+            })?;
     }
     let toolchain = std::env::var("RUSTUP_TOOLCHAIN").unwrap_or_else(|_| "system-rustc".into());
-    buf.extend_from_slice(b"toolchain:");
-    buf.extend_from_slice(toolchain.as_bytes());
-    buf.push(0);
-    Ok(Digest::of_bytes(&buf))
+    let mut tag = b"toolchain:".to_vec();
+    tag.extend_from_slice(toolchain.as_bytes());
+    builder.push_bytes(&tag);
+    Ok(builder.finish())
 }
 
 fn tool_env() -> BTreeMap<String, String> {
-    let mut env = BTreeMap::new();
-    for key in [
-        "PATH",
-        "HOME",
-        "CARGO_HOME",
-        "RUSTUP_HOME",
-        "RUSTUP_TOOLCHAIN",
-    ] {
-        if let Ok(value) = std::env::var(key) {
-            env.insert(key.into(), value);
-        }
-    }
-    env
+    core_tool_env(&["CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"])
 }
 
 #[cfg(test)]

--- a/crates/fabrik-rust/src/compile.rs
+++ b/crates/fabrik-rust/src/compile.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use fabrik_cas::Digest;
-use fabrik_core::{Action, PlanNode, ResourceRequest, WorkspacePath};
+use fabrik_core::{
+    tool_env as core_tool_env, Action, InputDigestBuilder, PlanNode, ResourceRequest, WorkspacePath,
+};
 use fabrik_frontend::Target;
 
 use crate::artifact::{
@@ -323,8 +325,7 @@ fn build_input_digest(
     workspace_root: &Path,
     dep_artifacts: &BTreeMap<String, DepArtifact>,
 ) -> Result<Digest, CompileError> {
-    let mut buf = Vec::new();
-    buf.extend_from_slice(b"fabrik.rust.input.v1\0");
+    let mut builder = InputDigestBuilder::new(b"fabrik.rust.input.v1\0");
 
     // Sources: deterministic order via sorted clone.
     let mut srcs: Vec<&String> = target.srcs.iter().collect();
@@ -335,17 +336,13 @@ fn build_input_digest(
         } else {
             format!("{}/{}", target.package, src)
         };
-        let abs = workspace_root.join(&ws_rel);
-        let bytes = std::fs::read(&abs).map_err(|source| CompileError::ReadSource {
-            label: target.id(),
-            path: ws_rel.clone(),
-            source,
-        })?;
-        let digest = Digest::of_bytes(&bytes);
-        buf.extend_from_slice(ws_rel.as_bytes());
-        buf.push(0);
-        buf.extend_from_slice(digest.as_bytes());
-        buf.push(0);
+        builder
+            .push_source(workspace_root, &ws_rel)
+            .map_err(|source| CompileError::ReadSource {
+                label: target.id(),
+                path: ws_rel.clone(),
+                source,
+            })?;
     }
 
     // Dep action digests, in label order. We only mix in deps that
@@ -355,11 +352,9 @@ fn build_input_digest(
     dep_labels.sort();
     for label in dep_labels {
         if let Some(art) = dep_artifacts.get(label) {
-            buf.extend_from_slice(b"dep:");
-            buf.extend_from_slice(label.as_bytes());
-            buf.push(0);
-            buf.extend_from_slice(art.action_digest.as_bytes());
-            buf.push(0);
+            let mut keyed = b"dep:".to_vec();
+            keyed.extend_from_slice(label.as_bytes());
+            builder.push_keyed(&keyed, &art.action_digest);
         }
     }
 
@@ -371,33 +366,24 @@ fn build_input_digest(
     // surface as a different cache slot for env reasons too (PATH is
     // in the env).
     let toolchain = std::env::var("RUSTUP_TOOLCHAIN").unwrap_or_else(|_| "system-rustc".into());
-    buf.extend_from_slice(b"toolchain:");
-    buf.extend_from_slice(toolchain.as_bytes());
-    buf.push(0);
+    let mut tag = b"toolchain:".to_vec();
+    tag.extend_from_slice(toolchain.as_bytes());
+    builder.push_bytes(&tag);
 
-    Ok(Digest::of_bytes(&buf))
+    Ok(builder.finish())
 }
 
 /// Minimal env for rustc invocations. Anything not in this list is
 /// unobservable from the action and therefore not part of the cache
-/// key - keeping it small reduces accidental cache invalidation when
-/// a developer has unrelated env set.
+/// key.
 fn tool_env() -> BTreeMap<String, String> {
-    let mut env = BTreeMap::new();
-    for key in [
-        "PATH",
-        "HOME",
+    core_tool_env(&[
         "CARGO_HOME",
         "RUSTUP_HOME",
         "RUSTUP_TOOLCHAIN",
         "RUSTC",
         "RUSTC_WRAPPER",
-    ] {
-        if let Ok(value) = std::env::var(key) {
-            env.insert(key.into(), value);
-        }
-    }
-    env
+    ])
 }
 
 #[cfg(test)]

--- a/crates/fabrik-rust/src/lib.rs
+++ b/crates/fabrik-rust/src/lib.rs
@@ -22,4 +22,4 @@ mod plan;
 pub use artifact::{DepArtifact, RustKind};
 pub use build_script::{compile_build_script, BuildScriptOutputs, BUILD_SCRIPT_OUTPUTS_FILENAME};
 pub use compile::{compile_target, CompileError};
-pub use plan::{build_plan, BuiltPlan, PlanBuildError};
+pub use plan::{build_plan, PlanBuildError};

--- a/crates/fabrik-rust/src/plan.rs
+++ b/crates/fabrik-rust/src/plan.rs
@@ -6,32 +6,12 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 
-use fabrik_core::Plan;
+use fabrik_core::{Action, BuiltPlan, NodeInfo, Plan};
 use fabrik_frontend::Target;
 
 use crate::artifact::{DepArtifact, RustKind};
 use crate::build_script::{compile_build_script, output_path as build_script_output_path};
 use crate::compile::{compile_target, CompileError};
-
-/// The result of compiling a workspace + root target into a plan.
-/// `root_index` identifies the root target's node so callers can pull
-/// its outcome out of the plan results.
-#[derive(Debug, Clone)]
-pub struct BuiltPlan {
-    pub plan: Plan,
-    pub root_index: usize,
-    /// Project-root-relative id of the root target.
-    pub root_id: String,
-    /// Per-node action label/kind index, exposed for telemetry and CLI
-    /// output. Order matches `plan.nodes`.
-    pub nodes: Vec<NodeInfo>,
-}
-
-#[derive(Debug, Clone)]
-pub struct NodeInfo {
-    pub label: String,
-    pub kind: RustKind,
-}
 
 #[derive(Debug, thiserror::Error)]
 pub enum PlanBuildError {
@@ -116,7 +96,7 @@ pub fn build_plan(
             id_to_plan_idx.insert(label.clone(), plan_idx);
             node_info.push(NodeInfo {
                 label: label.clone(),
-                kind: RustKind::BuildScript,
+                kind: RustKind::BuildScript.as_str().to_string(),
             });
             dep_artifacts.insert(
                 label.clone(),
@@ -172,7 +152,7 @@ pub fn build_plan(
         id_to_plan_idx.insert(target.id(), plan_idx);
         node_info.push(NodeInfo {
             label: target.id(),
-            kind: artifact.kind,
+            kind: artifact.kind.as_str().to_string(),
         });
         dep_artifacts.insert(target.id(), artifact);
         if *target_idx == root_target_idx {
@@ -180,12 +160,28 @@ pub fn build_plan(
         }
     }
 
+    let root_idx = root_index.expect("root was visited");
+    let output = root_output_path(&plan.nodes[root_idx]);
     Ok(BuiltPlan {
         plan,
-        root_index: root_index.expect("root was visited"),
+        root_index: root_idx,
         root_id: root_id.to_string(),
+        output,
         nodes: node_info,
     })
+}
+
+/// First declared output of the root node, or empty if the plugin's
+/// root has none (e.g. a build-script root). Mirrors the previous
+/// behavior the CLI wrapped this plan in: callers wanted "the file the
+/// build produced" and pulled it from `plan.nodes[root_index].action`.
+fn root_output_path(node: &fabrik_core::PlanNode) -> String {
+    match &node.action {
+        Action::RunCommand { outputs, .. } => outputs
+            .first()
+            .map(|p| p.as_str().to_string())
+            .unwrap_or_default(),
+    }
 }
 
 fn dfs(
@@ -328,7 +324,7 @@ mod tests {
         let built = build_plan(&[target], "pkg/build", tmp.path()).unwrap();
         assert_eq!(built.plan.nodes.len(), 1);
         assert_eq!(built.plan.nodes[0].label, "pkg/build");
-        assert_eq!(built.nodes[0].kind, RustKind::BuildScript);
+        assert_eq!(built.nodes[0].kind, "cargo_build_script");
         // The action's argv must reference build.rs and run via /bin/sh
         // (the build_script handler emits a single shell pipeline).
         let fabrik_core::Action::RunCommand { argv, outputs, .. } = &built.plan.nodes[0].action;


### PR DESCRIPTION
## Summary

- Promote `tool_env`, `WorkspacePath::from_package_relative`, `InputDigestBuilder`, and `BuiltPlan`/`NodeInfo` from per-plugin copies into `fabrik-core` so the next build-system plugin (Go is next in line) inherits one answer instead of four divergent ones.
- Centralize `cache_tag` and the workspace+target lookup in `crates/fabrik-cli/src/commands/util.rs`; the inline `match outcome.cache` and `load_workspace + .find(label)` that lived in every verb are gone.
- Both plugins now return the unified `BuiltPlan` shape, which lets the CLI drop its bridge wrapper. The plugin dispatcher in `commands/build.rs` is a few lines and adding a third plugin is one extra arm.

No behavior change. The `input_digest` byte encoding is preserved exactly, so action cache slots stay valid.

## Notes for the reviewer

- The user asked separately about (a) waiting for a release to use Fabrik to build Fabrik and (b) Bazel's daemon model. This PR is the code-quality / scalability pass; the other two are research tracked in conversation. Fabrik already self-hosts via `cargo_binary` (CI runs `fabrik run //:fabrik`); the granular per-crate path still needs per-target features and `vendor/` source materialization before it can replace cargo. Bazel daemon: yes Bazel uses one (Skyframe in a long-lived JVM) and persistent workers for JVM-shaped toolchains; recommendation for Fabrik is *measure first* — if Starlark parse + graph build dominates cold-start, a daemon pays off; persistent workers don't, since rustc is AOT-native.

## Test plan

- [x] `cargo test --workspace --all-targets` (178 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `shellspec` (83 examples pass)
- [x] `fabrik run //:fabrik` (dogfood path)
- [x] `fabrik build //examples/rust/granular/basic-app:hello` (re-run shows cache hits, confirming input_digest encoding preserved)
- [x] `fabrik test //examples/rust/granular/basic-app:greeting_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)