### PR TITLE
chore: add Blick review configuration

### DIFF
--- a/.blick/skills/fabrik-rust-review/SKILL.md
+++ b/.blick/skills/fabrik-rust-review/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: fabrik-rust-review
+description: Project-specific PR-review rules for the tuist/fabrik Rust workspace. Focuses on the things only this repo knows: the adopted root build path, `fabrik.toml` placement, workspace-local `.fabrik/out` semantics, toolchain pinning, shellspec coverage, and keeping crate roots small.
+---
+
+# Fabrik Rust Review
+
+This skill is intentionally narrow. **Generic Rust style, formatting,
+naming, and most lint hygiene are already covered by `rustfmt` and
+`clippy` in CI, so do not flag those.** Focus on the repo-specific
+rules below.
+
+For each finding, cite `path:line` and quote the relevant snippet.
+
+---
+
+## 1. The repo root stays on the adopted `cargo_binary` path
+
+The workspace root currently ships `fabrik` through a root
+`[[cargo.binary]]` target in `fabrik.toml`. That is the production path
+until granular third-party build-script and feature support is complete.
+
+### Flag
+
+- **A diff that changes the repo-root `fabrik.toml` away from
+  `[[cargo.binary]]` for `name = "fabrik"` / `cargo_package =
+  "fabrik-cli"` without also showing that the missing granular
+  third-party support is implemented.** This is a correctness and
+  self-hosting risk. **Severity: high.**
+- **Docs or CLI help that claim the repo self-host now builds through
+  the granular Rust path by default.** **Severity: medium.**
+
+### Do not flag
+
+- Example workspaces under `examples/` that intentionally demonstrate
+  granular targets.
+
+---
+
+## 2. Build manifests live in `fabrik.toml`, not under `.fabrik/`
+
+The `.fabrik/` directory is the workspace cache and output area. It is
+not a source-controlled manifest location.
+
+### Flag
+
+- **A new checked-in `fabrik.toml` under `.fabrik/` or code that treats
+  `.fabrik/**/fabrik.toml` as a real package manifest.** This confuses
+  cache state with source state. **Severity: high.**
+- **Docs or tests that instruct contributors to edit `.fabrik/` as if it
+  were the canonical project config.** **Severity: medium.**
+
+### Do not flag
+
+- Tests that intentionally assert `.fabrik/` is skipped during workspace
+  discovery.
+
+---
+
+## 3. Build outputs stay under workspace-local `.fabrik/out`
+
+This repo intentionally keeps build outputs under
+`<workspace>/.fabrik/out/...` rather than moving them into an XDG cache
+or a global state directory.
+
+### Flag
+
+- **Code that relocates user-visible build artifacts away from
+  `.fabrik/out/...` without an explicit compatibility plan.**
+  **Severity: high.**
+- **CLI help, tests, or docs that drift away from the `.fabrik/out/...`
+  contract after artifact-path changes.** **Severity: medium.**
+
+### Do not flag
+
+- CAS storage and other internal global-cache metadata that do not
+  change the user-visible output location.
+
+---
+
+## 4. Toolchain pinning and command invocation must stay aligned
+
+The repo deliberately pins Rust in both `mise.toml` and the workspace
+`Cargo.toml`, and contributor-facing commands should use `mise exec --`.
+
+### Flag
+
+- **A diff that changes `mise.toml` `rust = "..."`
+  without the matching workspace `rust-version` change in `Cargo.toml`,
+  or vice versa.** **Severity: medium.**
+- **A toolchain bump without the matching spec updates or without any
+  explanation in the diff.** **Severity: medium.**
+- **Contributor docs, scripts, or tests that invoke `cargo` directly for
+  this repo instead of `mise exec -- cargo ...`.** **Severity: medium.**
+
+### Do not flag
+
+- Internal implementation code that shells out to Cargo as product
+  behavior rather than contributor workflow documentation.
+
+---
+
+## 5. CLI contract changes need ShellSpec coverage
+
+`spec/*.sh` is the end-to-end contract for the CLI.
+
+### Flag
+
+- **A change under `crates/fabrik-cli/src/` that alters user-visible
+  command behavior, help text, stdout/stderr, exit status, or declared
+  artifact paths without matching ShellSpec coverage.**
+  **Severity: medium.**
+- **A new CLI subcommand or error message path without an end-to-end spec
+  exercising it.** **Severity: medium.**
+
+### Do not flag
+
+- Pure refactors that do not change observable CLI behavior.
+
+---
+
+## 6. Planner/compiler behavior changes need focused tests nearby
+
+Most semantic behavior in this repo is verifiable with in-process Rust
+tests next to the module that changed.
+
+### Flag
+
+- **A semantic change in `crates/fabrik-core`, `fabrik-frontend`,
+  `fabrik-rust`, `fabrik-elixir`, `fabrik-apple`, or `fabrik-cas`
+  without focused unit tests near the changed code or a strong
+  end-to-end spec covering the same behavior.** **Severity: medium.**
+- **Changes to digest stability, manifest parsing, target planning,
+  output-path generation, cache keys, or toolchain resolution that land
+  without tests.** **Severity: medium.**
+
+### Do not flag
+
+- Test-only refactors or comment-only changes.
+
+---
+
+## 7. Keep `lib.rs` and `main.rs` as dispatch tables
+
+This repo prefers crate roots that read like a table of contents:
+`mod` declarations, re-exports, and light dispatch, not mixed
+implementation.
+
+### Flag
+
+- **A new or heavily expanded `lib.rs` / `main.rs` that mixes unrelated
+  logic or grows into a monolith instead of splitting modules.**
+  **Severity: low.**
+
+### Do not flag
+
+- Small crate roots that remain mostly declarations and re-exports.
+
+---
+
+## 8. No em dashes in user-facing text
+
+README copy, CLI help, error messages, commit text, and docs should not
+use em dashes in this repo.
+
+### Flag
+
+- **New user-facing strings or documentation that introduce an em dash
+  character.** **Severity: low.**
+
+---
+
+## Out of scope
+
+- Generic naming, formatting, or lint nits already enforced by
+  `rustfmt`/`clippy`
+- Suggestions to add comments where the code is already clear
+- Suggestions to move tests away from the module they exercise

