### PR TITLE
Detect CI cache volume roots

### DIFF
--- a/crates/fabrik-cli/src/cache_provider.rs
+++ b/crates/fabrik-cli/src/cache_provider.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::env;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -8,6 +9,8 @@ use fabrik_frontend::{
     CacheProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
 };
 use serde::Deserialize;
+
+pub(crate) const FABRIK_CACHE_DIR_ENV: &str = "FABRIK_CACHE_DIR";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ResolvedCacheProviderConfig {
@@ -76,13 +79,76 @@ fn resolve_config(workspace: &Path, xdg: &Xdg) -> Result<ResolvedCacheProviderCo
 }
 
 fn build_provider(xdg: &Xdg, config: ResolvedCacheProviderConfig) -> Result<CacheProvider> {
+    let local_root = local_cas_root(xdg);
     match config {
-        ResolvedCacheProviderConfig::Local => Ok(CacheProvider::open_local(xdg.fabrik_cas())),
+        ResolvedCacheProviderConfig::Local => Ok(CacheProvider::open_local(local_root)),
         ResolvedCacheProviderConfig::Tuist(config) => {
-            CacheProvider::tuist(xdg.fabrik_cas(), credentials_root(xdg), config)
+            CacheProvider::tuist(local_root, credentials_root(xdg), config)
                 .context("configuring Tuist cache provider")
         }
     }
+}
+
+fn local_cas_root(xdg: &Xdg) -> PathBuf {
+    if let Some(root) = non_empty_env_path(FABRIK_CACHE_DIR_ENV) {
+        return root;
+    }
+
+    if let Some(root) = detected_ci_cache_root() {
+        return root;
+    }
+
+    xdg.fabrik_cas()
+}
+
+fn detected_ci_cache_root() -> Option<PathBuf> {
+    detected_ci_cache_root_with_mount_and_vars(Path::new("/cache"), env::vars_os())
+}
+
+#[cfg(test)]
+fn detected_ci_cache_root_with_mount(cache_mount: &Path) -> Option<PathBuf> {
+    detected_ci_cache_root_with_mount_and_vars(cache_mount, env::vars_os())
+}
+
+fn detected_ci_cache_root_with_mount_and_vars<I, K, V>(
+    cache_mount: &Path,
+    vars: I,
+) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<std::ffi::OsStr>,
+    V: AsRef<std::ffi::OsStr>,
+{
+    let mut github_actions = false;
+    let mut namespace = false;
+    for (key, value) in vars {
+        if value.as_ref().is_empty() {
+            continue;
+        }
+        let key = key.as_ref().to_string_lossy();
+        github_actions |= key == "GITHUB_ACTIONS";
+        namespace |= key.starts_with("NSC_") || key.starts_with("NSCLOUD_");
+    }
+
+    if !github_actions {
+        return None;
+    }
+
+    if namespace && cache_mount_exists(cache_mount) {
+        return Some(cache_mount.join("fabrik").join("cas"));
+    }
+
+    None
+}
+
+fn cache_mount_exists(path: &Path) -> bool {
+    std::fs::metadata(path).is_ok_and(|metadata| metadata.is_dir())
+}
+
+fn non_empty_env_path(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
 }
 
 fn resolve_provider_config(
@@ -308,7 +374,11 @@ fn non_empty(value: Option<String>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn xdg_under(root: &Path) -> Xdg {
         Xdg {
@@ -328,6 +398,29 @@ mod tests {
         let dir = xdg.config_home.join("fabrik");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("config.toml"), body).unwrap();
+    }
+
+    fn with_env<F: FnOnce()>(vars: &[(&str, Option<&str>)], f: F) {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let saved: Vec<(&str, Option<OsString>)> = vars
+            .iter()
+            .map(|(key, _)| (*key, env::var_os(key)))
+            .collect();
+        for (key, value) in vars {
+            match value {
+                Some(value) => env::set_var(key, value),
+                None => env::remove_var(key),
+            }
+        }
+        f();
+        for (key, value) in saved {
+            match value {
+                Some(value) => env::set_var(key, value),
+                None => env::remove_var(key),
+            }
+        }
     }
 
     fn expect_tuist(config: ResolvedCacheProviderConfig) -> fabrik_cas::TuistCacheConfig {
@@ -480,5 +573,73 @@ account = "acme"
 
         assert_eq!(config.url, DEFAULT_TUIST_URL);
         assert_eq!(config.provider_name, "tuist");
+    }
+
+    #[test]
+    fn local_cas_root_uses_explicit_env_override() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        let explicit = tmp.path().join("explicit-cas");
+
+        with_env(
+            &[
+                (FABRIK_CACHE_DIR_ENV, Some(explicit.to_str().unwrap())),
+                ("GITHUB_ACTIONS", Some("true")),
+                ("NSC_WORKSPACE", Some("workspace")),
+            ],
+            || {
+                assert_eq!(local_cas_root(&xdg), explicit);
+            },
+        );
+    }
+
+    #[test]
+    fn namespace_github_actions_uses_cache_volume_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path().join("cache-volume");
+        std::fs::create_dir(&mount).unwrap();
+
+        with_env(
+            &[
+                (FABRIK_CACHE_DIR_ENV, None),
+                ("GITHUB_ACTIONS", Some("true")),
+                ("NSC_WORKSPACE", Some("workspace")),
+            ],
+            || {
+                assert_eq!(
+                    detected_ci_cache_root_with_mount(&mount),
+                    Some(mount.join("fabrik").join("cas"))
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn ci_detection_ignores_non_namespace_runners() {
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path().join("cache-volume");
+        std::fs::create_dir(&mount).unwrap();
+
+        assert_eq!(
+            detected_ci_cache_root_with_mount_and_vars(&mount, [("GITHUB_ACTIONS", "true")]),
+            None
+        );
+    }
+
+    #[test]
+    fn local_cas_root_falls_back_to_xdg() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+
+        with_env(
+            &[
+                (FABRIK_CACHE_DIR_ENV, None),
+                ("GITHUB_ACTIONS", None),
+                ("NSC_WORKSPACE", None),
+            ],
+            || {
+                assert_eq!(local_cas_root(&xdg), xdg.fabrik_cas());
+            },
+        );
     }
 }

--- a/crates/fabrik-cli/src/cache_provider.rs
+++ b/crates/fabrik-cli/src/cache_provider.rs
@@ -101,48 +101,11 @@ fn local_cas_root(xdg: &Xdg) -> PathBuf {
     xdg.fabrik_cas()
 }
 
+/// Cache-store root carved out of a CI-provided cache volume, if one is
+/// available. The CI/runner detection lives in [`crate::ci`]; this only
+/// owns the `fabrik/cas` subtree convention.
 fn detected_ci_cache_root() -> Option<PathBuf> {
-    detected_ci_cache_root_with_mount_and_vars(Path::new("/cache"), env::vars_os())
-}
-
-#[cfg(test)]
-fn detected_ci_cache_root_with_mount(cache_mount: &Path) -> Option<PathBuf> {
-    detected_ci_cache_root_with_mount_and_vars(cache_mount, env::vars_os())
-}
-
-fn detected_ci_cache_root_with_mount_and_vars<I, K, V>(
-    cache_mount: &Path,
-    vars: I,
-) -> Option<PathBuf>
-where
-    I: IntoIterator<Item = (K, V)>,
-    K: AsRef<std::ffi::OsStr>,
-    V: AsRef<std::ffi::OsStr>,
-{
-    let mut github_actions = false;
-    let mut namespace = false;
-    for (key, value) in vars {
-        if value.as_ref().is_empty() {
-            continue;
-        }
-        let key = key.as_ref().to_string_lossy();
-        github_actions |= key == "GITHUB_ACTIONS";
-        namespace |= key.starts_with("NSC_") || key.starts_with("NSCLOUD_");
-    }
-
-    if !github_actions {
-        return None;
-    }
-
-    if namespace && cache_mount_exists(cache_mount) {
-        return Some(cache_mount.join("fabrik").join("cas"));
-    }
-
-    None
-}
-
-fn cache_mount_exists(path: &Path) -> bool {
-    std::fs::metadata(path).is_ok_and(|metadata| metadata.is_dir())
+    crate::ci::cache_volume_mount().map(|mount| mount.join("fabrik").join("cas"))
 }
 
 fn non_empty_env_path(name: &str) -> Option<PathBuf> {
@@ -590,39 +553,6 @@ account = "acme"
             || {
                 assert_eq!(local_cas_root(&xdg), explicit);
             },
-        );
-    }
-
-    #[test]
-    fn namespace_github_actions_uses_cache_volume_when_present() {
-        let tmp = TempDir::new().unwrap();
-        let mount = tmp.path().join("cache-volume");
-        std::fs::create_dir(&mount).unwrap();
-
-        with_env(
-            &[
-                (FABRIK_CACHE_DIR_ENV, None),
-                ("GITHUB_ACTIONS", Some("true")),
-                ("NSC_WORKSPACE", Some("workspace")),
-            ],
-            || {
-                assert_eq!(
-                    detected_ci_cache_root_with_mount(&mount),
-                    Some(mount.join("fabrik").join("cas"))
-                );
-            },
-        );
-    }
-
-    #[test]
-    fn ci_detection_ignores_non_namespace_runners() {
-        let tmp = TempDir::new().unwrap();
-        let mount = tmp.path().join("cache-volume");
-        std::fs::create_dir(&mount).unwrap();
-
-        assert_eq!(
-            detected_ci_cache_root_with_mount_and_vars(&mount, [("GITHUB_ACTIONS", "true")]),
-            None
         );
     }
 

--- a/crates/fabrik-cli/src/ci.rs
+++ b/crates/fabrik-cli/src/ci.rs
@@ -1,0 +1,193 @@
+//! Detection of CI environments and the persistent cache volumes some
+//! runners expose.
+//!
+//! Two questions are answered independently so neither is hard-wired to a
+//! single vendor:
+//!
+//! - *Are we on a recognised CI provider?* Decided by [`CI_MARKERS`].
+//! - *Does a runner mount a persistent cache volume, and where?* Decided
+//!   by [`CACHE_VOLUME_RUNNERS`].
+//!
+//! Both are data-driven tables. Supporting another CI provider (Bitrise,
+//! `CircleCI`, ...) or another runner provider (Namespace, ...) is a matter
+//! of adding a row, not of threading new boolean flags through the
+//! detection logic.
+
+use std::env;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+/// Environment variables whose presence marks a supported CI provider.
+///
+/// A cache volume is only trusted when one of these is set, so that a
+/// stray `NSC_*`/`NSCLOUD_*` variable on a developer machine does not
+/// redirect the local cache.
+const CI_MARKERS: &[&str] = &[
+    // GitHub Actions
+    "GITHUB_ACTIONS",
+    // Depot CI runs GitHub Actions workflows and documents compatibility
+    // with standard GitHub Actions runner environment variables, so it is
+    // expected to surface `GITHUB_ACTIONS` rather than a Depot-specific
+    // marker here.
+    //
+    // GitLab CI/CD
+    "GITLAB_CI",
+    // Semaphore
+    "SEMAPHORE",
+    // Jenkins
+    "JENKINS_URL",
+];
+
+/// A runner provider that mounts a persistent cache volume into the build.
+struct CacheVolumeRunner {
+    /// Recognises the runner from the name of an environment variable.
+    signals: fn(&str) -> bool,
+    /// Path where the runner mounts its cache volume.
+    mount: &'static str,
+}
+
+/// Known runners that expose a persistent cache volume.
+const CACHE_VOLUME_RUNNERS: &[CacheVolumeRunner] = &[
+    // Namespace (namespace.so) cloud runners expose a cache volume at
+    // `/cache` and advertise themselves through `NSC_*` / `NSCLOUD_*`.
+    CacheVolumeRunner {
+        signals: |key| key.starts_with("NSC_") || key.starts_with("NSCLOUD_"),
+        mount: "/cache",
+    },
+];
+
+/// Mount of a CI-provided persistent cache volume, if the process runs on
+/// a recognised CI runner that exposes one and the mount is present.
+///
+/// Returns the bare mount point; callers decide which subtree they own.
+pub(crate) fn cache_volume_mount() -> Option<PathBuf> {
+    detect_cache_volume_mount(None, env::vars_os())
+}
+
+/// Pure core of [`cache_volume_mount`], exposed so tests can drive it with
+/// an arbitrary variable set and a stand-in mount point.
+///
+/// `mount_override` replaces the matched runner's real mount (e.g. `/cache`)
+/// with a path the test controls.
+fn detect_cache_volume_mount<I, K, V>(mount_override: Option<&Path>, vars: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let mut on_ci = false;
+    let mut runner: Option<&CacheVolumeRunner> = None;
+    for (key, value) in vars {
+        if value.as_ref().is_empty() {
+            continue;
+        }
+        let key = key.as_ref().to_string_lossy();
+        on_ci |= CI_MARKERS.contains(&key.as_ref());
+        if runner.is_none() {
+            runner = CACHE_VOLUME_RUNNERS.iter().find(|runner| (runner.signals)(&key));
+        }
+    }
+
+    if !on_ci {
+        return None;
+    }
+
+    let runner = runner?;
+    let mount = mount_override.unwrap_or_else(|| Path::new(runner.mount));
+    mount_is_dir(mount).then(|| mount.to_path_buf())
+}
+
+fn mount_is_dir(path: &Path) -> bool {
+    std::fs::metadata(path).is_ok_and(|metadata| metadata.is_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_mount_for_ci_runner_with_present_volume() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mount = tmp.path().join("cache-volume");
+        std::fs::create_dir(&mount).unwrap();
+
+        assert_eq!(
+            detect_cache_volume_mount(
+                Some(&mount),
+                [("GITHUB_ACTIONS", "true"), ("NSC_WORKSPACE", "workspace")],
+            ),
+            Some(mount.clone())
+        );
+    }
+
+    #[test]
+    fn ignores_runner_without_recognised_ci_provider() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mount = tmp.path().join("cache-volume");
+        std::fs::create_dir(&mount).unwrap();
+
+        assert_eq!(
+            detect_cache_volume_mount(Some(&mount), [("NSC_WORKSPACE", "workspace")]),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_ci_provider_without_cache_volume_runner() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mount = tmp.path().join("cache-volume");
+        std::fs::create_dir(&mount).unwrap();
+
+        assert_eq!(
+            detect_cache_volume_mount(Some(&mount), [("GITHUB_ACTIONS", "true")]),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_mount_for_other_recognised_ci_providers() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mount = tmp.path().join("cache-volume");
+        std::fs::create_dir(&mount).unwrap();
+
+        for marker in ["GITLAB_CI", "SEMAPHORE", "JENKINS_URL"] {
+            assert_eq!(
+                detect_cache_volume_mount(
+                    Some(&mount),
+                    [(marker, "true"), ("NSC_WORKSPACE", "workspace")],
+                ),
+                Some(mount.clone()),
+                "expected {marker} to be recognised as CI"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_runner_when_mount_is_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mount = tmp.path().join("missing-volume");
+
+        assert_eq!(
+            detect_cache_volume_mount(
+                Some(&mount),
+                [("GITHUB_ACTIONS", "true"), ("NSC_WORKSPACE", "workspace")],
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_marker_values_do_not_count_as_ci() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mount = tmp.path().join("cache-volume");
+        std::fs::create_dir(&mount).unwrap();
+
+        assert_eq!(
+            detect_cache_volume_mount(
+                Some(&mount),
+                [("GITHUB_ACTIONS", ""), ("NSC_WORKSPACE", "workspace")],
+            ),
+            None
+        );
+    }
+}

--- a/crates/fabrik-cli/src/main.rs
+++ b/crates/fabrik-cli/src/main.rs
@@ -3,6 +3,7 @@
 //! resulting exit code.
 
 mod cache_provider;
+mod ci;
 mod cli;
 mod commands;
 mod dispatch;

--- a/crates/fabrik-core/src/gha_cache_bridge.rs
+++ b/crates/fabrik-core/src/gha_cache_bridge.rs
@@ -1,0 +1,512 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use fabrik_cas::{ActionResult, CacheProvider, Digest};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::{Error, Result};
+
+const ENABLE_ENV: &str = "FABRIK_GITHUB_ACTIONS_CACHE_BRIDGE";
+const TOKEN: &str = "fabrik-gha-cache-bridge";
+
+pub(crate) fn enabled() -> bool {
+    std::env::var_os(ENABLE_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
+pub(crate) struct Bridge {
+    base_url: String,
+    task: JoinHandle<()>,
+}
+
+impl Bridge {
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub(crate) fn token() -> &'static str {
+        TOKEN
+    }
+}
+
+impl Drop for Bridge {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub(crate) async fn start(cache: CacheProvider) -> Result<Option<Bridge>> {
+    if !enabled() {
+        return Ok(None);
+    }
+
+    start_enabled(cache).await.map(Some)
+}
+
+async fn start_enabled(cache: CacheProvider) -> Result<Bridge> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|source| Error::CacheBridge {
+            message: format!("binding local listener: {source}"),
+        })?;
+    let addr = listener.local_addr().map_err(|source| Error::CacheBridge {
+        message: format!("reading local listener address: {source}"),
+    })?;
+    let base_url = format!("http://{addr}/");
+    let state = Arc::new(Mutex::new(State::new(cache)));
+    let task = tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let state = Arc::clone(&state);
+            tokio::spawn(async move {
+                let _ = handle_connection(stream, state).await;
+            });
+        }
+    });
+
+    Ok(Bridge { base_url, task })
+}
+
+struct State {
+    cache: CacheProvider,
+    next_upload_id: u64,
+    uploads: HashMap<u64, PendingUpload>,
+}
+
+impl State {
+    fn new(cache: CacheProvider) -> Self {
+        Self {
+            cache,
+            next_upload_id: 1,
+            uploads: HashMap::new(),
+        }
+    }
+
+    fn reserve(&mut self, key: String, version: String) -> u64 {
+        let id = self.next_upload_id;
+        self.next_upload_id += 1;
+        self.uploads.insert(
+            id,
+            PendingUpload {
+                key,
+                version,
+                bytes: Vec::new(),
+            },
+        );
+        id
+    }
+}
+
+struct PendingUpload {
+    key: String,
+    version: String,
+    bytes: Vec<u8>,
+}
+
+struct Request {
+    method: String,
+    path: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+async fn handle_connection(mut stream: TcpStream, state: Arc<Mutex<State>>) -> Result<()> {
+    let Some(request) = read_request(&mut stream).await? else {
+        return Ok(());
+    };
+    let response = handle_request(request, state).await;
+    write_response(&mut stream, response).await
+}
+
+async fn handle_request(request: Request, state: Arc<Mutex<State>>) -> Response {
+    if request.method == "GET" && request.path.starts_with("/_apis/artifactcache/cache?") {
+        return restore(request, state).await;
+    }
+    if request.method == "POST" && request.path == "/_apis/artifactcache/caches" {
+        return reserve(request, state).await;
+    }
+    if request.method == "PATCH" && request.path.starts_with("/_apis/artifactcache/caches/") {
+        return upload_chunk(request, state).await;
+    }
+    if request.method == "POST" && request.path.starts_with("/_apis/artifactcache/caches/") {
+        return commit(request, state).await;
+    }
+    if request.method == "GET" && request.path.starts_with("/_fabrik/gha-cache/archive/") {
+        return download(request, state).await;
+    }
+    Response::not_found()
+}
+
+async fn restore(request: Request, state: Arc<Mutex<State>>) -> Response {
+    let query = request.path.split_once('?').map_or("", |(_, query)| query);
+    let keys = query_param(query, "keys")
+        .map(|keys| keys.split(',').map(ToString::to_string).collect::<Vec<_>>())
+        .unwrap_or_default();
+    let Some(version) = query_param(query, "version") else {
+        return Response::status(400, "missing version");
+    };
+
+    let cache = { state.lock().await.cache.clone() };
+    for key in keys {
+        let action = cache_key_digest(&key, &version);
+        let Ok(Some(result)) = cache.get_action_result(&action).await else {
+            continue;
+        };
+        let digest = result.stdout;
+        let body = RestoreResponse {
+            cache_key: key,
+            archive_location: format!(
+                "http://{}/_fabrik/gha-cache/archive/{digest}",
+                request
+                    .headers
+                    .get("host")
+                    .map_or("127.0.0.1", String::as_str)
+            ),
+        };
+        return Response::json(200, &body);
+    }
+
+    Response::empty(204)
+}
+
+async fn reserve(request: Request, state: Arc<Mutex<State>>) -> Response {
+    let Ok(body) = serde_json::from_slice::<ReserveRequest>(&request.body) else {
+        return Response::status(400, "invalid reserve body");
+    };
+    let id = state.lock().await.reserve(body.key, body.version);
+    Response::json(200, &ReserveResponse { cache_id: id })
+}
+
+async fn upload_chunk(request: Request, state: Arc<Mutex<State>>) -> Response {
+    let Some(id) = upload_id(&request.path) else {
+        return Response::status(404, "unknown upload");
+    };
+    let start = request
+        .headers
+        .get("content-range")
+        .and_then(|value| content_range_start(value))
+        .unwrap_or(0);
+    let mut state = state.lock().await;
+    let Some(upload) = state.uploads.get_mut(&id) else {
+        return Response::status(404, "unknown upload");
+    };
+    let end = start + request.body.len();
+    if upload.bytes.len() < end {
+        upload.bytes.resize(end, 0);
+    }
+    upload.bytes[start..end].copy_from_slice(&request.body);
+    Response::empty(204)
+}
+
+async fn commit(request: Request, state: Arc<Mutex<State>>) -> Response {
+    let Some(id) = upload_id(&request.path) else {
+        return Response::status(404, "unknown upload");
+    };
+    let (cache, upload) = {
+        let mut state = state.lock().await;
+        let Some(upload) = state.uploads.remove(&id) else {
+            return Response::status(404, "unknown upload");
+        };
+        (state.cache.clone(), upload)
+    };
+    let Ok(blob) = cache.put_blob(&upload.bytes).await else {
+        return Response::status(500, "failed to store archive");
+    };
+    let Ok(empty) = cache.put_blob(&[]).await else {
+        return Response::status(500, "failed to store archive metadata");
+    };
+    let result = ActionResult {
+        exit_code: 0,
+        stdout: blob,
+        stderr: empty,
+        outputs: BTreeMap::default(),
+    };
+    let action = cache_key_digest(&upload.key, &upload.version);
+    if cache.put_action_result(&action, &result).await.is_err() {
+        return Response::status(500, "failed to store archive index");
+    }
+
+    Response::json(200, &serde_json::json!({}))
+}
+
+async fn download(request: Request, state: Arc<Mutex<State>>) -> Response {
+    let Some(raw) = request.path.rsplit('/').next() else {
+        return Response::not_found();
+    };
+    let Some(digest) = Digest::from_hex(raw) else {
+        return Response::not_found();
+    };
+    let cache = { state.lock().await.cache.clone() };
+    match cache.get_blob(&digest).await {
+        Ok(bytes) => Response {
+            status: 200,
+            content_type: "application/octet-stream",
+            body: bytes,
+        },
+        Err(_) => Response::not_found(),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReserveRequest {
+    key: String,
+    version: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReserveResponse {
+    cache_id: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RestoreResponse {
+    cache_key: String,
+    archive_location: String,
+}
+
+struct Response {
+    status: u16,
+    content_type: &'static str,
+    body: Vec<u8>,
+}
+
+impl Response {
+    fn empty(status: u16) -> Self {
+        Self {
+            status,
+            content_type: "application/octet-stream",
+            body: Vec::new(),
+        }
+    }
+
+    fn status(status: u16, message: &str) -> Self {
+        Self {
+            status,
+            content_type: "text/plain",
+            body: message.as_bytes().to_vec(),
+        }
+    }
+
+    fn not_found() -> Self {
+        Self::status(404, "not found")
+    }
+
+    fn json(status: u16, value: &impl Serialize) -> Self {
+        Self {
+            status,
+            content_type: "application/json",
+            body: serde_json::to_vec(value).expect("response serializes"),
+        }
+    }
+}
+
+async fn read_request(stream: &mut TcpStream) -> Result<Option<Request>> {
+    let mut raw = Vec::new();
+    let header_end = loop {
+        let mut buf = [0_u8; 8192];
+        let n = stream.read(&mut buf).await.map_err(|source| Error::Wait {
+            program: "github actions cache bridge".to_string(),
+            source,
+        })?;
+        if n == 0 {
+            return Ok(None);
+        }
+        raw.extend_from_slice(&buf[..n]);
+        if let Some(pos) = find_header_end(&raw) {
+            break pos;
+        }
+    };
+
+    let header = String::from_utf8_lossy(&raw[..header_end]);
+    let mut lines = header.lines();
+    let Some(start) = lines.next() else {
+        return Ok(None);
+    };
+    let mut parts = start.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_string();
+    let path = parts.next().unwrap_or_default().to_string();
+    let mut headers = HashMap::new();
+    for line in lines {
+        if let Some((key, value)) = line.split_once(':') {
+            headers.insert(key.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+    let content_length = headers
+        .get("content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    let body_start = header_end + 4;
+    let mut body = raw[body_start..].to_vec();
+    while body.len() < content_length {
+        let mut buf = vec![0_u8; content_length - body.len()];
+        stream
+            .read_exact(&mut buf)
+            .await
+            .map_err(|source| Error::Wait {
+                program: "github actions cache bridge".to_string(),
+                source,
+            })?;
+        body.extend_from_slice(&buf);
+    }
+    body.truncate(content_length);
+
+    Ok(Some(Request {
+        method,
+        path,
+        headers,
+        body,
+    }))
+}
+
+async fn write_response(stream: &mut TcpStream, response: Response) -> Result<()> {
+    let status_text = match response.status {
+        204 => "No Content",
+        400 => "Bad Request",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "OK",
+    };
+    let head = format!(
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        response.status,
+        status_text,
+        response.content_type,
+        response.body.len()
+    );
+    stream
+        .write_all(head.as_bytes())
+        .await
+        .map_err(|source| Error::Wait {
+            program: "github actions cache bridge".to_string(),
+            source,
+        })?;
+    stream
+        .write_all(&response.body)
+        .await
+        .map_err(|source| Error::Wait {
+            program: "github actions cache bridge".to_string(),
+            source,
+        })?;
+    Ok(())
+}
+
+fn find_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn upload_id(path: &str) -> Option<u64> {
+    path.rsplit('/').next()?.parse().ok()
+}
+
+fn content_range_start(value: &str) -> Option<usize> {
+    let value = value.strip_prefix("bytes ")?;
+    let (start, _) = value.split_once('-')?;
+    start.parse().ok()
+}
+
+fn query_param(query: &str, name: &str) -> Option<String> {
+    query.split('&').find_map(|part| {
+        let (key, value) = part.split_once('=')?;
+        (key == name).then(|| percent_decode(value))
+    })
+}
+
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(hex) = u8::from_str_radix(&value[i + 1..i + 3], 16) {
+                out.push(hex);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn cache_key_digest(key: &str, version: &str) -> Digest {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"fabrik.gha-cache.v1\0");
+    bytes.extend_from_slice(key.as_bytes());
+    bytes.push(0);
+    bytes.extend_from_slice(version.as_bytes());
+    Digest::of_bytes(&bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn v1_protocol_round_trips_archive_through_cache_provider() {
+        let tmp = TempDir::new().unwrap();
+        let cache = CacheProvider::open_local(tmp.path().join("cas"));
+        let bridge = start_enabled(cache).await.unwrap();
+        let client = reqwest::Client::new();
+        let base = bridge.base_url();
+
+        let reserve = client
+            .post(format!("{base}_apis/artifactcache/caches"))
+            .json(&serde_json::json!({
+                "key": "npm-linux-lock",
+                "version": "version-1"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert!(reserve.status().is_success());
+        let reserve: serde_json::Value = reserve.json().await.unwrap();
+        let cache_id = reserve["cacheId"].as_u64().unwrap();
+
+        let archive = b"archive-bytes";
+        let upload = client
+            .patch(format!("{base}_apis/artifactcache/caches/{cache_id}"))
+            .header("Content-Range", "bytes 0-12/*")
+            .body(archive.as_slice().to_vec())
+            .send()
+            .await
+            .unwrap();
+        assert!(upload.status().is_success());
+
+        let commit = client
+            .post(format!("{base}_apis/artifactcache/caches/{cache_id}"))
+            .json(&serde_json::json!({ "size": archive.len() }))
+            .send()
+            .await
+            .unwrap();
+        assert!(commit.status().is_success());
+
+        let restore = client
+            .get(format!(
+                "{base}_apis/artifactcache/cache?keys=npm-linux-lock&version=version-1"
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert!(restore.status().is_success());
+        let restore: serde_json::Value = restore.json().await.unwrap();
+        assert_eq!(restore["cacheKey"], "npm-linux-lock");
+        let archive_location = restore["archiveLocation"].as_str().unwrap();
+
+        let downloaded = client
+            .get(archive_location)
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(&downloaded[..], archive);
+    }
+}

--- a/crates/fabrik-core/src/lib.rs
+++ b/crates/fabrik-core/src/lib.rs
@@ -20,6 +20,7 @@ use tracing::{debug, instrument};
 
 mod directory_blob;
 mod env;
+mod gha_cache_bridge;
 mod input_digest;
 mod path;
 mod plan;
@@ -92,6 +93,8 @@ pub enum Error {
     },
     #[error("invalid cached directory output `{path}`: {message}")]
     InvalidDirectoryOutput { path: String, message: String },
+    #[error("github actions cache bridge failed: {message}")]
+    CacheBridge { message: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -247,7 +250,7 @@ impl Runner {
     }
 
     pub async fn run(&self, action: &Action) -> Result<Outcome> {
-        let key = action.digest();
+        let key = effective_action_digest(action);
         if let Some(hit) = lookup_cached(&self.cache, &self.workspace_root, &key).await? {
             return Ok(hit);
         }
@@ -291,7 +294,7 @@ pub async fn run_with_cache(
     cache: &CacheProvider,
     opts: RunOpts,
 ) -> Result<Outcome> {
-    let key = action.digest();
+    let key = effective_action_digest(action);
     if let Some(hit) = lookup_cached(cache, workspace_root, &key).await? {
         return Ok(hit);
     }
@@ -457,7 +460,7 @@ pub async fn run_with_cache_streaming(
     cache: &CacheProvider,
     opts: RunOpts,
 ) -> Result<Outcome> {
-    let key = action.digest();
+    let key = effective_action_digest(action);
     if let Some(hit) = lookup_cached(cache, workspace_root, &key).await? {
         return Ok(hit);
     }
@@ -476,6 +479,42 @@ pub async fn run_with_cache_streaming(
         result,
         cache: CacheState::Miss,
     })
+}
+
+fn effective_action_digest(action: &Action) -> Digest {
+    if !gha_cache_bridge::enabled() {
+        return action.digest();
+    }
+
+    match action {
+        Action::RunCommand {
+            argv,
+            env,
+            cwd,
+            input_digest,
+            outputs,
+            resources,
+            timeout_ms,
+            remote,
+        } => {
+            let mut env = env.clone();
+            env.insert(
+                "FABRIK_GITHUB_ACTIONS_CACHE_BRIDGE".to_string(),
+                "v1".to_string(),
+            );
+            Action::RunCommand {
+                argv: argv.clone(),
+                env,
+                cwd: cwd.clone(),
+                input_digest: *input_digest,
+                outputs: outputs.clone(),
+                resources: resources.clone(),
+                timeout_ms: *timeout_ms,
+                remote: remote.clone(),
+            }
+            .digest()
+        }
+    }
 }
 
 async fn execute_streaming(
@@ -578,13 +617,15 @@ async fn execute_run_command(
 ) -> Result<ActionResult> {
     let (program, rest) = argv.split_first().ok_or(Error::EmptyArgv)?;
     tracing::Span::current().record("program", tracing::field::display(program));
+    let bridge = gha_cache_bridge::start(cache.clone()).await?;
+    let env = bridge_env(env, bridge.as_ref());
 
     let mut command = Command::new(program);
     command.args(rest);
     // Don't inherit the parent's env: actions must declare every
     // variable they depend on, or the cache key lies.
     command.env_clear();
-    for (k, v) in env {
+    for (k, v) in &env {
         command.env(k, v);
     }
     // Close stdin - actions never read from a parent terminal.
@@ -634,6 +675,26 @@ async fn execute_run_command(
         }
         None => work.await,
     }
+}
+
+fn bridge_env(
+    env: &BTreeMap<String, String>,
+    bridge: Option<&gha_cache_bridge::Bridge>,
+) -> BTreeMap<String, String> {
+    let mut env = env.clone();
+    if let Some(bridge) = bridge {
+        env.insert(
+            "ACTIONS_CACHE_URL".to_string(),
+            bridge.base_url().to_string(),
+        );
+        env.insert(
+            "ACTIONS_RUNTIME_TOKEN".to_string(),
+            gha_cache_bridge::Bridge::token().to_string(),
+        );
+        env.insert("ACTIONS_CACHE_SERVICE_V2".to_string(), String::new());
+        env.remove("ACTIONS_RESULTS_URL");
+    }
+    env
 }
 
 async fn execute_run_command_streaming(
@@ -1121,13 +1182,15 @@ async fn execute_child_streaming(
 ) -> Result<ActionResult> {
     let (program, rest) = argv.split_first().ok_or(Error::EmptyArgv)?;
     tracing::Span::current().record("program", tracing::field::display(program));
+    let bridge = gha_cache_bridge::start(cache.clone()).await?;
+    let env = bridge_env(env, bridge.as_ref());
 
     let mut command = Command::new(program);
     command.args(rest);
     if !inherit_parent_env {
         command.env_clear();
     }
-    for (k, v) in env {
+    for (k, v) in &env {
         command.env(k, v);
     }
     command.stdin(Stdio::null());

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -51,6 +51,7 @@ export default defineConfig({
               text: "Introduction",
               items: [
                 { text: "What is Fabrik", link: "/guide/what-is-fabrik" },
+                { text: "Cache", link: "/guide/cache" },
               ],
             },
             {

--- a/docs/guide/cache.md
+++ b/docs/guide/cache.md
@@ -1,0 +1,74 @@
+# Cache
+
+Fabrik stores blobs and action results in a local content-addressed
+store. Every cacheable action uses that same store, whether it comes
+from a build-system rule, a script rule, or `fabrik exec`.
+
+When a remote cache provider is configured, the local CAS stays in
+front. Local hits remain filesystem-fast, and misses can mirror their
+blobs and action results to the remote provider so another machine can
+restore them later.
+
+## Local CAS Root
+
+By default, Fabrik stores its local CAS under the user's XDG cache
+directory:
+
+```txt
+<XDG_CACHE_HOME>/fabrik/cas
+```
+
+Set `FABRIK_CACHE_DIR` to choose the local CAS root explicitly:
+
+```sh
+FABRIK_CACHE_DIR=/cache/fabrik/cas fabrik build crates/app/app
+```
+
+The override applies to every cacheable action, including native build
+rules and scripts.
+
+## Cache Location In CI
+
+On GitHub Actions, Fabrik detects known runner cache volumes when the
+provider exposes a stable mounted filesystem. Namespace Cache Volumes
+are detected automatically and Fabrik stores its CAS under
+`/cache/fabrik/cas` when the `/cache` mount is present.
+
+Some runner providers accelerate caching without exposing a mounted
+filesystem to the job. Instead, they provide a faster backend for the
+GitHub Actions cache protocol through the runner environment, a
+compatible cache action, or object storage under the hood. Depot,
+BuildJet, RunsOn, WarpBuild, and Blacksmith's default dependency cache
+generally fall into that category. Those providers do not change
+Fabrik's local CAS root automatically. Use `FABRIK_CACHE_DIR` when a
+provider gives your job a mounted volume, for example a Blacksmith
+Sticky Disk mounted at a path you chose.
+
+Remote reuse works through Fabrik's cache provider, not through the CI
+runner. A cache miss in CI can write to the fast local mounted volume
+and mirror the same action result and blobs to remote storage. A local
+developer running the same target can then fetch those blobs from the
+remote provider and restore the declared outputs without running the
+command again.
+
+## GitHub Actions Cache Bridge
+
+Fabrik can also expose a GitHub Actions cache-compatible endpoint to
+tools it runs. Set `FABRIK_GITHUB_ACTIONS_CACHE_BRIDGE=1` before
+invoking Fabrik:
+
+```sh
+FABRIK_GITHUB_ACTIONS_CACHE_BRIDGE=1 fabrik run images/build
+```
+
+For local cache misses, Fabrik starts an action-scoped cache service and
+injects `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` into the child
+process environment. Tools inside that action that use the GitHub
+Actions cache protocol can save and restore archives through Fabrik's
+cache provider instead of talking to the CI runner cache directly.
+
+The bridge currently targets the v1 GitHub Actions cache protocol used
+by cache clients that honor `ACTIONS_CACHE_URL`. It is meant for nested
+tool caches inside a Fabrik action. Workflow-level `uses: actions/cache`
+steps still run outside Fabrik, so Fabrik cannot change their
+environment unless the workflow explicitly routes them through Fabrik.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ features:
     linkText: Read the definition
   - title: A real cache contract
     details: Actions carry explicit inputs, outputs, environment dependencies, and runtime semantics, so reuse is deterministic instead of accidental.
+    link: /guide/cache
+    linkText: Learn about caching
   - title: A portable compute contract
     details: The same operational definition can stay on the host today and map onto other execution backends as the infrastructure evolves.
   - title: Scripts without rewrites


### PR DESCRIPTION
## Summary
- Add `FABRIK_CACHE_DIR` as an explicit local CAS root override.
- Detect Namespace GitHub Actions cache volumes and use `/cache/fabrik/cas` when available.
- Add an opt-in GitHub Actions cache bridge for local child actions via `FABRIK_GITHUB_ACTIONS_CACHE_BRIDGE=1`.
- Add a general cache guide and link it from the docs home and sidebar.

## Testing
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p fabrik-core`
- `mise exec -- cargo test -p fabrik-cli cache_provider`
- `mise exec -- cargo clippy -p fabrik-core --all-targets -- -D warnings`
- `mise exec -- cargo clippy -p fabrik-cli --all-targets -- -D warnings`
