### PR TITLE
feat: Add runner runtime sessions

### DIFF
--- a/crates/fabrik-apple/src/artifact.rs
+++ b/crates/fabrik-apple/src/artifact.rs
@@ -8,7 +8,7 @@ pub fn app_bundle_path(package: &str, name: &str) -> String {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppleKind {
-    IosApp,
+    SimulatorApp,
     SwiftLibrary,
     AppleStaticFramework,
     AppleDynamicFramework,
@@ -18,7 +18,7 @@ pub enum AppleKind {
 impl AppleKind {
     pub fn parse(kind: &str) -> Option<Self> {
         match kind {
-            "apple_ios_app" => Some(Self::IosApp),
+            "apple_ios_app" | "apple_simulator_app" => Some(Self::SimulatorApp),
             "swift_library" => Some(Self::SwiftLibrary),
             "apple_static_framework" => Some(Self::AppleStaticFramework),
             "apple_dynamic_framework" => Some(Self::AppleDynamicFramework),
@@ -29,7 +29,7 @@ impl AppleKind {
 
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::IosApp => "apple_ios_app",
+            Self::SimulatorApp => "apple_simulator_app",
             Self::SwiftLibrary => "swift_library",
             Self::AppleStaticFramework => "apple_static_framework",
             Self::AppleDynamicFramework => "apple_dynamic_framework",

--- a/crates/fabrik-apple/src/compile.rs
+++ b/crates/fabrik-apple/src/compile.rs
@@ -56,12 +56,7 @@ pub fn compile_ios_app(target: &Target, workspace_root: &Path) -> Result<PlanNod
 }
 
 pub fn launch_ios_app(target: &Target, _workspace_root: &Path) -> Result<AppleAction, AppleError> {
-    if target.kind != "apple_ios_app" {
-        return Err(AppleError::UnsupportedKind {
-            label: target.id(),
-            kind: target.kind.clone(),
-        });
-    }
+    ensure_ios_simulator_app(target)?;
 
     let bundle_id = required_attr(target, "bundle_id")?;
     let app_dir = app_bundle_path(&target.package, &target.name);
@@ -90,12 +85,7 @@ pub fn launch_ios_app(target: &Target, _workspace_root: &Path) -> Result<AppleAc
 }
 
 fn build_ios_app_action(target: &Target, workspace_root: &Path) -> Result<AppleAction, AppleError> {
-    if target.kind != "apple_ios_app" {
-        return Err(AppleError::UnsupportedKind {
-            label: target.id(),
-            kind: target.kind.clone(),
-        });
-    }
+    ensure_ios_simulator_app(target)?;
     if target.srcs.is_empty() {
         return Err(AppleError::NoSources { label: target.id() });
     }
@@ -147,6 +137,17 @@ fn build_ios_app_action(target: &Target, workspace_root: &Path) -> Result<AppleA
         },
         output: app_dir,
     })
+}
+
+fn ensure_ios_simulator_app(target: &Target) -> Result<(), AppleError> {
+    match target.kind.as_str() {
+        "apple_ios_app" => Ok(()),
+        "apple_simulator_app" if target.attrs.get("platform").is_some_and(|p| p == "ios") => Ok(()),
+        _ => Err(AppleError::UnsupportedKind {
+            label: target.id(),
+            kind: target.kind.clone(),
+        }),
+    }
 }
 
 fn build_script(
@@ -356,10 +357,11 @@ mod tests {
 
     fn app_target(srcs: &[&str]) -> Target {
         let mut attrs = BTreeMap::new();
+        attrs.insert("platform".to_string(), "ios".to_string());
         attrs.insert("bundle_id".to_string(), "dev.fabrik.demo".to_string());
         Target {
             package: "App".to_string(),
-            kind: "apple_ios_app".to_string(),
+            kind: "apple_simulator_app".to_string(),
             name: "Demo".to_string(),
             srcs: srcs.iter().map(|s| (*s).to_string()).collect(),
             deps: Vec::new(),
@@ -391,7 +393,7 @@ mod tests {
     #[test]
     fn missing_bundle_id_is_an_error() {
         let mut target = app_target(&["Sources/App.swift"]);
-        target.attrs.clear();
+        target.attrs.remove("bundle_id");
         let err = compile_ios_app(&target, Path::new("/tmp")).unwrap_err();
         assert!(matches!(err, AppleError::MissingAttr { .. }));
     }

--- a/crates/fabrik-apple/src/plan.rs
+++ b/crates/fabrik-apple/src/plan.rs
@@ -12,7 +12,7 @@ use crate::swift::{compile_swift_target, SwiftError, TargetDepMode};
 pub enum PlanBuildError {
     #[error("no target matches `{0}`")]
     UnknownRoot(String),
-    #[error("apple_ios_app target {label} does not support deps yet")]
+    #[error("apple_simulator_app target {label} does not support deps yet")]
     UnsupportedDeps { label: String },
     #[error("dependency cycle through `{0}`")]
     Cycle(String),
@@ -56,7 +56,7 @@ pub fn build_plan(
         dep: root_id.to_string(),
         kind: target.kind.clone(),
     })?;
-    if kind == AppleKind::IosApp {
+    if kind == AppleKind::SimulatorApp {
         return build_ios_plan(target, root_id, workspace_root);
     }
 
@@ -148,7 +148,7 @@ fn validate_swift_deps(
                 dep: dep.clone(),
             })?;
         let dep_kind = &targets[*dep_target_idx].kind;
-        if !supports_kind(dep_kind) || dep_kind == "apple_ios_app" {
+        if !supports_kind(dep_kind) || is_simulator_app_kind(dep_kind) {
             return Err(PlanBuildError::NonAppleDep {
                 label: target.id(),
                 dep: dep.clone(),
@@ -248,7 +248,7 @@ fn dfs(
                 dep: dep.clone(),
             })?;
         let dep_kind = &targets[*dep_idx].kind;
-        if supports_kind(dep_kind) && dep_kind != "apple_ios_app" {
+        if supports_kind(dep_kind) && !is_simulator_app_kind(dep_kind) {
             dfs(*dep_idx, targets, target_index, visited, on_stack, order)?;
         }
     }
@@ -256,6 +256,10 @@ fn dfs(
     visited.insert(idx);
     order.push(idx);
     Ok(())
+}
+
+fn is_simulator_app_kind(kind: &str) -> bool {
+    matches!(kind, "apple_ios_app" | "apple_simulator_app")
 }
 
 #[cfg(test)]
@@ -270,10 +274,11 @@ mod tests {
         std::fs::create_dir_all(tmp.path().join("App")).unwrap();
         std::fs::write(tmp.path().join("App/App.swift"), "import SwiftUI").unwrap();
         let mut attrs = BTreeMap::new();
+        attrs.insert("platform".to_string(), "ios".to_string());
         attrs.insert("bundle_id".to_string(), "dev.fabrik.demo".to_string());
         let target = Target {
             package: "App".to_string(),
-            kind: "apple_ios_app".to_string(),
+            kind: "apple_simulator_app".to_string(),
             name: "Demo".to_string(),
             srcs: vec!["App.swift".to_string()],
             deps: Vec::new(),

--- a/crates/fabrik-apple/src/swift.rs
+++ b/crates/fabrik-apple/src/swift.rs
@@ -81,7 +81,7 @@ pub fn compile_swift_target(
         AppleKind::MacosCommandLineApplication => {
             compile_command_line_application(target, workspace_root, dep_artifacts)
         }
-        AppleKind::IosApp => Err(SwiftError::UnsupportedKind {
+        AppleKind::SimulatorApp => Err(SwiftError::UnsupportedKind {
             label: target.id(),
             kind: target.kind.clone(),
         }),

--- a/crates/fabrik-cli/src/cli.rs
+++ b/crates/fabrik-cli/src/cli.rs
@@ -70,6 +70,15 @@ pub enum Cmd {
     /// The verb is uniform across target kinds: target-specific
     /// composition lives in build-file declarations, not in the CLI.
     Run {
+        /// Serve a local JSON-RPC runtime control socket for this run.
+        #[arg(long)]
+        runtime_rpc: bool,
+
+        /// Runtime RPC socket path. Defaults to
+        /// `.fabrik/runtime/<session>/control.sock`.
+        #[arg(long)]
+        runtime_rpc_socket: Option<PathBuf>,
+
         /// Target id, e.g. `examples/hello/hello` or `./hello`.
         target: String,
     },
@@ -148,6 +157,12 @@ pub enum Cmd {
         cmd: ToolchainCmd,
     },
 
+    /// Runtime session inspection and control.
+    Runtime {
+        #[command(subcommand)]
+        cmd: RuntimeCmd,
+    },
+
     /// Generate `vendor/fabrik.toml` from the project's Cargo.lock.
     ///
     /// Reads `cargo metadata` for the resolve graph and emits one
@@ -180,6 +195,19 @@ pub enum ToolchainCmd {
         /// the current host platform.
         #[arg(long)]
         platform: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum RuntimeCmd {
+    /// Serve the local runtime JSON-RPC endpoint for a session directory.
+    Rpc {
+        /// Runtime session directory containing session.json and logs.
+        session_dir: PathBuf,
+
+        /// Socket path. Defaults to `<session-dir>/control.sock`.
+        #[arg(long)]
+        socket: Option<PathBuf>,
     },
 }
 

--- a/crates/fabrik-cli/src/commands/mod.rs
+++ b/crates/fabrik-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod build;
 pub mod cache;
 pub mod exec;
 pub mod run;
+pub mod runtime;
 pub mod targets;
 pub mod test;
 pub mod toolchain;

--- a/crates/fabrik-cli/src/commands/run.rs
+++ b/crates/fabrik-cli/src/commands/run.rs
@@ -1,49 +1,36 @@
 //! `fabrik run` - execute the action(s) that produce a target.
-//!
-//! For a `rust_binary`, that action is the rustc invocation. The verb
-//! is the same regardless of target type: target-specific composition
-//! lives in the build-file declarations, not in the CLI.
 
-use std::collections::BTreeMap;
+mod action;
+mod apple_runtime;
+mod output;
+mod runtime_descriptor;
+mod session;
+
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
-use fabrik_cas::{Cas, Digest};
-use fabrik_core::{
-    workspace_tool, workspace_tool_env, Action, InputDigestBuilder, ResourceRequest, RunOpts,
-    Runner, WorkspacePath,
-};
-use serde::Serialize;
-use tokio::io::AsyncWriteExt;
+use fabrik_cas::Cas;
+use fabrik_core::{RunOpts, Runner};
 
-use crate::cli::{exit_from, Format, CACHE_DIR};
+use self::action::action_for;
+use self::apple_runtime::is_apple_simulator_app;
+use self::runtime_descriptor::runtime_descriptor;
+use crate::cli::{exit_from, Format};
 use crate::commands::util::{cache_tag, find_target};
-use crate::render;
 
-#[derive(Serialize)]
-struct RunRecord<'a> {
-    target: &'a str,
-    kind: &'a str,
-    action_digest: String,
-    cache: &'a str,
-    exit_code: i32,
-    output: String,
+pub struct RunArgs {
+    pub format: Format,
+    pub runtime_rpc: bool,
+    pub runtime_rpc_socket: Option<PathBuf>,
 }
 
-struct ActionPlan {
-    action: Action,
-    output: String,
-    output_dir: Option<PathBuf>,
-}
-
-pub async fn run(workspace: &Path, cas: &Cas, target_id: &str, format: Format) -> Result<ExitCode> {
+pub async fn run(workspace: &Path, cas: &Cas, target_id: &str, args: RunArgs) -> Result<ExitCode> {
     let (targets, idx) = find_target(workspace, target_id)?;
     let target = &targets[idx];
 
-    if target.kind == "apple_ios_app" {
-        return run_apple_ios_app(workspace, cas, target_id, &targets, target, format).await;
+    if is_apple_simulator_app(target) {
+        return run_apple_ios_app(workspace, cas, target_id, &targets, target, args).await;
     }
 
     let plan = action_for(workspace, target)?;
@@ -57,7 +44,16 @@ pub async fn run(workspace: &Path, cas: &Cas, target_id: &str, format: Format) -
         .await
         .context("executing action")?;
 
-    render_run_output(cas, &outcome, target_id, target, &plan.output, format).await?;
+    finish_run(
+        workspace,
+        cas,
+        &outcome,
+        target_id,
+        target,
+        &plan.output,
+        args,
+    )
+    .await?;
     Ok(exit_from(outcome.result.exit_code))
 }
 
@@ -67,7 +63,7 @@ async fn run_apple_ios_app(
     target_id: &str,
     targets: &[fabrik_frontend::Target],
     target: &fabrik_frontend::Target,
-    format: Format,
+    args: RunArgs,
 ) -> Result<ExitCode> {
     let built =
         fabrik_apple::build_plan(targets, target_id, workspace).context("building app plan")?;
@@ -82,432 +78,65 @@ async fn run_apple_ios_app(
         .await
         .with_context(|| format!("launching app target {target_id}"))?;
 
-    render_run_output(cas, &outcome, target_id, target, &launch.output, format).await?;
+    finish_run(
+        workspace,
+        cas,
+        &outcome,
+        target_id,
+        target,
+        &launch.output,
+        args,
+    )
+    .await?;
     Ok(exit_from(outcome.result.exit_code))
 }
 
-async fn render_run_output(
+async fn finish_run(
+    workspace: &Path,
     cas: &Cas,
     outcome: &fabrik_core::Outcome,
     target_id: &str,
     target: &fabrik_frontend::Target,
     output: &str,
-    format: Format,
+    args: RunArgs,
 ) -> Result<()> {
+    let RunArgs {
+        format,
+        runtime_rpc,
+        runtime_rpc_socket,
+    } = args;
     let stdout_blob = cas.get_blob(&outcome.result.stdout).await?;
     let stderr_blob = cas.get_blob(&outcome.result.stderr).await?;
     let tag = cache_tag(outcome.cache);
-    let record = RunRecord {
-        target: target_id,
-        kind: &target.kind,
-        action_digest: outcome.action.to_string(),
-        cache: tag,
-        exit_code: outcome.result.exit_code,
-        output: output.to_string(),
-    };
-
-    match format {
-        Format::Human => {
-            let mut out = tokio::io::stdout();
-            out.write_all(&stdout_blob).await?;
-            out.flush().await?;
-            let mut err = tokio::io::stderr();
-            err.write_all(&stderr_blob).await?;
-            let trailer = format!(
-                "fabrik: ran {target_id} (cache {tag}, exit={})\n",
-                outcome.result.exit_code
-            );
-            err.write_all(trailer.as_bytes()).await?;
-            err.flush().await?;
-        }
-        Format::Json | Format::Toon => {
-            // Subprocess stderr stays on stderr (so e.g. rustc's
-            // diagnostics still flow to the terminal); the structured
-            // outcome record goes to stdout where agents pick it up.
-            let mut err = tokio::io::stderr();
-            err.write_all(&stderr_blob).await?;
-            err.flush().await?;
-            let mut out = tokio::io::stdout();
-            out.write_all(render::structured(format, &record)?.as_bytes())
-                .await?;
-            out.flush().await?;
-        }
-    }
-    Ok(())
-}
-
-fn action_for(workspace: &Path, target: &fabrik_frontend::Target) -> Result<ActionPlan> {
-    match target.kind.as_str() {
-        "rust_binary" => rust_binary_action(workspace, target),
-        "cargo_binary" => cargo_binary_action(workspace, target),
-        "task" => task_action(workspace, target),
-        other => anyhow::bail!("running `{other}` targets is not yet supported"),
-    }
-}
-
-fn rust_binary_action(workspace: &Path, target: &fabrik_frontend::Target) -> Result<ActionPlan> {
-    let main_src = target
-        .srcs
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("rust_binary {} has no srcs", target.id()))?;
-    let src_rel = source_path(target, main_src)?;
-    let out_rel = if target.package.is_empty() {
-        format!("{CACHE_DIR}/out/{}", target.name)
-    } else {
-        format!("{CACHE_DIR}/out/{}/{}", target.package, target.name)
-    };
-    let input_digest = input_digest(workspace, target)?;
-    let output_dir = workspace.join(CACHE_DIR).join("out").join(&target.package);
-    let rustc = workspace_tool(workspace, "rustc")?;
-
-    Ok(ActionPlan {
-        action: Action::RunCommand {
-            argv: vec![
-                rustc,
-                "--edition=2021".into(),
-                format!("--crate-name={}", target.name),
-                "--crate-type=bin".into(),
-                "-o".into(),
-                out_rel.clone(),
-                src_rel.as_str().to_string(),
-            ],
-            env: tool_env(workspace, &["rustc"])?,
-            cwd: None,
-            input_digest,
-            outputs: vec![],
-            resources: ResourceRequest::default(),
-            timeout_ms: Some(120_000),
-        },
-        output: out_rel,
-        output_dir: Some(output_dir),
-    })
-}
-
-fn cargo_binary_action(workspace: &Path, target: &fabrik_frontend::Target) -> Result<ActionPlan> {
-    if target.srcs.is_empty() {
-        anyhow::bail!("cargo_binary {} has no srcs", target.id());
-    }
-    let cargo_package = target
-        .attrs
-        .get("cargo_package")
-        .ok_or_else(|| anyhow::anyhow!("cargo_binary {} has no cargo_package", target.id()))?;
-    let bin = target.attrs.get("bin").unwrap_or(&target.name);
-    let input_digest = input_digest(workspace, target)?;
-    let output = format!("target/debug/{bin}{}", std::env::consts::EXE_SUFFIX);
-    let cargo = workspace_tool(workspace, "cargo")?;
-
-    Ok(ActionPlan {
-        action: Action::RunCommand {
-            argv: vec![
-                cargo,
-                "build".into(),
-                "--locked".into(),
-                "--package".into(),
-                cargo_package.to_string(),
-                "--bin".into(),
-                bin.to_string(),
-            ],
-            env: tool_env(workspace, &["cargo", "rustc"])?,
-            cwd: None,
-            input_digest,
-            outputs: vec![],
-            resources: ResourceRequest::new(2, 0),
-            timeout_ms: Some(300_000),
-        },
-        output,
-        output_dir: None,
-    })
-}
-
-fn task_action(workspace: &Path, target: &fabrik_frontend::Target) -> Result<ActionPlan> {
-    let argv_json = target
-        .attrs
-        .get("argv_json")
-        .ok_or_else(|| anyhow::anyhow!("task {} has no argv", target.id()))?;
-    let argv: Vec<String> = serde_json::from_str(argv_json)
-        .with_context(|| format!("parsing argv for task {}", target.id()))?;
-    if argv.is_empty() {
-        anyhow::bail!("task {} has empty argv", target.id());
-    }
-    let env = match target.attrs.get("env_json") {
-        Some(raw) => serde_json::from_str(raw)
-            .with_context(|| format!("parsing env for task {}", target.id()))?,
-        None => BTreeMap::new(),
-    };
-    let cwd = match target.attrs.get("cwd") {
-        Some(raw) => Some(
-            WorkspacePath::try_from(raw.as_str())
-                .with_context(|| format!("invalid cwd for task {}", target.id()))?,
+    let mut runtime = runtime_descriptor(target_id, target)?;
+    let session = match (&mut runtime, runtime_rpc) {
+        (Some(runtime), true) => Some(
+            session::prepare(
+                workspace,
+                target_id,
+                runtime,
+                runtime_rpc_socket,
+                &stdout_blob,
+                &stderr_blob,
+            )
+            .await?,
         ),
-        None => None,
+        (None, true) => anyhow::bail!("--runtime-rpc requires a target with runtime metadata"),
+        (_, false) => None,
     };
-    let outputs = match target.attrs.get("outputs_json") {
-        Some(raw) => {
-            let values: Vec<String> = serde_json::from_str(raw)
-                .with_context(|| format!("parsing outputs for task {}", target.id()))?;
-            values
-                .iter()
-                .map(|value| {
-                    WorkspacePath::try_from(value.as_str())
-                        .with_context(|| format!("invalid output `{value}` in {}", target.id()))
-                })
-                .collect::<Result<_>>()?
-        }
-        None => Vec::new(),
-    };
-    let cache = target
-        .attrs
-        .get("cache")
-        .map_or(Ok(true), |raw| raw.parse::<bool>())
-        .with_context(|| format!("parsing cache setting for task {}", target.id()))?;
-    let timeout_ms = parse_attr::<u64>(target, "timeout_ms")?;
-    let cpu_slots = parse_attr::<usize>(target, "cpu_slots")?.unwrap_or(1);
-    let memory_bytes = parse_attr::<u64>(target, "memory_bytes")?.unwrap_or(0);
-    let input_digest = if cache {
-        input_digest(workspace, target)?
-    } else {
-        Some(uncached_task_digest(target))
-    };
+    let record = output::RunRecord::new(
+        target_id,
+        &target.kind,
+        outcome,
+        tag,
+        output.to_string(),
+        runtime,
+    );
+    output::render(format, &stdout_blob, &stderr_blob, &record).await?;
 
-    Ok(ActionPlan {
-        action: Action::RunCommand {
-            argv,
-            env,
-            cwd,
-            input_digest,
-            outputs,
-            resources: ResourceRequest::new(cpu_slots, memory_bytes),
-            timeout_ms,
-        },
-        output: String::new(),
-        output_dir: None,
-    })
-}
-
-fn source_path(target: &fabrik_frontend::Target, src: &str) -> Result<WorkspacePath> {
-    WorkspacePath::from_package_relative(&target.package, src)
-        .with_context(|| format!("invalid source path `{src}` in {}", target.id()))
-}
-
-fn parse_attr<T>(target: &fabrik_frontend::Target, name: &str) -> Result<Option<T>>
-where
-    T: std::str::FromStr,
-    T::Err: std::error::Error + Send + Sync + 'static,
-{
-    target
-        .attrs
-        .get(name)
-        .map(|value| {
-            value
-                .parse::<T>()
-                .with_context(|| format!("parsing {name} for {}", target.id()))
-        })
-        .transpose()
-}
-
-fn uncached_task_digest(target: &fabrik_frontend::Target) -> Digest {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let mut buf = Vec::new();
-    buf.extend_from_slice(b"fabrik.task.uncached.v1\0");
-    buf.extend_from_slice(target.id().as_bytes());
-    buf.push(0);
-    buf.extend_from_slice(&nonce.to_le_bytes());
-    Digest::of_bytes(&buf)
-}
-
-/// Hash the declared sources of a target into a single digest the
-/// action depends on. Two targets that disagree on either the set of
-/// source paths or on any source's contents get different digests, so
-/// the action cache invalidates correctly.
-///
-/// The encoding is the empty domain prefix followed by sorted
-/// `(workspace_path, file_digest)` pairs. The empty domain matches the
-/// historical wire format from when this verb predated the granular
-/// rust planner; bumping it would invalidate every adopted-mode cache
-/// slot in the wild.
-fn input_digest(workspace: &Path, target: &fabrik_frontend::Target) -> Result<Option<Digest>> {
-    if target.srcs.is_empty() {
-        return Ok(None);
+    if let Some(session) = session {
+        crate::commands::runtime::rpc(&session.dir, Some(&session.socket)).await?;
     }
 
-    let mut paths: Vec<_> = target
-        .srcs
-        .iter()
-        .map(|src| source_path(target, src))
-        .collect::<Result<_>>()?;
-    paths.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-
-    let mut builder = InputDigestBuilder::new(b"");
-    for path in paths {
-        builder
-            .push_source(workspace, path.as_str())
-            .with_context(|| format!("hashing source input `{path}`"))?;
-    }
-    Ok(Some(builder.finish()))
-}
-
-fn tool_env(workspace: &Path, tools: &[&str]) -> Result<BTreeMap<String, String>> {
-    Ok(workspace_tool_env(
-        workspace,
-        tools,
-        &["CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"],
-    )?)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fabrik_frontend::Target;
-    use tempfile::TempDir;
-
-    fn target(package: &str, kind: &str, srcs: &[&str]) -> Target {
-        Target {
-            package: package.into(),
-            kind: kind.into(),
-            name: "demo".into(),
-            srcs: srcs.iter().map(|s| (*s).into()).collect(),
-            deps: vec![],
-            attrs: BTreeMap::new(),
-        }
-    }
-
-    #[test]
-    fn source_path_joins_package_and_rejects_escapes() {
-        let t = target("crates/foo", "rust_binary", &["src/main.rs"]);
-        assert_eq!(
-            source_path(&t, "src/main.rs").unwrap().as_str(),
-            "crates/foo/src/main.rs"
-        );
-        let root = target("", "rust_binary", &["main.rs"]);
-        assert_eq!(source_path(&root, "main.rs").unwrap().as_str(), "main.rs");
-
-        // A `..` in the declared src must not let the target escape its
-        // own package. The frontend collects whatever the user wrote;
-        // path validation lives here.
-        let escape = target("pkg", "rust_binary", &["../escape.rs"]);
-        assert!(source_path(&escape, "../escape.rs").is_err());
-    }
-
-    #[test]
-    fn input_digest_is_none_when_no_srcs_are_declared() {
-        let tmp = TempDir::new().unwrap();
-        let t = target("", "rust_binary", &[]);
-        assert!(input_digest(tmp.path(), &t).unwrap().is_none());
-    }
-
-    #[test]
-    fn input_digest_changes_with_content_and_is_stable_across_runs() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
-        std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() {}").unwrap();
-        let t = target("pkg", "rust_binary", &["main.rs"]);
-
-        let first = input_digest(tmp.path(), &t).unwrap().unwrap();
-        let second = input_digest(tmp.path(), &t).unwrap().unwrap();
-        assert_eq!(first, second, "stable for identical content");
-
-        // Edit the file: digest must change.
-        std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() { /*!*/ }").unwrap();
-        let third = input_digest(tmp.path(), &t).unwrap().unwrap();
-        assert_ne!(first, third, "content change must invalidate the digest");
-    }
-
-    #[test]
-    fn input_digest_is_independent_of_declared_src_order() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
-        std::fs::write(tmp.path().join("pkg/a.rs"), b"a").unwrap();
-        std::fs::write(tmp.path().join("pkg/b.rs"), b"b").unwrap();
-        let forward = target("pkg", "rust_binary", &["a.rs", "b.rs"]);
-        let reversed = target("pkg", "rust_binary", &["b.rs", "a.rs"]);
-        assert_eq!(
-            input_digest(tmp.path(), &forward).unwrap().unwrap(),
-            input_digest(tmp.path(), &reversed).unwrap().unwrap()
-        );
-    }
-
-    #[test]
-    fn rust_binary_action_has_expected_argv_and_output() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
-        std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() {}").unwrap();
-        let t = target("pkg", "rust_binary", &["main.rs"]);
-        let plan = rust_binary_action(tmp.path(), &t).unwrap();
-
-        assert_eq!(plan.output, format!("{CACHE_DIR}/out/pkg/demo"));
-        assert_eq!(
-            plan.output_dir.as_deref(),
-            Some(tmp.path().join(CACHE_DIR).join("out").join("pkg")).as_deref()
-        );
-        match plan.action {
-            Action::RunCommand {
-                argv,
-                input_digest,
-                cwd,
-                ..
-            } => {
-                assert_eq!(argv[0], "rustc");
-                assert!(argv.contains(&"--crate-type=bin".to_string()));
-                assert!(argv.iter().any(|a| a == "--crate-name=demo"));
-                assert_eq!(argv.last().map(String::as_str), Some("pkg/main.rs"));
-                assert!(input_digest.is_some(), "rust_binary must hash its inputs");
-                assert!(cwd.is_none(), "rust_binary runs at the workspace root");
-            }
-        }
-    }
-
-    #[test]
-    fn rust_binary_action_root_package_drops_separator() {
-        let tmp = TempDir::new().unwrap();
-        std::fs::write(tmp.path().join("main.rs"), b"fn main() {}").unwrap();
-        let t = target("", "rust_binary", &["main.rs"]);
-        let plan = rust_binary_action(tmp.path(), &t).unwrap();
-        assert_eq!(plan.output, format!("{CACHE_DIR}/out/demo"));
-    }
-
-    #[test]
-    fn cargo_binary_action_uses_attrs_and_falls_back_to_name_for_bin() {
-        let mut t = target("", "cargo_binary", &["Cargo.toml"]);
-        t.attrs.insert("cargo_package".into(), "fabrik-cli".into());
-        // No explicit `bin`: defaults to `name`.
-        let tmp = TempDir::new().unwrap();
-        std::fs::write(tmp.path().join("Cargo.toml"), b"[package]\nname=\"x\"\n").unwrap();
-        let plan = cargo_binary_action(tmp.path(), &t).unwrap();
-        match plan.action {
-            Action::RunCommand { argv, .. } => {
-                assert_eq!(argv[0], "cargo");
-                assert!(argv.contains(&"--locked".to_string()));
-                assert!(argv
-                    .windows(2)
-                    .any(|w| w[0] == "--package" && w[1] == "fabrik-cli"));
-                assert!(argv.windows(2).any(|w| w[0] == "--bin" && w[1] == "demo"));
-            }
-        }
-        assert!(plan.output_dir.is_none());
-    }
-
-    #[test]
-    fn cargo_binary_action_requires_cargo_package_attr() {
-        let t = target("", "cargo_binary", &["Cargo.toml"]);
-        let tmp = TempDir::new().unwrap();
-        let err = cargo_binary_action(tmp.path(), &t)
-            .err()
-            .expect("missing cargo_package must error")
-            .to_string();
-        assert!(err.contains("cargo_package"), "got {err}");
-    }
-
-    #[test]
-    fn action_for_rejects_unsupported_kinds() {
-        let tmp = TempDir::new().unwrap();
-        let t = target("", "rust_library", &["lib.rs"]);
-        let err = action_for(tmp.path(), &t)
-            .err()
-            .expect("rust_library is unsupported")
-            .to_string();
-        assert!(err.contains("rust_library"), "got {err}");
-    }
+    Ok(())
 }

--- a/crates/fabrik-cli/src/commands/run/action.rs
+++ b/crates/fabrik-cli/src/commands/run/action.rs
@@ -1,0 +1,149 @@
+mod task;
+#[cfg(test)]
+mod tests;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use fabrik_cas::Digest;
+use fabrik_core::{
+    workspace_tool, workspace_tool_env, Action, InputDigestBuilder, ResourceRequest, WorkspacePath,
+};
+
+use crate::cli::CACHE_DIR;
+
+pub(super) struct ActionPlan {
+    pub(super) action: Action,
+    pub(super) output: String,
+    pub(super) output_dir: Option<PathBuf>,
+}
+
+pub(super) fn action_for(workspace: &Path, target: &fabrik_frontend::Target) -> Result<ActionPlan> {
+    match target.kind.as_str() {
+        "rust_binary" => rust_binary_action(workspace, target),
+        "cargo_binary" => cargo_binary_action(workspace, target),
+        "task" | "runtime_task" | "runner_task" => task::task_action(workspace, target),
+        other => anyhow::bail!("running `{other}` targets is not yet supported"),
+    }
+}
+
+fn rust_binary_action(workspace: &Path, target: &fabrik_frontend::Target) -> Result<ActionPlan> {
+    let main_src = target
+        .srcs
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("rust_binary {} has no srcs", target.id()))?;
+    let src_rel = source_path(target, main_src)?;
+    let out_rel = if target.package.is_empty() {
+        format!("{CACHE_DIR}/out/{}", target.name)
+    } else {
+        format!("{CACHE_DIR}/out/{}/{}", target.package, target.name)
+    };
+    let rustc = workspace_tool(workspace, "rustc")?;
+
+    Ok(ActionPlan {
+        action: Action::RunCommand {
+            argv: vec![
+                rustc,
+                "--edition=2021".into(),
+                format!("--crate-name={}", target.name),
+                "--crate-type=bin".into(),
+                "-o".into(),
+                out_rel.clone(),
+                src_rel.as_str().to_string(),
+            ],
+            env: tool_env(workspace, &["rustc"])?,
+            cwd: None,
+            input_digest: input_digest(workspace, target)?,
+            outputs: vec![],
+            resources: ResourceRequest::default(),
+            timeout_ms: Some(120_000),
+        },
+        output: out_rel,
+        output_dir: Some(workspace.join(CACHE_DIR).join("out").join(&target.package)),
+    })
+}
+
+fn cargo_binary_action(workspace: &Path, target: &fabrik_frontend::Target) -> Result<ActionPlan> {
+    if target.srcs.is_empty() {
+        anyhow::bail!("cargo_binary {} has no srcs", target.id());
+    }
+    let cargo_package = target
+        .attrs
+        .get("cargo_package")
+        .ok_or_else(|| anyhow::anyhow!("cargo_binary {} has no cargo_package", target.id()))?;
+    let bin = target.attrs.get("bin").unwrap_or(&target.name);
+    let cargo = workspace_tool(workspace, "cargo")?;
+
+    Ok(ActionPlan {
+        action: Action::RunCommand {
+            argv: vec![
+                cargo,
+                "build".into(),
+                "--locked".into(),
+                "--package".into(),
+                cargo_package.to_string(),
+                "--bin".into(),
+                bin.to_string(),
+            ],
+            env: tool_env(workspace, &["cargo", "rustc"])?,
+            cwd: None,
+            input_digest: input_digest(workspace, target)?,
+            outputs: vec![],
+            resources: ResourceRequest::new(2, 0),
+            timeout_ms: Some(300_000),
+        },
+        output: format!("target/debug/{bin}{}", std::env::consts::EXE_SUFFIX),
+        output_dir: None,
+    })
+}
+
+fn source_path(target: &fabrik_frontend::Target, src: &str) -> Result<WorkspacePath> {
+    WorkspacePath::from_package_relative(&target.package, src)
+        .with_context(|| format!("invalid source path `{src}` in {}", target.id()))
+}
+
+fn input_digest(workspace: &Path, target: &fabrik_frontend::Target) -> Result<Option<Digest>> {
+    if target.srcs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut paths: Vec<_> = target
+        .srcs
+        .iter()
+        .map(|src| source_path(target, src))
+        .collect::<Result<_>>()?;
+    paths.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+    let mut builder = InputDigestBuilder::new(b"");
+    for path in paths {
+        builder
+            .push_source(workspace, path.as_str())
+            .with_context(|| format!("hashing source input `{path}`"))?;
+    }
+    Ok(Some(builder.finish()))
+}
+
+fn tool_env(workspace: &Path, tools: &[&str]) -> Result<BTreeMap<String, String>> {
+    Ok(workspace_tool_env(
+        workspace,
+        tools,
+        &["CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"],
+    )?)
+}
+
+fn parse_attr<T>(target: &fabrik_frontend::Target, name: &str) -> Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    target
+        .attrs
+        .get(name)
+        .map(|value| {
+            value
+                .parse::<T>()
+                .with_context(|| format!("parsing {name} for {}", target.id()))
+        })
+        .transpose()
+}

--- a/crates/fabrik-cli/src/commands/run/action/task.rs
+++ b/crates/fabrik-cli/src/commands/run/action/task.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use fabrik_cas::Digest;
+use fabrik_core::{Action, ResourceRequest, WorkspacePath};
+
+use super::{input_digest, parse_attr, ActionPlan};
+
+pub(super) fn task_action(
+    workspace: &Path,
+    target: &fabrik_frontend::Target,
+) -> Result<ActionPlan> {
+    let cache = target
+        .attrs
+        .get("cache")
+        .map_or(Ok(true), |raw| raw.parse::<bool>())
+        .with_context(|| format!("parsing cache setting for task {}", target.id()))?;
+    let input_digest = if cache {
+        input_digest(workspace, target)?
+    } else {
+        Some(uncached_task_digest(target))
+    };
+
+    Ok(ActionPlan {
+        action: Action::RunCommand {
+            argv: task_argv(target)?,
+            env: task_env(target)?,
+            cwd: task_cwd(target)?,
+            input_digest,
+            outputs: task_outputs(target)?,
+            resources: task_resources(target)?,
+            timeout_ms: parse_attr::<u64>(target, "timeout_ms")?,
+        },
+        output: String::new(),
+        output_dir: None,
+    })
+}
+
+fn task_argv(target: &fabrik_frontend::Target) -> Result<Vec<String>> {
+    let argv_json = target
+        .attrs
+        .get("argv_json")
+        .ok_or_else(|| anyhow::anyhow!("task {} has no argv", target.id()))?;
+    let argv: Vec<String> = serde_json::from_str(argv_json)
+        .with_context(|| format!("parsing argv for task {}", target.id()))?;
+    if argv.is_empty() {
+        anyhow::bail!("task {} has empty argv", target.id());
+    }
+    Ok(argv)
+}
+
+fn task_env(target: &fabrik_frontend::Target) -> Result<BTreeMap<String, String>> {
+    match target.attrs.get("env_json") {
+        Some(raw) => serde_json::from_str(raw)
+            .with_context(|| format!("parsing env for task {}", target.id())),
+        None => Ok(BTreeMap::new()),
+    }
+}
+
+fn task_cwd(target: &fabrik_frontend::Target) -> Result<Option<WorkspacePath>> {
+    target
+        .attrs
+        .get("cwd")
+        .map(|raw| {
+            WorkspacePath::try_from(raw.as_str())
+                .with_context(|| format!("invalid cwd for task {}", target.id()))
+        })
+        .transpose()
+}
+
+fn task_outputs(target: &fabrik_frontend::Target) -> Result<Vec<WorkspacePath>> {
+    let Some(raw) = target.attrs.get("outputs_json") else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_str::<Vec<String>>(raw)
+        .with_context(|| format!("parsing outputs for task {}", target.id()))?
+        .iter()
+        .map(|value| {
+            WorkspacePath::try_from(value.as_str())
+                .with_context(|| format!("invalid output `{value}` in {}", target.id()))
+        })
+        .collect()
+}
+
+fn task_resources(target: &fabrik_frontend::Target) -> Result<ResourceRequest> {
+    let cpu_slots = parse_attr::<usize>(target, "cpu_slots")?.unwrap_or(1);
+    let memory_bytes = parse_attr::<u64>(target, "memory_bytes")?.unwrap_or(0);
+    Ok(ResourceRequest::new(cpu_slots, memory_bytes))
+}
+
+fn uncached_task_digest(target: &fabrik_frontend::Target) -> Digest {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"fabrik.task.uncached.v1\0");
+    buf.extend_from_slice(target.id().as_bytes());
+    buf.push(0);
+    buf.extend_from_slice(&nonce.to_le_bytes());
+    Digest::of_bytes(&buf)
+}

--- a/crates/fabrik-cli/src/commands/run/action/tests.rs
+++ b/crates/fabrik-cli/src/commands/run/action/tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+use fabrik_core::Action;
+use fabrik_frontend::Target;
+use tempfile::TempDir;
+
+fn target(package: &str, kind: &str, srcs: &[&str]) -> Target {
+    Target {
+        package: package.into(),
+        kind: kind.into(),
+        name: "demo".into(),
+        srcs: srcs.iter().map(|s| (*s).into()).collect(),
+        deps: vec![],
+        attrs: BTreeMap::new(),
+    }
+}
+
+#[test]
+fn source_path_joins_package_and_rejects_escapes() {
+    let t = target("crates/foo", "rust_binary", &["src/main.rs"]);
+    assert_eq!(
+        source_path(&t, "src/main.rs").unwrap().as_str(),
+        "crates/foo/src/main.rs"
+    );
+    let root = target("", "rust_binary", &["main.rs"]);
+    assert_eq!(source_path(&root, "main.rs").unwrap().as_str(), "main.rs");
+
+    let escape = target("pkg", "rust_binary", &["../escape.rs"]);
+    assert!(source_path(&escape, "../escape.rs").is_err());
+}
+
+#[test]
+fn input_digest_is_none_when_no_srcs_are_declared() {
+    let tmp = TempDir::new().unwrap();
+    let t = target("", "rust_binary", &[]);
+    assert!(input_digest(tmp.path(), &t).unwrap().is_none());
+}
+
+#[test]
+fn input_digest_changes_with_content_and_is_stable_across_runs() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
+    std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() {}").unwrap();
+    let t = target("pkg", "rust_binary", &["main.rs"]);
+
+    let first = input_digest(tmp.path(), &t).unwrap().unwrap();
+    let second = input_digest(tmp.path(), &t).unwrap().unwrap();
+    assert_eq!(first, second, "stable for identical content");
+
+    std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() { /*!*/ }").unwrap();
+    let third = input_digest(tmp.path(), &t).unwrap().unwrap();
+    assert_ne!(first, third, "content change must invalidate the digest");
+}
+
+#[test]
+fn input_digest_is_independent_of_declared_src_order() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
+    std::fs::write(tmp.path().join("pkg/a.rs"), b"a").unwrap();
+    std::fs::write(tmp.path().join("pkg/b.rs"), b"b").unwrap();
+    let forward = target("pkg", "rust_binary", &["a.rs", "b.rs"]);
+    let reversed = target("pkg", "rust_binary", &["b.rs", "a.rs"]);
+    assert_eq!(
+        input_digest(tmp.path(), &forward).unwrap().unwrap(),
+        input_digest(tmp.path(), &reversed).unwrap().unwrap()
+    );
+}
+
+#[test]
+fn rust_binary_action_has_expected_argv_and_output() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
+    std::fs::write(tmp.path().join("pkg/main.rs"), b"fn main() {}").unwrap();
+    let t = target("pkg", "rust_binary", &["main.rs"]);
+    let plan = rust_binary_action(tmp.path(), &t).unwrap();
+
+    assert_eq!(plan.output, format!("{CACHE_DIR}/out/pkg/demo"));
+    assert_eq!(
+        plan.output_dir.as_deref(),
+        Some(tmp.path().join(CACHE_DIR).join("out").join("pkg")).as_deref()
+    );
+    match plan.action {
+        Action::RunCommand {
+            argv,
+            input_digest,
+            cwd,
+            ..
+        } => {
+            assert_eq!(argv[0], "rustc");
+            assert!(argv.contains(&"--crate-type=bin".to_string()));
+            assert!(argv.iter().any(|a| a == "--crate-name=demo"));
+            assert_eq!(argv.last().map(String::as_str), Some("pkg/main.rs"));
+            assert!(input_digest.is_some(), "rust_binary must hash its inputs");
+            assert!(cwd.is_none(), "rust_binary runs at the workspace root");
+        }
+    }
+}
+
+#[test]
+fn rust_binary_action_root_package_drops_separator() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("main.rs"), b"fn main() {}").unwrap();
+    let t = target("", "rust_binary", &["main.rs"]);
+    let plan = rust_binary_action(tmp.path(), &t).unwrap();
+    assert_eq!(plan.output, format!("{CACHE_DIR}/out/demo"));
+}
+
+#[test]
+fn cargo_binary_action_uses_attrs_and_falls_back_to_name_for_bin() {
+    let mut t = target("", "cargo_binary", &["Cargo.toml"]);
+    t.attrs.insert("cargo_package".into(), "fabrik-cli".into());
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("Cargo.toml"), b"[package]\nname=\"x\"\n").unwrap();
+    let plan = cargo_binary_action(tmp.path(), &t).unwrap();
+    match plan.action {
+        Action::RunCommand { argv, .. } => {
+            assert_eq!(argv[0], "cargo");
+            assert!(argv.contains(&"--locked".to_string()));
+            assert!(argv
+                .windows(2)
+                .any(|w| w[0] == "--package" && w[1] == "fabrik-cli"));
+            assert!(argv.windows(2).any(|w| w[0] == "--bin" && w[1] == "demo"));
+        }
+    }
+    assert!(plan.output_dir.is_none());
+}
+
+#[test]
+fn cargo_binary_action_requires_cargo_package_attr() {
+    let t = target("", "cargo_binary", &["Cargo.toml"]);
+    let tmp = TempDir::new().unwrap();
+    let err = cargo_binary_action(tmp.path(), &t)
+        .err()
+        .expect("missing cargo_package must error")
+        .to_string();
+    assert!(err.contains("cargo_package"), "got {err}");
+}
+
+#[test]
+fn action_for_rejects_unsupported_kinds() {
+    let tmp = TempDir::new().unwrap();
+    let t = target("", "rust_library", &["lib.rs"]);
+    let err = action_for(tmp.path(), &t)
+        .err()
+        .expect("rust_library is unsupported")
+        .to_string();
+    assert!(err.contains("rust_library"), "got {err}");
+}

--- a/crates/fabrik-cli/src/commands/run/apple_runtime.rs
+++ b/crates/fabrik-cli/src/commands/run/apple_runtime.rs
@@ -1,0 +1,107 @@
+use super::runtime_descriptor::{RuntimeDescriptor, RuntimeInterface};
+
+pub(super) fn is_apple_simulator_app(target: &fabrik_frontend::Target) -> bool {
+    target.kind == "apple_ios_app"
+        || (target.kind == "apple_simulator_app"
+            && target
+                .attrs
+                .get("platform")
+                .is_some_and(|platform| platform == "ios"))
+}
+
+pub(super) fn ios_simulator_descriptor(
+    target_id: &str,
+    target: &fabrik_frontend::Target,
+) -> RuntimeDescriptor {
+    let executable = target
+        .attrs
+        .get("executable_name")
+        .cloned()
+        .unwrap_or_else(|| target.name.clone());
+    RuntimeDescriptor {
+        kind: "ios_simulator".to_string(),
+        subject: target_id.to_string(),
+        session: None,
+        rpc: None,
+        capabilities: ["logs", "screenshot", "ui_tree", "ui_action"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        interfaces: ios_simulator_interfaces(&executable),
+    }
+}
+
+fn ios_simulator_interfaces(executable: &str) -> Vec<RuntimeInterface> {
+    vec![
+        interface(
+            "logs",
+            "stream",
+            [
+                "xcrun",
+                "simctl",
+                "spawn",
+                "booted",
+                "log",
+                "stream",
+                "--style",
+                "compact",
+                "--predicate",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .chain([format!("process == \"{executable}\"")])
+            .collect(),
+            "Stream runtime logs for the launched simulator app",
+        ),
+        interface(
+            "screenshot",
+            "artifact",
+            [
+                "xcrun",
+                "simctl",
+                "io",
+                "booted",
+                "screenshot",
+                "<output.png>",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+            "Capture the visible simulator screen",
+        ),
+        interface(
+            "ui_tree",
+            "accessibility",
+            ["axe", "describe-ui", "--udid", "booted"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            "Inspect the visible accessibility hierarchy",
+        ),
+        interface(
+            "tap",
+            "ui_action",
+            [
+                "axe",
+                "tap",
+                "--udid",
+                "booted",
+                "--label",
+                "<accessibility-label>",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+            "Interact with the UI through accessibility targeting",
+        ),
+    ]
+}
+
+fn interface(name: &str, kind: &str, argv: Vec<String>, description: &str) -> RuntimeInterface {
+    RuntimeInterface {
+        name: name.to_string(),
+        kind: kind.to_string(),
+        argv,
+        description: Some(description.to_string()),
+    }
+}

--- a/crates/fabrik-cli/src/commands/run/output.rs
+++ b/crates/fabrik-cli/src/commands/run/output.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use fabrik_core::Outcome;
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+
+use super::runtime_descriptor::RuntimeDescriptor;
+use crate::cli::Format;
+use crate::render;
+
+#[derive(Serialize)]
+pub(super) struct RunRecord<'a> {
+    target: &'a str,
+    kind: &'a str,
+    action_digest: String,
+    cache: &'a str,
+    exit_code: i32,
+    output: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runtime: Option<RuntimeDescriptor>,
+}
+
+impl<'a> RunRecord<'a> {
+    pub(super) fn new(
+        target: &'a str,
+        kind: &'a str,
+        outcome: &Outcome,
+        cache: &'a str,
+        output: String,
+        runtime: Option<RuntimeDescriptor>,
+    ) -> Self {
+        Self {
+            target,
+            kind,
+            action_digest: outcome.action.to_string(),
+            cache,
+            exit_code: outcome.result.exit_code,
+            output,
+            runtime,
+        }
+    }
+}
+
+pub(super) async fn render(
+    format: Format,
+    stdout_blob: &[u8],
+    stderr_blob: &[u8],
+    record: &RunRecord<'_>,
+) -> Result<()> {
+    match format {
+        Format::Human => render_human(stdout_blob, stderr_blob, record).await,
+        Format::Json | Format::Toon => render_structured(format, stderr_blob, record).await,
+    }
+}
+
+async fn render_human(
+    stdout_blob: &[u8],
+    stderr_blob: &[u8],
+    record: &RunRecord<'_>,
+) -> Result<()> {
+    let mut out = tokio::io::stdout();
+    out.write_all(stdout_blob).await?;
+    out.flush().await?;
+
+    let mut err = tokio::io::stderr();
+    err.write_all(stderr_blob).await?;
+    err.write_all(
+        format!(
+            "fabrik: ran {} (cache {}, exit={})\n",
+            record.target, record.cache, record.exit_code
+        )
+        .as_bytes(),
+    )
+    .await?;
+    if let Some(runtime) = &record.runtime {
+        err.write_all(runtime_trailer(runtime).as_bytes()).await?;
+    }
+    err.flush().await?;
+    Ok(())
+}
+
+async fn render_structured(
+    format: Format,
+    stderr_blob: &[u8],
+    record: &RunRecord<'_>,
+) -> Result<()> {
+    let mut err = tokio::io::stderr();
+    err.write_all(stderr_blob).await?;
+    err.flush().await?;
+
+    let mut out = tokio::io::stdout();
+    out.write_all(render::structured(format, record)?.as_bytes())
+        .await?;
+    out.flush().await?;
+    Ok(())
+}
+
+fn runtime_trailer(runtime: &RuntimeDescriptor) -> String {
+    let names = runtime
+        .interfaces
+        .iter()
+        .map(|interface| interface.name.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "fabrik: runtime kind={} subject={} interfaces={names}\n",
+        runtime.kind, runtime.subject
+    )
+}

--- a/crates/fabrik-cli/src/commands/run/runtime_descriptor.rs
+++ b/crates/fabrik-cli/src/commands/run/runtime_descriptor.rs
@@ -1,0 +1,109 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::apple_runtime::{ios_simulator_descriptor, is_apple_simulator_app};
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct RuntimeDescriptor {
+    pub(super) kind: String,
+    pub(super) subject: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) session: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) rpc: Option<RuntimeRpcDescriptor>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) interfaces: Vec<RuntimeInterface>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct RuntimeRpcDescriptor {
+    transport: &'static str,
+    socket: String,
+}
+
+impl RuntimeRpcDescriptor {
+    pub(super) fn new(socket: String) -> Self {
+        Self {
+            transport: "jsonrpc",
+            socket,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct RuntimeInterface {
+    pub(super) name: String,
+    pub(super) kind: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub(super) argv: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) description: Option<String>,
+}
+
+pub(super) fn runtime_descriptor(
+    target_id: &str,
+    target: &fabrik_frontend::Target,
+) -> Result<Option<RuntimeDescriptor>> {
+    if target.kind == "runtime_task" || target.kind == "runner_task" {
+        return runtime_task_descriptor(target_id, target).map(Some);
+    }
+
+    if is_apple_simulator_app(target) {
+        return Ok(Some(ios_simulator_descriptor(target_id, target)));
+    }
+
+    Ok(None)
+}
+
+fn runtime_task_descriptor(
+    target_id: &str,
+    target: &fabrik_frontend::Target,
+) -> Result<RuntimeDescriptor> {
+    let runtime = target
+        .attrs
+        .get("runtime")
+        .ok_or_else(|| anyhow::anyhow!("runtime_task {} has no runtime", target.id()))?
+        .to_string();
+    let subject = target
+        .attrs
+        .get("runtime_target")
+        .or_else(|| target.attrs.get("runner_target"))
+        .cloned()
+        .unwrap_or_else(|| target_id.to_string());
+    let capabilities = parse_json_attr::<Vec<String>>(target, "runtime_capabilities_json")?
+        .or(parse_json_attr::<Vec<String>>(
+            target,
+            "runner_capabilities_json",
+        )?)
+        .unwrap_or_default();
+    let interfaces = parse_json_attr::<Vec<RuntimeInterface>>(target, "runtime_interfaces_json")?
+        .or(parse_json_attr::<Vec<RuntimeInterface>>(
+            target,
+            "runner_interfaces_json",
+        )?)
+        .unwrap_or_default();
+    Ok(RuntimeDescriptor {
+        kind: runtime,
+        subject,
+        session: None,
+        rpc: None,
+        capabilities,
+        interfaces,
+    })
+}
+
+fn parse_json_attr<T>(target: &fabrik_frontend::Target, name: &str) -> Result<Option<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    target
+        .attrs
+        .get(name)
+        .map(|value| {
+            serde_json::from_str::<T>(value)
+                .with_context(|| format!("parsing {name} for {}", target.id()))
+        })
+        .transpose()
+}

--- a/crates/fabrik-cli/src/commands/run/session.rs
+++ b/crates/fabrik-cli/src/commands/run/session.rs
@@ -1,0 +1,91 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use tokio::fs;
+
+use super::runtime_descriptor::{RuntimeDescriptor, RuntimeRpcDescriptor};
+use crate::cli::CACHE_DIR;
+
+pub(super) struct RuntimeSession {
+    pub(super) dir: PathBuf,
+    pub(super) socket: PathBuf,
+}
+
+pub(super) async fn prepare(
+    workspace: &Path,
+    target_id: &str,
+    runtime: &mut RuntimeDescriptor,
+    socket: Option<PathBuf>,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<RuntimeSession> {
+    let name = session_name(target_id);
+    let dir = workspace.join(CACHE_DIR).join("runtime").join(&name);
+    let socket = socket.unwrap_or_else(|| default_socket(&dir, &name));
+    fs::create_dir_all(&dir)
+        .await
+        .with_context(|| format!("creating runtime session {}", dir.display()))?;
+    fs::write(dir.join("stdout.log"), stdout)
+        .await
+        .with_context(|| format!("writing {}", dir.join("stdout.log").display()))?;
+    fs::write(dir.join("stderr.log"), stderr)
+        .await
+        .with_context(|| format!("writing {}", dir.join("stderr.log").display()))?;
+
+    runtime.session = Some(display_path(workspace, &dir));
+    runtime.rpc = Some(RuntimeRpcDescriptor::new(display_path(workspace, &socket)));
+    write_session_json(&dir, target_id, runtime).await?;
+    Ok(RuntimeSession { dir, socket })
+}
+
+fn default_socket(dir: &Path, session_name: &str) -> PathBuf {
+    let socket = dir.join("control.sock");
+    if socket.as_os_str().len() < 100 {
+        return socket;
+    }
+    std::env::temp_dir().join(format!("fabrik-{session_name}.sock"))
+}
+
+fn session_name(target_id: &str) -> String {
+    let started = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let target = target_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    format!("{target}-{started}")
+}
+
+async fn write_session_json(
+    dir: &Path,
+    target_id: &str,
+    runtime: &RuntimeDescriptor,
+) -> Result<()> {
+    let raw = serde_json::to_vec_pretty(&SessionJson { target_id, runtime })?;
+    fs::write(dir.join("session.json"), raw)
+        .await
+        .with_context(|| format!("writing {}", dir.join("session.json").display()))
+}
+
+fn display_path(workspace: &Path, path: &Path) -> String {
+    path.strip_prefix(workspace)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "/")
+}
+
+#[derive(Serialize)]
+struct SessionJson<'a> {
+    target_id: &'a str,
+    runtime: &'a RuntimeDescriptor,
+}

--- a/crates/fabrik-cli/src/commands/runtime.rs
+++ b/crates/fabrik-cli/src/commands/runtime.rs
@@ -1,0 +1,21 @@
+//! Runtime session inspection and control.
+
+#[cfg(unix)]
+mod protocol;
+#[cfg(unix)]
+mod query;
+#[cfg(unix)]
+mod server;
+#[cfg(unix)]
+mod session;
+
+#[cfg(unix)]
+pub use server::rpc;
+
+#[cfg(not(unix))]
+pub async fn rpc(
+    _session_dir: &std::path::Path,
+    _socket: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    anyhow::bail!("runtime JSON-RPC over Unix sockets is only supported on Unix platforms")
+}

--- a/crates/fabrik-cli/src/commands/runtime/protocol.rs
+++ b/crates/fabrik-cli/src/commands/runtime/protocol.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct Request {
+    #[serde(default)]
+    pub(super) jsonrpc: Option<String>,
+    pub(super) id: Option<Value>,
+    pub(super) method: String,
+    #[serde(default)]
+    pub(super) params: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct Response {
+    jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<RpcError>,
+}
+
+#[derive(Debug, Serialize)]
+struct RpcError {
+    code: i32,
+    message: String,
+}
+
+pub(super) fn success_response(id: Option<Value>, result: Value) -> Response {
+    Response {
+        jsonrpc: "2.0",
+        id,
+        result: Some(result),
+        error: None,
+    }
+}
+
+pub(super) fn error_response(id: Option<Value>, code: i32, message: &str) -> Response {
+    Response {
+        jsonrpc: "2.0",
+        id,
+        result: None,
+        error: Some(RpcError {
+            code,
+            message: message.to_string(),
+        }),
+    }
+}
+
+pub(super) fn parse_error(message: &str) -> Response {
+    error_response(None, -32700, message)
+}
+
+pub(super) async fn write_response<W>(write: &mut W, response: Response) -> Result<()>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    write_json_line(write, &response).await
+}
+
+pub(super) async fn write_json_line<W, T>(write: &mut W, value: &T) -> Result<()>
+where
+    W: AsyncWriteExt + Unpin,
+    T: Serialize,
+{
+    let mut line = serde_json::to_vec(value)?;
+    line.push(b'\n');
+    write.write_all(&line).await?;
+    write.flush().await?;
+    Ok(())
+}

--- a/crates/fabrik-cli/src/commands/runtime/query.rs
+++ b/crates/fabrik-cli/src/commands/runtime/query.rs
@@ -1,0 +1,65 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub(super) struct EventQuery {
+    pub(super) cursor: Option<String>,
+    pub(super) domain: Option<String>,
+    pub(super) kind: Option<String>,
+    pub(super) limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub(super) struct LogQuery {
+    pub(super) cursor: Option<String>,
+    pub(super) source: Option<String>,
+    pub(super) text: Option<String>,
+    pub(super) levels: Vec<String>,
+    pub(super) limit: Option<usize>,
+}
+
+pub(super) fn event_matches(event: &Value, query: &EventQuery) -> bool {
+    if let Some(cursor) = &query.cursor {
+        if event
+            .get("cursor")
+            .and_then(Value::as_str)
+            .is_some_and(|c| c <= cursor.as_str())
+        {
+            return false;
+        }
+    }
+    if let Some(domain) = &query.domain {
+        if event.get("domain").and_then(Value::as_str) != Some(domain.as_str()) {
+            return false;
+        }
+    }
+    if let Some(kind) = &query.kind {
+        if event.get("kind").and_then(Value::as_str) != Some(kind.as_str()) {
+            return false;
+        }
+    }
+    true
+}
+
+pub(super) fn log_matches(record: &Value, query: &LogQuery) -> bool {
+    if let Some(source) = &query.source {
+        if record.get("source").and_then(Value::as_str) != Some(source.as_str()) {
+            return false;
+        }
+    }
+    if !query.levels.is_empty() {
+        let level = record.get("level").and_then(Value::as_str);
+        if level.is_none_or(|level| !query.levels.iter().any(|want| want == level)) {
+            return false;
+        }
+    }
+    if let Some(text) = &query.text {
+        let message = record.get("message").and_then(Value::as_str).unwrap_or("");
+        if !message.contains(text) {
+            return false;
+        }
+    }
+    true
+}

--- a/crates/fabrik-cli/src/commands/runtime/server.rs
+++ b/crates/fabrik-cli/src/commands/runtime/server.rs
@@ -1,0 +1,174 @@
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use tokio::fs;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::time::sleep;
+
+use super::protocol::{
+    error_response, parse_error, success_response, write_json_line, write_response, Request,
+};
+use super::query::{EventQuery, LogQuery};
+use super::session::RuntimeSession;
+
+pub async fn rpc(session_dir: &Path, socket: Option<&Path>) -> Result<()> {
+    let session = RuntimeSession::new(session_dir);
+    session
+        .describe()
+        .await
+        .with_context(|| format!("loading runtime session {}", session_dir.display()))?;
+    fs::create_dir_all(session_dir).await.with_context(|| {
+        format!(
+            "creating runtime session directory {}",
+            session_dir.display()
+        )
+    })?;
+
+    let socket = socket.map_or_else(|| session_dir.join("control.sock"), Path::to_path_buf);
+    remove_stale_socket(&socket).await?;
+    let listener = UnixListener::bind(&socket)
+        .with_context(|| format!("binding runtime RPC socket {}", socket.display()))?;
+    eprintln!("fabrik: runtime rpc listening on {}", socket.display());
+
+    loop {
+        let (stream, _) = listener.accept().await.context("accepting RPC client")?;
+        let session = session.clone();
+        tokio::spawn(async move {
+            if let Err(err) = handle_client(stream, session).await {
+                tracing::warn!("runtime RPC client failed: {err:#}");
+            }
+        });
+    }
+}
+
+async fn remove_stale_socket(socket: &Path) -> Result<()> {
+    if fs::try_exists(socket).await.unwrap_or(false) {
+        fs::remove_file(socket)
+            .await
+            .with_context(|| format!("removing stale socket {}", socket.display()))?;
+    }
+    Ok(())
+}
+
+async fn handle_client(stream: UnixStream, session: RuntimeSession) -> Result<()> {
+    let (read, mut write) = stream.into_split();
+    let mut lines = BufReader::new(read).lines();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let request = match serde_json::from_str::<Request>(&line) {
+            Ok(request) => request,
+            Err(err) => {
+                write_response(&mut write, parse_error(&err.to_string())).await?;
+                continue;
+            }
+        };
+        if let Some(response) = validate_jsonrpc(&request) {
+            write_response(&mut write, response).await?;
+            continue;
+        }
+        if request.method == "logs.stream" {
+            stream_logs(&mut write, &session, request).await?;
+            continue;
+        }
+        let id = request.id.clone();
+        let response = match dispatch(&session, request).await {
+            Ok(result) => success_response(id, result),
+            Err(err) => error_response(id, -32000, &err.to_string()),
+        };
+        write_response(&mut write, response).await?;
+    }
+    Ok(())
+}
+
+fn validate_jsonrpc(request: &Request) -> Option<super::protocol::Response> {
+    request
+        .jsonrpc
+        .as_deref()
+        .is_some_and(|version| version != "2.0")
+        .then(|| error_response(request.id.clone(), -32600, "expected jsonrpc version 2.0"))
+}
+
+async fn dispatch(session: &RuntimeSession, request: Request) -> Result<Value> {
+    match request.method.as_str() {
+        "runtime.describe" => session.describe().await,
+        "events.query" => {
+            let query = serde_json::from_value::<EventQuery>(request.params)
+                .context("invalid events.query params")?;
+            session.events(query).await
+        }
+        "logs.query" => {
+            let query = serde_json::from_value::<LogQuery>(request.params)
+                .context("invalid logs.query params")?;
+            session.logs(query).await
+        }
+        other => anyhow::bail!("unknown runtime RPC method `{other}`"),
+    }
+}
+
+async fn stream_logs<W>(write: &mut W, session: &RuntimeSession, request: Request) -> Result<()>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let query =
+        serde_json::from_value::<LogQuery>(request.params).context("invalid logs.stream params")?;
+    write_response(
+        write,
+        success_response(request.id, json!({ "subscribed": true })),
+    )
+    .await?;
+    let mut seen = 0usize;
+    loop {
+        let records = session.log_files(&query).await?;
+        for record in records.iter().skip(seen) {
+            let notification = json!({
+                "jsonrpc": "2.0",
+                "method": "logs.record",
+                "params": record
+            });
+            write_json_line(write, &notification).await?;
+        }
+        seen = records.len();
+        sleep(Duration::from_millis(250)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    #[tokio::test]
+    async fn json_rpc_connection_serves_log_query() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("session.json"), "{}")
+            .await
+            .unwrap();
+        fs::write(tmp.path().join("stdout.log"), "ready\n")
+            .await
+            .unwrap();
+        let (client, server) = UnixStream::pair().unwrap();
+        let session = RuntimeSession::new(tmp.path());
+        let server_task = tokio::spawn(async move { handle_client(server, session).await });
+        let (read, mut write) = client.into_split();
+        write
+            .write_all(
+                br#"{"jsonrpc":"2.0","id":7,"method":"logs.query","params":{"source":"stdout"}}"#,
+            )
+            .await
+            .unwrap();
+        write.write_all(b"\n").await.unwrap();
+        let mut lines = BufReader::new(read).lines();
+        let line = lines.next_line().await.unwrap().unwrap();
+        let response: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(response["id"], 7);
+        assert_eq!(response["result"]["records"][0]["message"], "ready");
+        drop(write);
+        server_task.await.unwrap().unwrap();
+    }
+}

--- a/crates/fabrik-cli/src/commands/runtime/session.rs
+++ b/crates/fabrik-cli/src/commands/runtime/session.rs
@@ -1,0 +1,175 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use tokio::fs;
+
+use super::query::{event_matches, log_matches, EventQuery, LogQuery};
+
+#[derive(Clone)]
+pub(super) struct RuntimeSession {
+    dir: PathBuf,
+}
+
+impl RuntimeSession {
+    pub(super) fn new(dir: &Path) -> Self {
+        Self {
+            dir: dir.to_path_buf(),
+        }
+    }
+
+    pub(super) async fn describe(&self) -> Result<Value> {
+        read_json_file(&self.dir.join("session.json")).await
+    }
+
+    pub(super) async fn events(&self, query: EventQuery) -> Result<Value> {
+        let mut events = Vec::new();
+        for event in read_ndjson(&self.dir.join("events.ndjson")).await? {
+            if !event_matches(&event, &query) {
+                continue;
+            }
+            events.push(event);
+            if events.len() >= query.limit.unwrap_or(200) {
+                break;
+            }
+        }
+        Ok(json!({ "events": events }))
+    }
+
+    pub(super) async fn logs(&self, query: LogQuery) -> Result<Value> {
+        let mut records = self.log_events(&query).await?;
+        if records.is_empty() {
+            records = self.log_files(&query).await?;
+        }
+        records.truncate(query.limit.unwrap_or(200));
+        Ok(json!({ "records": records }))
+    }
+
+    pub(super) async fn log_files(&self, query: &LogQuery) -> Result<Vec<Value>> {
+        let mut out = Vec::new();
+        for source in ["stdout", "stderr"] {
+            if query.source.as_deref().is_some_and(|want| want != source) {
+                continue;
+            }
+            let path = self.dir.join(format!("{source}.log"));
+            let Ok(content) = fs::read_to_string(&path).await else {
+                continue;
+            };
+            out.extend(content.lines().enumerate().filter_map(|(idx, line)| {
+                let record = json!({
+                    "cursor": format!("{source}:{idx:012}"),
+                    "source": source,
+                    "level": if source == "stderr" { "error" } else { "info" },
+                    "message": line,
+                    "fields": {}
+                });
+                log_matches(&record, query).then_some(record)
+            }));
+        }
+        Ok(out)
+    }
+
+    async fn log_events(&self, query: &LogQuery) -> Result<Vec<Value>> {
+        let records = read_ndjson(&self.dir.join("events.ndjson"))
+            .await?
+            .into_iter()
+            .filter(|event| event.get("domain").and_then(Value::as_str) == Some("logs"))
+            .filter(|event| event_is_after_cursor(event, query.cursor.as_deref()))
+            .map(|event| event.get("payload").cloned().unwrap_or(event))
+            .filter(|record| log_matches(record, query))
+            .collect();
+        Ok(records)
+    }
+}
+
+fn event_is_after_cursor(event: &Value, cursor: Option<&str>) -> bool {
+    let Some(cursor) = cursor else {
+        return true;
+    };
+    event
+        .get("cursor")
+        .and_then(Value::as_str)
+        .is_none_or(|event_cursor| event_cursor > cursor)
+}
+
+async fn read_json_file(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path)
+        .await
+        .with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+async fn read_ndjson(path: &Path) -> Result<Vec<Value>> {
+    let Ok(raw) = fs::read_to_string(path).await else {
+        return Ok(Vec::new());
+    };
+    raw.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).context("parsing runtime event"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn describe_reads_session_json() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("session.json"),
+            r#"{"sessionId":"s1","runtime":{"kind":"test"}}"#,
+        )
+        .await
+        .unwrap();
+        let value = RuntimeSession::new(tmp.path()).describe().await.unwrap();
+        assert_eq!(value["sessionId"], "s1");
+        assert_eq!(value["runtime"]["kind"], "test");
+    }
+
+    #[tokio::test]
+    async fn logs_query_filters_stdout_log() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("stdout.log"), "ready\nwarning: slow\n")
+            .await
+            .unwrap();
+        let value = RuntimeSession::new(tmp.path())
+            .logs(LogQuery {
+                text: Some("slow".to_string()),
+                ..LogQuery::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(value["records"].as_array().unwrap().len(), 1);
+        assert_eq!(value["records"][0]["message"], "warning: slow");
+    }
+
+    #[tokio::test]
+    async fn events_query_filters_domain_and_cursor() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("events.ndjson"),
+            concat!(
+                r#"{"cursor":"0001","domain":"logs","kind":"record"}"#,
+                "\n",
+                r#"{"cursor":"0002","domain":"ui","kind":"snapshot"}"#,
+                "\n",
+                r#"{"cursor":"0003","domain":"logs","kind":"record"}"#,
+                "\n"
+            ),
+        )
+        .await
+        .unwrap();
+        let value = RuntimeSession::new(tmp.path())
+            .events(EventQuery {
+                cursor: Some("0001".to_string()),
+                domain: Some("logs".to_string()),
+                ..EventQuery::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(value["events"].as_array().unwrap().len(), 1);
+        assert_eq!(value["events"][0]["cursor"], "0003");
+    }
+}

--- a/crates/fabrik-cli/src/main.rs
+++ b/crates/fabrik-cli/src/main.rs
@@ -53,9 +53,23 @@ async fn dispatch(cli: Cli) -> Result<ExitCode> {
     let format: Format = cli.format;
 
     match cli.command {
-        Cmd::Run { target } => {
+        Cmd::Run {
+            target,
+            runtime_rpc,
+            runtime_rpc_socket,
+        } => {
             let target = resolve_target_arg(&workspace, &target)?;
-            commands::run::run(&workspace, &cas, &target, format).await
+            commands::run::run(
+                &workspace,
+                &cas,
+                &target,
+                commands::run::RunArgs {
+                    format,
+                    runtime_rpc,
+                    runtime_rpc_socket,
+                },
+            )
+            .await
         }
         Cmd::Build { target } => {
             let target = resolve_target_arg(&workspace, &target)?;
@@ -94,6 +108,15 @@ async fn dispatch(cli: Cli) -> Result<ExitCode> {
         Cmd::Toolchain {
             cmd: cli::ToolchainCmd::Inspect { platform },
         } => commands::toolchain::inspect(&workspace, format, platform.as_deref())
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Cmd::Runtime {
+            cmd:
+                cli::RuntimeCmd::Rpc {
+                    session_dir,
+                    socket,
+                },
+        } => commands::runtime::rpc(&session_dir, socket.as_deref())
             .await
             .map(|()| ExitCode::SUCCESS),
         Cmd::Targets => commands::targets::print_targets(&workspace, format)

--- a/crates/fabrik-core/src/plan.rs
+++ b/crates/fabrik-core/src/plan.rs
@@ -44,7 +44,7 @@ pub struct PlanOutcome {
 
 /// Per-node metadata that travels alongside a [`Plan`] for telemetry
 /// and CLI rendering. The `kind` is the originating target kind
-/// (`rust_library`, `apple_ios_app`, ...), kept as a string so the
+/// (`rust_library`, `apple_simulator_app`, ...), kept as a string so the
 /// shape is uniform across plugins. Plugin-internal enum
 /// representations stay inside the plugin.
 #[derive(Debug, Clone)]

--- a/crates/fabrik-frontend/src/manifest.rs
+++ b/crates/fabrik-frontend/src/manifest.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::error::{Error, Result};
 use crate::target::Target;
@@ -16,7 +16,7 @@ struct Manifest {
     cargo: CargoSection,
     apple: AppleSection,
     task: Vec<TaskTarget>,
-    target: Vec<GenericTarget>,
+    target: Vec<RuleTarget>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -39,6 +39,7 @@ struct CargoSection {
 #[serde(default, deny_unknown_fields)]
 struct AppleSection {
     ios_app: Vec<AppleIosAppTarget>,
+    simulator_app: Vec<AppleSimulatorAppTarget>,
     swift_library: Vec<AppleSwiftTarget>,
     static_framework: Vec<AppleFrameworkTarget>,
     dynamic_framework: Vec<AppleFrameworkTarget>,
@@ -64,6 +65,29 @@ struct TaskTarget {
     timeout_ms: Option<u64>,
     cpu_slots: Option<usize>,
     memory_bytes: Option<u64>,
+    runtime: Option<RuntimeTask>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RuntimeTask {
+    kind: Option<String>,
+    runtime: Option<String>,
+    target: Option<String>,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    interface: Vec<RuntimeInterface>,
+}
+
+#[derive(Debug, serde::Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RuntimeInterface {
+    name: String,
+    kind: String,
+    #[serde(default)]
+    argv: Vec<String>,
+    description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -126,6 +150,23 @@ struct AppleIosAppTarget {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+struct AppleSimulatorAppTarget {
+    name: String,
+    platform: String,
+    bundle_id: String,
+    #[serde(default)]
+    srcs: Vec<String>,
+    #[serde(default)]
+    src_globs: Vec<String>,
+    #[serde(default)]
+    deps: Vec<String>,
+    executable_name: Option<String>,
+    minimum_os: Option<String>,
+    simulator: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AppleSwiftTarget {
     name: String,
     #[serde(default)]
@@ -159,17 +200,19 @@ struct AppleFrameworkTarget {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct GenericTarget {
-    kind: String,
+struct RuleTarget {
     name: String,
+    rule: Option<String>,
+    kind: Option<String>,
+    #[serde(default)]
+    attrs: toml::Table,
+    runtime: Option<RuntimeTask>,
     #[serde(default)]
     srcs: Vec<String>,
     #[serde(default)]
     src_globs: Vec<String>,
     #[serde(default)]
     deps: Vec<String>,
-    #[serde(default)]
-    attrs: BTreeMap<String, String>,
 }
 
 pub fn load_toml_str(name: &str, src: &str) -> Result<Vec<Target>> {
@@ -188,7 +231,27 @@ pub(crate) fn load_toml_with(
     })?;
     let mut targets = Vec::new();
 
-    for t in manifest.rust.library {
+    push_rust_targets(&mut targets, manifest.rust, workspace_root, package, name)?;
+    push_cargo_targets(&mut targets, manifest.cargo, workspace_root, package, name)?;
+    push_apple_targets(&mut targets, manifest.apple, workspace_root, package, name)?;
+    for t in manifest.task {
+        targets.push(task_target(t, workspace_root, package, name)?);
+    }
+    for t in manifest.target {
+        targets.push(rule_target(t, workspace_root, package, name)?);
+    }
+
+    Ok(targets)
+}
+
+fn push_rust_targets(
+    targets: &mut Vec<Target>,
+    rust: RustSection,
+    workspace_root: &Path,
+    package: &str,
+    name: &str,
+) -> Result<()> {
+    for t in rust.library {
         targets.push(rust_target(
             "rust_library",
             t,
@@ -197,7 +260,7 @@ pub(crate) fn load_toml_with(
             name,
         )?);
     }
-    for t in manifest.rust.binary {
+    for t in rust.binary {
         targets.push(rust_target(
             "rust_binary",
             t,
@@ -206,10 +269,10 @@ pub(crate) fn load_toml_with(
             name,
         )?);
     }
-    for t in manifest.rust.test {
+    for t in rust.test {
         targets.push(rust_target("rust_test", t, workspace_root, package, name)?);
     }
-    for t in manifest.rust.proc_macro {
+    for t in rust.proc_macro {
         targets.push(rust_target(
             "rust_proc_macro",
             t,
@@ -218,16 +281,44 @@ pub(crate) fn load_toml_with(
             name,
         )?);
     }
-    for t in manifest.cargo.binary {
+    Ok(())
+}
+
+fn push_cargo_targets(
+    targets: &mut Vec<Target>,
+    cargo: CargoSection,
+    workspace_root: &Path,
+    package: &str,
+    name: &str,
+) -> Result<()> {
+    for t in cargo.binary {
         targets.push(cargo_binary_target(t, workspace_root, package, name)?);
     }
-    for t in manifest.cargo.build_script {
+    for t in cargo.build_script {
         targets.push(cargo_build_script_target(t, workspace_root, package, name)?);
     }
-    for t in manifest.apple.ios_app {
+    Ok(())
+}
+
+fn push_apple_targets(
+    targets: &mut Vec<Target>,
+    apple: AppleSection,
+    workspace_root: &Path,
+    package: &str,
+    name: &str,
+) -> Result<()> {
+    for t in apple.ios_app {
         targets.push(apple_ios_app_target(t, workspace_root, package, name)?);
     }
-    for t in manifest.apple.swift_library {
+    for t in apple.simulator_app {
+        targets.push(apple_simulator_app_target(
+            t,
+            workspace_root,
+            package,
+            name,
+        )?);
+    }
+    for t in apple.swift_library {
         targets.push(apple_swift_target(
             "swift_library",
             t,
@@ -236,7 +327,7 @@ pub(crate) fn load_toml_with(
             name,
         )?);
     }
-    for t in manifest.apple.static_framework {
+    for t in apple.static_framework {
         targets.push(apple_framework_target(
             "apple_static_framework",
             t,
@@ -245,7 +336,7 @@ pub(crate) fn load_toml_with(
             name,
         )?);
     }
-    for t in manifest.apple.dynamic_framework {
+    for t in apple.dynamic_framework {
         targets.push(apple_framework_target(
             "apple_dynamic_framework",
             t,
@@ -254,7 +345,7 @@ pub(crate) fn load_toml_with(
             name,
         )?);
     }
-    for t in manifest.apple.macos_command_line_application {
+    for t in apple.macos_command_line_application {
         targets.push(apple_swift_target(
             "macos_command_line_application",
             t,
@@ -263,14 +354,7 @@ pub(crate) fn load_toml_with(
             name,
         )?);
     }
-    for t in manifest.task {
-        targets.push(task_target(t, workspace_root, package, name)?);
-    }
-    for t in manifest.target {
-        targets.push(generic_target(t, workspace_root, package, name)?);
-    }
-
-    Ok(targets)
+    Ok(())
 }
 
 fn rust_target(
@@ -342,9 +426,41 @@ fn apple_ios_app_target(
     insert_opt(&mut attrs, "executable_name", t.executable_name);
     insert_opt(&mut attrs, "minimum_os", t.minimum_os);
     insert_opt(&mut attrs, "simulator", t.simulator);
+    attrs.insert("platform".to_string(), "ios".to_string());
     Ok(Target {
         package: package.to_string(),
         kind: "apple_ios_app".to_string(),
+        name: checked_name(t.name, display_name)?,
+        srcs: resolve_srcs(t.srcs, t.src_globs, workspace_root, package, display_name)?,
+        deps: normalize_deps(t.deps, package, display_name)?,
+        attrs,
+    })
+}
+
+fn apple_simulator_app_target(
+    t: AppleSimulatorAppTarget,
+    workspace_root: &Path,
+    package: &str,
+    display_name: &str,
+) -> Result<Target> {
+    if t.platform != "ios" {
+        return Err(Error::Eval {
+            path: display_name.to_string(),
+            message: format!(
+                "apple.simulator_app platform `{}` is not supported yet; use `ios`",
+                t.platform
+            ),
+        });
+    }
+    let mut attrs = BTreeMap::new();
+    attrs.insert("platform".to_string(), t.platform);
+    attrs.insert("bundle_id".to_string(), t.bundle_id);
+    insert_opt(&mut attrs, "executable_name", t.executable_name);
+    insert_opt(&mut attrs, "minimum_os", t.minimum_os);
+    insert_opt(&mut attrs, "simulator", t.simulator);
+    Ok(Target {
+        package: package.to_string(),
+        kind: "apple_simulator_app".to_string(),
         name: checked_name(t.name, display_name)?,
         srcs: resolve_srcs(t.srcs, t.src_globs, workspace_root, package, display_name)?,
         deps: normalize_deps(t.deps, package, display_name)?,
@@ -395,20 +511,171 @@ fn apple_framework_target(
     })
 }
 
-fn generic_target(
-    t: GenericTarget,
+fn rule_target(
+    t: RuleTarget,
+    workspace_root: &Path,
+    package: &str,
+    display_name: &str,
+) -> Result<Target> {
+    let rule = t.rule.clone();
+    let kind = t.kind.clone();
+    match (rule.as_deref(), kind.as_deref()) {
+        (Some(rule), None) => builtin_rule_target(rule, t, workspace_root, package, display_name),
+        (None, Some(_)) => legacy_generic_target(t, workspace_root, package, display_name),
+        (None, None) => Err(Error::Eval {
+            path: display_name.to_string(),
+            message: format!("target `{}` must set `rule`", t.name),
+        }),
+        (Some(_), Some(_)) => Err(Error::Eval {
+            path: display_name.to_string(),
+            message: format!("target `{}` must not set both `rule` and `kind`", t.name),
+        }),
+    }
+}
+
+fn builtin_rule_target(
+    rule: &str,
+    t: RuleTarget,
+    workspace_root: &Path,
+    package: &str,
+    display_name: &str,
+) -> Result<Target> {
+    let name = t.name;
+    let runtime = t.runtime;
+    let attrs = t.attrs;
+    match rule {
+        "command" => {
+            let mut command = decode_rule_attrs::<TaskTarget>(&name, attrs, display_name)?;
+            command.runtime = runtime;
+            task_target(command, workspace_root, package, display_name)
+        }
+        "rust.library" => rust_target(
+            "rust_library",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "rust.binary" => rust_target(
+            "rust_binary",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "rust.test" => rust_target(
+            "rust_test",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "rust.proc_macro" => rust_target(
+            "rust_proc_macro",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "cargo.binary" => cargo_binary_target(
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "cargo.build_script" => cargo_build_script_target(
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "apple.simulator_app" => apple_simulator_app_target(
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "apple.ios_app" => apple_ios_app_target(
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "apple.swift_library" => apple_swift_target(
+            "swift_library",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "apple.static_framework" => apple_framework_target(
+            "apple_static_framework",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "apple.dynamic_framework" => apple_framework_target(
+            "apple_dynamic_framework",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        "apple.macos_command_line_application" => apple_swift_target(
+            "macos_command_line_application",
+            decode_rule_attrs(&name, attrs, display_name)?,
+            workspace_root,
+            package,
+            display_name,
+        ),
+        other => Err(Error::Eval {
+            path: display_name.to_string(),
+            message: format!("unknown rule `{other}` for target `{name}`"),
+        }),
+    }
+}
+
+fn legacy_generic_target(
+    t: RuleTarget,
     workspace_root: &Path,
     package: &str,
     display_name: &str,
 ) -> Result<Target> {
     Ok(Target {
         package: package.to_string(),
-        kind: t.kind,
+        kind: t.kind.expect("legacy target kind was checked"),
         name: checked_name(t.name, display_name)?,
         srcs: resolve_srcs(t.srcs, t.src_globs, workspace_root, package, display_name)?,
         deps: normalize_deps(t.deps, package, display_name)?,
-        attrs: t.attrs,
+        attrs: string_attrs(t.attrs, display_name)?,
     })
+}
+
+fn decode_rule_attrs<T>(name: &str, mut attrs: toml::Table, display_name: &str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    attrs.insert("name".to_string(), toml::Value::String(name.to_string()));
+    toml::Value::Table(attrs)
+        .try_into()
+        .map_err(|e| Error::Eval {
+            path: display_name.to_string(),
+            message: format!("invalid attrs for target `{name}`: {e}"),
+        })
+}
+
+fn string_attrs(attrs: toml::Table, display_name: &str) -> Result<BTreeMap<String, String>> {
+    attrs
+        .into_iter()
+        .map(|(key, value)| match value {
+            toml::Value::String(value) => Ok((key, value)),
+            other => Err(Error::Eval {
+                path: display_name.to_string(),
+                message: format!("legacy target attr `{key}` must be a string, got {other}"),
+            }),
+        })
+        .collect()
 }
 
 fn task_target(
@@ -418,24 +685,10 @@ fn task_target(
     display_name: &str,
 ) -> Result<Target> {
     let mut attrs = BTreeMap::new();
-    attrs.insert(
-        "argv_json".to_string(),
-        serde_json::to_string(&t.argv).expect("task argv is serializable"),
-    );
-    if !t.env.is_empty() {
-        attrs.insert(
-            "env_json".to_string(),
-            serde_json::to_string(&t.env).expect("task env is serializable"),
-        );
-    }
-    if !t.outputs.is_empty() {
-        attrs.insert(
-            "outputs_json".to_string(),
-            serde_json::to_string(&t.outputs).expect("task outputs are serializable"),
-        );
-    }
+    insert_task_attrs(&mut attrs, &t.argv, &t.env, &t.outputs);
     insert_opt(&mut attrs, "cwd", t.cwd);
-    attrs.insert("cache".to_string(), t.cache.to_string());
+    let has_runtime = t.runtime.is_some();
+    attrs.insert("cache".to_string(), (t.cache && !has_runtime).to_string());
     if let Some(timeout_ms) = t.timeout_ms {
         attrs.insert("timeout_ms".to_string(), timeout_ms.to_string());
     }
@@ -445,14 +698,78 @@ fn task_target(
     if let Some(memory_bytes) = t.memory_bytes {
         attrs.insert("memory_bytes".to_string(), memory_bytes.to_string());
     }
+    if let Some(runtime) = t.runtime {
+        insert_runtime_attrs(&mut attrs, runtime, package, display_name)?;
+    }
     Ok(Target {
         package: package.to_string(),
-        kind: "task".to_string(),
+        kind: if has_runtime { "runtime_task" } else { "task" }.to_string(),
         name: checked_name(t.name, display_name)?,
         srcs: resolve_srcs(t.srcs, t.src_globs, workspace_root, package, display_name)?,
         deps: Vec::new(),
         attrs,
     })
+}
+
+fn insert_runtime_attrs(
+    attrs: &mut BTreeMap<String, String>,
+    runtime: RuntimeTask,
+    package: &str,
+    display_name: &str,
+) -> Result<()> {
+    let kind = runtime
+        .kind
+        .or(runtime.runtime)
+        .ok_or_else(|| Error::Eval {
+            path: display_name.to_string(),
+            message: "runtime metadata must set `kind`".to_string(),
+        })?;
+    attrs.insert("runtime".to_string(), kind);
+    if !runtime.capabilities.is_empty() {
+        attrs.insert(
+            "runtime_capabilities_json".to_string(),
+            serde_json::to_string(&runtime.capabilities)
+                .expect("runtime capabilities are serializable"),
+        );
+    }
+    if !runtime.interface.is_empty() {
+        attrs.insert(
+            "runtime_interfaces_json".to_string(),
+            serde_json::to_string(&runtime.interface).expect("runtime interfaces are serializable"),
+        );
+    }
+    if let Some(target) = runtime.target {
+        let normalized = normalize_build_dep(package, &target).map_err(|e| Error::Eval {
+            path: display_name.to_string(),
+            message: e.to_string(),
+        })?;
+        attrs.insert("runtime_target".to_string(), normalized);
+    }
+    Ok(())
+}
+
+fn insert_task_attrs(
+    attrs: &mut BTreeMap<String, String>,
+    argv: &[String],
+    env: &BTreeMap<String, String>,
+    outputs: &[String],
+) {
+    attrs.insert(
+        "argv_json".to_string(),
+        serde_json::to_string(argv).expect("task argv is serializable"),
+    );
+    if !env.is_empty() {
+        attrs.insert(
+            "env_json".to_string(),
+            serde_json::to_string(env).expect("task env is serializable"),
+        );
+    }
+    if !outputs.is_empty() {
+        attrs.insert(
+            "outputs_json".to_string(),
+            serde_json::to_string(outputs).expect("task outputs are serializable"),
+        );
+    }
 }
 
 fn insert_opt(attrs: &mut BTreeMap<String, String>, key: &str, value: Option<String>) {
@@ -582,6 +899,89 @@ deps = [":core"]
     }
 
     #[test]
+    fn loads_rule_targets_from_toml() {
+        let targets = load_toml_str(
+            "fabrik.toml",
+            r#"
+[[target]]
+name = "core"
+rule = "rust.library"
+
+[target.attrs]
+srcs = ["src/lib.rs"]
+edition = "2021"
+
+[[target]]
+name = "cli"
+rule = "rust.binary"
+
+[target.attrs]
+srcs = ["src/main.rs"]
+deps = ["core"]
+edition = "2021"
+"#,
+        )
+        .unwrap();
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].kind, "rust_library");
+        assert_eq!(targets[0].srcs, vec!["src/lib.rs".to_string()]);
+        assert_eq!(targets[1].kind, "rust_binary");
+        assert_eq!(targets[1].deps, vec!["core".to_string()]);
+    }
+
+    #[test]
+    fn loads_command_rule_with_runtime() {
+        let targets = load_toml_str(
+            "fabrik.toml",
+            r#"
+[[target]]
+name = "dev"
+rule = "command"
+
+[target.attrs]
+argv = ["npm", "run", "dev"]
+cache = true
+
+[target.runtime]
+kind = "web_server"
+capabilities = ["logs", "http"]
+
+[[target.runtime.interface]]
+name = "logs"
+kind = "stream"
+argv = ["tail", "-f", ".fabrik/runtime/dev/stdout.log"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].kind, "runtime_task");
+        assert_eq!(targets[0].attrs["cache"], "false");
+        assert_eq!(targets[0].attrs["runtime"], "web_server");
+        assert!(targets[0].attrs["runtime_capabilities_json"].contains("http"));
+    }
+
+    #[test]
+    fn loads_apple_simulator_app_rule() {
+        let targets = load_toml_str(
+            "fabrik.toml",
+            r#"
+[[target]]
+name = "Demo"
+rule = "apple.simulator_app"
+
+[target.attrs]
+platform = "ios"
+bundle_id = "dev.fabrik.demo"
+srcs = ["Sources/App.swift"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].kind, "apple_simulator_app");
+        assert_eq!(targets[0].attrs["platform"], "ios");
+    }
+
+    #[test]
     fn expands_src_globs() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
@@ -606,12 +1006,13 @@ src_globs = ["src/*.rs"]
     }
 
     #[test]
-    fn loads_apple_ios_app() {
+    fn loads_apple_simulator_app() {
         let targets = load_toml_str(
             "fabrik.toml",
             r#"
-[[apple.ios_app]]
+[[apple.simulator_app]]
 name = "Demo"
+platform = "ios"
 bundle_id = "dev.fabrik.demo"
 srcs = ["Sources/App.swift"]
 minimum_os = "17.0"
@@ -619,7 +1020,8 @@ minimum_os = "17.0"
         )
         .unwrap();
         assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].kind, "apple_ios_app");
+        assert_eq!(targets[0].kind, "apple_simulator_app");
+        assert_eq!(targets[0].attrs["platform"], "ios");
         assert_eq!(targets[0].attrs["bundle_id"], "dev.fabrik.demo");
         assert_eq!(targets[0].attrs["minimum_os"], "17.0");
     }
@@ -679,5 +1081,37 @@ GREETING = "hello"
         assert!(targets[0].attrs["argv_json"].contains("printf hello"));
         assert!(targets[0].attrs["env_json"].contains("GREETING"));
         assert!(targets[0].attrs["outputs_json"].contains("out.txt"));
+    }
+
+    #[test]
+    fn loads_runtime_task_target() {
+        let targets = load_toml_str(
+            "fabrik.toml",
+            r#"
+[[task]]
+name = "ios"
+argv = ["xcrun", "simctl", "launch", "booted", "dev.fabrik.demo"]
+
+[task.runtime]
+kind = "ios_simulator"
+target = "Demo"
+capabilities = ["logs", "ui_tree", "ui_action"]
+
+[[task.runtime.interface]]
+name = "logs"
+kind = "stream"
+argv = ["xcrun", "simctl", "spawn", "booted", "log", "stream"]
+description = "Stream simulator logs"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].kind, "runtime_task");
+        assert_eq!(targets[0].attrs["runtime"], "ios_simulator");
+        assert_eq!(targets[0].attrs["runtime_target"], "Demo");
+        assert_eq!(targets[0].attrs["cache"], "false");
+        assert!(targets[0].attrs["runtime_capabilities_json"].contains("ui_tree"));
+        assert!(targets[0].attrs["runtime_interfaces_json"].contains("logs"));
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,10 @@
 ## Supported Today
 
 - [Rust](rust.md): granular `rust.library`, `rust.binary`, `rust.test`, `rust.proc_macro`, plus the `cargo.binary` escape hatch.
-- [Apple and iOS](apple.md): build and launch a Swift iOS simulator app bundle.
-- [Tasks](tasks.md): checked-in runtime tasks that run through `fabrik run`.
+- [Apple](apple.md): build and launch a Swift iOS simulator app bundle.
+- [Rules and targets](rules.md): canonical `[[target]] rule = "..."` model and Starlark rule-authoring direction.
+- [Tasks](tasks.md): checked-in command targets that run through `fabrik run`.
+- [Runtime sessions](runtime.md): headless runtime target inspection and control model.
 - [Cache and execution](cache-and-execution.md): action cache, CAS, declared outputs, uncached runtime work, and resource bounds.
 
 ## Target IDs

--- a/docs/agent-native.md
+++ b/docs/agent-native.md
@@ -4,13 +4,13 @@ Fabrik should not stand out as "Bazel, but easier." The stronger position is:
 
 > Fabrik is the build system designed for coding agents and humans to understand, repair, and operate.
 
-Agents are effective when a system exposes structured data, schemas, precise causality, local reproductions, and machine-applicable patches. Fabrik should make those the default interface to builds, tests, runtime tasks, caching, and remote execution.
+Agents are effective when a system exposes structured data, schemas, precise causality, local reproductions, and machine-applicable patches. Fabrik should make those the default interface to builds, tests, runtime targets, caching, and remote execution.
 
 ## Standout Features
 
 ### Build Doctor
 
-Every failed build, test, or runtime task should produce a structured diagnosis object, not only logs.
+Every failed build, test, or runtime target should produce a structured diagnosis object, not only logs.
 
 The diagnosis should include:
 
@@ -100,16 +100,18 @@ Agents should be able to discover how to write a target from Fabrik itself:
 
 ```sh
 fabrik schema rust.binary
-fabrik explain-schema apple.ios_app
+fabrik explain-schema apple.simulator_app
 fabrik examples rust.test
 fabrik validate
 ```
 
 ### Runtime Observability
 
-Runtime tasks should be first-class. `fabrik run`, `fabrik test`, and checked-in task targets should expose structured state for live execution, retries, timeouts, side effects, simulator and process metadata, captured artifacts, and test failures.
+Runtime-capable targets should be first-class. `fabrik run`, `fabrik test`, and checked-in command targets should expose structured state for live execution, retries, timeouts, side effects, simulator and process metadata, captured artifacts, and test failures.
 
 For an iOS app, a failed launch should report whether the simulator was unavailable, bundle installation failed, the app crashed, signing failed, a runtime was missing, or boot timed out.
+
+Runtime metadata on `[[target]]` is the first concrete shape for this. A command target with `[target.runtime]` is an uncached runtime action that advertises a `runtime` descriptor in structured `fabrik run` output. The descriptor names the runtime kind, the subject being operated on, coarse capabilities, and concrete interfaces such as log streams, screenshots, accessibility tree capture, and UI actions.
 
 ### Cache Explainability
 

--- a/docs/apple.md
+++ b/docs/apple.md
@@ -1,7 +1,7 @@
 # Apple and Swift
 
 Fabrik supports granular Swift/macOS targets and a first-pass
-`apple.ios_app` target for Swift iOS simulator apps.
+`apple.simulator_app` target for Swift simulator apps.
 
 ## Swift Libraries and macOS Tools
 
@@ -53,13 +53,16 @@ module_name = "Greeter"
 bundle_id = "dev.fabrik.Greeter"
 ```
 
-## iOS Simulator Apps
+## Simulator Apps
 
-`apple.ios_app` builds a simulator `.app` bundle.
+`apple.simulator_app` builds a simulator `.app` bundle. The only
+supported platform today is `ios`; the target name leaves room for
+watchOS and tvOS simulator apps without introducing a second concept.
 
 ```toml
-[[apple.ios_app]]
+[[apple.simulator_app]]
 name = "Demo"
+platform = "ios"
 bundle_id = "dev.fabrik.ios-demo"
 srcs = ["Sources/App.swift"]
 minimum_os = "17.0"
@@ -86,7 +89,7 @@ FABRIK_IOS_SIMULATOR=<udid> fabrik run examples/apple/ios/simulator-app/Demo
 ## Cache Behavior
 
 - Swift libraries, Swift frameworks, macOS command-line applications,
-  and `apple.ios_app` builds are cacheable.
+  and `apple.simulator_app` builds are cacheable.
 - `fabrik run` first reuses the cacheable app build, then runs an uncached install and launch action.
 - Simulator boot, install, and launch are runtime side effects and are intentionally not cached.
 
@@ -96,6 +99,6 @@ FABRIK_IOS_SIMULATOR=<udid> fabrik run examples/apple/ios/simulator-app/Demo
 - SwiftPM package resolution/import is not wired yet. The intended shape
   is to use `Package.swift` for external package resolution while keeping
   the local build graph declared with Fabrik's lower-level TOML targets.
-- iOS app dependencies are not wired yet.
+- Simulator app dependencies are not wired yet.
 - Apple resource processing, asset catalogs, entitlements, and signing
   beyond simulator ad hoc signing are still future work.

--- a/docs/cache-and-execution.md
+++ b/docs/cache-and-execution.md
@@ -16,13 +16,13 @@ These are cacheable today:
 - Rust test binary execution.
 - `cargo.binary` actions.
 - Apple Swift compile, archive, framework, and macOS executable actions.
-- `apple.ios_app` build actions.
+- `apple.simulator_app` build actions.
 - `task` targets with `cache = true`.
 - Literal `fabrik exec` commands, unless the command or declared inputs change.
 
 These are intentionally uncached:
 
-- `apple.ios_app` simulator install and launch.
+- `apple.simulator_app` simulator install and launch.
 - `task` targets with `cache = false`.
 
 ## Resource Bounds

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,13 +67,13 @@ This is the dogfood gate. Don't proceed past Phase 3 until it's met.
 
 ## Phase 4: Adopted-mode Rust + second plugin (week 12-15)
 
-**Goal:** Add `rust.workspace` (adopted mode) so external cargo projects can drop in. Add a second built-in plugin (`task`) to validate the plugin contract against two real implementations.
+**Goal:** Add `rust.workspace` (adopted mode) so external cargo projects can drop in. Add a second built-in rule (`command`) to validate the rule contract against two real implementations.
 
 - `rust.workspace` target type: reads `Cargo.toml`, runs `cargo metadata` cooperatively, generates declared-mode targets internally. Same handlers as declared mode; cache entries kept in a separate namespace.
-- `task` plugin: generic runtime task target type for ad-hoc commands. Forces us to confirm the plugin SDK is reusable, not just rust-shaped.
-- Sharpen the plugin SDK based on what hurt during the second-plugin build: helper functions for action declaration, glob handling, output declaration, schema validation.
+- `command` rule: generic process target type for ad-hoc commands. Forces us to confirm the rule SDK is reusable, not just rust-shaped.
+- Sharpen the rule SDK based on what hurt during the second-rule build: helper functions for action declaration, glob handling, output declaration, schema validation.
 
-**Exit criterion:** an existing cargo workspace adopts Fabrik with one `fabrik.toml` file containing `[[rust.workspace]]` and gets cache hits across builds. The `task` plugin is usable for shell-out targets without poking inside Fabrik internals.
+**Exit criterion:** an existing cargo workspace adopts Fabrik with one `fabrik.toml` file containing `rule = "rust.workspace"` and gets cache hits across builds. The `command` rule is usable for shell-out targets without poking inside Fabrik internals.
 
 ## Phase 5: DSL maturity: profiles, LSP, schema registry (week 16-19)
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,165 @@
+# Rules and Targets
+
+Fabrik build files describe targets. A target names a rule, and the
+rule decides how attributes become actions, providers, runnable
+metadata, and runtime metadata.
+
+```toml
+[[target]]
+name = "cli"
+rule = "rust.binary"
+
+[target.attrs]
+srcs = ["src/main.rs"]
+deps = ["core"]
+edition = "2021"
+```
+
+This is the canonical shape. Older domain-specific tables such as
+`[[rust.binary]]` and `[[apple.simulator_app]]` are compatibility sugar
+for built-in rules.
+
+## Consumer Model
+
+Rust library and binary:
+
+```toml
+[[target]]
+name = "core"
+rule = "rust.library"
+
+[target.attrs]
+srcs = ["src/lib.rs"]
+edition = "2021"
+
+[[target]]
+name = "cli"
+rule = "rust.binary"
+
+[target.attrs]
+srcs = ["src/main.rs"]
+deps = ["core"]
+edition = "2021"
+```
+
+iOS simulator app:
+
+```toml
+[[target]]
+name = "Demo"
+rule = "apple.simulator_app"
+
+[target.attrs]
+platform = "ios"
+bundle_id = "dev.example.demo"
+srcs = ["Sources/App.swift"]
+minimum_os = "17.0"
+```
+
+Nx-style cached command:
+
+```toml
+[[target]]
+name = "bundle"
+rule = "command"
+
+[target.attrs]
+argv = ["pnpm", "vite", "build"]
+src_globs = ["src/**/*.ts", "src/**/*.tsx", "index.html"]
+outputs = ["dist"]
+env = { NODE_ENV = "production" }
+cache = true
+```
+
+Runtime-aware command:
+
+```toml
+[[target]]
+name = "dev"
+rule = "command"
+
+[target.attrs]
+argv = ["pnpm", "vite", "--host", "127.0.0.1"]
+cache = false
+
+[target.runtime]
+kind = "web_server"
+capabilities = ["logs", "http"]
+
+[[target.runtime.interface]]
+name = "logs"
+kind = "stream"
+argv = ["tail", "-f", ".fabrik/runtime/dev/stdout.log"]
+```
+
+Run any runnable target with the same verb:
+
+```sh
+fabrik run cli
+fabrik run Demo
+fabrik run --runtime-rpc dev
+```
+
+## Built-In Rules
+
+- `command`: generic process rule for cached or uncached commands.
+- `rust.library`, `rust.binary`, `rust.test`, `rust.proc_macro`.
+- `cargo.binary`, `cargo.build_script`.
+- `apple.simulator_app`, `apple.ios_app`, `apple.swift_library`,
+  `apple.static_framework`, `apple.dynamic_framework`,
+  `apple.macos_command_line_application`.
+
+## Rule Authoring
+
+Rules are not defined in `fabrik.toml`. `fabrik.toml` consumes rules by
+declaring targets. Rule packages should be authored separately.
+
+The intended extension language is Starlark because it gives Fabrik a
+deterministic rule and macro language without requiring third-party
+rules to be compiled into Fabrik itself.
+
+An eventual rule package could look like this:
+
+```python
+def _command_impl(ctx):
+    output_files = [ctx.actions.declare_file(path) for path in ctx.attr.outputs]
+    ctx.actions.run(
+        argv = ctx.attr.argv,
+        inputs = ctx.files.srcs,
+        outputs = output_files,
+        env = ctx.attr.env,
+    )
+    return [
+        DefaultInfo(files = output_files),
+        RunInfo(argv = ctx.attr.argv),
+    ]
+
+command = rule(
+    implementation = _command_impl,
+    attrs = {
+        "argv": attr.string_list(mandatory = True),
+        "srcs": attr.label_list(allow_files = True),
+        "outputs": attr.string_list(),
+        "env": attr.string_dict(),
+        "cache": attr.bool(default = True),
+    },
+    runnable = True,
+)
+```
+
+Macros should live in the same Starlark layer and expand to rule
+invocations:
+
+```python
+def rust_cli(name, srcs, deps = []):
+    rust_binary(
+        name = name,
+        srcs = srcs,
+        deps = deps,
+        edition = "2021",
+    )
+```
+
+Fabrik still owns scheduling, caching, CAS storage, runtime sessions,
+and the final action execution. Starlark rules should analyze
+attributes and declare actions; they should not run builds directly.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,342 @@
+# Runtime Targets and Headless Sessions
+
+Runtime targets are for side-effecting software that an agent may need to
+observe or control after launch: simulator apps, dev servers, desktop
+apps, emulators, and test harnesses with live state.
+
+## TOML Shape
+
+Fabrik attaches runtime metadata to targets:
+
+- `[[target]]`: target declaration.
+- `rule = "command"`: generic command rule, cacheable by default.
+- `[target.runtime]`: optional runtime inspection metadata for the
+  enclosing target. A command target with runtime metadata is never
+  cacheable.
+- `rule = "apple.simulator_app"`: Apple simulator app bundle. It uses
+  `platform = "ios"` today, with room for `watchos` and `tvos` later.
+
+```toml
+[[target]]
+name = "dev"
+rule = "command"
+
+[target.attrs]
+argv = ["npm", "run", "dev"]
+
+[target.runtime]
+kind = "web_server"
+capabilities = ["logs", "http", "screenshot"]
+
+[[target.runtime.interface]]
+name = "logs"
+kind = "stream"
+argv = ["tail", "-f", ".fabrik/runtime/dev/stdout.log"]
+```
+
+Structured `fabrik run` output includes a `runtime` descriptor:
+
+```json
+{
+  "target": "app/dev",
+  "kind": "runtime_task",
+  "runtime": {
+    "kind": "web_server",
+    "subject": "app/dev",
+    "capabilities": ["logs", "http"],
+    "interfaces": []
+  }
+}
+```
+
+## Headless Sessions
+
+Headless mode should make a running target inspectable without a GUI.
+The session should be local-first and file-backed so agents can recover
+after interruptions.
+
+```text
+.fabrik/runtime/<session-id>/
+  session.json
+  events.ndjson
+  stdout.log
+  stderr.log
+  artifacts/
+  control.sock
+```
+
+`session.json` records the target, runtime kind, pid or simulator UDID,
+start time, capabilities, and interface schemas. `events.ndjson`
+contains append-only lifecycle, log, artifact, UI, and diagnostic
+events. `control.sock` accepts local commands such as stop, restart,
+send input, capture screenshot, snapshot UI, tap, type text, and stream
+logs.
+
+## Transport
+
+Use JSON-RPC over a Unix domain socket for the first headless control
+plane, plus NDJSON for event replay and streaming. This keeps the
+protocol easy for coding agents, shell tools, and editors to consume
+without generated clients.
+
+For the normal agent workflow, ask `fabrik run` to create and serve the
+session:
+
+```sh
+fabrik run --runtime-rpc app/dev
+```
+
+Structured output includes the session path and socket:
+
+```json
+{
+  "runtime": {
+    "kind": "web_server",
+    "session": ".fabrik/runtime/app-dev-1778520000000",
+    "rpc": {
+      "transport": "jsonrpc",
+      "socket": ".fabrik/runtime/app-dev-1778520000000/control.sock"
+    }
+  }
+}
+```
+
+Serve the local RPC endpoint for an existing session directory when
+replaying or debugging a saved session:
+
+```sh
+fabrik runtime rpc .fabrik/runtime/<session-id>
+```
+
+The default socket is `.fabrik/runtime/<session-id>/control.sock`
+when the path fits platform limits. On platforms with short Unix
+socket path limits, Fabrik uses a temporary socket path and reports it
+in the run record.
+Requests are newline-delimited JSON-RPC 2.0 messages:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"runtime.describe","params":{}}
+```
+
+gRPC can be added later for remote runners or long-lived IDE
+integrations, but it should not be the only local protocol. Local
+agents need inspectable files, stable JSON, and simple streams more
+than they need a binary RPC dependency.
+
+## RPC Contract
+
+The runtime RPC contract should be platform-agnostic. A web server, an
+iOS simulator app, a macOS app, and an emulator should all expose the
+same core domains where the concepts overlap. Platform-specific
+features are extensions advertised through capabilities.
+
+Core domains:
+
+- `session`: identity, status, capabilities, and declared interfaces.
+- `events`: ordered lifecycle, log, diagnostic, artifact, and UI
+  events.
+- `logs`: queryable and streamable text records.
+- `artifacts`: screenshots, captures, traces, result bundles, and other
+  files.
+- `process`: generic lifecycle control.
+- `input`: generic text, signal, and stdin-style input where supported.
+
+Extension domains use runtime-specific prefixes:
+
+- `ui.*`: visual and accessibility inspection or interaction.
+- `apple.simulator.*`: simulator-only controls such as status bar,
+  location, appearance, hardware keyboard, and device buttons.
+- `browser.*`: browser-specific controls such as navigation, DOM
+  inspection, console logs, and network events.
+
+The extension rule is strict: if a method is useful outside one
+runtime, promote it to a core or shared domain. If it depends on a
+runtime-specific substrate, keep it behind a namespaced capability.
+
+### Session
+
+```json
+{
+  "id": "runtime.describe",
+  "params": {}
+}
+```
+
+Returns:
+
+```json
+{
+  "sessionId": "01HX...",
+  "target": "examples/apple/ios/simulator-app/Demo",
+  "runtime": { "kind": "ios_simulator", "platform": "ios" },
+  "state": "running",
+  "capabilities": [
+    "logs.query",
+    "logs.stream",
+    "artifacts.read",
+    "ui.snapshot",
+    "ui.action",
+    "apple.simulator.location"
+  ]
+}
+```
+
+### Events
+
+`events.subscribe` streams new events after an optional cursor.
+`events.query` replays events from `events.ndjson`.
+
+Every event has the same envelope:
+
+```json
+{
+  "cursor": "00000000042",
+  "time": "2026-05-11T16:20:00Z",
+  "domain": "logs",
+  "kind": "record",
+  "severity": "info",
+  "source": "stdout",
+  "payload": {}
+}
+```
+
+### Logs
+
+Logs are a core domain because every runtime can expose them, even if
+the backend source differs.
+
+```json
+{
+  "id": "logs.query",
+  "params": {
+    "source": "app",
+    "since": "2026-05-11T16:00:00Z",
+    "levels": ["error", "warn"],
+    "text": "database",
+    "limit": 200
+  }
+}
+```
+
+```json
+{
+  "id": "logs.stream",
+  "params": {
+    "source": "app",
+    "cursor": "00000000100",
+    "levels": ["info", "warn", "error"]
+  }
+}
+```
+
+The normalized log record shape:
+
+```json
+{
+  "time": "2026-05-11T16:20:00Z",
+  "source": "app",
+  "level": "info",
+  "message": "Started",
+  "fields": {
+    "process": "Demo",
+    "pid": 1234,
+    "subsystem": "dev.fabrik"
+  }
+}
+```
+
+For Apple simulators, `source = "app"` might come from `simctl spawn
+log stream`; for a web server, it might come from stdout. Agents should
+not need to care.
+
+### Artifacts
+
+Artifacts are files with metadata and stable paths:
+
+```json
+{
+  "id": "artifacts.list",
+  "params": { "kind": "screenshot" }
+}
+```
+
+```json
+{
+  "id": "artifacts.read",
+  "params": { "artifactId": "screenshot/latest" }
+}
+```
+
+The response returns metadata plus a path or bytes depending on the
+transport:
+
+```json
+{
+  "artifactId": "screenshot/latest",
+  "kind": "screenshot",
+  "mediaType": "image/png",
+  "path": ".fabrik/runtime/01HX/artifacts/screenshot.png"
+}
+```
+
+### UI
+
+UI is shared by many runtimes but optional. A runtime advertises
+`ui.snapshot` when it can inspect UI state and `ui.action` when it can
+interact with it.
+
+```json
+{
+  "id": "ui.snapshot",
+  "params": { "format": "accessibility-tree" }
+}
+```
+
+```json
+{
+  "id": "ui.perform",
+  "params": {
+    "action": "tap",
+    "target": { "label": "Continue" }
+  }
+}
+```
+
+Coordinates are a fallback. Stable element ids or accessibility labels
+are preferred because they survive screen size and density differences.
+
+### Platform Extensions
+
+Apple simulator-specific actions stay in an extension domain:
+
+```json
+{
+  "id": "apple.simulator.setLocation",
+  "params": { "latitude": 52.52, "longitude": 13.405 }
+}
+```
+
+```json
+{
+  "id": "apple.simulator.setAppearance",
+  "params": { "appearance": "dark" }
+}
+```
+
+An agent discovers these through `runtime.describe`. It should never
+guess that a session supports an extension just because the runtime kind
+looks familiar.
+
+## Agent Model
+
+A coding harness usually separates:
+
+- process execution, captured as stdout, stderr, exit status, and
+  lifecycle events
+- artifacts, written to stable paths
+- control actions, exposed as small typed commands
+- observation streams, replayable from disk and subscribable live
+
+Fabrik runtime sessions should follow that model. A human can still run
+`fabrik run`; an agent can run it, read the returned session id, tail
+events, and send control messages through the socket.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,10 +1,14 @@
-# Tasks
+# Command Targets
 
-Fabrik supports checked-in runtime tasks through `[[task]]` targets. Run them with `fabrik run`.
+Fabrik supports checked-in command targets through the built-in
+`command` rule. Run them with `fabrik run`.
 
 ```toml
-[[task]]
+[[target]]
 name = "print"
+rule = "command"
+
+[target.attrs]
 argv = ["/bin/sh", "-c", "cat tasks/input.txt"]
 srcs = ["input.txt"]
 ```
@@ -15,7 +19,6 @@ fabrik run tasks/print
 
 ## Fields
 
-- `name`: target name.
 - `argv`: command and arguments.
 - `srcs`: package-relative inputs that participate in the cache key.
 - `src_globs`: package-relative glob inputs.
@@ -30,11 +33,14 @@ fabrik run tasks/print
 Environment values use a TOML subtable:
 
 ```toml
-[[task]]
+[[target]]
 name = "with_env"
+rule = "command"
+
+[target.attrs]
 argv = ["/bin/sh", "-c", "printf \"$MESSAGE\""]
 
-[task.env]
+[target.attrs.env]
 MESSAGE = "hello"
 ```
 
@@ -45,10 +51,77 @@ Tasks are cacheable by default. The cache key includes argv, env, cwd, declared 
 Use `cache = false` for tasks with runtime side effects:
 
 ```toml
-[[task]]
+[[target]]
 name = "counter"
+rule = "command"
+
+[target.attrs]
 argv = ["/bin/sh", "-c", "printf run >> tasks/log"]
 cache = false
 ```
 
 Uncached tasks still run through the same bounded executor, but every invocation gets a fresh action key.
+
+## Build-Like Tasks
+
+Use `srcs`, `outputs`, and the default `cache = true` when a command behaves like a build step:
+
+```toml
+[[target]]
+name = "bundle"
+rule = "command"
+
+[target.attrs]
+argv = ["./scripts/bundle.sh"]
+src_globs = ["src/**/*.js"]
+outputs = [".fabrik/out/app/bundle.js"]
+```
+
+This stays a `command` rule target; there is no separate build-task
+namespace. Domain-specific rules such as `rust.binary`, `cargo.binary`,
+and `apple.simulator_app` are still preferred when Fabrik has native
+semantics for the toolchain.
+
+## Runtime Metadata
+
+Add a nested `runtime` table when a command launches or attaches to
+software that an agent should inspect or interact with through a stable
+surface. Runtime-aware commands are always uncached, regardless of the
+`cache` field.
+
+```toml
+[[target]]
+name = "ios_demo"
+rule = "command"
+
+[target.attrs]
+argv = ["xcrun", "simctl", "launch", "booted", "dev.fabrik.demo"]
+
+[target.runtime]
+kind = "ios_simulator"
+target = "App/Demo"
+capabilities = ["logs", "ui_tree", "ui_action"]
+
+[[target.runtime.interface]]
+name = "logs"
+kind = "stream"
+argv = ["xcrun", "simctl", "spawn", "booted", "log", "stream"]
+description = "Stream simulator logs"
+
+[[target.runtime.interface]]
+name = "ui_tree"
+kind = "accessibility"
+argv = ["axe", "describe-ui", "--udid", "booted"]
+description = "Inspect the visible accessibility hierarchy"
+```
+
+Under `--format json` and `--format toon`, the run record includes a `runtime` object with:
+
+- `kind`: the runtime family, for example `ios_simulator`.
+- `subject`: the target or runtime object being operated on.
+- `session`: session directory when `fabrik run --runtime-rpc` is active.
+- `rpc`: JSON-RPC transport metadata when `fabrik run --runtime-rpc` is active.
+- `capabilities`: coarse feature names such as `logs`, `screenshot`, `ui_tree`, or `ui_action`.
+- `interfaces`: named commands an agent can use after launch.
+
+`apple.simulator_app` targets also emit a default `ios_simulator` runtime descriptor after launch. It advertises log streaming, screenshots, accessibility tree inspection, and accessibility-targeted taps so agents have a common starting point for simulator inspection.

--- a/examples/apple/ios/simulator-app/README.md
+++ b/examples/apple/ios/simulator-app/README.md
@@ -2,7 +2,7 @@
 
 This example represents a first-pass SwiftUI iOS simulator app bundle.
 
-It uses `apple.ios_app` to compile Swift sources, assemble an `.app`
+It uses `apple.simulator_app` to compile Swift sources, assemble an `.app`
 bundle, write `Info.plist`, sign the bundle, and launch it through the
 simulator flow when run.
 

--- a/examples/apple/ios/simulator-app/fabrik.toml
+++ b/examples/apple/ios/simulator-app/fabrik.toml
@@ -1,5 +1,6 @@
-[[apple.ios_app]]
+[[apple.simulator_app]]
 name = "Demo"
+platform = "ios"
 bundle_id = "dev.fabrik.ios-demo"
 srcs = ["Sources/App.swift"]
 minimum_os = "17.0"

--- a/spec/build_spec.sh
+++ b/spec/build_spec.sh
@@ -139,15 +139,16 @@ struct DemoApp: App {
 }
 EOF
     cat > "$WORKSPACE/App/fabrik.toml" <<'EOF'
-[[apple.ios_app]]
+[[apple.simulator_app]]
 name = "Demo"
+platform = "ios"
 bundle_id = "dev.fabrik.demo"
 srcs = ["Sources/App.swift"]
 minimum_os = "17.0"
 EOF
     When call env PATH="$WORKSPACE/bin:$PATH" "$FABRIK_BIN" -C "$WORKSPACE" build App/Demo
     The status should be success
-    The stderr should include 'apple_ios_app'
+    The stderr should include 'apple_simulator_app'
     The path "$WORKSPACE/.fabrik/out/App/Demo.app" should be directory
     The path "$WORKSPACE/.fabrik/out/App/Demo.app/Info.plist" should be file
     The path "$WORKSPACE/.fabrik/out/App/Demo.app/Demo" should be file

--- a/spec/cli_surface_spec.sh
+++ b/spec/cli_surface_spec.sh
@@ -12,6 +12,7 @@ Describe 'fabrik --help'
     The stdout should include 'test'
     The stdout should include 'exec'
     The stdout should include 'cache'
+    The stdout should include 'runtime'
     The stdout should include '--directory'
     The stdout should include 'toon'
   End

--- a/spec/examples_apple_spec.sh
+++ b/spec/examples_apple_spec.sh
@@ -54,7 +54,7 @@ Describe 'Apple examples'
     fake_apple_tools
     When call env PATH="$WORKSPACE/bin:$PATH" "$FABRIK_BIN" -C "$WORKSPACE" build examples/apple/ios/simulator-app/Demo
     The status should be success
-    The stderr should include 'apple_ios_app'
+    The stderr should include 'apple_simulator_app'
     The path "$WORKSPACE/.fabrik/out/examples/apple/ios/simulator-app/Demo.app" should be directory
     The path "$WORKSPACE/.fabrik/out/examples/apple/ios/simulator-app/Demo.app/Info.plist" should be file
     The path "$WORKSPACE/.fabrik/out/examples/apple/ios/simulator-app/Demo.app/Demo" should be file

--- a/spec/run_spec.sh
+++ b/spec/run_spec.sh
@@ -91,7 +91,7 @@ EOF
     The path "$WORKSPACE/target/debug/app" should be exist
   End
 
-  It 'runs a task target declared in fabrik.toml'
+  It 'runs a legacy task target declared in fabrik.toml'
     mkdir -p "$WORKSPACE/tasks"
     cat > "$WORKSPACE/tasks/input.txt" <<'EOF'
 hello task
@@ -108,7 +108,7 @@ EOF
     The stderr should include 'cache miss'
   End
 
-  It 'reuses the cache for a cacheable task target'
+  It 'reuses the cache for a cacheable legacy task target'
     mkdir -p "$WORKSPACE/tasks"
     cat > "$WORKSPACE/tasks/input.txt" <<'EOF'
 cached task
@@ -126,7 +126,7 @@ EOF
     The stderr should include 'cache hit'
   End
 
-  It 'runs an uncached task target every time'
+  It 'runs an uncached legacy task target every time'
     mkdir -p "$WORKSPACE/tasks"
     cat > "$WORKSPACE/tasks/fabrik.toml" <<'EOF'
 [[task]]
@@ -141,7 +141,36 @@ EOF
     The stderr should include 'cache miss'
   End
 
-  It 'builds and launches an apple_ios_app target'
+  It 'runs a runtime command target and emits its runtime interfaces'
+    mkdir -p "$WORKSPACE/tasks"
+    cat > "$WORKSPACE/tasks/fabrik.toml" <<'EOF'
+[[target]]
+name = "launch"
+rule = "command"
+
+[target.attrs]
+argv = ["/bin/sh", "-c", "printf launched"]
+
+[target.runtime]
+kind = "ios_simulator"
+capabilities = ["logs", "ui_tree", "ui_action"]
+
+[[target.runtime.interface]]
+name = "logs"
+kind = "stream"
+argv = ["xcrun", "simctl", "spawn", "booted", "log", "stream"]
+description = "Stream simulator logs"
+EOF
+    When call "$FABRIK_BIN" --format json -C "$WORKSPACE" run tasks/launch
+    The status should be success
+    The stdout should include '"kind":"runtime_task"'
+    The stdout should include '"runtime":{"kind":"ios_simulator"'
+    The stdout should include '"capabilities":["logs","ui_tree","ui_action"]'
+    The stdout should include '"name":"logs"'
+    The stdout should include '"argv":["xcrun","simctl","spawn","booted","log","stream"]'
+  End
+
+  It 'builds and launches an apple_simulator_app target'
     mkdir -p "$WORKSPACE/bin" "$WORKSPACE/App/Sources"
     cat > "$WORKSPACE/bin/xcrun" <<'EOF'
 #!/bin/sh
@@ -192,8 +221,9 @@ struct DemoApp: App {
 }
 EOF
     cat > "$WORKSPACE/App/fabrik.toml" <<'EOF'
-[[apple.ios_app]]
+[[apple.simulator_app]]
 name = "Demo"
+platform = "ios"
 bundle_id = "dev.fabrik.demo"
 srcs = ["Sources/App.swift"]
 minimum_os = "17.0"
@@ -203,6 +233,70 @@ EOF
     The stderr should include 'cache miss'
     The contents of file "$WORKSPACE/simctl.log" should include 'simctl install booted'
     The contents of file "$WORKSPACE/simctl.log" should include 'simctl launch booted dev.fabrik.demo'
+  End
+
+  It 'emits simulator runtime interfaces for an apple_simulator_app target'
+    mkdir -p "$WORKSPACE/bin" "$WORKSPACE/App/Sources"
+    cat > "$WORKSPACE/bin/xcrun" <<'EOF'
+#!/bin/sh
+if [ "$1" = "--sdk" ] && [ "$3" = "--show-sdk-path" ]; then
+  echo "/tmp/fake-iphonesimulator.sdk"
+  exit 0
+fi
+if [ "$1" = "--sdk" ] && [ "$3" = "swiftc" ]; then
+  shift 3
+  exec swiftc "$@"
+fi
+if [ "$1" = "simctl" ]; then
+  exit 0
+fi
+exit 2
+EOF
+    cat > "$WORKSPACE/bin/swiftc" <<'EOF'
+#!/bin/sh
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+mkdir -p "$(dirname "$out")"
+printf 'fake app binary' > "$out"
+EOF
+    cat > "$WORKSPACE/bin/codesign" <<'EOF'
+#!/bin/sh
+for last do :; done
+app="$last"
+mkdir -p "$app/_CodeSignature"
+printf 'signed' > "$app/_CodeSignature/CodeResources"
+EOF
+    chmod +x "$WORKSPACE/bin/xcrun" "$WORKSPACE/bin/swiftc" "$WORKSPACE/bin/codesign"
+    cat > "$WORKSPACE/App/Sources/App.swift" <<'EOF'
+import SwiftUI
+
+@main
+struct DemoApp: App {
+    var body: some Scene {
+        WindowGroup { Text("Hello") }
+    }
+}
+EOF
+    cat > "$WORKSPACE/App/fabrik.toml" <<'EOF'
+[[apple.simulator_app]]
+name = "Demo"
+platform = "ios"
+bundle_id = "dev.fabrik.demo"
+srcs = ["Sources/App.swift"]
+minimum_os = "17.0"
+EOF
+    When call env PATH="$WORKSPACE/bin:$PATH" "$FABRIK_BIN" --format json -C "$WORKSPACE" run App/Demo
+    The status should be success
+    The stdout should include '"runtime":{"kind":"ios_simulator"'
+    The stdout should include '"capabilities":["logs","screenshot","ui_tree","ui_action"]'
+    The stdout should include '"name":"ui_tree"'
+    The stdout should include '"name":"tap"'
   End
 
   It 'errors when the target id does not match any target'


### PR DESCRIPTION
## Summary

Adds agent-friendly runtime sessions and aligns Fabrik around a target/rule model.

- Makes `[[target]]` with `rule = "..."` the canonical TOML shape for built-in rules such as `rust.binary`, `apple.simulator_app`, and `command`.
- Keeps existing `[[rust.*]]`, `[[apple.*]]`, and `[[task]]` declarations as compatibility sugar that lower to the same internal target model.
- Documents Starlark as the intended rule and macro authoring layer, with Fabrik retaining ownership of scheduling, caching, CAS, actions, and runtime sessions.
- Adds nested `[target.runtime]` metadata for runnable targets that should expose runtime capabilities and interfaces to agents.
- Adds `fabrik run --runtime-rpc <target>` to create a file-backed runtime session and serve a local JSON-RPC control socket from the run command.
- Keeps `fabrik runtime rpc <session-dir>` as a lower-level replay or debugging command for an existing session directory.
- Renames the Apple simulator target shape to `[[apple.simulator_app]]` with `platform = "ios"`, while keeping compatibility for `[[apple.ios_app]]`.
- Emits runtime descriptors from `fabrik run` for runtime-aware command targets and Apple simulator apps so agents can discover logs, screenshots, UI tree, and UI action capabilities.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test --workspace`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise exec -- cargo build --release`
- `mise exec -- shellspec spec/cli_surface_spec.sh spec/build_spec.sh spec/run_spec.sh spec/examples_apple_spec.sh spec/examples_targets_spec.sh`
- Manual Apple simulator run for `examples/apple/ios/simulator-app/Demo`
- Manual JSON-RPC smoke test against `fabrik runtime rpc`
- Manual `fabrik run --runtime-rpc` smoke test using `[[target]] rule = "command"` and querying stdout logs through the reported socket