--- a/.github/workflows/blick.yml
+++ b/.github/workflows/blick.yml
@@ -1,0 +1,70 @@
+name: blick
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: blick-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_ATTESTATIONS: 0
+
+jobs:
+  review:
+    name: Review
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: install mise toolchain
+        uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "node"
+
+      - name: install blick and opencode
+        run: |
+          mise use -g github:tuist/blick
+          mise use -g npm:opencode-ai
+
+      - name: run blick review
+        env:
+          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${FIREWORKS_API_KEY:-}" ]; then
+            echo "FIREWORKS_API_KEY is not set; add it to repo secrets so opencode can authenticate against Fireworks." >&2
+            exit 1
+          fi
+          blick review \
+            --base "origin/${{ github.event.pull_request.base.ref }}" \
+            --json --stream
+
+      - name: publish review
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: blick publish
+
+      - name: upload run logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blick-runs
+          path: .blick/runs/
+          if-no-files-found: ignore

--- a/.github/workflows/blick.yml
+++ b/.github/workflows/blick.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: install mise toolchain
-        uses: jdx/mise-action@v4.0.1
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           install_args: "node github:tuist/blick npm:opencode-ai"

--- a/.github/workflows/blick.yml
+++ b/.github/workflows/blick.yml
@@ -34,23 +34,12 @@ jobs:
         uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "node"
-
-      - name: install blick and opencode
-        run: |
-          mise use -g github:tuist/blick
-          mise use -g npm:opencode-ai
+          install_args: "node github:tuist/blick npm:opencode-ai"
 
       - name: run blick review
         env:
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-        shell: bash
         run: |
-          set -euo pipefail
-          if [ -z "${FIREWORKS_API_KEY:-}" ]; then
-            echo "FIREWORKS_API_KEY is not set; add it to repo secrets so opencode can authenticate against Fireworks." >&2
-            exit 1
-          fi
           blick review \
             --base "origin/${{ github.event.pull_request.base.ref }}" \
             --json --stream

--- a/.github/workflows/fabrik.yml
+++ b/.github/workflows/fabrik.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           shared-key: clippy
           cache-on-failure: true
-          cache-bin: true
+          cache-bin: false
 
       - name: cargo clippy
         run: mise exec -- cargo clippy --workspace --all-targets -- -D warnings
@@ -83,7 +83,7 @@ jobs:
         with:
           shared-key: unit-tests-${{ matrix.os }}
           cache-on-failure: true
-          cache-bin: true
+          cache-bin: false
 
       - name: cargo test
         run: mise exec -- cargo test --workspace --all-targets
@@ -109,7 +109,7 @@ jobs:
         with:
           shared-key: release-build-${{ matrix.os }}
           cache-on-failure: true
