### PR TITLE
fix(release): package supported microsandbox targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
           # Restrict to rust so shellspec (no Windows binary) doesn't
           # block the Windows job.
           install_args: "rust"
+      - if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:

--- a/crates/once-core/Cargo.toml
+++ b/crates/once-core/Cargo.toml
@@ -18,7 +18,7 @@ tokio.workspace = true
 tracing.workspace = true
 jsonwebtoken = { version = "10.2.0", default-features = false, features = ["rust_crypto"] }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
 microsandbox = { git = "https://github.com/superradcompany/microsandbox.git", rev = "975b62bfd331df7111b2de9abc1416fc87d7790b", version = "0.5.1", default-features = false, features = ["prebuilt"] }
 
 [dev-dependencies]

--- a/crates/once-core/src/remote/microsandbox.rs
+++ b/crates/once-core/src/remote/microsandbox.rs
@@ -5,15 +5,15 @@ use once_cas::{ActionResult, CacheProvider};
 
 use crate::{Error, Result, WorkspacePath};
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 use super::join_path;
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 use crate::stream::{self, Destination};
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 use std::time::Duration;
 
 #[allow(clippy::too_many_arguments)]
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 pub(super) async fn execute_command(
     argv: &[String],
     env: &BTreeMap<String, String>,
@@ -72,12 +72,12 @@ pub(super) async fn execute_command(
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 struct SandboxCleanup {
     sandbox: Option<microsandbox::Sandbox>,
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 impl SandboxCleanup {
     fn new(sandbox: microsandbox::Sandbox) -> Self {
         Self {
@@ -96,7 +96,7 @@ impl SandboxCleanup {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 impl Drop for SandboxCleanup {
     fn drop(&mut self) {
         let Some(sandbox) = self.sandbox.take() else {
@@ -117,12 +117,12 @@ impl Drop for SandboxCleanup {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 fn spawn_cleanup(sandbox: microsandbox::Sandbox) -> tokio::task::JoinHandle<Result<()>> {
     tokio::spawn(cleanup_sandbox(sandbox))
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 async fn cleanup_sandbox(sandbox: microsandbox::Sandbox) -> Result<()> {
     let stop_result = sandbox
         .stop_and_wait()
@@ -139,7 +139,7 @@ async fn cleanup_sandbox(sandbox: microsandbox::Sandbox) -> Result<()> {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[cfg(not(unix))]
+#[cfg(not(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))))]
 pub(super) async fn execute_command(
     _argv: &[String],
     _env: &BTreeMap<String, String>,
@@ -151,12 +151,13 @@ pub(super) async fn execute_command(
 ) -> Result<ActionResult> {
     Err(Error::RemoteProviderConfig {
         provider: "microsandbox".to_string(),
-        message: "the embedded Microsandbox provider is only available on Unix platforms"
-            .to_string(),
+        message:
+            "the embedded Microsandbox provider is only available on Linux and Apple Silicon macOS"
+                .to_string(),
     })
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 async fn collect_output(
     handle: &mut microsandbox::ExecHandle,
     cache: &CacheProvider,
@@ -220,7 +221,7 @@ async fn collect_output(
     })
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 fn microsandbox_error(source: &microsandbox::MicrosandboxError) -> Error {
     Error::RemoteProviderApi {
         provider: "microsandbox".to_string(),
@@ -228,7 +229,7 @@ fn microsandbox_error(source: &microsandbox::MicrosandboxError) -> Error {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64")))]
 fn sandbox_name() -> String {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
## Summary
- Installs `libcap-ng-dev` in the Linux release packaging job so `once-cli` can link the embedded Microsandbox provider.
- Limits the embedded Microsandbox dependency to Linux and Apple Silicon macOS, avoiding the Intel macOS dependency path that fails in `msb_krun_utils`.
- Keeps unsupported targets on the existing provider configuration error path.

## Testing
- `mise exec -- cargo check -p once-cli`
- `rustup target add x86_64-apple-darwin`
- `mise exec -- cargo check -p once-cli --target x86_64-apple-darwin`
- `mise exec -- cargo clippy -p once-core --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "—" .github/workflows/release.yml crates/once-core/Cargo.toml crates/once-core/src/remote/microsandbox.rs || true`
