### PR TITLE
fix: host script runtime fallback

### DIFF
--- a/crates/once-core/src/env/mise.rs
+++ b/crates/once-core/src/env/mise.rs
@@ -3,7 +3,10 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use super::{path::build_action_path, select_extra_env, tool_env};
+use super::{
+    path::{build_action_path, stable_system_path},
+    select_extra_env, tool_env,
+};
 
 /// Resolve `tool` through the workspace's mise config when one exists.
 ///
@@ -21,11 +24,15 @@ pub fn workspace_tool(workspace: &Path, tool: &str) -> Result<String, ToolEnvErr
         .output()
         .map_err(|source| ToolEnvError::SpawnMise { source })?;
     if !output.status.success() {
-        return Err(ToolEnvError::MiseFailed {
+        let error = ToolEnvError::MiseFailed {
             command: format!("mise which {tool}"),
             status: output.status.code().unwrap_or(-1),
             stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        });
+        };
+        if let Some(host_tool) = stable_host_tool(tool) {
+            return Ok(host_tool);
+        }
+        return Err(error);
     }
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
@@ -67,6 +74,35 @@ pub fn workspace_tool_var(workspace: &Path, key: &str) -> Result<Option<String>,
 
 fn has_mise_config(workspace: &Path) -> bool {
     workspace.join("mise.toml").is_file()
+}
+
+fn stable_host_tool(tool: &str) -> Option<String> {
+    stable_system_path()
+        .into_iter()
+        .map(|dir| dir.join(tool))
+        .find(|path| is_executable(path))
+        .map(|path| path.to_string_lossy().into_owned())
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.is_file()
+        && path
+            .metadata()
+            .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(windows)]
+fn is_executable(path: &Path) -> bool {
+    if path.is_file() {
+        return true;
+    }
+    ["exe", "bat", "cmd"]
+        .iter()
+        .map(|extension| path.with_extension(extension))
+        .any(|path| path.is_file())
 }
 
 fn mise_env(workspace: &Path) -> Result<BTreeMap<String, String>, ToolEnvError> {
@@ -132,5 +168,11 @@ mod tests {
         let env = workspace_tool_env(tmp.path(), &["rustc"], &["RUSTUP_TOOLCHAIN"]).unwrap();
         assert_eq!(env, tool_env(&["RUSTUP_TOOLCHAIN"]));
         assert_eq!(workspace_tool(tmp.path(), "rustc").unwrap(), "rustc");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stable_host_tool_resolves_system_shells() {
+        assert!(stable_host_tool("sh").is_some());
     }
 }

--- a/crates/once-core/src/env/path.rs
+++ b/crates/once-core/src/env/path.rs
@@ -31,7 +31,7 @@ fn push_unique(dirs: &mut Vec<PathBuf>, dir: PathBuf) {
     }
 }
 
-fn stable_system_path() -> Vec<PathBuf> {
+pub(super) fn stable_system_path() -> Vec<PathBuf> {
     #[cfg(windows)]
     {
         let mut dirs = Vec::new();


### PR DESCRIPTION
## What changed

Script runtime resolution now falls back to executable host tools in Once's stable system PATH when `mise which <runtime>` reports that the runtime is not a mise-managed bin.

## Why

The documented script flow supports commands like `once exec -- bash scripts/build.sh` and Once shebangs such as `#!/usr/bin/env -S once exec -- bash`. In a workspace with `mise.toml`, those failed when `bash` was available on the host but not managed by mise.

## Impact

Pinned mise tools remain preferred. Host shell runtimes such as `sh` and `bash` can be used for annotated scripts without requiring users to add those system shells to mise.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-core env::mise`
- `mise exec -- cargo test -p once-cli commands::exec`
- `mise exec -- cargo build --release`
- `mise exec -- shellspec spec/exec_spec.sh`