-          cache-bin: true
+          cache-bin: false
 
       - name: cargo build
         run: mise exec -- cargo build --release
@@ -142,7 +142,7 @@ jobs:
         with:
           shared-key: targets-${{ matrix.os }}
           cache-on-failure: true
-          cache-bin: true
+          cache-bin: false
 
       - name: download fabrik binary
         uses: actions/download-artifact@v4
@@ -178,7 +178,7 @@ jobs:
         with:
           shared-key: dogfood-${{ matrix.os }}
           cache-on-failure: true
-          cache-bin: true
+          cache-bin: false
 
       - name: download fabrik binary
         uses: actions/download-artifact@v4
@@ -214,7 +214,7 @@ jobs:
         with:
           shared-key: shellspec-${{ matrix.os }}
           cache-on-failure: true
-          cache-bin: true
+          cache-bin: false
 
       - name: download fabrik binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/fabrik.yml
+++ b/.github/workflows/fabrik.yml
@@ -35,7 +35,7 @@ jobs:
         run: rustup component add rustfmt
 
       - name: cargo fmt
-        run: cargo fmt --all -- --check
+        run: mise exec -- cargo fmt --all -- --check
 
   clippy:
     name: clippy
@@ -60,7 +60,7 @@ jobs:
           cache-bin: true
 
       - name: cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: mise exec -- cargo clippy --workspace --all-targets -- -D warnings
 
   unit-tests:
     name: unit tests (${{ matrix.os }})
@@ -112,7 +112,7 @@ jobs:
           cache-bin: true
 
       - name: cargo build
-        run: cargo build --release
+        run: mise exec -- cargo build --release
 
       - name: upload fabrik binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/fabrik.yml
+++ b/.github/workflows/fabrik.yml
@@ -86,7 +86,7 @@ jobs:
           cache-bin: true
 
       - name: cargo test
-        run: cargo test --workspace --all-targets
+        run: mise exec -- cargo test --workspace --all-targets
 
   release-build:
     name: release build (${{ matrix.os }})

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /.fabrik
+/.blick/runs/
 /vendor
 *.swp
 .DS_Store

--- a/blick.toml
+++ b/blick.toml
@@ -1,0 +1,34 @@
+[agent]
+kind = "opencode"
+model = "fireworks-ai/accounts/fireworks/models/kimi-k2p5"
+
+[defaults]
+base = "origin/main"
+max_concurrency = 2
+fail_on = "high"
+
+[[skills]]
+name = "rust-best-practices"
+source = "apollographql/skills"
+subpath = "skills/rust-best-practices"
+
+[[skills]]
+name = "fabrik-rust-review"
+source = "./.blick/skills/fabrik-rust-review"
+
+[[reviews]]
+name = "default"
+skills = ["rust-best-practices", "fabrik-rust-review"]
+prompt = """
+Focus on correctness, invalidation, build-graph behavior, artifact paths,
+CLI contract regressions, and test coverage.
+
+Skip style nits since rustfmt, clippy, and shellspec already cover the basics.
+"""
+
+[learn]
+lookback_days = 7
+min_signal = 3
+base = "main"
+draft = true
+branch = "blick/learn"

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,9 @@ rust = "1.86"
 shellspec = "latest"
 git-cliff = "2.12.0"
 "github:tuist/fabrik" = "0.7.0"
+"github:tuist/blick" = "0.8.0"
 node = "22.11.0"
+"npm:opencode-ai" = "1.15.0"
 aube = "1.10.4"
 # Elixir + OTP power the granular elixir.* targets and the compile
 # daemon spec tests. Pinned to a precompiled elixir-on-otp pair so


### PR DESCRIPTION
## Summary
- add a root `blick.toml` that configures an `opencode`-backed default review against `origin/main`
- combine Apollo's remote `rust-best-practices` skill with a local `fabrik-rust-review` skill for Fabrik-specific review rules
- teach Blick to flag adopted-vs-granular build path regressions, `.fabrik/out` contract drift, toolchain pin mismatches, and missing ShellSpec or focused unit coverage
- ignore `.blick/runs/` review artifacts in git

## Testing
- `git diff --check`
- `mise exec -- cargo run -- config --repo /Users/pepicrft/.superconductor/worktrees/fabrik/sc-zero-meissner-cb3b --explain` (run from `/Users/pepicrft/src/github.com/tuist/blick`)
- Fabrik test suite not run (not requested)
