### PR TITLE
chore: trim redundant titles from GitHub release notes

### DIFF
--- a/mise/tasks/release/notes.sh
+++ b/mise/tasks/release/notes.sh
@@ -25,7 +25,15 @@ fi
 latest_version="$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)"
 
 if [[ -n "${latest_version}" ]]; then
-  git cliff --config cliff.toml --repository . --tag "${version}" -- "${latest_version}..HEAD"
+  rendered="$(git cliff --config cliff.toml --repository . --tag "${version}" -- "${latest_version}..HEAD")"
 else
-  git cliff --config cliff.toml --repository . --tag "${version}"
+  rendered="$(git cliff --config cliff.toml --repository . --tag "${version}")"
 fi
+
+# GitHub release pages already display the version and a "Changelog"
+# heading, so drop everything up to the marker that the cliff template
+# emits right after those titles.
+awk '
+  !found && /<!-- RELEASE NOTES START -->/ { found = 1; next }
+  found
+' <<<"${rendered}"


### PR DESCRIPTION
## Summary
- The GitHub release page already shows the version label, so the rendered `# Changelog` / `All notable changes…` / `## What's Changed in <version>` titles produced by git-cliff were pure repetition.
- `mise/tasks/release/notes.sh` now captures the cliff output and skips everything up to the `<!-- RELEASE NOTES START -->` marker the template already emits, so release bodies start directly at the grouped commit list and keep the `Full Changelog` link.
- `CHANGELOG.md` generation is unaffected because `release:changelog` still consumes the unfiltered template.

## Testing
- `mise exec -- bash mise/tasks/release/notes.sh --version 0.5.0` against the local `0.4.0..0.5.0` range, confirming the output starts at `### ✨ Features`.
