### PR TITLE
fix(website): run worker before assets

### DIFF
--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -11,7 +11,8 @@
     "directory": "./_site",
     "binding": "ASSETS",
     "html_handling": "auto-trailing-slash",
-    "not_found_handling": "404-page"
+    "not_found_handling": "404-page",
+    "run_worker_first": true
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary
- Default Cloudflare behavior with `assets` + `main` is asset-first: static files are served before the Worker runs, which silently bypasses the content negotiation, `Content-Signal` header, and `Link` header.
- Setting `assets.run_worker_first: true` makes the Worker handle every request and delegate to `env.ASSETS.fetch()` for static files.

## Testing
- Verified against the first live deploy (https://fabrik-website.tuist-cc0.workers.dev): `Accept: text/markdown` returned HTML, and HTML responses had no `Content-Signal`/`Link` headers.
- After this change deploys, the Worker should intercept every request and emit the discovery headers + serve Markdown alternates when negotiated.
