### PR TITLE
refactor: architectural review pass and add --quiet flag

### DIFF
--- a/crates/fabrik-apple/src/artifact.rs
+++ b/crates/fabrik-apple/src/artifact.rs
@@ -1,9 +1,8 @@
 pub fn app_bundle_path(package: &str, name: &str) -> String {
-    if package.is_empty() {
-        format!(".fabrik/out/{name}.app")
-    } else {
-        format!(".fabrik/out/{package}/{name}.app")
-    }
+    format!(
+        "{}.app",
+        fabrik_frontend::workspace_output_dir(package, name)
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,11 +115,7 @@ impl SwiftLinkInput {
 }
 
 pub fn swift_out_dir(package: &str, name: &str) -> String {
-    if package.is_empty() {
-        format!(".fabrik/out/{name}")
-    } else {
-        format!(".fabrik/out/{package}/{name}")
-    }
+    fabrik_frontend::workspace_output_dir(package, name)
 }
 
 pub fn swift_static_library_path(out_dir: &str, module_name: &str) -> String {
@@ -128,22 +123,18 @@ pub fn swift_static_library_path(out_dir: &str, module_name: &str) -> String {
 }
 
 pub fn executable_path(package: &str, name: &str) -> String {
-    if package.is_empty() {
-        format!(".fabrik/out/{name}{}", std::env::consts::EXE_SUFFIX)
-    } else {
-        format!(
-            ".fabrik/out/{package}/{name}{}",
-            std::env::consts::EXE_SUFFIX
-        )
-    }
+    format!(
+        "{}{}",
+        fabrik_frontend::workspace_output_dir(package, name),
+        std::env::consts::EXE_SUFFIX
+    )
 }
 
 pub fn framework_path(package: &str, name: &str) -> String {
-    if package.is_empty() {
-        format!(".fabrik/out/{name}.framework")
-    } else {
-        format!(".fabrik/out/{package}/{name}.framework")
-    }
+    format!(
+        "{}.framework",
+        fabrik_frontend::workspace_output_dir(package, name)
+    )
 }
 
 pub fn parent_dir(path: &str) -> String {

--- a/crates/fabrik-apple/src/plan.rs
+++ b/crates/fabrik-apple/src/plan.rs
@@ -1,9 +1,8 @@
-use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use fabrik_core::{BuiltPlan, NodeInfo, Plan};
-use fabrik_frontend::{external_dep_id, Target};
+use fabrik_frontend::{external_dep_id, PlanGraphError, Target};
 
 use crate::artifact::{AppleKind, SwiftArtifact};
 use crate::compile::{compile_ios_app, AppleError};
@@ -35,6 +34,16 @@ pub enum PlanBuildError {
     Swift(#[from] SwiftError),
 }
 
+impl From<PlanGraphError> for PlanBuildError {
+    fn from(err: PlanGraphError) -> Self {
+        match err {
+            PlanGraphError::UnknownRoot(id) => Self::UnknownRoot(id),
+            PlanGraphError::Cycle(id) => Self::Cycle(id),
+            PlanGraphError::MissingDep { label, dep } => Self::MissingDep { label, dep },
+        }
+    }
+}
+
 pub fn supports_kind(kind: &str) -> bool {
     AppleKind::parse(kind).is_some()
 }
@@ -44,18 +53,9 @@ pub fn build_plan(
     root_id: &str,
     workspace_root: &Path,
 ) -> Result<BuiltPlan, PlanBuildError> {
-    let target_index: HashMap<String, usize> = targets
-        .iter()
-        .enumerate()
-        .map(|(i, t)| (t.id(), i))
-        .collect();
-    let root_target_idx = *target_index
-        .get(root_id)
-        .ok_or_else(|| PlanBuildError::UnknownRoot(root_id.to_string()))?;
-    let target = targets
-        .iter()
-        .find(|t| t.id() == root_id)
-        .ok_or_else(|| PlanBuildError::UnknownRoot(root_id.to_string()))?;
+    let target_index = fabrik_frontend::target_index(targets);
+    let root_target_idx = fabrik_frontend::resolve_root(&target_index, root_id)?;
+    let target = &targets[root_target_idx];
     let kind = AppleKind::parse(&target.kind).ok_or_else(|| PlanBuildError::NonAppleDep {
         label: target.id(),
         dep: root_id.to_string(),
@@ -66,17 +66,12 @@ pub fn build_plan(
     }
     let deps_by_target = target_dep_ids(targets)?;
 
-    let mut order = Vec::new();
-    let mut on_stack = BTreeSet::new();
-    let mut visited = BTreeSet::new();
-    dfs(
-        root_target_idx,
+    let order = fabrik_frontend::topological_sort(
         targets,
         &deps_by_target,
         &target_index,
-        &mut visited,
-        &mut on_stack,
-        &mut order,
+        root_target_idx,
+        |kind| supports_kind(kind) && !is_simulator_app_kind(kind),
     )?;
 
     let mut plan = Plan::new();
@@ -92,7 +87,7 @@ pub fn build_plan(
         let deps = &deps_by_target[*target_idx];
         validate_swift_deps(target, deps.as_ref(), targets, &target_index)?;
         let mut target_for_compile = target.clone();
-        target_for_compile.deps = deps.iter().cloned().collect();
+        target_for_compile.deps.clone_from(deps);
         target_for_compile.external_deps = Vec::new();
         let (plan_idx, import_idx, artifact) = push_swift_target(
             &mut plan,
@@ -173,14 +168,11 @@ fn validate_swift_deps(
     Ok(())
 }
 
-fn target_dep_ids(targets: &[Target]) -> Result<Vec<Cow<'_, [String]>>, PlanBuildError> {
+fn target_dep_ids(targets: &[Target]) -> Result<Vec<Vec<String>>, PlanBuildError> {
     targets.iter().map(target_dep_id).collect()
 }
 
-fn target_dep_id(target: &Target) -> Result<Cow<'_, [String]>, PlanBuildError> {
-    if target.external_deps.is_empty() {
-        return Ok(Cow::Borrowed(&target.deps));
-    }
+fn target_dep_id(target: &Target) -> Result<Vec<String>, PlanBuildError> {
     let mut deps = target.deps.clone();
     for dep in &target.external_deps {
         let Some(product_name) = swift_product_name(&dep.spec) else {
@@ -191,7 +183,7 @@ fn target_dep_id(target: &Target) -> Result<Cow<'_, [String]>, PlanBuildError> {
         };
         deps.push(external_dep_id(&dep.graph, product_name));
     }
-    Ok(Cow::Owned(deps))
+    Ok(deps)
 }
 
 fn swift_product_name(spec: &serde_json::Value) -> Option<&str> {
@@ -263,48 +255,6 @@ fn push_swift_target(
         import_index,
         swift_plan.artifact,
     ))
-}
-
-fn dfs(
-    idx: usize,
-    targets: &[Target],
-    deps_by_target: &[Cow<'_, [String]>],
-    target_index: &HashMap<String, usize>,
-    visited: &mut BTreeSet<usize>,
-    on_stack: &mut BTreeSet<usize>,
-    order: &mut Vec<usize>,
-) -> Result<(), PlanBuildError> {
-    if visited.contains(&idx) {
-        return Ok(());
-    }
-    if on_stack.contains(&idx) {
-        return Err(PlanBuildError::Cycle(targets[idx].id()));
-    }
-    on_stack.insert(idx);
-    for dep in deps_by_target[idx].iter() {
-        let dep_idx = target_index
-            .get(dep)
-            .ok_or_else(|| PlanBuildError::MissingDep {
-                label: targets[idx].id(),
-                dep: dep.clone(),
-            })?;
-        let dep_kind = &targets[*dep_idx].kind;
-        if supports_kind(dep_kind) && !is_simulator_app_kind(dep_kind) {
-            dfs(
-                *dep_idx,
-                targets,
-                deps_by_target,
-                target_index,
-                visited,
-                on_stack,
-                order,
-            )?;
-        }
-    }
-    on_stack.remove(&idx);
-    visited.insert(idx);
-    order.push(idx);
-    Ok(())
 }
 
 fn is_simulator_app_kind(kind: &str) -> bool {

--- a/crates/fabrik-cli/src/cli.rs
+++ b/crates/fabrik-cli/src/cli.rs
@@ -22,6 +22,35 @@ pub enum Format {
     Toon,
 }
 
+/// Output policy passed to command handlers. Bundles the chosen
+/// [`Format`] with the global `--quiet` flag so commands have one
+/// argument to consult instead of two. Cheap to copy; future flags
+/// that affect rendering (e.g. `--no-color`) drop in here.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Output {
+    pub format: Format,
+    /// When true, suppress human-mode success and progress trailers
+    /// (e.g. "fabrik: built ..." lines). Errors and the structured
+    /// envelope of `--format json`/`toon` are never suppressed.
+    pub quiet: bool,
+}
+
+impl Output {
+    #[must_use]
+    pub fn new(format: Format, quiet: bool) -> Self {
+        Self { format, quiet }
+    }
+
+    /// Whether human-mode progress and success trailers should print.
+    /// Always false in non-human formats, since those don't produce
+    /// trailers in the first place; combining the checks here keeps
+    /// call sites readable.
+    #[must_use]
+    pub fn show_human_trailers(self) -> bool {
+        self.format == Format::Human && !self.quiet
+    }
+}
+
 /// Release pipeline sets `FABRIK_VERSION` at build time so the binary
 /// reports the actual release tag rather than the pre-1.0 root package
 /// version. Falls back to the Cargo version for local dev builds.
@@ -54,6 +83,13 @@ pub struct Cli {
     /// -vvv: trace). Overridden by `RUST_LOG`.
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub verbose: u8,
+
+    /// Suppress human-mode success and progress trailers ("fabrik:
+    /// built ...", per-node hit/miss lines). Errors and the structured
+    /// envelope of `--format json`/`toon` still print. Mirrors the
+    /// `-q` flag of common build tools.
+    #[arg(short = 'q', long, global = true)]
+    pub quiet: bool,
 
     /// Print the command surface at the current command depth.
     #[arg(long, global = true)]
@@ -381,4 +417,20 @@ fn parse_workspace_path(raw: &str) -> std::result::Result<WorkspacePath, String>
 pub fn exit_from(code: i32) -> ExitCode {
     let clamped = u8::try_from(code & 0xff).unwrap_or(1);
     ExitCode::from(clamped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_show_human_trailers_only_when_human_and_not_quiet() {
+        assert!(Output::new(Format::Human, false).show_human_trailers());
+        assert!(!Output::new(Format::Human, true).show_human_trailers());
+        // Structured formats never emit human trailers, so quiet has no
+        // effect on the predicate either way.
+        assert!(!Output::new(Format::Json, false).show_human_trailers());
+        assert!(!Output::new(Format::Json, true).show_human_trailers());
+        assert!(!Output::new(Format::Toon, false).show_human_trailers());
+    }
 }

--- a/crates/fabrik-cli/src/commands/build.rs
+++ b/crates/fabrik-cli/src/commands/build.rs
@@ -13,12 +13,13 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use fabrik_cas::Cas;
-use fabrik_core::{BuiltPlan, CacheState};
+use fabrik_core::CacheState;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::cli::Format;
 use crate::commands::util::cache_tag;
+use crate::planner::plan_for_target;
 use crate::render;
 
 #[derive(Serialize)]
@@ -40,7 +41,7 @@ struct NodeRecord<'a> {
 
 pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) -> Result<ExitCode> {
     let targets = fabrik_frontend::load_workspace(workspace).context("loading workspace")?;
-    let built = build_plan(&targets, target, workspace).context("building plan")?;
+    let built = plan_for_target(&targets, target, workspace).context("building plan")?;
     let runner = crate::commands::util::runner(cas, workspace);
 
     let outcomes = runner
@@ -112,28 +113,4 @@ pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) ->
     }
 
     Ok(ExitCode::SUCCESS)
-}
-
-/// Dispatch to the matching plugin's planner. Adding a new plugin is
-/// one extra arm here; the CLI rendering and execution paths above
-/// stay plugin-agnostic because every plugin returns the unified
-/// [`BuiltPlan`] shape.
-fn build_plan(
-    targets: &[fabrik_frontend::Target],
-    target_id: &str,
-    workspace: &Path,
-) -> Result<BuiltPlan> {
-    let target = targets
-        .iter()
-        .find(|t| t.id() == target_id)
-        .ok_or_else(|| anyhow::anyhow!("no target matches `{target_id}`"))?;
-    if fabrik_apple::supports_kind(&target.kind) {
-        Ok(fabrik_apple::build_plan(targets, target_id, workspace)?)
-    } else if fabrik_elixir::supports_kind(&target.kind) {
-        Ok(fabrik_elixir::build_plan(targets, target_id, workspace)?)
-    } else if fabrik_go::supports_kind(&target.kind) {
-        Ok(fabrik_go::build_plan(targets, target_id, workspace)?)
-    } else {
-        Ok(fabrik_rust::build_plan(targets, target_id, workspace)?)
-    }
 }

--- a/crates/fabrik-cli/src/commands/build.rs
+++ b/crates/fabrik-cli/src/commands/build.rs
@@ -17,7 +17,7 @@ use fabrik_core::CacheState;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::commands::util::cache_tag;
 use crate::planner::plan_for_target;
 use crate::render;
@@ -39,7 +39,7 @@ struct NodeRecord<'a> {
     action_digest: String,
 }
 
-pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) -> Result<ExitCode> {
+pub async fn build(workspace: &Path, cas: &Cas, target: &str, output: Output) -> Result<ExitCode> {
     let targets = fabrik_frontend::load_workspace(workspace).context("loading workspace")?;
     let built = plan_for_target(&targets, target, workspace).context("building plan")?;
     let runner = crate::commands::util::runner(cas, workspace);
@@ -57,32 +57,34 @@ pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) ->
 
     let output_path = built.output.clone();
 
-    match format {
+    match output.format {
         Format::Human => {
-            let mut err = tokio::io::stderr();
-            for o in &outcomes {
-                let info = &built.nodes[o.index];
-                // Right-pad single-letter "hit" so columns line up.
-                let tag = match o.outcome.cache {
-                    CacheState::Hit => "hit ",
-                    CacheState::Miss => "miss",
-                };
-                let line = format!(
-                    "fabrik: [{tag}] {kind:<16} {label}\n",
-                    kind = info.kind,
-                    label = o.label,
+            if output.show_human_trailers() {
+                let mut err = tokio::io::stderr();
+                for o in &outcomes {
+                    let info = &built.nodes[o.index];
+                    // Right-pad single-letter "hit" so columns line up.
+                    let tag = match o.outcome.cache {
+                        CacheState::Hit => "hit ",
+                        CacheState::Miss => "miss",
+                    };
+                    let line = format!(
+                        "fabrik: [{tag}] {kind:<16} {label}\n",
+                        kind = info.kind,
+                        label = o.label,
+                    );
+                    err.write_all(line.as_bytes()).await?;
+                }
+                let trailer = format!(
+                    "fabrik: built {target} ({n} nodes, {hits} hit, {miss} miss) -> {out}\n",
+                    n = outcomes.len(),
+                    hits = cache_hits,
+                    miss = cache_misses,
+                    out = output_path,
                 );
-                err.write_all(line.as_bytes()).await?;
+                err.write_all(trailer.as_bytes()).await?;
+                err.flush().await?;
             }
-            let trailer = format!(
-                "fabrik: built {target} ({n} nodes, {hits} hit, {miss} miss) -> {out}\n",
-                n = outcomes.len(),
-                hits = cache_hits,
-                miss = cache_misses,
-                out = output_path,
-            );
-            err.write_all(trailer.as_bytes()).await?;
-            err.flush().await?;
         }
         Format::Json | Format::Toon => {
             let mut err = tokio::io::stderr();
@@ -106,7 +108,7 @@ pub async fn build(workspace: &Path, cas: &Cas, target: &str, format: Format) ->
                 output: output_path,
             };
             let mut out = tokio::io::stdout();
-            out.write_all(render::structured(format, &summary)?.as_bytes())
+            out.write_all(render::structured(output.format, &summary)?.as_bytes())
                 .await?;
             out.flush().await?;
         }

--- a/crates/fabrik-cli/src/commands/cache.rs
+++ b/crates/fabrik-cli/src/commands/cache.rs
@@ -5,7 +5,7 @@ use fabrik_cas::Cas;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::render;
 
 #[derive(Serialize)]
@@ -20,7 +20,7 @@ struct CacheStats {
     actions: CacheEntry,
 }
 
-pub async fn print_stats(cas: &Cas, format: Format) -> Result<()> {
+pub async fn print_stats(cas: &Cas, output: Output) -> Result<()> {
     let s = cas.stats().await?;
     let stats = CacheStats {
         blobs: CacheEntry {
@@ -32,12 +32,12 @@ pub async fn print_stats(cas: &Cas, format: Format) -> Result<()> {
             bytes: s.action_bytes,
         },
     };
-    let body = match format {
+    let body = match output.format {
         Format::Human => format!(
             "blobs:   {} ({} bytes)\nactions: {} ({} bytes)\n",
             s.blob_count, s.blob_bytes, s.action_count, s.action_bytes,
         ),
-        Format::Json | Format::Toon => render::structured(format, &stats)?,
+        Format::Json | Format::Toon => render::structured(output.format, &stats)?,
     };
     let mut out = tokio::io::stdout();
     out.write_all(body.as_bytes()).await?;

--- a/crates/fabrik-cli/src/commands/deps/mod.rs
+++ b/crates/fabrik-cli/src/commands/deps/mod.rs
@@ -6,7 +6,7 @@ use fabrik_cas::Cas;
 use fabrik_core::CacheState;
 use fabrik_frontend::{DependencyEcosystem, DependencyEntry};
 
-use crate::cli::Format;
+use crate::cli::Output;
 
 mod elixir;
 mod go;
@@ -30,7 +30,7 @@ use graph::{write_graph_to, ResolvedGraph};
 pub async fn sync(
     workspace: &Path,
     cas: &Cas,
-    format: Format,
+    output: Output,
     name: Option<&str>,
 ) -> Result<ExitCode> {
     let entries = selected_entries(workspace, name)?;
@@ -38,7 +38,7 @@ pub async fn sync(
     for entry in entries {
         reports.push(sync_entry(workspace, cas, &entry).await?);
     }
-    write_sync_report(format, &reports).await?;
+    write_sync_report(output, &reports).await?;
     Ok(ExitCode::SUCCESS)
 }
 

--- a/crates/fabrik-cli/src/commands/deps/report.rs
+++ b/crates/fabrik-cli/src/commands/deps/report.rs
@@ -7,7 +7,7 @@ use fabrik_frontend::DependencyEcosystem;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::render;
 
 pub(in crate::commands::deps) struct SyncReport {
@@ -23,11 +23,14 @@ pub(in crate::commands::deps) struct SyncReport {
 }
 
 pub(in crate::commands::deps) async fn write_sync_report(
-    format: Format,
+    output: Output,
     reports: &[SyncReport],
 ) -> Result<()> {
-    match format {
+    match output.format {
         Format::Human => {
+            if !output.show_human_trailers() {
+                return Ok(());
+            }
             let mut err = tokio::io::stderr();
             for report in reports {
                 let mut line = format!(
@@ -54,7 +57,7 @@ pub(in crate::commands::deps) async fn write_sync_report(
         Format::Json | Format::Toon => {
             let mut out = tokio::io::stdout();
             let payload: Vec<_> = reports.iter().map(SyncReportPayload::from).collect();
-            let body = render::structured(format, &payload)?;
+            let body = render::structured(output.format, &payload)?;
             out.write_all(body.as_bytes()).await?;
             out.flush().await?;
         }

--- a/crates/fabrik-cli/src/commands/exec.rs
+++ b/crates/fabrik-cli/src/commands/exec.rs
@@ -21,7 +21,7 @@ use fabrik_core::{Action, ResourceRequest, RunOpts, WorkspacePath};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::{exit_from, Format};
+use crate::cli::{exit_from, Format, Output};
 use crate::commands::util::cache_tag;
 use crate::render;
 
@@ -43,7 +43,7 @@ pub struct ExecArgs {
     pub argv: Vec<String>,
 }
 
-pub async fn exec(workspace: &Path, cas: &Cas, args: ExecArgs, format: Format) -> Result<ExitCode> {
+pub async fn exec(workspace: &Path, cas: &Cas, args: ExecArgs, output: Output) -> Result<ExitCode> {
     let ExecArgs {
         env,
         cwd,
@@ -83,14 +83,22 @@ pub async fn exec(workspace: &Path, cas: &Cas, args: ExecArgs, format: Format) -
         cache: tag,
         exit_code: outcome.result.exit_code,
     };
-    let trailer = match format {
-        Format::Human => format!(
-            "fabrik: cache {tag} action={} exit={}\n",
-            outcome.action, outcome.result.exit_code
-        ),
-        Format::Json | Format::Toon => render::structured(format, &trailer)?,
+    let trailer = match output.format {
+        Format::Human => {
+            if output.quiet {
+                String::new()
+            } else {
+                format!(
+                    "fabrik: cache {tag} action={} exit={}\n",
+                    outcome.action, outcome.result.exit_code
+                )
+            }
+        }
+        Format::Json | Format::Toon => render::structured(output.format, &trailer)?,
     };
-    err.write_all(trailer.as_bytes()).await?;
+    if !trailer.is_empty() {
+        err.write_all(trailer.as_bytes()).await?;
+    }
     err.flush().await?;
 
     Ok(exit_from(outcome.result.exit_code))

--- a/crates/fabrik-cli/src/commands/init/mod.rs
+++ b/crates/fabrik-cli/src/commands/init/mod.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Context, Result};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::render;
 
 use self::template::{Prompt, RenderedTemplate, Template, Validation};
@@ -89,11 +89,12 @@ struct PromptView {
     validation: Validation,
 }
 
-pub async fn run(workspace: &Path, args: InitArgs, format: Format) -> Result<ExitCode> {
+pub async fn run(workspace: &Path, args: InitArgs, output: Output) -> Result<ExitCode> {
+    let format = output.format;
     let templates = catalog::load().context("loading init templates")?;
     if args.templates {
         write_response(
-            format,
+            output,
             human::render_catalog(&templates),
             &InitResponse::Catalog {
                 templates: templates
@@ -116,7 +117,7 @@ pub async fn run(workspace: &Path, args: InitArgs, format: Format) -> Result<Exi
             human::render_catalog(&templates)
         );
         write_response(
-            format,
+            output,
             human_body,
             &InitResponse::SelectTemplate {
                 templates: templates
@@ -141,7 +142,7 @@ pub async fn run(workspace: &Path, args: InitArgs, format: Format) -> Result<Exi
         if !resolved.missing.is_empty() {
             let human_body = human::render_missing_inputs(template, &resolved.missing, true);
             write_response(
-                format,
+                output,
                 human_body,
                 &InitResponse::NeedsInput {
                     template: template_view(template, Some(&resolved.values)),
@@ -164,7 +165,7 @@ pub async fn run(workspace: &Path, args: InitArgs, format: Format) -> Result<Exi
     write_rendered(&destination, &rendered, args.force)?;
     let next_steps = display_next_steps(workspace, &destination, &rendered.next_steps);
     write_response(
-        format,
+        output,
         human::render_created(template, &destination, &next_steps),
         &InitResponse::Created {
             template: template_view(template, None),
@@ -261,10 +262,13 @@ fn write_rendered(destination: &Path, rendered: &RenderedTemplate, force: bool) 
     Ok(())
 }
 
-async fn write_response(format: Format, human_body: String, response: &InitResponse) -> Result<()> {
-    let body = match format {
+async fn write_response(output: Output, human_body: String, response: &InitResponse) -> Result<()> {
+    let body = match output.format {
+        // `fabrik init` is interactive; --quiet shouldn't swallow the
+        // user's only confirmation that something was created. Keep
+        // human output unconditional here.
         Format::Human => human_body,
-        Format::Json | Format::Toon => render::structured(format, response)?,
+        Format::Json | Format::Toon => render::structured(output.format, response)?,
     };
     let mut out = tokio::io::stdout();
     out.write_all(body.as_bytes()).await?;

--- a/crates/fabrik-cli/src/commands/run.rs
+++ b/crates/fabrik-cli/src/commands/run.rs
@@ -16,11 +16,11 @@ use fabrik_core::RunOpts;
 use self::action::action_for;
 use self::apple_runtime::is_apple_simulator_app;
 use self::runtime_descriptor::runtime_descriptor;
-use crate::cli::{exit_from, Format};
+use crate::cli::{exit_from, Output};
 use crate::commands::util::{cache_tag, find_target};
 
 pub struct RunArgs {
-    pub format: Format,
+    pub output: Output,
     pub runtime_rpc: bool,
     pub runtime_rpc_socket: Option<PathBuf>,
 }
@@ -97,11 +97,11 @@ async fn finish_run(
     outcome: &fabrik_core::Outcome,
     target_id: &str,
     target: &fabrik_frontend::Target,
-    output: &str,
+    output_path: &str,
     args: RunArgs,
 ) -> Result<()> {
     let RunArgs {
-        format,
+        output,
         runtime_rpc,
         runtime_rpc_socket,
     } = args;
@@ -129,10 +129,10 @@ async fn finish_run(
         &target.kind,
         outcome,
         tag,
-        output.to_string(),
+        output_path.to_string(),
         runtime,
     );
-    output::render(format, &stdout_blob, &stderr_blob, &record).await?;
+    output::render(output, &stdout_blob, &stderr_blob, &record).await?;
 
     if let Some(session) = session {
         crate::commands::runtime::rpc(&session.dir, Some(&session.socket)).await?;

--- a/crates/fabrik-cli/src/commands/run/output.rs
+++ b/crates/fabrik-cli/src/commands/run/output.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
 use super::runtime_descriptor::RuntimeDescriptor;
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::render;
 
 #[derive(Serialize)]
@@ -41,18 +41,21 @@ impl<'a> RunRecord<'a> {
 }
 
 pub(super) async fn render(
-    format: Format,
+    output: Output,
     stdout_blob: &[u8],
     stderr_blob: &[u8],
     record: &RunRecord<'_>,
 ) -> Result<()> {
-    match format {
-        Format::Human => render_human(stdout_blob, stderr_blob, record).await,
-        Format::Json | Format::Toon => render_structured(format, stderr_blob, record).await,
+    match output.format {
+        Format::Human => render_human(output, stdout_blob, stderr_blob, record).await,
+        Format::Json | Format::Toon => {
+            render_structured(output.format, stderr_blob, record).await
+        }
     }
 }
 
 async fn render_human(
+    output: Output,
     stdout_blob: &[u8],
     stderr_blob: &[u8],
     record: &RunRecord<'_>,
@@ -63,16 +66,18 @@ async fn render_human(
 
     let mut err = tokio::io::stderr();
     err.write_all(stderr_blob).await?;
-    err.write_all(
-        format!(
-            "fabrik: ran {} (cache {}, exit={})\n",
-            record.target, record.cache, record.exit_code
+    if output.show_human_trailers() {
+        err.write_all(
+            format!(
+                "fabrik: ran {} (cache {}, exit={})\n",
+                record.target, record.cache, record.exit_code
+            )
+            .as_bytes(),
         )
-        .as_bytes(),
-    )
-    .await?;
-    if let Some(runtime) = &record.runtime {
-        err.write_all(runtime_trailer(runtime).as_bytes()).await?;
+        .await?;
+        if let Some(runtime) = &record.runtime {
+            err.write_all(runtime_trailer(runtime).as_bytes()).await?;
+        }
     }
     err.flush().await?;
     Ok(())

--- a/crates/fabrik-cli/src/commands/run/output.rs
+++ b/crates/fabrik-cli/src/commands/run/output.rs
@@ -48,9 +48,7 @@ pub(super) async fn render(
 ) -> Result<()> {
     match output.format {
         Format::Human => render_human(output, stdout_blob, stderr_blob, record).await,
-        Format::Json | Format::Toon => {
-            render_structured(output.format, stderr_blob, record).await
-        }
+        Format::Json | Format::Toon => render_structured(output.format, stderr_blob, record).await,
     }
 }
 

--- a/crates/fabrik-cli/src/commands/surface/mod.rs
+++ b/crates/fabrik-cli/src/commands/surface/mod.rs
@@ -1,17 +1,17 @@
 use anyhow::Result;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::render;
 
 mod human;
 mod model;
 
-pub async fn print(path: &[&str], format: Format) -> Result<()> {
+pub async fn print(path: &[&str], output: Output) -> Result<()> {
     let surface = model::load(path)?;
-    let body = match format {
+    let body = match output.format {
         Format::Human => human::render(&surface),
-        Format::Json | Format::Toon => render::structured(format, &surface)?,
+        Format::Json | Format::Toon => render::structured(output.format, &surface)?,
     };
     let mut out = tokio::io::stdout();
     out.write_all(body.as_bytes()).await?;

--- a/crates/fabrik-cli/src/commands/targets.rs
+++ b/crates/fabrik-cli/src/commands/targets.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::render;
 
 /// JSON view of a [`fabrik_frontend::Target`] that includes the
@@ -54,8 +54,9 @@ struct TargetsToonView<'a> {
     targets: BTreeMap<String, TargetFields<'a>>,
 }
 
-pub async fn print_targets(workspace: &Path, format: Format) -> Result<()> {
+pub async fn print_targets(workspace: &Path, output: Output) -> Result<()> {
     let targets = fabrik_frontend::load_workspace(workspace).context("loading workspace")?;
+    let format = output.format;
     if format == Format::Toon {
         let targets = TargetsToonView {
             targets: targets

--- a/crates/fabrik-cli/src/commands/test.rs
+++ b/crates/fabrik-cli/src/commands/test.rs
@@ -37,7 +37,7 @@ pub async fn test(
     let target = &targets[idx];
     if target.kind != "rust_test" {
         anyhow::bail!(
-            "target {target_id} has kind `{}`; expected rust_test",
+            "target {target_id} has kind `{}`; expected rust_test. Run `fabrik targets` to list rust_test targets",
             target.kind
         );
     }

--- a/crates/fabrik-cli/src/commands/test.rs
+++ b/crates/fabrik-cli/src/commands/test.rs
@@ -10,7 +10,7 @@ use fabrik_core::{workspace_tool_env, Action, CacheState, ResourceRequest};
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::{exit_from, Format};
+use crate::cli::{exit_from, Format, Output};
 use crate::commands::util::{cache_tag, find_target};
 use crate::render;
 
@@ -31,7 +31,7 @@ pub async fn test(
     cas: &Cas,
     target_id: &str,
     test_args: Vec<String>,
-    format: Format,
+    output: Output,
 ) -> Result<ExitCode> {
     let (targets, idx) = find_target(workspace, target_id)?;
     let target = &targets[idx];
@@ -80,7 +80,7 @@ pub async fn test(
         test_action_digest: test_outcome.action.to_string(),
     };
 
-    render_output(cas, &test_outcome, &summary, format).await?;
+    render_output(cas, &test_outcome, &summary, output).await?;
     Ok(exit_from(test_outcome.result.exit_code))
 }
 
@@ -118,29 +118,31 @@ async fn render_output(
     cas: &Cas,
     outcome: &fabrik_core::Outcome,
     summary: &TestSummary<'_>,
-    format: Format,
+    output: Output,
 ) -> Result<()> {
     let stdout = cas.get_blob(&outcome.result.stdout).await?;
     let stderr = cas.get_blob(&outcome.result.stderr).await?;
 
-    match format {
+    match output.format {
         Format::Human => {
             let mut out = tokio::io::stdout();
             out.write_all(&stdout).await?;
             out.flush().await?;
             let mut err = tokio::io::stderr();
             err.write_all(&stderr).await?;
-            let trailer = format!(
-                "fabrik: tested {label} (build {nodes} nodes, {hits} hit, {misses} miss; test cache {test_cache}, exit={exit}) -> {binary}\n",
-                label = summary.target,
-                nodes = summary.build_nodes,
-                hits = summary.build_cache_hits,
-                misses = summary.build_cache_misses,
-                test_cache = summary.test_cache,
-                exit = summary.exit_code,
-                binary = summary.binary,
-            );
-            err.write_all(trailer.as_bytes()).await?;
+            if output.show_human_trailers() {
+                let trailer = format!(
+                    "fabrik: tested {label} (build {nodes} nodes, {hits} hit, {misses} miss; test cache {test_cache}, exit={exit}) -> {binary}\n",
+                    label = summary.target,
+                    nodes = summary.build_nodes,
+                    hits = summary.build_cache_hits,
+                    misses = summary.build_cache_misses,
+                    test_cache = summary.test_cache,
+                    exit = summary.exit_code,
+                    binary = summary.binary,
+                );
+                err.write_all(trailer.as_bytes()).await?;
+            }
             err.flush().await?;
         }
         Format::Json | Format::Toon => {
@@ -149,7 +151,7 @@ async fn render_output(
             err.write_all(&stderr).await?;
             err.flush().await?;
             let mut out = tokio::io::stdout();
-            out.write_all(render::structured(format, summary)?.as_bytes())
+            out.write_all(render::structured(output.format, summary)?.as_bytes())
                 .await?;
             out.flush().await?;
         }

--- a/crates/fabrik-cli/src/commands/toolchain/mod.rs
+++ b/crates/fabrik-cli/src/commands/toolchain/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::Result;
 use tokio::io::AsyncWriteExt;
 
-use crate::cli::Format;
+use crate::cli::{Format, Output};
 use crate::render;
 
 mod contract;
@@ -14,11 +14,11 @@ mod lock;
 mod mise;
 mod platform;
 
-pub async fn inspect(workspace: &Path, format: Format, platform: Option<&str>) -> Result<()> {
+pub async fn inspect(workspace: &Path, output: Output, platform: Option<&str>) -> Result<()> {
     let contract = mise::inspect_workspace(workspace, platform)?;
-    let body = match format {
+    let body = match output.format {
         Format::Human => human::render(&contract),
-        Format::Json | Format::Toon => render::structured(format, &contract)?,
+        Format::Json | Format::Toon => render::structured(output.format, &contract)?,
     };
 
     let mut out = tokio::io::stdout();

--- a/crates/fabrik-cli/src/commands/util.rs
+++ b/crates/fabrik-cli/src/commands/util.rs
@@ -20,7 +20,11 @@ pub fn find_target(workspace: &Path, target_id: &str) -> Result<(Vec<Target>, us
     let idx = targets
         .iter()
         .position(|t| t.id() == target_id)
-        .ok_or_else(|| anyhow!("no target matches `{target_id}`"))?;
+        .ok_or_else(|| {
+            anyhow!(
+                "no target matches `{target_id}`. Run `fabrik targets` to list declared targets"
+            )
+        })?;
     Ok((targets, idx))
 }
 

--- a/crates/fabrik-cli/src/dispatch.rs
+++ b/crates/fabrik-cli/src/dispatch.rs
@@ -6,12 +6,13 @@ use anyhow::{Context, Result};
 use fabrik_cas::Cas;
 use fabrik_core::Xdg;
 
-use crate::cli::{self, Cli, Cmd, Format};
+use crate::cli::{self, Cli, Cmd, Output};
 use crate::commands;
 
 pub(crate) async fn dispatch(cli: Cli) -> Result<ExitCode> {
+    let output = Output::new(cli.format, cli.quiet);
     if cli.list {
-        return commands::surface::print(&cli.surface_path(), cli.format)
+        return commands::surface::print(&cli.surface_path(), output)
             .await
             .map(|()| ExitCode::SUCCESS);
     }
@@ -22,7 +23,7 @@ pub(crate) async fn dispatch(cli: Cli) -> Result<ExitCode> {
 
     let workspace = resolve_workspace(cli.directory)?;
     let cas = Cas::open(Xdg::from_env().fabrik_cas());
-    run_command(&workspace, &cas, cli.format, command).await
+    run_command(&workspace, &cas, output, command).await
 }
 
 fn resolve_workspace(directory: Option<PathBuf>) -> Result<PathBuf> {
@@ -49,7 +50,7 @@ fn resolve_workspace(directory: Option<PathBuf>) -> Result<PathBuf> {
 async fn run_command(
     workspace: &Path,
     cas: &Cas,
-    format: Format,
+    output: Output,
     command: Cmd,
 ) -> Result<ExitCode> {
     match command {
@@ -61,16 +62,16 @@ async fn run_command(
             run_target_command(
                 workspace,
                 cas,
-                format,
+                output,
                 target,
                 runtime_rpc,
                 runtime_rpc_socket,
             )
             .await
         }
-        Cmd::Build { target } => build_target_command(workspace, cas, format, target).await,
+        Cmd::Build { target } => build_target_command(workspace, cas, output, target).await,
         Cmd::Test { target, test_args } => {
-            test_target_command(workspace, cas, format, target, test_args).await
+            test_target_command(workspace, cas, output, target, test_args).await
         }
         Cmd::Exec {
             env,
@@ -89,19 +90,19 @@ async fn run_command(
                     cache_failures,
                     argv,
                 },
-                format,
+                output,
             )
             .await
         }
         Cmd::Cache {
             cmd: Some(cli::CacheCmd::Stats),
-        } => commands::cache::print_stats(cas, format)
+        } => commands::cache::print_stats(cas, output)
             .await
             .map(|()| ExitCode::SUCCESS),
         Cmd::Cache { cmd: None } => anyhow::bail!("cache subcommand required"),
         Cmd::Toolchain {
             cmd: Some(cli::ToolchainCmd::Inspect { platform }),
-        } => commands::toolchain::inspect(workspace, format, platform.as_deref())
+        } => commands::toolchain::inspect(workspace, output, platform.as_deref())
             .await
             .map(|()| ExitCode::SUCCESS),
         Cmd::Toolchain { cmd: None } => anyhow::bail!("toolchain subcommand required"),
@@ -115,19 +116,19 @@ async fn run_command(
             .await
             .map(|()| ExitCode::SUCCESS),
         Cmd::Runtime { cmd: None } => anyhow::bail!("runtime subcommand required"),
-        Cmd::Targets => commands::targets::print_targets(workspace, format)
+        Cmd::Targets => commands::targets::print_targets(workspace, output)
             .await
             .map(|()| ExitCode::SUCCESS),
         Cmd::Deps {
             cmd: Some(cli::DepsCmd::Sync { name }),
-        } => commands::deps::sync(workspace, cas, format, name.as_deref()).await,
+        } => commands::deps::sync(workspace, cas, output, name.as_deref()).await,
         Cmd::Deps { cmd: None } => anyhow::bail!("deps subcommand required"),
-        Cmd::Init(args) => commands::init::run(workspace, args, format).await,
+        Cmd::Init(args) => commands::init::run(workspace, args, output).await,
         Cmd::Vendor => {
             eprintln!(
                 "fabrik: `fabrik vendor` is deprecated and will be removed in v0.8.0; use `fabrik deps sync` instead"
             );
-            commands::deps::sync(workspace, cas, format, None).await
+            commands::deps::sync(workspace, cas, output, None).await
         }
         #[cfg(unix)]
         Cmd::ElixirCompile(args) => commands::elixir_compile::run(workspace, &args),
@@ -141,7 +142,7 @@ async fn run_command(
 async fn run_target_command(
     workspace: &Path,
     cas: &Cas,
-    format: Format,
+    output: Output,
     target: Option<String>,
     runtime_rpc: bool,
     runtime_rpc_socket: Option<PathBuf>,
@@ -152,7 +153,7 @@ async fn run_target_command(
         cas,
         &target,
         commands::run::RunArgs {
-            format,
+            output,
             runtime_rpc,
             runtime_rpc_socket,
         },
@@ -163,22 +164,22 @@ async fn run_target_command(
 async fn build_target_command(
     workspace: &Path,
     cas: &Cas,
-    format: Format,
+    output: Output,
     target: Option<String>,
 ) -> Result<ExitCode> {
     let target = resolve_required_target(workspace, target)?;
-    commands::build::build(workspace, cas, &target, format).await
+    commands::build::build(workspace, cas, &target, output).await
 }
 
 async fn test_target_command(
     workspace: &Path,
     cas: &Cas,
-    format: Format,
+    output: Output,
     target: Option<String>,
     test_args: Vec<String>,
 ) -> Result<ExitCode> {
     let target = resolve_required_target(workspace, target)?;
-    commands::test::test(workspace, cas, &target, test_args, format).await
+    commands::test::test(workspace, cas, &target, test_args, output).await
 }
 
 fn resolve_required_target(workspace: &Path, target: Option<String>) -> Result<String> {

--- a/crates/fabrik-cli/src/main.rs
+++ b/crates/fabrik-cli/src/main.rs
@@ -5,6 +5,7 @@
 mod cli;
 mod commands;
 mod dispatch;
+mod planner;
 mod render;
 
 use std::process::ExitCode;

--- a/crates/fabrik-cli/src/planner.rs
+++ b/crates/fabrik-cli/src/planner.rs
@@ -1,0 +1,138 @@
+//! Language planner registry.
+//!
+//! Each language crate exports a `supports_kind` predicate and a
+//! `build_plan` constructor. The CLI used to dispatch on `target.kind`
+//! with a hand-coded `if/else if` ladder, so adding a language meant
+//! editing every dispatcher in step. The registry below collects the
+//! per-language entries once; verbs that need a planner consult it
+//! through [`plan_for_target`] and the dispatch ladder disappears.
+
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use fabrik_core::BuiltPlan;
+use fabrik_frontend::Target;
+
+/// One language's planner entry. `name` is for diagnostics only; the
+/// dispatcher matches via [`supports_kind`].
+pub struct LanguagePlanner {
+    /// Diagnostic name. Surfaced in tests and (in the future) tracing.
+    #[allow(dead_code)]
+    pub name: &'static str,
+    pub supports_kind: fn(&str) -> bool,
+    pub build_plan: fn(&[Target], &str, &Path) -> Result<BuiltPlan>,
+}
+
+/// Static set of language planners. The last entry doubles as the
+/// fallback when no other entry recognises a kind: today that is the
+/// Rust planner, which accepts every rust-shaped kind and is the
+/// expected target for hand-authored projects. Adding a language means
+/// adding one entry here, no other dispatcher edits required.
+const PLANNERS: &[LanguagePlanner] = &[
+    LanguagePlanner {
+        name: "apple",
+        supports_kind: fabrik_apple::supports_kind,
+        build_plan: apple_build_plan,
+    },
+    LanguagePlanner {
+        name: "elixir",
+        supports_kind: fabrik_elixir::supports_kind,
+        build_plan: elixir_build_plan,
+    },
+    LanguagePlanner {
+        name: "go",
+        supports_kind: fabrik_go::supports_kind,
+        build_plan: go_build_plan,
+    },
+    LanguagePlanner {
+        name: "rust",
+        supports_kind: |_| true,
+        build_plan: rust_build_plan,
+    },
+];
+
+/// Look up the planner that owns `kind`. Returns the first matching
+/// entry in [`PLANNERS`]; order is intentional so apple/elixir/go win
+/// before the rust fallback claims everything else.
+#[must_use]
+pub fn planner_for(kind: &str) -> &'static LanguagePlanner {
+    PLANNERS
+        .iter()
+        .find(|p| (p.supports_kind)(kind))
+        .expect("rust planner is the catch-all and must always match")
+}
+
+/// Build a plan for `target_id`, dispatching by kind.
+pub fn plan_for_target(
+    targets: &[Target],
+    target_id: &str,
+    workspace_root: &Path,
+) -> Result<BuiltPlan> {
+    let target = targets
+        .iter()
+        .find(|t| t.id() == target_id)
+        .ok_or_else(|| {
+            anyhow!(
+                "no target matches `{target_id}`. Run `fabrik targets` to list declared targets"
+            )
+        })?;
+    let planner = planner_for(&target.kind);
+    (planner.build_plan)(targets, target_id, workspace_root)
+}
+
+fn apple_build_plan(
+    targets: &[Target],
+    target_id: &str,
+    workspace_root: &Path,
+) -> Result<BuiltPlan> {
+    Ok(fabrik_apple::build_plan(
+        targets,
+        target_id,
+        workspace_root,
+    )?)
+}
+
+fn elixir_build_plan(
+    targets: &[Target],
+    target_id: &str,
+    workspace_root: &Path,
+) -> Result<BuiltPlan> {
+    Ok(fabrik_elixir::build_plan(
+        targets,
+        target_id,
+        workspace_root,
+    )?)
+}
+
+fn go_build_plan(targets: &[Target], target_id: &str, workspace_root: &Path) -> Result<BuiltPlan> {
+    Ok(fabrik_go::build_plan(targets, target_id, workspace_root)?)
+}
+
+fn rust_build_plan(
+    targets: &[Target],
+    target_id: &str,
+    workspace_root: &Path,
+) -> Result<BuiltPlan> {
+    Ok(fabrik_rust::build_plan(targets, target_id, workspace_root)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn planner_lookup_routes_each_supported_kind_to_its_owner() {
+        assert_eq!(planner_for("apple_simulator_app").name, "apple");
+        assert_eq!(planner_for("elixir_library").name, "elixir");
+        assert_eq!(planner_for("go_binary").name, "go");
+        assert_eq!(planner_for("rust_library").name, "rust");
+        assert_eq!(planner_for("rust_binary").name, "rust");
+    }
+
+    #[test]
+    fn planner_lookup_falls_back_to_rust_for_unknown_kinds() {
+        // The rust planner is the catch-all; an unknown kind reaches it
+        // and lets the per-crate planner surface the real error.
+        assert_eq!(planner_for("totally_made_up_kind").name, "rust");
+    }
+}

--- a/crates/fabrik-core/src/directory_blob.rs
+++ b/crates/fabrik-core/src/directory_blob.rs
@@ -1,0 +1,206 @@
+//! Binary encoding for directory-shaped action outputs.
+//!
+//! When an action's declared output is a directory (e.g. an `ebin/`
+//! tree or a `.app` bundle), the runner serializes every file inside
+//! into one CAS blob. The format is a magic prefix followed by
+//! length-tagged entries (path length, mode, content length, then the
+//! path bytes and the content bytes). Restoring is the inverse walk:
+//! recreate the directory at the declared output path with each
+//! entry's contents and unix permission bits.
+
+use std::path::Path;
+
+use crate::path::WorkspacePath;
+use crate::{Error, Result};
+
+pub(crate) const DIRECTORY_BLOB_MAGIC: &[u8] = b"fabrik.directory.v1\0";
+
+pub(crate) fn capture_directory_blob(root: &Path) -> std::io::Result<Vec<u8>> {
+    let mut files = Vec::new();
+    collect_directory_files(root, root, &mut files)?;
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut out = Vec::from(DIRECTORY_BLOB_MAGIC);
+    for (rel, mode, bytes) in files {
+        let path_bytes = rel.as_bytes();
+        let path_len = u32::try_from(path_bytes.len()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "directory path is too long",
+            )
+        })?;
+        let content_len = u64::try_from(bytes.len()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "directory file is too large",
+            )
+        })?;
+        out.extend_from_slice(&path_len.to_le_bytes());
+        out.extend_from_slice(&mode.to_le_bytes());
+        out.extend_from_slice(&content_len.to_le_bytes());
+        out.extend_from_slice(path_bytes);
+        out.extend_from_slice(&bytes);
+    }
+    Ok(out)
+}
+
+fn collect_directory_files(
+    root: &Path,
+    dir: &Path,
+    files: &mut Vec<(String, u32, Vec<u8>)>,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let metadata = entry.metadata()?;
+        if metadata.is_dir() {
+            collect_directory_files(root, &path, files)?;
+        } else if metadata.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .expect("directory walk stays under root")
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            #[cfg(unix)]
+            let mode = {
+                use std::os::unix::fs::PermissionsExt;
+                metadata.permissions().mode() & 0o777
+            };
+            #[cfg(not(unix))]
+            let mode = 0o644;
+            files.push((rel, mode, std::fs::read(&path)?));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn restore_directory_blob(logical_path: &str, abs: &Path, bytes: &[u8]) -> Result<()> {
+    let files = decode_directory_blob(logical_path, bytes)?;
+    if abs.exists() {
+        let metadata = std::fs::metadata(abs).map_err(|source| Error::RestoreOutput {
+            path: logical_path.to_string(),
+            source,
+        })?;
+        if metadata.is_dir() {
+            std::fs::remove_dir_all(abs).map_err(|source| Error::RestoreOutput {
+                path: logical_path.to_string(),
+                source,
+            })?;
+        } else {
+            std::fs::remove_file(abs).map_err(|source| Error::RestoreOutput {
+                path: logical_path.to_string(),
+                source,
+            })?;
+        }
+    }
+    std::fs::create_dir_all(abs).map_err(|source| Error::RestoreOutput {
+        path: logical_path.to_string(),
+        source,
+    })?;
+    for (rel, mode, content) in files {
+        let rel_path = WorkspacePath::try_from(rel.as_str()).map_err(|source| {
+            Error::InvalidDirectoryOutput {
+                path: logical_path.to_string(),
+                message: source.to_string(),
+            }
+        })?;
+        if rel_path.as_str().is_empty() {
+            return Err(Error::InvalidDirectoryOutput {
+                path: logical_path.to_string(),
+                message: "directory entry path is empty".to_string(),
+            });
+        }
+        let dest = rel_path.resolve(abs);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| Error::RestoreOutput {
+                path: logical_path.to_string(),
+                source,
+            })?;
+        }
+        std::fs::write(&dest, content).map_err(|source| Error::RestoreOutput {
+            path: logical_path.to_string(),
+            source,
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(mode.max(0o400)))
+                .map_err(|source| Error::RestoreOutput {
+                    path: logical_path.to_string(),
+                    source,
+                })?;
+        }
+    }
+    Ok(())
+}
+
+fn decode_directory_blob(logical_path: &str, bytes: &[u8]) -> Result<Vec<(String, u32, Vec<u8>)>> {
+    let mut pos = DIRECTORY_BLOB_MAGIC.len();
+    let mut files = Vec::new();
+    while pos < bytes.len() {
+        let path_len = usize::try_from(read_u32(logical_path, bytes, &mut pos)?).map_err(|_| {
+            Error::InvalidDirectoryOutput {
+                path: logical_path.to_string(),
+                message: "entry path length does not fit usize".to_string(),
+            }
+        })?;
+        let mode = read_u32(logical_path, bytes, &mut pos)?;
+        let content_len =
+            usize::try_from(read_u64(logical_path, bytes, &mut pos)?).map_err(|_| {
+                Error::InvalidDirectoryOutput {
+                    path: logical_path.to_string(),
+                    message: "entry content length does not fit usize".to_string(),
+                }
+            })?;
+        if bytes.len().saturating_sub(pos) < path_len {
+            return Err(Error::InvalidDirectoryOutput {
+                path: logical_path.to_string(),
+                message: "truncated entry path".to_string(),
+            });
+        }
+        let path_bytes = &bytes[pos..pos + path_len];
+        pos += path_len;
+        let path = std::str::from_utf8(path_bytes)
+            .map_err(|e| Error::InvalidDirectoryOutput {
+                path: logical_path.to_string(),
+                message: format!("entry path is not utf-8: {e}"),
+            })?
+            .to_string();
+        if bytes.len().saturating_sub(pos) < content_len {
+            return Err(Error::InvalidDirectoryOutput {
+                path: logical_path.to_string(),
+                message: "truncated entry content".to_string(),
+            });
+        }
+        let content = bytes[pos..pos + content_len].to_vec();
+        pos += content_len;
+        files.push((path, mode, content));
+    }
+    Ok(files)
+}
+
+fn read_u32(logical_path: &str, bytes: &[u8], pos: &mut usize) -> Result<u32> {
+    if bytes.len().saturating_sub(*pos) < 4 {
+        return Err(Error::InvalidDirectoryOutput {
+            path: logical_path.to_string(),
+            message: "truncated u32".to_string(),
+        });
+    }
+    let mut raw = [0u8; 4];
+    raw.copy_from_slice(&bytes[*pos..*pos + 4]);
+    *pos += 4;
+    Ok(u32::from_le_bytes(raw))
+}
+
+fn read_u64(logical_path: &str, bytes: &[u8], pos: &mut usize) -> Result<u64> {
+    if bytes.len().saturating_sub(*pos) < 8 {
+        return Err(Error::InvalidDirectoryOutput {
+            path: logical_path.to_string(),
+            message: "truncated u64".to_string(),
+        });
+    }
+    let mut raw = [0u8; 8];
+    raw.copy_from_slice(&bytes[*pos..*pos + 8]);
+    *pos += 8;
+    Ok(u64::from_le_bytes(raw))
+}

--- a/crates/fabrik-core/src/lib.rs
+++ b/crates/fabrik-core/src/lib.rs
@@ -17,12 +17,15 @@ use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, instrument};
 
+mod directory_blob;
 mod env;
 mod input_digest;
 mod path;
 mod plan;
 mod resources;
 mod xdg;
+
+use directory_blob::{capture_directory_blob, restore_directory_blob, DIRECTORY_BLOB_MAGIC};
 
 pub use env::{
     select_tool_env, tool_env, workspace_tool, workspace_tool_env, workspace_tool_var, ToolEnvError,
@@ -37,7 +40,6 @@ pub use xdg::Xdg;
 /// the canonical encoding (or the [`Action`] schema) changes in a way
 /// that should invalidate the cache.
 const ACTION_DIGEST_DOMAIN: &[u8] = b"fabrik.action.v2\0";
-const DIRECTORY_BLOB_MAGIC: &[u8] = b"fabrik.directory.v1\0";
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -126,9 +128,9 @@ impl Action {
         Digest::of_bytes(&buf)
     }
 
-    pub fn resource_request(&self) -> ResourceRequest {
+    pub fn resource_request(&self) -> &ResourceRequest {
         match self {
-            Action::RunCommand { resources, .. } => resources.clone(),
+            Action::RunCommand { resources, .. } => resources,
         }
     }
 }
@@ -215,7 +217,10 @@ impl Runner {
         // Permits guard real subprocess execution, not cache lookups.
         // Dropping the future on cancellation releases the permit
         // without ever entering execute().
-        let _permit = self.resources.acquire(action.resource_request()).await;
+        let _permit = self
+            .resources
+            .acquire(action.resource_request().clone())
+            .await;
         // Re-check under the permit: another runner may have produced
         // the entry while we were queued.
         if let Some(hit) = lookup_cached(&self.cas, &self.workspace_root, &key).await? {
@@ -409,196 +414,6 @@ async fn capture_outputs(
         captured.insert(rel.as_str().to_string(), digest);
     }
     Ok(captured)
-}
-
-fn capture_directory_blob(root: &Path) -> std::io::Result<Vec<u8>> {
-    let mut files = Vec::new();
-    collect_directory_files(root, root, &mut files)?;
-    files.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut out = Vec::from(DIRECTORY_BLOB_MAGIC);
-    for (rel, mode, bytes) in files {
-        let path_bytes = rel.as_bytes();
-        let path_len = u32::try_from(path_bytes.len()).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "directory path is too long",
-            )
-        })?;
-        let content_len = u64::try_from(bytes.len()).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "directory file is too large",
-            )
-        })?;
-        out.extend_from_slice(&path_len.to_le_bytes());
-        out.extend_from_slice(&mode.to_le_bytes());
-        out.extend_from_slice(&content_len.to_le_bytes());
-        out.extend_from_slice(path_bytes);
-        out.extend_from_slice(&bytes);
-    }
-    Ok(out)
-}
-
-fn collect_directory_files(
-    root: &Path,
-    dir: &Path,
-    files: &mut Vec<(String, u32, Vec<u8>)>,
-) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let metadata = entry.metadata()?;
-        if metadata.is_dir() {
-            collect_directory_files(root, &path, files)?;
-        } else if metadata.is_file() {
-            let rel = path
-                .strip_prefix(root)
-                .expect("directory walk stays under root")
-                .to_string_lossy()
-                .replace(std::path::MAIN_SEPARATOR, "/");
-            #[cfg(unix)]
-            let mode = {
-                use std::os::unix::fs::PermissionsExt;
-                metadata.permissions().mode() & 0o777
-            };
-            #[cfg(not(unix))]
-            let mode = 0o644;
-            files.push((rel, mode, std::fs::read(&path)?));
-        }
-    }
-    Ok(())
-}
-
-fn restore_directory_blob(logical_path: &str, abs: &Path, bytes: &[u8]) -> Result<()> {
-    let files = decode_directory_blob(logical_path, bytes)?;
-    if abs.exists() {
-        let metadata = std::fs::metadata(abs).map_err(|source| Error::RestoreOutput {
-            path: logical_path.to_string(),
-            source,
-        })?;
-        if metadata.is_dir() {
-            std::fs::remove_dir_all(abs).map_err(|source| Error::RestoreOutput {
-                path: logical_path.to_string(),
-                source,
-            })?;
-        } else {
-            std::fs::remove_file(abs).map_err(|source| Error::RestoreOutput {
-                path: logical_path.to_string(),
-                source,
-            })?;
-        }
-    }
-    std::fs::create_dir_all(abs).map_err(|source| Error::RestoreOutput {
-        path: logical_path.to_string(),
-        source,
-    })?;
-    for (rel, mode, content) in files {
-        let rel_path = WorkspacePath::try_from(rel.as_str()).map_err(|source| {
-            Error::InvalidDirectoryOutput {
-                path: logical_path.to_string(),
-                message: source.to_string(),
-            }
-        })?;
-        if rel_path.as_str().is_empty() {
-            return Err(Error::InvalidDirectoryOutput {
-                path: logical_path.to_string(),
-                message: "directory entry path is empty".to_string(),
-            });
-        }
-        let dest = rel_path.resolve(abs);
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent).map_err(|source| Error::RestoreOutput {
-                path: logical_path.to_string(),
-                source,
-            })?;
-        }
-        std::fs::write(&dest, content).map_err(|source| Error::RestoreOutput {
-            path: logical_path.to_string(),
-            source,
-        })?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(mode.max(0o400)))
-                .map_err(|source| Error::RestoreOutput {
-                    path: logical_path.to_string(),
-                    source,
-                })?;
-        }
-    }
-    Ok(())
-}
-
-fn decode_directory_blob(logical_path: &str, bytes: &[u8]) -> Result<Vec<(String, u32, Vec<u8>)>> {
-    let mut pos = DIRECTORY_BLOB_MAGIC.len();
-    let mut files = Vec::new();
-    while pos < bytes.len() {
-        let path_len = usize::try_from(read_u32(logical_path, bytes, &mut pos)?).map_err(|_| {
-            Error::InvalidDirectoryOutput {
-                path: logical_path.to_string(),
-                message: "entry path length does not fit usize".to_string(),
-            }
-        })?;
-        let mode = read_u32(logical_path, bytes, &mut pos)?;
-        let content_len =
-            usize::try_from(read_u64(logical_path, bytes, &mut pos)?).map_err(|_| {
-                Error::InvalidDirectoryOutput {
-                    path: logical_path.to_string(),
-                    message: "entry content length does not fit usize".to_string(),
-                }
-            })?;
-        if bytes.len().saturating_sub(pos) < path_len {
-            return Err(Error::InvalidDirectoryOutput {
-                path: logical_path.to_string(),
-                message: "truncated entry path".to_string(),
-            });
-        }
-        let path_bytes = &bytes[pos..pos + path_len];
-        pos += path_len;
-        let path = std::str::from_utf8(path_bytes)
-            .map_err(|e| Error::InvalidDirectoryOutput {
-                path: logical_path.to_string(),
-                message: format!("entry path is not utf-8: {e}"),
-            })?
-            .to_string();
-        if bytes.len().saturating_sub(pos) < content_len {
-            return Err(Error::InvalidDirectoryOutput {
-                path: logical_path.to_string(),
-                message: "truncated entry content".to_string(),
-            });
-        }
-        let content = bytes[pos..pos + content_len].to_vec();
-        pos += content_len;
-        files.push((path, mode, content));
-    }
-    Ok(files)
-}
-
-fn read_u32(logical_path: &str, bytes: &[u8], pos: &mut usize) -> Result<u32> {
-    if bytes.len().saturating_sub(*pos) < 4 {
-        return Err(Error::InvalidDirectoryOutput {
-            path: logical_path.to_string(),
-            message: "truncated u32".to_string(),
-        });
-    }
-    let mut raw = [0u8; 4];
-    raw.copy_from_slice(&bytes[*pos..*pos + 4]);
-    *pos += 4;
-    Ok(u32::from_le_bytes(raw))
-}
-
-fn read_u64(logical_path: &str, bytes: &[u8], pos: &mut usize) -> Result<u64> {
-    if bytes.len().saturating_sub(*pos) < 8 {
-        return Err(Error::InvalidDirectoryOutput {
-            path: logical_path.to_string(),
-            message: "truncated u64".to_string(),
-        });
-    }
-    let mut raw = [0u8; 8];
-    raw.copy_from_slice(&bytes[*pos..*pos + 8]);
-    *pos += 8;
-    Ok(u64::from_le_bytes(raw))
 }
 
 async fn execute_run_command(
@@ -1041,7 +856,7 @@ mod tests {
             "argv": ["true"]
         }))
         .unwrap();
-        assert_eq!(decoded.resource_request(), ResourceRequest::default());
+        assert_eq!(decoded.resource_request(), &ResourceRequest::default());
     }
 
     #[test]

--- a/crates/fabrik-core/src/path.rs
+++ b/crates/fabrik-core/src/path.rs
@@ -111,6 +111,18 @@ impl fmt::Display for WorkspacePath {
     }
 }
 
+impl AsRef<str> for WorkspacePath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for WorkspacePath {
+    fn as_ref(&self) -> &Path {
+        Path::new(&self.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fabrik-elixir/src/artifact.rs
+++ b/crates/fabrik-elixir/src/artifact.rs
@@ -43,21 +43,16 @@ pub struct BeamArtifact {
 /// per-application `ebin/` convention so the layout stays familiar to
 /// anyone reading the cache contents on disk.
 pub fn ebin_dir(package: &str, name: &str) -> String {
-    if package.is_empty() {
-        format!(".fabrik/out/{name}.ebin")
-    } else {
-        format!(".fabrik/out/{package}/{name}.ebin")
-    }
+    format!(
+        "{}.ebin",
+        fabrik_frontend::workspace_output_dir(package, name)
+    )
 }
 
 /// Workspace-relative path to the launcher escript that an
 /// `elixir.binary` produces.
 pub fn escript_path(package: &str, name: &str) -> String {
-    if package.is_empty() {
-        format!(".fabrik/out/{name}")
-    } else {
-        format!(".fabrik/out/{package}/{name}")
-    }
+    fabrik_frontend::workspace_output_dir(package, name)
 }
 
 #[cfg(test)]

--- a/crates/fabrik-elixir/src/daemon.rs
+++ b/crates/fabrik-elixir/src/daemon.rs
@@ -44,7 +44,7 @@ pub const SOCKET_ENV_VAR: &str = "FABRIK_ELIXIR_DAEMON_SOCKET";
 /// workspace argument is unused for the default path but kept in the
 /// signature so callers don't have to special-case overrides.
 pub fn default_socket_path(_workspace_root: &Path) -> PathBuf {
-    Xdg::from_env().fabrik_runtime().join("elixir-daemon.sock")
+    socket_path_in(&Xdg::from_env())
 }
 
 /// Default location for the materialized daemon script:
@@ -52,8 +52,20 @@ pub fn default_socket_path(_workspace_root: &Path) -> PathBuf {
 /// script content is identical because it's embedded in the fabrik
 /// binary via [`DAEMON_SCRIPT`].
 pub fn default_script_path(_workspace_root: &Path) -> PathBuf {
-    Xdg::from_env()
-        .fabrik_data()
+    script_path_in(&Xdg::from_env())
+}
+
+/// Same as [`default_socket_path`] but resolves against an explicit
+/// [`Xdg`] value instead of reading the process environment. Lets tests
+/// exercise the layout without touching process-global env vars.
+pub fn socket_path_in(xdg: &Xdg) -> PathBuf {
+    xdg.fabrik_runtime().join("elixir-daemon.sock")
+}
+
+/// Same as [`default_script_path`] but resolves against an explicit
+/// [`Xdg`] value. See [`socket_path_in`].
+pub fn script_path_in(xdg: &Xdg) -> PathBuf {
+    xdg.fabrik_data()
         .join("daemon")
         .join(DAEMON_SCRIPT_FILENAME)
 }
@@ -226,39 +238,41 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    #[test]
-    fn default_socket_path_resolves_through_xdg_runtime() {
-        let tmp = TempDir::new().unwrap();
-        let runtime = tmp.path().join("runtime");
-        // Snapshot and restore the env so we don't leak overrides
-        // into other tests in the same process.
-        let prior = std::env::var_os("XDG_RUNTIME_DIR");
-        std::env::set_var("XDG_RUNTIME_DIR", &runtime);
-        let p = default_socket_path(tmp.path());
-        assert_eq!(p, runtime.join("fabrik").join("elixir-daemon.sock"));
-        match prior {
-            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
-            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+    fn xdg_under(root: &Path) -> Xdg {
+        Xdg {
+            cache_home: root.join("cache"),
+            state_home: root.join("state"),
+            data_home: root.join("data"),
+            config_home: root.join("config"),
+            runtime_dir: root.join("runtime"),
         }
     }
 
     #[test]
-    fn default_script_path_resolves_through_xdg_data() {
+    fn socket_path_resolves_through_xdg_runtime() {
         let tmp = TempDir::new().unwrap();
-        let data = tmp.path().join("data");
-        let prior = std::env::var_os("XDG_DATA_HOME");
-        std::env::set_var("XDG_DATA_HOME", &data);
-        let p = default_script_path(tmp.path());
+        let xdg = xdg_under(tmp.path());
         assert_eq!(
-            p,
-            data.join("fabrik")
+            socket_path_in(&xdg),
+            tmp.path()
+                .join("runtime")
+                .join("fabrik")
+                .join("elixir-daemon.sock")
+        );
+    }
+
+    #[test]
+    fn script_path_resolves_through_xdg_data() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        assert_eq!(
+            script_path_in(&xdg),
+            tmp.path()
+                .join("data")
+                .join("fabrik")
                 .join("daemon")
                 .join(DAEMON_SCRIPT_FILENAME)
         );
-        match prior {
-            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
     }
 
     #[test]

--- a/crates/fabrik-elixir/src/plan.rs
+++ b/crates/fabrik-elixir/src/plan.rs
@@ -3,11 +3,11 @@
 //! [`fabrik_core::Plan`] whose node ordering and edges respect every
 //! declared dependency.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use fabrik_core::{Action, BuiltPlan, NodeInfo, Plan};
-use fabrik_frontend::{external_dep_id, Target};
+use fabrik_frontend::{external_dep_id, PlanGraphError, Target};
 
 use crate::artifact::{BeamArtifact, ElixirKind};
 use crate::compile::{compile_target, CompileError};
@@ -32,6 +32,16 @@ pub enum PlanBuildError {
     InvalidExternalDepSpec { label: String, graph: String },
 }
 
+impl From<PlanGraphError> for PlanBuildError {
+    fn from(err: PlanGraphError) -> Self {
+        match err {
+            PlanGraphError::UnknownRoot(id) => Self::UnknownRoot(id),
+            PlanGraphError::Cycle(id) => Self::Cycle(id),
+            PlanGraphError::MissingDep { label, dep } => Self::MissingDep { label, dep },
+        }
+    }
+}
+
 /// Quick check used by the CLI dispatcher to pick between language
 /// planners.
 pub fn supports_kind(kind: &str) -> bool {
@@ -43,27 +53,16 @@ pub fn build_plan(
     root_id: &str,
     workspace_root: &Path,
 ) -> Result<BuiltPlan, PlanBuildError> {
-    let target_index: HashMap<String, usize> = targets
-        .iter()
-        .enumerate()
-        .map(|(i, t)| (t.id(), i))
-        .collect();
-    let root_target_idx = *target_index
-        .get(root_id)
-        .ok_or_else(|| PlanBuildError::UnknownRoot(root_id.to_string()))?;
+    let target_index = fabrik_frontend::target_index(targets);
+    let root_target_idx = fabrik_frontend::resolve_root(&target_index, root_id)?;
     let deps_by_target = target_dep_ids(targets)?;
 
-    let mut order: Vec<usize> = Vec::new();
-    let mut on_stack: BTreeSet<usize> = BTreeSet::new();
-    let mut visited: BTreeSet<usize> = BTreeSet::new();
-    dfs(
-        root_target_idx,
+    let order = fabrik_frontend::topological_sort(
         targets,
         &deps_by_target,
         &target_index,
-        &mut visited,
-        &mut on_stack,
-        &mut order,
+        root_target_idx,
+        |kind| ElixirKind::parse(kind).is_some(),
     )?;
 
     let mut plan = Plan::new();
@@ -152,48 +151,6 @@ fn target_dep_id(target: &Target) -> Result<Vec<String>, PlanBuildError> {
         deps.push(external_dep_id(&dep.graph, package_name));
     }
     Ok(deps)
-}
-
-fn dfs(
-    idx: usize,
-    targets: &[Target],
-    deps_by_target: &[Vec<String>],
-    target_index: &HashMap<String, usize>,
-    visited: &mut BTreeSet<usize>,
-    on_stack: &mut BTreeSet<usize>,
-    order: &mut Vec<usize>,
-) -> Result<(), PlanBuildError> {
-    if visited.contains(&idx) {
-        return Ok(());
-    }
-    if on_stack.contains(&idx) {
-        return Err(PlanBuildError::Cycle(targets[idx].id()));
-    }
-    on_stack.insert(idx);
-    for dep in &deps_by_target[idx] {
-        let dep_idx = target_index
-            .get(dep)
-            .ok_or_else(|| PlanBuildError::MissingDep {
-                label: targets[idx].id(),
-                dep: dep.clone(),
-            })?;
-        let dep_kind = &targets[*dep_idx].kind;
-        if ElixirKind::parse(dep_kind).is_some() {
-            dfs(
-                *dep_idx,
-                targets,
-                deps_by_target,
-                target_index,
-                visited,
-                on_stack,
-                order,
-            )?;
-        }
-    }
-    on_stack.remove(&idx);
-    visited.insert(idx);
-    order.push(idx);
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/fabrik-frontend/src/lib.rs
+++ b/crates/fabrik-frontend/src/lib.rs
@@ -14,6 +14,7 @@
 mod dependency;
 mod error;
 mod manifest;
+mod plan_builder;
 mod target;
 mod target_ref;
 mod workspace;
@@ -30,6 +31,10 @@ pub use dependency::{
 };
 pub use error::{Error, Result};
 pub use manifest::{load_dependency_entries_toml_str, load_toml_str};
+pub use plan_builder::{
+    resolve_root, target_index, topological_sort, workspace_output_dir,
+    BuildError as PlanGraphError,
+};
 pub use target::{ExternalDependency, Target};
 pub use target_ref::{
     absolutize, normalize_build_dep, normalize_cli_target, normalize_cli_target_from, target_id,

--- a/crates/fabrik-frontend/src/plan_builder.rs
+++ b/crates/fabrik-frontend/src/plan_builder.rs
@@ -1,0 +1,230 @@
+#![allow(clippy::implicit_hasher)]
+//! Shared scaffolding for per-language `build_plan` implementations.
+//!
+//! Every language plugin walks a flat target list, filters to its own
+//! kinds, topologically sorts what's reachable from a root, then drives
+//! a language-specific compile step over the sorted order. The DFS,
+//! the cycle detection, and the workspace-relative output path layout
+//! are identical across plugins; only the compile step and the kind
+//! predicate vary. This module exposes the invariants once so each
+//! plugin's `plan.rs` reduces to "set up the predicate, then call the
+//! shared sort + compile loop."
+
+use std::collections::{BTreeSet, HashMap};
+
+use crate::Target;
+
+/// Errors the shared planner can surface without needing to know which
+/// language plugin is calling it.
+#[derive(Debug, thiserror::Error)]
+pub enum BuildError {
+    #[error("no target matches `{0}`")]
+    UnknownRoot(String),
+    #[error("dependency cycle through `{0}`")]
+    Cycle(String),
+    #[error("dep `{dep}` of target {label} is not declared in any Fabrik build file")]
+    MissingDep { label: String, dep: String },
+}
+
+/// Workspace-relative directory where a language plugin should place
+/// the root output of `name` declared in `package`. Empty `package`
+/// (workspace-root targets) collapses the layout to one level.
+#[must_use]
+pub fn workspace_output_dir(package: &str, name: &str) -> String {
+    if package.is_empty() {
+        format!(".fabrik/out/{name}")
+    } else {
+        format!(".fabrik/out/{package}/{name}")
+    }
+}
+
+/// Build a `target id -> index` lookup over the workspace target list.
+#[must_use]
+pub fn target_index(targets: &[Target]) -> HashMap<String, usize> {
+    targets
+        .iter()
+        .enumerate()
+        .map(|(i, t)| (t.id(), i))
+        .collect()
+}
+
+/// Resolve `root_id` to its index, or return an `UnknownRoot` error
+/// shaped consistently across plugins.
+pub fn resolve_root(
+    target_index: &HashMap<String, usize>,
+    root_id: &str,
+) -> Result<usize, BuildError> {
+    target_index
+        .get(root_id)
+        .copied()
+        .ok_or_else(|| BuildError::UnknownRoot(root_id.to_string()))
+}
+
+/// Depth-first topological sort over the workspace target list.
+///
+/// `deps_by_target[i]` lists the declared dep ids of target `targets[i]`
+/// (typically `target.deps` plus any externalized deps the caller has
+/// already lowered to flat target ids). `traverse` is a predicate that
+/// gates whether the walker descends through a dep target by kind: it
+/// returns `true` for kinds the calling plugin compiles, and `false` for
+/// kinds it should treat as an opaque leaf (so a rust target depending
+/// on an elixir target doesn't make the elixir target part of the rust
+/// plan). Returns a reverse-postorder traversal that is already a valid
+/// topological sort.
+pub fn topological_sort<F>(
+    targets: &[Target],
+    deps_by_target: &[Vec<String>],
+    target_index: &HashMap<String, usize>,
+    root_idx: usize,
+    traverse: F,
+) -> Result<Vec<usize>, BuildError>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut order: Vec<usize> = Vec::new();
+    let mut on_stack: BTreeSet<usize> = BTreeSet::new();
+    let mut visited: BTreeSet<usize> = BTreeSet::new();
+    dfs(
+        root_idx,
+        targets,
+        deps_by_target,
+        target_index,
+        &traverse,
+        &mut visited,
+        &mut on_stack,
+        &mut order,
+    )?;
+    Ok(order)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dfs<F>(
+    idx: usize,
+    targets: &[Target],
+    deps_by_target: &[Vec<String>],
+    target_index: &HashMap<String, usize>,
+    traverse: &F,
+    visited: &mut BTreeSet<usize>,
+    on_stack: &mut BTreeSet<usize>,
+    order: &mut Vec<usize>,
+) -> Result<(), BuildError>
+where
+    F: Fn(&str) -> bool,
+{
+    if visited.contains(&idx) {
+        return Ok(());
+    }
+    if on_stack.contains(&idx) {
+        return Err(BuildError::Cycle(targets[idx].id()));
+    }
+    on_stack.insert(idx);
+    for dep in &deps_by_target[idx] {
+        let dep_idx = target_index
+            .get(dep)
+            .copied()
+            .ok_or_else(|| BuildError::MissingDep {
+                label: targets[idx].id(),
+                dep: dep.clone(),
+            })?;
+        if traverse(&targets[dep_idx].kind) {
+            dfs(
+                dep_idx,
+                targets,
+                deps_by_target,
+                target_index,
+                traverse,
+                visited,
+                on_stack,
+                order,
+            )?;
+        }
+    }
+    on_stack.remove(&idx);
+    visited.insert(idx);
+    order.push(idx);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn target(pkg: &str, name: &str, kind: &str, deps: &[&str]) -> Target {
+        Target {
+            package: pkg.into(),
+            external_package: None,
+            kind: kind.into(),
+            name: name.into(),
+            srcs: Vec::new(),
+            deps: deps.iter().map(|s| (*s).to_string()).collect(),
+            external_deps: Vec::new(),
+            attrs: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn workspace_output_dir_with_and_without_package() {
+        assert_eq!(workspace_output_dir("", "hello"), ".fabrik/out/hello");
+        assert_eq!(
+            workspace_output_dir("pkg", "hello"),
+            ".fabrik/out/pkg/hello"
+        );
+    }
+
+    #[test]
+    fn topological_sort_orders_deps_before_dependents() {
+        let targets = vec![
+            target("base", "base", "x_lib", &[]),
+            target("a", "a", "x_lib", &["base/base"]),
+            target("top", "top", "x_bin", &["a/a"]),
+        ];
+        let idx = target_index(&targets);
+        let deps = vec![
+            targets[0].deps.clone(),
+            targets[1].deps.clone(),
+            targets[2].deps.clone(),
+        ];
+        let order = topological_sort(&targets, &deps, &idx, 2, |k| k.starts_with("x_")).unwrap();
+        let label = |i: usize| targets[i].id();
+        let positions: Vec<_> = order.iter().map(|i| label(*i)).collect();
+        assert_eq!(positions, vec!["base/base", "a/a", "top/top"]);
+    }
+
+    #[test]
+    fn topological_sort_detects_cycles() {
+        let targets = vec![
+            target("a", "a", "x_lib", &["b/b"]),
+            target("b", "b", "x_lib", &["a/a"]),
+        ];
+        let idx = target_index(&targets);
+        let deps = vec![targets[0].deps.clone(), targets[1].deps.clone()];
+        let err = topological_sort(&targets, &deps, &idx, 0, |k| k.starts_with("x_")).unwrap_err();
+        assert!(matches!(err, BuildError::Cycle(_)));
+    }
+
+    #[test]
+    fn topological_sort_skips_traversal_for_unsupported_kinds() {
+        // `top` declares a dep on `other/other` whose kind isn't ours;
+        // the predicate returns false so we don't descend, but we still
+        // require the dep id to exist (so a typo on a foreign kind is
+        // still a MissingDep).
+        let targets = vec![
+            target("other", "other", "y_lib", &[]),
+            target("top", "top", "x_bin", &["other/other"]),
+        ];
+        let idx = target_index(&targets);
+        let deps = vec![targets[0].deps.clone(), targets[1].deps.clone()];
+        let order = topological_sort(&targets, &deps, &idx, 1, |k| k.starts_with("x_")).unwrap();
+        assert_eq!(order, vec![1]);
+    }
+
+    #[test]
+    fn topological_sort_reports_missing_dep() {
+        let targets = vec![target("top", "top", "x_bin", &["ghost/ghost"])];
+        let idx = target_index(&targets);
+        let deps = vec![targets[0].deps.clone()];
+        let err = topological_sort(&targets, &deps, &idx, 0, |_| true).unwrap_err();
+        assert!(matches!(err, BuildError::MissingDep { .. }));
+    }
+}

--- a/crates/fabrik-go/src/compile.rs
+++ b/crates/fabrik-go/src/compile.rs
@@ -135,11 +135,7 @@ fn build_input_digest(
 }
 
 fn executable_path(package: &str, name: &str) -> String {
-    if package.is_empty() {
-        format!(".fabrik/out/{name}")
-    } else {
-        format!(".fabrik/out/{package}/{name}")
-    }
+    fabrik_frontend::workspace_output_dir(package, name)
 }
 
 fn parent_dir(path: &str) -> String {

--- a/crates/fabrik-rust/src/plan.rs
+++ b/crates/fabrik-rust/src/plan.rs
@@ -3,11 +3,11 @@
 //! [`fabrik_core::Plan`] whose node ordering and edges respect every
 //! declared dependency.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use fabrik_core::{Action, BuiltPlan, NodeInfo, Plan};
-use fabrik_frontend::{external_dep_id, Target};
+use fabrik_frontend::{external_dep_id, PlanGraphError, Target};
 
 use crate::artifact::{DepArtifact, RustKind};
 use crate::build_script::{compile_build_script, output_path as build_script_output_path};
@@ -33,6 +33,16 @@ pub enum PlanBuildError {
     InvalidExternalDepSpec { label: String, graph: String },
 }
 
+impl From<PlanGraphError> for PlanBuildError {
+    fn from(err: PlanGraphError) -> Self {
+        match err {
+            PlanGraphError::UnknownRoot(id) => Self::UnknownRoot(id),
+            PlanGraphError::Cycle(id) => Self::Cycle(id),
+            PlanGraphError::MissingDep { label, dep } => Self::MissingDep { label, dep },
+        }
+    }
+}
+
 /// Build a plan for `root_id` from a flat target list.
 ///
 /// `targets` is the workspace-wide vector returned by
@@ -46,30 +56,16 @@ pub fn build_plan(
     root_id: &str,
     workspace_root: &Path,
 ) -> Result<BuiltPlan, PlanBuildError> {
-    let target_index: HashMap<String, usize> = targets
-        .iter()
-        .enumerate()
-        .map(|(i, t)| (t.id(), i))
-        .collect();
-    let root_target_idx = *target_index
-        .get(root_id)
-        .ok_or_else(|| PlanBuildError::UnknownRoot(root_id.to_string()))?;
+    let target_index = fabrik_frontend::target_index(targets);
+    let root_target_idx = fabrik_frontend::resolve_root(&target_index, root_id)?;
     let deps_by_target = target_dep_ids(targets)?;
 
-    // DFS to collect every target reachable from root, returning a
-    // reverse-postorder traversal that's already a valid topological
-    // sort.
-    let mut order: Vec<usize> = Vec::new();
-    let mut on_stack: BTreeSet<usize> = BTreeSet::new();
-    let mut visited: BTreeSet<usize> = BTreeSet::new();
-    dfs(
-        root_target_idx,
+    let order = fabrik_frontend::topological_sort(
         targets,
         &deps_by_target,
         &target_index,
-        &mut visited,
-        &mut on_stack,
-        &mut order,
+        root_target_idx,
+        |kind| RustKind::parse(kind).is_some(),
     )?;
 
     // Compile in topological order so each target's deps are already
@@ -207,51 +203,6 @@ fn root_output_path(node: &fabrik_core::PlanNode) -> String {
             .map(|p| p.as_str().to_string())
             .unwrap_or_default(),
     }
-}
-
-fn dfs(
-    idx: usize,
-    targets: &[Target],
-    deps_by_target: &[Vec<String>],
-    target_index: &HashMap<String, usize>,
-    visited: &mut BTreeSet<usize>,
-    on_stack: &mut BTreeSet<usize>,
-    order: &mut Vec<usize>,
-) -> Result<(), PlanBuildError> {
-    if visited.contains(&idx) {
-        return Ok(());
-    }
-    if on_stack.contains(&idx) {
-        return Err(PlanBuildError::Cycle(targets[idx].id()));
-    }
-    on_stack.insert(idx);
-    for dep in &deps_by_target[idx] {
-        let dep_idx = target_index
-            .get(dep)
-            .ok_or_else(|| PlanBuildError::MissingDep {
-                label: targets[idx].id(),
-                dep: dep.clone(),
-            })?;
-        // Non-rust deps would fail at compile time too; we only walk
-        // them here when they are rust-shaped targets so the cycle
-        // detector does not misreport a rust -> non-rust edge.
-        let dep_kind = &targets[*dep_idx].kind;
-        if RustKind::parse(dep_kind).is_some() {
-            dfs(
-                *dep_idx,
-                targets,
-                deps_by_target,
-                target_index,
-                visited,
-                on_stack,
-                order,
-            )?;
-        }
-    }
-    on_stack.remove(&idx);
-    visited.insert(idx);
-    order.push(idx);
-    Ok(())
 }
 
 #[cfg(test)]

--- a/spec/exec_spec.sh
+++ b/spec/exec_spec.sh
@@ -142,6 +142,44 @@ Describe 'fabrik exec'
     End
   End
 
+  Describe '--quiet'
+    It 'suppresses the human trailer on stderr but keeps subprocess stdout'
+      When call "$FABRIK_BIN" --quiet -C "$WORKSPACE" exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'printf hello'
+      The status should be success
+      # Wrapped program stdout still passes through untouched.
+      The stdout should equal 'hello'
+      # The "fabrik: cache ..." trailer must not appear under --quiet.
+      The stderr should not include 'cache miss'
+      The stderr should not include 'fabrik:'
+    End
+
+    It 'still emits the structured trailer when --quiet is combined with --format json'
+      # --quiet only gates human trailers; machine consumers asked
+      # for json get json regardless. Stdout remains the wrapped
+      # program's bytes so existing pipelines stay parseable.
+      When call "$FABRIK_BIN" --quiet --format json -C "$WORKSPACE" exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'printf hello'
+      The status should be success
+      The stdout should equal 'hello'
+      The stderr should include '"cache":"miss"'
+      The stderr should include '"exit_code":0'
+    End
+
+    It 'still surfaces errors when --quiet is set'
+      # Errors travel to stderr through a different code path than the
+      # success trailer; --quiet must not swallow them.
+      When call "$FABRIK_BIN" --quiet -C /nonexistent exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'true'
+      The status should not equal 0
+      The stderr should include 'fabrik:'
+    End
+
+    It 'accepts the short -q alias'
+      When call "$FABRIK_BIN" -q -C "$WORKSPACE" exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'printf hi'
+      The status should be success
+      The stdout should equal 'hi'
+      The stderr should not include 'cache miss'
+    End
+  End
+
   Describe '--format toon'
     It 'emits a TOON trailer on stderr; stdout stays the wrapped program transparent'
       When call "$FABRIK_BIN" --format toon -C "$WORKSPACE" exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'printf hello'


### PR DESCRIPTION
## Summary

Architectural review pass across the workspace, plus a global `--quiet` flag. Lands in three commits:

- **`chore`: serialize daemon env-mutating tests via explicit `Xdg`.** The two daemon path tests in `fabrik-elixir` were mutating `XDG_RUNTIME_DIR` / `XDG_DATA_HOME` without serialization, so concurrent `cargo test` runs could race. Extracted `socket_path_in(&Xdg)` / `script_path_in(&Xdg)` so tests exercise the layout against an explicit value instead of process env.
- **`refactor`: dedupe planner scaffolding, split `lib.rs`, tighten ownership.** Lifted the identical DFS + cycle detection + `workspace_output_dir` formatter from each language crate into a new `fabrik-frontend::plan_builder`. Replaced the per-verb `if fabrik_apple::supports_kind ... else if ...` ladder in the CLI with a `PLANNERS` slice in a new `fabrik-cli/src/planner.rs`. Moved the ~200-line directory-blob encoder out of `fabrik-core/src/lib.rs` into its own module (1283 to ~1090 lines). `Action::resource_request` returns `&ResourceRequest` instead of cloning; `WorkspacePath` gains `AsRef<str>` / `AsRef<Path>`; apple plan stops carrying `Cow<[String]>`. Target-not-found and wrong-kind errors now suggest "Run `fabrik targets`".
- **`feat(cli)`: add `--quiet` flag and bundle output options.** New global `-q` / `--quiet` that suppresses human-mode "fabrik: built ..." / per-node hit/miss / "fabrik: ran ..." trailers. Errors and `--format json`/`toon` output are untouched. Introduces a `cli::Output { format, quiet }` struct with a `show_human_trailers()` helper so command handlers take one value instead of two parallel params.

## Testing

- `mise exec -- cargo build --workspace`
- `mise exec -- cargo test --workspace` (290+ tests, all pass)
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- Manual smoke: `fabrik exec -- /bin/echo x` prints the trailer; `fabrik --quiet exec -- /bin/echo x` does not.
