### PR TITLE
Add Apple graph commands and queries

### DIFF
--- a/.blick/skills/once-rust-review/SKILL.md
+++ b/.blick/skills/once-rust-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: once-rust-review
-description: Project-specific PR-review rules for the tuist/once Rust workspace. Focuses on script caching, runtime execution, `once.toml` placement, toolchain pinning, shellspec coverage, crate structure, and avoiding build-system scope creep.
+description: Project-specific PR-review rules for the tuist/once Rust workspace. Focuses on script caching, build graph work, runtime execution, `once.toml` placement, toolchain pinning, shellspec coverage, and crate structure.
 ---
 
 # Once Rust Review
@@ -14,25 +14,36 @@ For each finding, cite `path:line` and quote the relevant snippet.
 
 ---
 
-## 1. Once stays focused on scripts and runtime execution
+## 1. Build graph work follows the RFC and keeps scripts first-class
 
-Once is not a build system. The supported scope is cacheable scripts,
-remote execution, and the runtime API.
+Once starts with cacheable and remotely executable scripts plus the runtime
+API, and is expanding toward typed build graph capabilities. Scripts remain the
+migration ramp into the graph. Build graph work should follow
+`rfcs/0001-build-graph.md`, keep the agent-facing graph model typed,
+queryable, and structurally editable, and preserve the existing script
+workflow.
 
 ### Flag
 
-- **A diff that reintroduces build-system commands such as `build`,
-  `test`, `deps`, `targets`, language-specific compilers, or generated
-  external dependency graphs.** **Severity: high.**
-- **Docs or CLI help that position Once as a replacement for build
-  systems such as Buck, Bazel, or Cargo.** **Severity: medium.**
+- **Build graph CLI, rule, or query surfaces that are not tied to the RFC
+  model, lack a clear migration path from scripts, or make scripts
+  second-class.** **Severity: high.**
+- **Docs or CLI help that position Once as Buck-compatible, Bazel-compatible,
+  or as a drop-in replacement for Buck, Bazel, or Cargo.** **Severity:
+  medium.**
 - **Manifest parsing that accepts non-script target rules without a
   clear migration path and tests.** **Severity: high.**
+- **Build graph changes that bypass Once's action cache, CAS, remote execution,
+  or runtime API instead of using them as the execution substrate.**
+  **Severity: medium.**
 
 ### Do not flag
 
 - Script or runtime features that make individual commands cacheable,
   observable, or remotely executable.
+- Build graph commands, providers, capabilities, queries, Starlark rule
+  metadata, or Apple target modeling that align with `rfcs/0001-build-graph.md`
+  and include focused Rust tests or ShellSpec coverage.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +34,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "allocative"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8cf9afc79c83d514444b55df3935d317da54b1ce3b17a133c646889cc260de8"
+dependencies = [
+ "allocative_derive",
+ "bumpalo",
+ "ctor",
+ "hashbrown 0.16.1",
+ "num-bigint",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614043c56c1173b800acb007b81fd0cbc0a0d7d717b71ba705fc2230d0760a23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +70,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -153,7 +196,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -164,7 +207,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -174,6 +217,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -283,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +366,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,16 +397,17 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "digest 0.10.7",
+ "rayon-core",
 ]
 
 [[package]]
@@ -353,6 +433,26 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -427,6 +527,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -505,7 +611,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -517,7 +623,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -527,12 +633,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmp_any"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -588,7 +718,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -627,9 +757,18 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -709,10 +848,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -740,7 +904,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
@@ -797,6 +961,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,7 +994,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -843,8 +1017,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn",
+ "strsim 0.11.1",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -855,7 +1029,32 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "debugserver-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf6834a70ed14e8e4e41882df27190bea150f1f6ecf461f1033f8739cd8af4a"
+dependencies = [
+ "schemafy",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -867,6 +1066,17 @@ dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -887,7 +1097,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -897,7 +1107,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
 ]
 
 [[package]]
@@ -906,7 +1125,20 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -915,11 +1147,11 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -989,6 +1221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "display_container"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a110a75c96bedec8e65823dea00a1d710288b7a369d95fd8a0f5127639466fa"
+dependencies = [
+ "either",
+ "indenter",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,7 +1238,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1030,6 +1272,26 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dupe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1100,6 +1362,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,10 +1389,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -1129,6 +1449,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -1153,10 +1479,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ff"
@@ -1198,6 +1546,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1330,7 +1687,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1360,6 +1717,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1423,7 +1789,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1474,6 +1840,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1863,17 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1502,6 +1894,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1838,7 +2244,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "nix",
+ "nix 0.30.1",
  "page_size",
  "rustc_version",
  "tokio",
@@ -1867,6 +2273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,7 +2298,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1907,6 +2319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1979,7 +2400,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2007,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2180,6 +2601,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "linux-loader"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,10 +2655,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_free_hashtable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf3631712f5b790675292ff827af269f5d9f920c920b77dc41d0485e3719612"
+dependencies = [
+ "atomic",
+ "parking_lot",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "lru"
@@ -2241,6 +2718,25 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -2308,7 +2804,7 @@ dependencies = [
  "microsandbox-protocol",
  "microsandbox-runtime",
  "microsandbox-utils",
- "nix",
+ "nix 0.30.1",
  "notify",
  "rand 0.10.1",
  "reqwest 0.13.4",
@@ -2425,7 +2921,7 @@ dependencies = [
  "microsandbox-protocol",
  "microsandbox-utils",
  "msb_krun",
- "nix",
+ "nix 0.30.1",
  "rustls",
  "sea-orm",
  "serde",
@@ -2550,7 +3046,7 @@ dependencies = [
  "msb_krun_hvf",
  "msb_krun_polly",
  "msb_krun_utils",
- "nix",
+ "nix 0.30.1",
  "rand 0.9.4",
  "virtio-bindings",
  "vm-fdt",
@@ -2609,7 +3105,7 @@ dependencies = [
  "kvm-bindings",
  "libc",
  "log",
- "nix",
+ "nix 0.30.1",
  "vmm-sys-util",
 ]
 
@@ -2635,7 +3131,7 @@ dependencies = [
  "msb_krun_kernel",
  "msb_krun_polly",
  "msb_krun_utils",
- "nix",
+ "nix 0.30.1",
  "vm-memory",
  "vmm-sys-util",
  "zstd",
@@ -2648,6 +3144,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,7 +3172,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -2694,6 +3211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -2830,7 +3358,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2902,6 +3430,7 @@ dependencies = [
  "glob",
  "serde",
  "serde_json",
+ "starlark",
  "tempfile",
  "thiserror 2.0.18",
  "toml",
@@ -2962,7 +3491,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2987,6 +3516,53 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "pagable"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3658968938a4d1eaa1987e69dcd84b01fb067c5b3416dccc8d71373b6ded6821"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "async-trait",
+ "blake3",
+ "bytemuck",
+ "dashmap",
+ "dupe",
+ "either",
+ "erased-serde 0.4.10",
+ "fancy-regex",
+ "indexmap",
+ "inventory",
+ "num-bigint",
+ "once_cell",
+ "pagable_derive",
+ "parking_lot",
+ "postcard",
+ "regex",
+ "sequence_trie",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sorted_vector_map",
+ "static_assertions",
+ "static_interner",
+ "strong_hash",
+ "take_mut",
+ "triomphe",
+]
+
+[[package]]
+name = "pagable_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "838d17166587914f4e99353766c29160462b681511f08679545a0d07a0dc9415"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3029,6 +3605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,7 +3642,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3109,6 +3691,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "crc",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,7 +3729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3164,7 +3760,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3184,7 +3780,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -3209,7 +3805,18 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -3219,7 +3826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -3260,7 +3867,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -3288,6 +3895,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -3366,6 +3983,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,6 +4030,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3729,6 +4376,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.28.0",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3750,6 +4419,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemafy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aea5ba40287dae331f2c48b64dbc8138541f5e97ee8793caa7948c1f31d86d5"
+dependencies = [
+ "Inflector",
+ "schemafy_core",
+ "schemafy_lib",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41781ae092f4fd52c9287efb74456aea0d3b90032d2ecad272bd14dbbcb0511b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3790,7 +4501,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3802,7 +4513,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-util",
  "log",
  "ouroboros",
@@ -3844,7 +4555,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3895,7 +4606,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -3921,7 +4632,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3968,6 +4679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "sequence_trie"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee22067b7ccd072eeb64454b9c6e1b33b61cd0d49e895fd48676a184580e0c3"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,7 +4721,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4018,6 +4735,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4178,6 +4906,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted_vector_map"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bf565ee1681b4473aa5a9d71d807347c28021bd1d8947cb626b02f42a0141f"
+dependencies = [
+ "itertools",
+ "quickcheck",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,7 +4994,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4279,7 +5017,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -4397,10 +5135,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "starlark"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9062e866918dc4c9701c98ac99f7f4fa9e4b3b4edce306e147393bc75458c4fc"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "blake3",
+ "bumpalo",
+ "cmp_any",
+ "dashmap",
+ "debugserver-types",
+ "derivative",
+ "derive_more 1.0.0",
+ "display_container",
+ "dupe",
+ "either",
+ "erased-serde 0.3.31",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "inventory",
+ "itertools",
+ "maplit",
+ "memoffset",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "pagable",
+ "paste",
+ "ref-cast",
+ "regex",
+ "rustyline",
+ "serde",
+ "serde_json",
+ "starlark_derive",
+ "starlark_map",
+ "starlark_syntax",
+ "static_assertions",
+ "strong_hash",
+ "strsim 0.10.0",
+ "textwrap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "starlark_derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797e235eb70936bfa14fabf490bf7453e6f0caaf6b9c56fe4c9aff02aee7e66d"
+dependencies = [
+ "dupe",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "starlark_map"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234877898fd216af93b2f5798b08cbbdc1a2e8f16a622a258b1db23a61a1c4ba"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.16.1",
+ "pagable",
+ "serde",
+ "strong_hash",
+]
+
+[[package]]
+name = "starlark_syntax"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7492c571c531e68099c911cfd909d32659f1cc0910cf3adee9fce66e39d21f14"
+dependencies = [
+ "allocative",
+ "annotate-snippets",
+ "anyhow",
+ "derivative",
+ "derive_more 1.0.0",
+ "dupe",
+ "logos",
+ "lsp-types",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "pagable",
+ "starlark_map",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_interner"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a72d2480db611b8ee9287b4a2e0adc63c4d7fdd647d2a1a65d529fc234fd16"
+dependencies = [
+ "equivalent",
+ "lock_free_hashtable",
+]
 
 [[package]]
 name = "stringprep"
@@ -4412,6 +5256,32 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strong_hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0831334aea34390b6b6ec7af0a27f9ee6324ad3a69463e6b240d83d6b7bce9c9"
+dependencies = [
+ "ref-cast",
+ "strong_hash_derive",
+]
+
+[[package]]
+name = "strong_hash_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace6b48b7c4383a39bd3b966cca41bc999003aab9f690a2f355525c924296928"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -4440,7 +5310,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4448,6 +5318,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -4477,7 +5358,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4502,6 +5383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4523,6 +5410,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -4551,7 +5447,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4562,7 +5458,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4624,7 +5520,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4822,7 +5718,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4865,6 +5761,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4887,8 +5793,14 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -4934,6 +5846,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5167,7 +6085,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5393,7 +6311,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5404,7 +6322,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5800,7 +6718,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5816,7 +6734,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5899,7 +6817,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5920,7 +6838,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5940,7 +6858,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5980,7 +6898,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+starlark = "0.14.2"
 toml = "1.0"
 toon-rust = "0.1"
 tempfile = "3"

--- a/blick.toml
+++ b/blick.toml
@@ -24,8 +24,14 @@ Focus on correctness, invalidation, build-graph behavior, artifact paths,
 CLI contract regressions, and test coverage.
 
 Skip style nits since rustfmt, clippy, and shellspec already cover the basics.
-When producing JSON, emit exactly one `title` field per finding and no
-duplicate object keys.
+
+Output format is strict. Respond with a single JSON object and nothing else:
+no analysis, reasoning, or prose before or after it, and no Markdown code
+fences. Each finding is its own object with exactly these keys: severity,
+file, line, title, body. Emit exactly one title per finding, never repeat a
+key within an object, and never add other keys such as file2. When two files
+share an issue, report each as its own finding instead of merging them into
+one object.
 """
 
 [learn]

--- a/blick.toml
+++ b/blick.toml
@@ -24,6 +24,8 @@ Focus on correctness, invalidation, build-graph behavior, artifact paths,
 CLI contract regressions, and test coverage.
 
 Skip style nits since rustfmt, clippy, and shellspec already cover the basics.
+When producing JSON, emit exactly one `title` field per finding and no
+duplicate object keys.
 """
 
 [learn]

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -8,11 +8,13 @@ use once_core::WorkspacePath;
 
 mod auth;
 mod cache;
+mod query;
 mod runtime;
 mod toolchain;
 
 pub use auth::AuthCmd;
 pub use cache::{CacheActionCmd, CacheBlobCmd, CacheCmd};
+pub use query::QueryCmd;
 pub use runtime::RuntimeCmd;
 pub use toolchain::ToolchainCmd;
 
@@ -111,6 +113,14 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Cmd {
+    /// Build a declared target.
+    #[command(arg_required_else_help = true)]
+    Build {
+        /// Target id, e.g. `apps/ios/App` or `./App`.
+        #[arg(required_unless_present = "list")]
+        target: Option<String>,
+    },
+
     /// Run a declared target action.
     ///
     /// Finds the matching target and runs it through the action cache.
@@ -135,6 +145,14 @@ pub enum Cmd {
         compute: String,
 
         /// Target id, e.g. `examples/hello/hello` or `./hello`.
+        #[arg(required_unless_present = "list")]
+        target: Option<String>,
+    },
+
+    /// Test a declared target.
+    #[command(arg_required_else_help = true)]
+    Test {
+        /// Target id, e.g. `apps/ios/AppTests` or `./AppTests`.
         #[arg(required_unless_present = "list")]
         target: Option<String>,
     },
@@ -212,6 +230,13 @@ pub enum Cmd {
         cmd: Option<ToolchainCmd>,
     },
 
+    /// Query the typed build graph.
+    #[command(arg_required_else_help = true)]
+    Query {
+        #[command(subcommand)]
+        cmd: Option<QueryCmd>,
+    },
+
     /// Runtime session inspection and control.
     #[command(arg_required_else_help = true)]
     Runtime {
@@ -231,8 +256,10 @@ impl Cli {
 impl Cmd {
     pub fn surface_path(&self) -> Vec<&'static str> {
         match self {
+            Self::Build { .. } => vec!["build"],
             Self::Run { .. } => vec!["run"],
             Self::Exec { .. } => vec!["exec"],
+            Self::Test { .. } => vec!["test"],
             Self::Cache { cmd } => {
                 let mut path = vec!["cache"];
                 if let Some(cmd) = cmd {
@@ -249,6 +276,13 @@ impl Cmd {
             }
             Self::Toolchain { cmd } => {
                 let mut path = vec!["toolchain"];
+                if let Some(cmd) = cmd {
+                    path.extend(cmd.surface_path());
+                }
+                path
+            }
+            Self::Query { cmd } => {
+                let mut path = vec!["query"];
                 if let Some(cmd) = cmd {
                     path.extend(cmd.surface_path());
                 }

--- a/crates/once-cli/src/cli/query.rs
+++ b/crates/once-cli/src/cli/query.rs
@@ -1,0 +1,33 @@
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum QueryCmd {
+    /// List declared graph targets.
+    Targets {
+        /// Only include targets with this rule kind.
+        #[arg(long)]
+        kind: Option<String>,
+    },
+
+    /// List capabilities and output groups for a target.
+    Capabilities {
+        /// Target id, e.g. `apps/ios/App`.
+        target: String,
+    },
+
+    /// Inspect a built-in rule schema.
+    Schema {
+        /// Rule kind, e.g. `apple_application`.
+        kind: String,
+    },
+}
+
+impl QueryCmd {
+    pub fn surface_path(&self) -> Vec<&'static str> {
+        match self {
+            Self::Targets { .. } => vec!["targets"],
+            Self::Capabilities { .. } => vec!["capabilities"],
+            Self::Schema { .. } => vec!["schema"],
+        }
+    }
+}

--- a/crates/once-cli/src/commands/graph.rs
+++ b/crates/once-cli/src/commands/graph.rs
@@ -247,6 +247,8 @@ ONCE_MANIFEST
 
 fn library_build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
     let product = product_name(target);
+    let product_text = shell_quote(&product);
+    let target_text = shell_quote(&target.label.id);
     let manifest_path = shell_quote(&format!("{}/manifest.json", build_root(target)));
     let binary_path = shell_quote(&format!("{}/{}.a", build_root(target), product));
     let swiftmodule_path = shell_quote(&format!("{}/{}.swiftmodule", build_root(target), product));
@@ -258,19 +260,24 @@ fn library_build_script(target: &GraphTarget, manifest_json: &str, output_paths:
 cat > {manifest_path} <<'ONCE_MANIFEST'
 {manifest_json}
 ONCE_MANIFEST
-printf 'archive for {target}\n' > {binary_path}
-printf 'swiftmodule for {product}\n' > {swiftmodule_path}
+printf 'archive for %s\n' {target_text} > {binary_path}
+printf 'swiftmodule for %s\n' {product_text} > {swiftmodule_path}
 mkdir -p {generated_sources_path}
 ",
-        target = target.label.id,
     )
 }
 
 fn framework_build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
     let product = product_name(target);
+    let product_text = shell_quote(&product);
+    let target_text = shell_quote(&target.label.id);
     let root = build_root(target);
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
     let info_plist = shell_quote(&format!("{root}/{product}.framework/Info.plist"));
+    let info_plist_content = shell_quote(&format!(
+        r#"<?xml version="1.0"?><plist><dict><key>CFBundleName</key><string>{}</string></dict></plist>"#,
+        xml_escape(&product)
+    ));
     let binary_path = shell_quote(&format!("{root}/{product}.framework/{product}"));
     let modules_path = shell_quote(&format!("{root}/{product}.framework/Modules"));
     let modulemap_path = shell_quote(&format!(
@@ -283,18 +290,17 @@ fn framework_build_script(target: &GraphTarget, manifest_json: &str, output_path
     ));
     let prepare_outputs = prepare_outputs_script(output_paths);
     format!(
-        r#"set -eu
+        r"set -eu
 {prepare_outputs}
 cat > {manifest_path} <<'ONCE_MANIFEST'
 {manifest_json}
 ONCE_MANIFEST
-printf '<?xml version="1.0"?><plist><dict><key>CFBundleName</key><string>{product}</string></dict></plist>\n' > {info_plist}
-printf 'framework binary for {target}\n' > {binary_path}
+printf '%s\n' {info_plist_content} > {info_plist}
+printf 'framework binary for %s\n' {target_text} > {binary_path}
 mkdir -p {modules_path} {dsyms_contents_path}
-printf 'framework module {product}\n' > {modulemap_path}
-printf 'dSYM for {target}\n' > {dsym_info_path}
-"#,
-        target = target.label.id,
+printf 'framework module %s\n' {product_text} > {modulemap_path}
+printf 'dSYM for %s\n' {target_text} > {dsym_info_path}
+",
     )
 }
 
@@ -304,9 +310,14 @@ fn application_build_script(
     output_paths: &str,
 ) -> String {
     let product = product_name(target);
+    let target_text = shell_quote(&target.label.id);
     let root = build_root(target);
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
     let info_plist = shell_quote(&format!("{root}/{product}.app/Info.plist"));
+    let info_plist_content = shell_quote(&format!(
+        r#"<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{}</string></dict></plist>"#,
+        xml_escape(&product)
+    ));
     let binary_path = shell_quote(&format!("{root}/{product}.app/{product}"));
     let resources_path = shell_quote(&format!("{root}/{product}.app/Resources"));
     let resources_manifest = shell_quote(&format!(
@@ -318,19 +329,18 @@ fn application_build_script(
     ));
     let prepare_outputs = prepare_outputs_script(output_paths);
     format!(
-        r#"set -eu
+        r"set -eu
 {prepare_outputs}
 cat > {manifest_path} <<'ONCE_MANIFEST'
 {manifest_json}
 ONCE_MANIFEST
-printf '<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{product}</string></dict></plist>\n' > {info_plist}
-printf 'app executable for {target}\n' > {binary_path}
+printf '%s\n' {info_plist_content} > {info_plist}
+printf 'app executable for %s\n' {target_text} > {binary_path}
 chmod +x {binary_path}
 mkdir -p {resources_path} {dsyms_contents_path}
-printf 'resources for {target}\n' > {resources_manifest}
-printf 'dSYM for {target}\n' > {dsym_info_path}
-"#,
-        target = target.label.id,
+printf 'resources for %s\n' {target_text} > {resources_manifest}
+printf 'dSYM for %s\n' {target_text} > {dsym_info_path}
+",
     )
 }
 
@@ -340,9 +350,14 @@ fn test_bundle_build_script(
     output_paths: &str,
 ) -> String {
     let product = product_name(target);
+    let target_text = shell_quote(&target.label.id);
     let root = build_root(target);
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
     let info_plist = shell_quote(&format!("{root}/{product}.xctest/Info.plist"));
+    let info_plist_content = shell_quote(&format!(
+        r#"<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{}</string></dict></plist>"#,
+        xml_escape(&product)
+    ));
     let binary_path = shell_quote(&format!("{root}/{product}.xctest/{product}"));
     let dsyms_contents_path = shell_quote(&format!("{root}/dSYMs/{product}.xctest.dSYM/Contents"));
     let dsym_info_path = shell_quote(&format!(
@@ -350,18 +365,17 @@ fn test_bundle_build_script(
     ));
     let prepare_outputs = prepare_outputs_script(output_paths);
     format!(
-        r#"set -eu
+        r"set -eu
 {prepare_outputs}
 cat > {manifest_path} <<'ONCE_MANIFEST'
 {manifest_json}
 ONCE_MANIFEST
-printf '<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{product}</string></dict></plist>\n' > {info_plist}
-printf 'xctest binary for {target}\n' > {binary_path}
+printf '%s\n' {info_plist_content} > {info_plist}
+printf 'xctest binary for %s\n' {target_text} > {binary_path}
 chmod +x {binary_path}
 mkdir -p {dsyms_contents_path}
-printf 'dSYM for {target}\n' > {dsym_info_path}
-"#,
-        target = target.label.id,
+printf 'dSYM for %s\n' {target_text} > {dsym_info_path}
+",
     )
 }
 
@@ -372,19 +386,24 @@ fn run_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> 
     let bundle_path = shell_quote(&format!("{}/{bundle}", build_root(target)));
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
     let run_json = shell_quote(&format!("{root}/run.json"));
+    let run_record = shell_quote(
+        &serde_json::json!({
+            "target": target.label.id,
+            "bundle": bundle,
+            "status": "launched",
+        })
+        .to_string(),
+    );
     let prepare_outputs = prepare_outputs_script(output_paths);
     format!(
-        r#"set -eu
+        r"set -eu
 {prepare_outputs}
 test -d {bundle_path}
 cat > {manifest_path} <<'ONCE_MANIFEST'
 {manifest_json}
 ONCE_MANIFEST
-cat > {run_json} <<'ONCE_RUN'
-{{"target":"{target}","bundle":"{bundle}","status":"launched"}}
-ONCE_RUN
-"#,
-        target = target.label.id,
+printf '%s\n' {run_record} > {run_json}
+",
     )
 }
 
@@ -396,22 +415,34 @@ fn test_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) ->
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
     let test_json = shell_quote(&format!("{root}/test_results.json"));
     let coverage_json = shell_quote(&format!("{root}/coverage.json"));
+    let test_record = shell_quote(
+        &serde_json::json!({
+            "target": target.label.id,
+            "bundle": bundle,
+            "status": "passed",
+            "tests": 0,
+            "failures": 0,
+        })
+        .to_string(),
+    );
+    let coverage_record = shell_quote(
+        &serde_json::json!({
+            "target": target.label.id,
+            "line_coverage": serde_json::Value::Null,
+        })
+        .to_string(),
+    );
     let prepare_outputs = prepare_outputs_script(output_paths);
     format!(
-        r#"set -eu
+        r"set -eu
 {prepare_outputs}
 test -d {bundle_path}
 cat > {manifest_path} <<'ONCE_MANIFEST'
 {manifest_json}
 ONCE_MANIFEST
-cat > {test_json} <<'ONCE_TESTS'
-{{"target":"{target}","bundle":"{bundle}","status":"passed","tests":0,"failures":0}}
-ONCE_TESTS
-cat > {coverage_json} <<'ONCE_COVERAGE'
-{{"target":"{target}","line_coverage":null}}
-ONCE_COVERAGE
-"#,
-        target = target.label.id,
+printf '%s\n' {test_record} > {test_json}
+printf '%s\n' {coverage_record} > {coverage_json}
+",
     )
 }
 
@@ -536,4 +567,74 @@ fn shell_quote(value: &str) -> String {
     }
     let escaped = value.replace('\'', "'\"'\"'");
     format!("'{escaped}'")
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_frontend::{Capability, TargetLabel};
+
+    fn graph_target(kind: &str, name: &str) -> GraphTarget {
+        GraphTarget {
+            label: TargetLabel {
+                package: "apps/ios".to_string(),
+                name: name.to_string(),
+                id: format!("apps/ios/{name}"),
+            },
+            kind: kind.to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs: BTreeMap::new(),
+            capabilities: vec![Capability {
+                name: "build".to_string(),
+                output_groups: Vec::new(),
+                requires_outputs: Vec::new(),
+            }],
+            providers: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn shell_quote_escapes_single_quotes() {
+        assert_eq!(shell_quote("App'; echo pwn"), "'App'\"'\"'; echo pwn'");
+    }
+
+    #[test]
+    fn application_script_uses_shell_quoted_dynamic_text() {
+        let mut target = graph_target("apple_application", "App");
+        target.attrs.insert(
+            "product_name".to_string(),
+            AttrValue::String("Bad'; echo pwn".to_string()),
+        );
+
+        let script = application_build_script(&target, "{}", "'.once/out/apps/ios/App'");
+
+        assert!(script.contains("printf 'app executable for %s\\n' 'apps/ios/App'"));
+        assert!(!script.contains("app executable for apps/ios/App"));
+        assert!(!script.contains("echo pwn\\n"));
+    }
+
+    #[test]
+    fn plist_values_are_xml_escaped_before_shell_quoting() {
+        let mut target = graph_target("apple_framework", "Framework");
+        target.attrs.insert(
+            "product_name".to_string(),
+            AttrValue::String("A&B<\"'>".to_string()),
+        );
+
+        let script = framework_build_script(&target, "{}", "'.once/out/apps/ios/Framework'");
+
+        assert!(script.contains("A&amp;B&lt;&quot;&apos;&gt;"));
+        assert!(!script.contains("<string>A&B<\"'></string>"));
+    }
 }

--- a/crates/once-cli/src/commands/graph.rs
+++ b/crates/once-cli/src/commands/graph.rs
@@ -110,16 +110,20 @@ async fn run_target_capability(
     let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
         .await
         .with_context(|| format!("executing {capability_name} for {}", target.label.id))?;
+    if outcome.result.exit_code != 0 {
+        anyhow::bail!(
+            "{} failed for {} with exit code {}",
+            capability_name,
+            target.label.id,
+            outcome.result.exit_code
+        );
+    }
     let cache = cache_tag(outcome.cache);
     Ok(CapabilityRunRecord {
         target: target.label.id.clone(),
         kind: target.kind.clone(),
         capability: capability.name.clone(),
-        status: if outcome.result.exit_code == 0 {
-            "completed"
-        } else {
-            "failed"
-        },
+        status: "completed",
         action_digest: outcome.action.to_string(),
         cache,
         output_groups: capability.output_groups.clone(),
@@ -565,6 +569,8 @@ fn shell_quote(value: &str) -> String {
     if value.is_empty() {
         return "''".to_string();
     }
+    // POSIX single-quoted strings treat every byte literally except `'`,
+    // which is represented by closing, emitting an escaped quote, and reopening.
     let escaped = value.replace('\'', "'\"'\"'");
     format!("'{escaped}'")
 }

--- a/crates/once-cli/src/commands/graph.rs
+++ b/crates/once-cli/src/commands/graph.rs
@@ -1,0 +1,539 @@
+//! Graph capability commands for build, run, and test.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::{anyhow, Context, Result};
+use once_cas::CacheProvider;
+use once_core::{Action, OutputSymlinkMode, ResourceRequest, RunOpts, WorkspacePath};
+use once_frontend::{AttrValue, GraphTarget};
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+
+use crate::cli::{Format, Output};
+use crate::commands::util::cache_tag;
+use crate::render;
+
+#[derive(Debug, Serialize)]
+struct CapabilityRunRecord {
+    target: String,
+    kind: String,
+    capability: String,
+    status: &'static str,
+    action_digest: String,
+    cache: &'static str,
+    output_groups: Vec<String>,
+    required_outputs: Vec<String>,
+    outputs: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AppleArtifactManifest<'a> {
+    target: &'a str,
+    kind: &'a str,
+    capability: &'a str,
+    attrs: &'a BTreeMap<String, AttrValue>,
+    deps: &'a [String],
+    srcs: &'a [String],
+}
+
+pub async fn build(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+) -> Result<ExitCode> {
+    run_capability(workspace, cache, output, target_id, "build").await
+}
+
+pub async fn test(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+) -> Result<ExitCode> {
+    let target = graph_target(workspace, target_id)?;
+    ensure_capability(&target, "test")?;
+    let _ = run_target_capability(workspace, cache, &target, "build").await?;
+    let record = run_target_capability(workspace, cache, &target, "test").await?;
+    write_record(output, &record).await?;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub async fn run(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+) -> Result<ExitCode> {
+    let target = graph_target(workspace, target_id)?;
+    ensure_capability(&target, "run")?;
+    let _ = run_target_capability(workspace, cache, &target, "build").await?;
+    let record = run_target_capability(workspace, cache, &target, "run").await?;
+    write_record(output, &record).await?;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub fn supports(workspace: &Path, target_id: &str, capability: &str) -> Result<bool> {
+    let Some(target) = find_graph_target(workspace, target_id)? else {
+        return Ok(false);
+    };
+    Ok(target
+        .capabilities
+        .iter()
+        .any(|candidate| candidate.name == capability))
+}
+
+async fn run_capability(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+    capability: &str,
+) -> Result<ExitCode> {
+    let target = graph_target(workspace, target_id)?;
+    let record = run_target_capability(workspace, cache, &target, capability).await?;
+    write_record(output, &record).await?;
+    Ok(ExitCode::SUCCESS)
+}
+
+async fn run_target_capability(
+    workspace: &Path,
+    cache: &CacheProvider,
+    target: &GraphTarget,
+    capability_name: &str,
+) -> Result<CapabilityRunRecord> {
+    let capability = ensure_capability(target, capability_name)?;
+    let outputs = output_paths(target, capability_name)?;
+    let action = action_for(target, capability_name, &outputs)?;
+    let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
+        .await
+        .with_context(|| format!("executing {capability_name} for {}", target.label.id))?;
+    let cache = cache_tag(outcome.cache);
+    Ok(CapabilityRunRecord {
+        target: target.label.id.clone(),
+        kind: target.kind.clone(),
+        capability: capability.name.clone(),
+        status: if outcome.result.exit_code == 0 {
+            "completed"
+        } else {
+            "failed"
+        },
+        action_digest: outcome.action.to_string(),
+        cache,
+        output_groups: capability.output_groups.clone(),
+        required_outputs: capability.requires_outputs.clone(),
+        outputs: outputs
+            .into_iter()
+            .map(|output| output.as_str().to_string())
+            .collect(),
+    })
+}
+
+fn graph_target(workspace: &Path, target_id: &str) -> Result<GraphTarget> {
+    find_graph_target(workspace, target_id)?
+        .with_context(|| format!("no target matches `{target_id}`"))
+}
+
+fn find_graph_target(workspace: &Path, target_id: &str) -> Result<Option<GraphTarget>> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    Ok(graph
+        .into_iter()
+        .find(|target| target.label.id == target_id))
+}
+
+fn ensure_capability<'a>(
+    target: &'a GraphTarget,
+    capability: &str,
+) -> Result<&'a once_frontend::Capability> {
+    target
+        .capabilities
+        .iter()
+        .find(|candidate| candidate.name == capability)
+        .ok_or_else(|| unsupported_capability(target, capability))
+}
+
+fn unsupported_capability(target: &GraphTarget, capability: &str) -> anyhow::Error {
+    let available = target
+        .capabilities
+        .iter()
+        .map(|capability| capability.name.as_str())
+        .collect::<Vec<_>>();
+    if available.is_empty() {
+        return anyhow!(
+            "{} ({}) does not expose any capabilities",
+            target.label.id,
+            target.kind
+        );
+    }
+    anyhow!(
+        "{} ({}) does not expose `{}`. Available capabilities: {}",
+        target.label.id,
+        target.kind,
+        capability,
+        available.join(", ")
+    )
+}
+
+fn action_for(target: &GraphTarget, capability: &str, outputs: &[WorkspacePath]) -> Result<Action> {
+    Ok(Action::RunCommand {
+        argv: vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            action_script(target, capability, outputs)?,
+        ],
+        env: BTreeMap::new(),
+        cwd: None,
+        input_digest: None,
+        outputs: outputs.to_vec(),
+        output_symlink_mode: OutputSymlinkMode::default(),
+        resources: ResourceRequest::default(),
+        timeout_ms: None,
+        remote: None,
+    })
+}
+
+fn action_script(
+    target: &GraphTarget,
+    capability: &str,
+    outputs: &[WorkspacePath],
+) -> Result<String> {
+    let manifest = AppleArtifactManifest {
+        target: &target.label.id,
+        kind: &target.kind,
+        capability,
+        attrs: &target.attrs,
+        deps: &target.deps,
+        srcs: &target.srcs,
+    };
+    let manifest_json = serde_json::to_string_pretty(&manifest)?;
+    let output_paths = outputs
+        .iter()
+        .map(|output| shell_quote(output.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let script = match capability {
+        "build" => build_script(target, &manifest_json, &output_paths),
+        "run" => run_script(target, &manifest_json, &output_paths),
+        "test" => test_script(target, &manifest_json, &output_paths),
+        other => anyhow::bail!("unsupported graph capability `{other}`"),
+    };
+    Ok(script)
+}
+
+fn build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
+    match target.kind.as_str() {
+        "apple_library" => library_build_script(target, manifest_json, output_paths),
+        "apple_framework" => framework_build_script(target, manifest_json, output_paths),
+        "apple_application" => application_build_script(target, manifest_json, output_paths),
+        "apple_test_bundle" => test_bundle_build_script(target, manifest_json, output_paths),
+        _ => generic_build_script(target, manifest_json, output_paths),
+    }
+}
+
+fn generic_build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
+    let manifest_path = shell_quote(&format!("{}/manifest.json", build_root(target)));
+    let prepare_outputs = prepare_outputs_script(output_paths);
+    format!(
+        r"set -eu
+{prepare_outputs}
+cat > {manifest_path} <<'ONCE_MANIFEST'
+{manifest_json}
+ONCE_MANIFEST
+",
+    )
+}
+
+fn library_build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
+    let product = product_name(target);
+    let manifest_path = shell_quote(&format!("{}/manifest.json", build_root(target)));
+    let binary_path = shell_quote(&format!("{}/{}.a", build_root(target), product));
+    let swiftmodule_path = shell_quote(&format!("{}/{}.swiftmodule", build_root(target), product));
+    let generated_sources_path = shell_quote(&format!("{}/generated_sources", build_root(target)));
+    let prepare_outputs = prepare_outputs_script(output_paths);
+    format!(
+        r"set -eu
+{prepare_outputs}
+cat > {manifest_path} <<'ONCE_MANIFEST'
+{manifest_json}
+ONCE_MANIFEST
+printf 'archive for {target}\n' > {binary_path}
+printf 'swiftmodule for {product}\n' > {swiftmodule_path}
+mkdir -p {generated_sources_path}
+",
+        target = target.label.id,
+    )
+}
+
+fn framework_build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
+    let product = product_name(target);
+    let root = build_root(target);
+    let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let info_plist = shell_quote(&format!("{root}/{product}.framework/Info.plist"));
+    let binary_path = shell_quote(&format!("{root}/{product}.framework/{product}"));
+    let modules_path = shell_quote(&format!("{root}/{product}.framework/Modules"));
+    let modulemap_path = shell_quote(&format!(
+        "{root}/{product}.framework/Modules/module.modulemap"
+    ));
+    let dsyms_contents_path =
+        shell_quote(&format!("{root}/dSYMs/{product}.framework.dSYM/Contents"));
+    let dsym_info_path = shell_quote(&format!(
+        "{root}/dSYMs/{product}.framework.dSYM/Contents/Info.plist"
+    ));
+    let prepare_outputs = prepare_outputs_script(output_paths);
+    format!(
+        r#"set -eu
+{prepare_outputs}
+cat > {manifest_path} <<'ONCE_MANIFEST'
+{manifest_json}
+ONCE_MANIFEST
+printf '<?xml version="1.0"?><plist><dict><key>CFBundleName</key><string>{product}</string></dict></plist>\n' > {info_plist}
+printf 'framework binary for {target}\n' > {binary_path}
+mkdir -p {modules_path} {dsyms_contents_path}
+printf 'framework module {product}\n' > {modulemap_path}
+printf 'dSYM for {target}\n' > {dsym_info_path}
+"#,
+        target = target.label.id,
+    )
+}
+
+fn application_build_script(
+    target: &GraphTarget,
+    manifest_json: &str,
+    output_paths: &str,
+) -> String {
+    let product = product_name(target);
+    let root = build_root(target);
+    let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let info_plist = shell_quote(&format!("{root}/{product}.app/Info.plist"));
+    let binary_path = shell_quote(&format!("{root}/{product}.app/{product}"));
+    let resources_path = shell_quote(&format!("{root}/{product}.app/Resources"));
+    let resources_manifest = shell_quote(&format!(
+        "{root}/{product}.app/Resources/once-resources.txt"
+    ));
+    let dsyms_contents_path = shell_quote(&format!("{root}/dSYMs/{product}.app.dSYM/Contents"));
+    let dsym_info_path = shell_quote(&format!(
+        "{root}/dSYMs/{product}.app.dSYM/Contents/Info.plist"
+    ));
+    let prepare_outputs = prepare_outputs_script(output_paths);
+    format!(
+        r#"set -eu
+{prepare_outputs}
+cat > {manifest_path} <<'ONCE_MANIFEST'
+{manifest_json}
+ONCE_MANIFEST
+printf '<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{product}</string></dict></plist>\n' > {info_plist}
+printf 'app executable for {target}\n' > {binary_path}
+chmod +x {binary_path}
+mkdir -p {resources_path} {dsyms_contents_path}
+printf 'resources for {target}\n' > {resources_manifest}
+printf 'dSYM for {target}\n' > {dsym_info_path}
+"#,
+        target = target.label.id,
+    )
+}
+
+fn test_bundle_build_script(
+    target: &GraphTarget,
+    manifest_json: &str,
+    output_paths: &str,
+) -> String {
+    let product = product_name(target);
+    let root = build_root(target);
+    let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let info_plist = shell_quote(&format!("{root}/{product}.xctest/Info.plist"));
+    let binary_path = shell_quote(&format!("{root}/{product}.xctest/{product}"));
+    let dsyms_contents_path = shell_quote(&format!("{root}/dSYMs/{product}.xctest.dSYM/Contents"));
+    let dsym_info_path = shell_quote(&format!(
+        "{root}/dSYMs/{product}.xctest.dSYM/Contents/Info.plist"
+    ));
+    let prepare_outputs = prepare_outputs_script(output_paths);
+    format!(
+        r#"set -eu
+{prepare_outputs}
+cat > {manifest_path} <<'ONCE_MANIFEST'
+{manifest_json}
+ONCE_MANIFEST
+printf '<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{product}</string></dict></plist>\n' > {info_plist}
+printf 'xctest binary for {target}\n' > {binary_path}
+chmod +x {binary_path}
+mkdir -p {dsyms_contents_path}
+printf 'dSYM for {target}\n' > {dsym_info_path}
+"#,
+        target = target.label.id,
+    )
+}
+
+fn run_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
+    let product = product_name(target);
+    let root = run_root(target);
+    let bundle = format!("{product}.app");
+    let bundle_path = shell_quote(&format!("{}/{bundle}", build_root(target)));
+    let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let run_json = shell_quote(&format!("{root}/run.json"));
+    let prepare_outputs = prepare_outputs_script(output_paths);
+    format!(
+        r#"set -eu
+{prepare_outputs}
+test -d {bundle_path}
+cat > {manifest_path} <<'ONCE_MANIFEST'
+{manifest_json}
+ONCE_MANIFEST
+cat > {run_json} <<'ONCE_RUN'
+{{"target":"{target}","bundle":"{bundle}","status":"launched"}}
+ONCE_RUN
+"#,
+        target = target.label.id,
+    )
+}
+
+fn test_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
+    let product = product_name(target);
+    let root = test_root(target);
+    let bundle = format!("{product}.xctest");
+    let bundle_path = shell_quote(&format!("{}/{bundle}", build_root(target)));
+    let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let test_json = shell_quote(&format!("{root}/test_results.json"));
+    let coverage_json = shell_quote(&format!("{root}/coverage.json"));
+    let prepare_outputs = prepare_outputs_script(output_paths);
+    format!(
+        r#"set -eu
+{prepare_outputs}
+test -d {bundle_path}
+cat > {manifest_path} <<'ONCE_MANIFEST'
+{manifest_json}
+ONCE_MANIFEST
+cat > {test_json} <<'ONCE_TESTS'
+{{"target":"{target}","bundle":"{bundle}","status":"passed","tests":0,"failures":0}}
+ONCE_TESTS
+cat > {coverage_json} <<'ONCE_COVERAGE'
+{{"target":"{target}","line_coverage":null}}
+ONCE_COVERAGE
+"#,
+        target = target.label.id,
+    )
+}
+
+fn prepare_outputs_script(output_paths: &str) -> String {
+    format!(
+        r#"for p in {output_paths}; do
+  case "$p" in
+    *.a|*.json|*.plist|*.swiftmodule) mkdir -p "$(dirname "$p")" ;;
+    *) mkdir -p "$p" ;;
+  esac
+done"#
+    )
+}
+
+fn output_paths(target: &GraphTarget, capability: &str) -> Result<Vec<WorkspacePath>> {
+    let product = product_name(target);
+    let paths = match capability {
+        "build" => match target.kind.as_str() {
+            "apple_library" => vec![
+                build_root(target),
+                format!("{}/{}.a", build_root(target), product),
+                format!("{}/{}.swiftmodule", build_root(target), product),
+                format!("{}/generated_sources", build_root(target)),
+            ],
+            "apple_framework" => vec![
+                build_root(target),
+                format!("{}/{product}.framework", build_root(target)),
+                format!("{}/dSYMs", build_root(target)),
+            ],
+            "apple_application" => vec![
+                build_root(target),
+                format!("{}/{product}.app", build_root(target)),
+                format!("{}/dSYMs", build_root(target)),
+            ],
+            "apple_test_bundle" => vec![
+                build_root(target),
+                format!("{}/{product}.xctest", build_root(target)),
+                format!("{}/dSYMs", build_root(target)),
+            ],
+            _ => vec![build_root(target)],
+        },
+        "run" => vec![run_root(target)],
+        "test" => vec![
+            test_root(target),
+            format!("{}/test_results.json", test_root(target)),
+            format!("{}/coverage.json", test_root(target)),
+        ],
+        other => anyhow::bail!("unsupported graph capability `{other}`"),
+    };
+    paths
+        .into_iter()
+        .map(|path| {
+            WorkspacePath::try_from(path.as_str())
+                .with_context(|| format!("invalid graph output path `{path}`"))
+        })
+        .collect()
+}
+
+fn build_root(target: &GraphTarget) -> String {
+    format!(".once/out/{}", target.label.id)
+}
+
+fn run_root(target: &GraphTarget) -> String {
+    format!(".once/out/{}/run", target.label.id)
+}
+
+fn test_root(target: &GraphTarget) -> String {
+    format!(".once/out/{}/test", target.label.id)
+}
+
+fn product_name(target: &GraphTarget) -> String {
+    target
+        .attrs
+        .get("product_name")
+        .and_then(|value| match value {
+            AttrValue::String(value) => Some(value.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| target.label.name.clone())
+}
+
+async fn write_record(output: Output, record: &CapabilityRunRecord) -> Result<()> {
+    let body = match output.format {
+        Format::Human => render_human(record),
+        Format::Json | Format::Toon => render::structured(output.format, record)?,
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(body.as_bytes()).await?;
+    out.flush().await?;
+    Ok(())
+}
+
+fn render_human(record: &CapabilityRunRecord) -> String {
+    let groups = if record.output_groups.is_empty() {
+        "none".to_string()
+    } else {
+        record.output_groups.join(", ")
+    };
+    let mut out = format!(
+        "once: {} {} ({}) cache {}, exit=0\noutputs: {}\n",
+        record.capability, record.target, record.kind, record.cache, groups
+    );
+    if !record.required_outputs.is_empty() {
+        out.push_str("requires: ");
+        out.push_str(&record.required_outputs.join(", "));
+        out.push('\n');
+    }
+    if !record.outputs.is_empty() {
+        out.push_str("paths:\n");
+        for path in &record.outputs {
+            out.push_str("  ");
+            out.push_str(path);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    let escaped = value.replace('\'', "'\"'\"'");
+    format!("'{escaped}'")
+}

--- a/crates/once-cli/src/commands/graph/action.rs
+++ b/crates/once-cli/src/commands/graph/action.rs
@@ -1,32 +1,18 @@
-//! Graph capability commands for build, run, and test.
+//! Turns a graph target and capability into a cacheable [`Action`].
+//!
+//! The current build, run, and test scripts are local placeholders: they
+//! materialize the artifact layout each Apple product kind is expected to
+//! produce and record a manifest, without invoking Xcode. Keeping this
+//! concern separate from orchestration lets the script generation grow into
+//! real toolchain invocations without turning the command module into a
+//! monolith.
 
 use std::collections::BTreeMap;
-use std::path::Path;
-use std::process::ExitCode;
 
-use anyhow::{anyhow, Context, Result};
-use once_cas::CacheProvider;
-use once_core::{Action, OutputSymlinkMode, ResourceRequest, RunOpts, WorkspacePath};
+use anyhow::{Context, Result};
+use once_core::{Action, OutputSymlinkMode, ResourceRequest, WorkspacePath};
 use once_frontend::{AttrValue, GraphTarget};
 use serde::Serialize;
-use tokio::io::AsyncWriteExt;
-
-use crate::cli::{Format, Output};
-use crate::commands::util::cache_tag;
-use crate::render;
-
-#[derive(Debug, Serialize)]
-struct CapabilityRunRecord {
-    target: String,
-    kind: String,
-    capability: String,
-    status: &'static str,
-    action_digest: String,
-    cache: &'static str,
-    output_groups: Vec<String>,
-    required_outputs: Vec<String>,
-    outputs: Vec<String>,
-}
 
 #[derive(Debug, Serialize)]
 struct AppleArtifactManifest<'a> {
@@ -38,149 +24,12 @@ struct AppleArtifactManifest<'a> {
     srcs: &'a [String],
 }
 
-pub async fn build(
-    workspace: &Path,
-    cache: &CacheProvider,
-    output: Output,
-    target_id: &str,
-) -> Result<ExitCode> {
-    run_capability(workspace, cache, output, target_id, "build").await
-}
-
-pub async fn test(
-    workspace: &Path,
-    cache: &CacheProvider,
-    output: Output,
-    target_id: &str,
-) -> Result<ExitCode> {
-    let target = graph_target(workspace, target_id)?;
-    ensure_capability(&target, "test")?;
-    let _ = run_target_capability(workspace, cache, &target, "build").await?;
-    let record = run_target_capability(workspace, cache, &target, "test").await?;
-    write_record(output, &record).await?;
-    Ok(ExitCode::SUCCESS)
-}
-
-pub async fn run(
-    workspace: &Path,
-    cache: &CacheProvider,
-    output: Output,
-    target_id: &str,
-) -> Result<ExitCode> {
-    let target = graph_target(workspace, target_id)?;
-    ensure_capability(&target, "run")?;
-    let _ = run_target_capability(workspace, cache, &target, "build").await?;
-    let record = run_target_capability(workspace, cache, &target, "run").await?;
-    write_record(output, &record).await?;
-    Ok(ExitCode::SUCCESS)
-}
-
-pub fn supports(workspace: &Path, target_id: &str, capability: &str) -> Result<bool> {
-    let Some(target) = find_graph_target(workspace, target_id)? else {
-        return Ok(false);
-    };
-    Ok(target
-        .capabilities
-        .iter()
-        .any(|candidate| candidate.name == capability))
-}
-
-async fn run_capability(
-    workspace: &Path,
-    cache: &CacheProvider,
-    output: Output,
-    target_id: &str,
-    capability: &str,
-) -> Result<ExitCode> {
-    let target = graph_target(workspace, target_id)?;
-    let record = run_target_capability(workspace, cache, &target, capability).await?;
-    write_record(output, &record).await?;
-    Ok(ExitCode::SUCCESS)
-}
-
-async fn run_target_capability(
-    workspace: &Path,
-    cache: &CacheProvider,
+/// Build the cacheable action that produces a capability's outputs.
+pub(super) fn action_for(
     target: &GraphTarget,
-    capability_name: &str,
-) -> Result<CapabilityRunRecord> {
-    let capability = ensure_capability(target, capability_name)?;
-    let outputs = output_paths(target, capability_name)?;
-    let action = action_for(target, capability_name, &outputs)?;
-    let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
-        .await
-        .with_context(|| format!("executing {capability_name} for {}", target.label.id))?;
-    if outcome.result.exit_code != 0 {
-        anyhow::bail!(
-            "{} failed for {} with exit code {}",
-            capability_name,
-            target.label.id,
-            outcome.result.exit_code
-        );
-    }
-    let cache = cache_tag(outcome.cache);
-    Ok(CapabilityRunRecord {
-        target: target.label.id.clone(),
-        kind: target.kind.clone(),
-        capability: capability.name.clone(),
-        status: "completed",
-        action_digest: outcome.action.to_string(),
-        cache,
-        output_groups: capability.output_groups.clone(),
-        required_outputs: capability.requires_outputs.clone(),
-        outputs: outputs
-            .into_iter()
-            .map(|output| output.as_str().to_string())
-            .collect(),
-    })
-}
-
-fn graph_target(workspace: &Path, target_id: &str) -> Result<GraphTarget> {
-    find_graph_target(workspace, target_id)?
-        .with_context(|| format!("no target matches `{target_id}`"))
-}
-
-fn find_graph_target(workspace: &Path, target_id: &str) -> Result<Option<GraphTarget>> {
-    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    Ok(graph
-        .into_iter()
-        .find(|target| target.label.id == target_id))
-}
-
-fn ensure_capability<'a>(
-    target: &'a GraphTarget,
     capability: &str,
-) -> Result<&'a once_frontend::Capability> {
-    target
-        .capabilities
-        .iter()
-        .find(|candidate| candidate.name == capability)
-        .ok_or_else(|| unsupported_capability(target, capability))
-}
-
-fn unsupported_capability(target: &GraphTarget, capability: &str) -> anyhow::Error {
-    let available = target
-        .capabilities
-        .iter()
-        .map(|capability| capability.name.as_str())
-        .collect::<Vec<_>>();
-    if available.is_empty() {
-        return anyhow!(
-            "{} ({}) does not expose any capabilities",
-            target.label.id,
-            target.kind
-        );
-    }
-    anyhow!(
-        "{} ({}) does not expose `{}`. Available capabilities: {}",
-        target.label.id,
-        target.kind,
-        capability,
-        available.join(", ")
-    )
-}
-
-fn action_for(target: &GraphTarget, capability: &str, outputs: &[WorkspacePath]) -> Result<Action> {
+    outputs: &[WorkspacePath],
+) -> Result<Action> {
     Ok(Action::RunCommand {
         argv: vec![
             "/bin/sh".to_string(),
@@ -196,6 +45,51 @@ fn action_for(target: &GraphTarget, capability: &str, outputs: &[WorkspacePath])
         timeout_ms: None,
         remote: None,
     })
+}
+
+/// Workspace-relative outputs a capability declares for a target kind.
+pub(super) fn output_paths(target: &GraphTarget, capability: &str) -> Result<Vec<WorkspacePath>> {
+    let product = product_name(target);
+    let paths = match capability {
+        "build" => match target.kind.as_str() {
+            "apple_library" => vec![
+                build_root(target),
+                format!("{}/{}.a", build_root(target), product),
+                format!("{}/{}.swiftmodule", build_root(target), product),
+                format!("{}/generated_sources", build_root(target)),
+            ],
+            "apple_framework" => vec![
+                build_root(target),
+                format!("{}/{product}.framework", build_root(target)),
+                format!("{}/dSYMs", build_root(target)),
+            ],
+            "apple_application" => vec![
+                build_root(target),
+                format!("{}/{product}.app", build_root(target)),
+                format!("{}/dSYMs", build_root(target)),
+            ],
+            "apple_test_bundle" => vec![
+                build_root(target),
+                format!("{}/{product}.xctest", build_root(target)),
+                format!("{}/dSYMs", build_root(target)),
+            ],
+            _ => vec![build_root(target)],
+        },
+        "run" => vec![run_root(target)],
+        "test" => vec![
+            test_root(target),
+            format!("{}/test_results.json", test_root(target)),
+            format!("{}/coverage.json", test_root(target)),
+        ],
+        other => anyhow::bail!("unsupported graph capability `{other}`"),
+    };
+    paths
+        .into_iter()
+        .map(|path| {
+            WorkspacePath::try_from(path.as_str())
+                .with_context(|| format!("invalid graph output path `{path}`"))
+        })
+        .collect()
 }
 
 fn action_script(
@@ -461,50 +355,6 @@ done"#
     )
 }
 
-fn output_paths(target: &GraphTarget, capability: &str) -> Result<Vec<WorkspacePath>> {
-    let product = product_name(target);
-    let paths = match capability {
-        "build" => match target.kind.as_str() {
-            "apple_library" => vec![
-                build_root(target),
-                format!("{}/{}.a", build_root(target), product),
-                format!("{}/{}.swiftmodule", build_root(target), product),
-                format!("{}/generated_sources", build_root(target)),
-            ],
-            "apple_framework" => vec![
-                build_root(target),
-                format!("{}/{product}.framework", build_root(target)),
-                format!("{}/dSYMs", build_root(target)),
-            ],
-            "apple_application" => vec![
-                build_root(target),
-                format!("{}/{product}.app", build_root(target)),
-                format!("{}/dSYMs", build_root(target)),
-            ],
-            "apple_test_bundle" => vec![
-                build_root(target),
-                format!("{}/{product}.xctest", build_root(target)),
-                format!("{}/dSYMs", build_root(target)),
-            ],
-            _ => vec![build_root(target)],
-        },
-        "run" => vec![run_root(target)],
-        "test" => vec![
-            test_root(target),
-            format!("{}/test_results.json", test_root(target)),
-            format!("{}/coverage.json", test_root(target)),
-        ],
-        other => anyhow::bail!("unsupported graph capability `{other}`"),
-    };
-    paths
-        .into_iter()
-        .map(|path| {
-            WorkspacePath::try_from(path.as_str())
-                .with_context(|| format!("invalid graph output path `{path}`"))
-        })
-        .collect()
-}
-
 fn build_root(target: &GraphTarget) -> String {
     format!(".once/out/{}", target.label.id)
 }
@@ -526,43 +376,6 @@ fn product_name(target: &GraphTarget) -> String {
             _ => None,
         })
         .unwrap_or_else(|| target.label.name.clone())
-}
-
-async fn write_record(output: Output, record: &CapabilityRunRecord) -> Result<()> {
-    let body = match output.format {
-        Format::Human => render_human(record),
-        Format::Json | Format::Toon => render::structured(output.format, record)?,
-    };
-    let mut out = tokio::io::stdout();
-    out.write_all(body.as_bytes()).await?;
-    out.flush().await?;
-    Ok(())
-}
-
-fn render_human(record: &CapabilityRunRecord) -> String {
-    let groups = if record.output_groups.is_empty() {
-        "none".to_string()
-    } else {
-        record.output_groups.join(", ")
-    };
-    let mut out = format!(
-        "once: {} {} ({}) cache {}, exit=0\noutputs: {}\n",
-        record.capability, record.target, record.kind, record.cache, groups
-    );
-    if !record.required_outputs.is_empty() {
-        out.push_str("requires: ");
-        out.push_str(&record.required_outputs.join(", "));
-        out.push('\n');
-    }
-    if !record.outputs.is_empty() {
-        out.push_str("paths:\n");
-        for path in &record.outputs {
-            out.push_str("  ");
-            out.push_str(path);
-            out.push('\n');
-        }
-    }
-    out
 }
 
 fn shell_quote(value: &str) -> String {
@@ -610,18 +423,54 @@ mod tests {
         }
     }
 
+    fn with_product(kind: &str, name: &str, product: &str) -> GraphTarget {
+        let mut target = graph_target(kind, name);
+        target.attrs.insert(
+            "product_name".to_string(),
+            AttrValue::String(product.to_string()),
+        );
+        target
+    }
+
     #[test]
     fn shell_quote_escapes_single_quotes() {
         assert_eq!(shell_quote("App'; echo pwn"), "'App'\"'\"'; echo pwn'");
     }
 
     #[test]
-    fn application_script_uses_shell_quoted_dynamic_text() {
-        let mut target = graph_target("apple_application", "App");
-        target.attrs.insert(
-            "product_name".to_string(),
-            AttrValue::String("Bad'; echo pwn".to_string()),
+    fn shell_quote_handles_empty_string() {
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn xml_escape_escapes_all_entities() {
+        assert_eq!(
+            xml_escape(r#"A&B<C>D"E'F"#),
+            "A&amp;B&lt;C&gt;D&quot;E&apos;F"
         );
+    }
+
+    #[test]
+    fn product_name_prefers_attr_then_label() {
+        assert_eq!(
+            product_name(&graph_target("apple_library", "AppCore")),
+            "AppCore"
+        );
+        assert_eq!(
+            product_name(&with_product("apple_library", "AppCore", "CoreKit")),
+            "CoreKit"
+        );
+        // A non-string product_name attr falls back to the target name.
+        let mut target = graph_target("apple_library", "AppCore");
+        target
+            .attrs
+            .insert("product_name".to_string(), AttrValue::Integer(7));
+        assert_eq!(product_name(&target), "AppCore");
+    }
+
+    #[test]
+    fn application_script_uses_shell_quoted_dynamic_text() {
+        let target = with_product("apple_application", "App", "Bad'; echo pwn");
 
         let script = application_build_script(&target, "{}", "'.once/out/apps/ios/App'");
 
@@ -631,16 +480,172 @@ mod tests {
     }
 
     #[test]
+    fn library_script_quotes_dynamic_text() {
+        let target = with_product("apple_library", "AppCore", "Bad'; echo pwn");
+
+        let script = library_build_script(&target, "{}", "'.once/out/apps/ios/AppCore'");
+
+        assert!(script.contains("printf 'archive for %s\\n' 'apps/ios/AppCore'"));
+        assert!(script.contains("'.once/out/apps/ios/AppCore/Bad'\"'\"'; echo pwn.a'"));
+        assert!(!script.contains("> .once/out/apps/ios/AppCore/Bad'; echo pwn.a"));
+    }
+
+    #[test]
+    fn test_bundle_script_quotes_dynamic_text() {
+        let target = with_product("apple_test_bundle", "AppTests", "Bad'; echo pwn");
+
+        let script = test_bundle_build_script(&target, "{}", "'.once/out/apps/ios/AppTests'");
+
+        assert!(script.contains("printf 'xctest binary for %s\\n' 'apps/ios/AppTests'"));
+        assert!(!script.contains("echo pwn\\n"));
+    }
+
+    #[test]
     fn plist_values_are_xml_escaped_before_shell_quoting() {
-        let mut target = graph_target("apple_framework", "Framework");
-        target.attrs.insert(
-            "product_name".to_string(),
-            AttrValue::String("A&B<\"'>".to_string()),
-        );
+        let target = with_product("apple_framework", "Framework", "A&B<\"'>");
 
         let script = framework_build_script(&target, "{}", "'.once/out/apps/ios/Framework'");
 
         assert!(script.contains("A&amp;B&lt;&quot;&apos;&gt;"));
         assert!(!script.contains("<string>A&B<\"'></string>"));
+    }
+
+    #[test]
+    fn run_script_guards_on_built_bundle() {
+        let target = graph_target("apple_application", "App");
+
+        let script = run_script(&target, "{}", "'.once/out/apps/ios/App/run'");
+
+        assert!(script.contains("test -d '.once/out/apps/ios/App/App.app'"));
+        assert!(script.contains(r#""status":"launched""#));
+        assert!(script.contains("> '.once/out/apps/ios/App/run/run.json'"));
+    }
+
+    #[test]
+    fn test_script_guards_on_built_bundle_and_emits_results() {
+        let target = graph_target("apple_test_bundle", "AppTests");
+
+        let script = test_script(&target, "{}", "'.once/out/apps/ios/AppTests/test'");
+
+        assert!(script.contains("test -d '.once/out/apps/ios/AppTests/AppTests.xctest'"));
+        assert!(script.contains(r#""status":"passed""#));
+        assert!(script.contains("> '.once/out/apps/ios/AppTests/test/test_results.json'"));
+        assert!(script.contains("> '.once/out/apps/ios/AppTests/test/coverage.json'"));
+    }
+
+    #[test]
+    fn prepare_outputs_creates_dirs_for_files_and_dirs() {
+        let script = prepare_outputs_script("'.once/out/x' '.once/out/x/App.a'");
+        assert!(script.contains(r#"*.a|*.json|*.plist|*.swiftmodule) mkdir -p "$(dirname "$p")""#));
+        assert!(script.contains(r#"*) mkdir -p "$p""#));
+    }
+
+    fn output_strings(target: &GraphTarget, capability: &str) -> Vec<String> {
+        output_paths(target, capability)
+            .unwrap()
+            .into_iter()
+            .map(|path| path.as_str().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn output_paths_cover_library_products() {
+        assert_eq!(
+            output_strings(&graph_target("apple_library", "AppCore"), "build"),
+            vec![
+                ".once/out/apps/ios/AppCore".to_string(),
+                ".once/out/apps/ios/AppCore/AppCore.a".to_string(),
+                ".once/out/apps/ios/AppCore/AppCore.swiftmodule".to_string(),
+                ".once/out/apps/ios/AppCore/generated_sources".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn output_paths_cover_bundle_products() {
+        assert_eq!(
+            output_strings(&graph_target("apple_framework", "DesignSystem"), "build"),
+            vec![
+                ".once/out/apps/ios/DesignSystem".to_string(),
+                ".once/out/apps/ios/DesignSystem/DesignSystem.framework".to_string(),
+                ".once/out/apps/ios/DesignSystem/dSYMs".to_string(),
+            ]
+        );
+        assert_eq!(
+            output_strings(&graph_target("apple_application", "App"), "build"),
+            vec![
+                ".once/out/apps/ios/App".to_string(),
+                ".once/out/apps/ios/App/App.app".to_string(),
+                ".once/out/apps/ios/App/dSYMs".to_string(),
+            ]
+        );
+        assert_eq!(
+            output_strings(&graph_target("apple_test_bundle", "AppTests"), "build"),
+            vec![
+                ".once/out/apps/ios/AppTests".to_string(),
+                ".once/out/apps/ios/AppTests/AppTests.xctest".to_string(),
+                ".once/out/apps/ios/AppTests/dSYMs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn output_paths_cover_run_and_test() {
+        assert_eq!(
+            output_strings(&graph_target("apple_application", "App"), "run"),
+            vec![".once/out/apps/ios/App/run".to_string()]
+        );
+        assert_eq!(
+            output_strings(&graph_target("apple_test_bundle", "AppTests"), "test"),
+            vec![
+                ".once/out/apps/ios/AppTests/test".to_string(),
+                ".once/out/apps/ios/AppTests/test/test_results.json".to_string(),
+                ".once/out/apps/ios/AppTests/test/coverage.json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn output_paths_use_product_name_when_set() {
+        assert_eq!(
+            output_strings(&with_product("apple_application", "App", "Once"), "build"),
+            vec![
+                ".once/out/apps/ios/App".to_string(),
+                ".once/out/apps/ios/App/Once.app".to_string(),
+                ".once/out/apps/ios/App/dSYMs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn output_paths_reject_unknown_capability() {
+        let err = output_paths(&graph_target("apple_library", "AppCore"), "lint")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unsupported graph capability `lint`"));
+    }
+
+    #[test]
+    fn action_for_wraps_script_in_sh_invocation() {
+        let target = graph_target("apple_library", "AppCore");
+        let outputs = output_paths(&target, "build").unwrap();
+        let Action::RunCommand {
+            argv,
+            outputs: action_outputs,
+            input_digest,
+            ..
+        } = action_for(&target, "build", &outputs).unwrap();
+        assert_eq!(argv[0], "/bin/sh");
+        assert_eq!(argv[1], "-c");
+        assert!(argv[2].contains("ONCE_MANIFEST"));
+        assert_eq!(action_outputs, outputs);
+        assert!(input_digest.is_none());
+    }
+
+    #[test]
+    fn action_script_rejects_unknown_capability() {
+        let target = graph_target("apple_library", "AppCore");
+        let err = action_script(&target, "lint", &[]).unwrap_err().to_string();
+        assert!(err.contains("unsupported graph capability `lint`"));
     }
 }

--- a/crates/once-cli/src/commands/graph/action.rs
+++ b/crates/once-cli/src/commands/graph/action.rs
@@ -2,9 +2,12 @@
 //!
 //! The current build, run, and test scripts are local placeholders: they
 //! materialize the artifact layout each Apple product kind is expected to
-//! produce and record a manifest, without invoking Xcode. Keeping this
-//! concern separate from orchestration lets the script generation grow into
-//! real toolchain invocations without turning the command module into a
+//! produce and record a manifest, without invoking Xcode. They are not a
+//! bypass of Once's execution substrate: every capability runs as an
+//! [`Action`] through `once_core::run_with_cache`, so it goes through the
+//! action cache and content-addressed storage like any other action. Keeping
+//! this concern separate from orchestration lets the script generation grow
+//! into real toolchain invocations without turning the command module into a
 //! monolith.
 
 use std::collections::BTreeMap;
@@ -630,6 +633,16 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unsupported graph capability `lint`"));
+    }
+
+    #[test]
+    fn output_paths_reject_product_name_that_escapes_workspace() {
+        // A product_name carrying `..` would otherwise steer generated paths
+        // (and the chmod target) outside the workspace. WorkspacePath rejects
+        // the escape before any script is built or run.
+        let target = with_product("apple_application", "App", "../../etc/App");
+        let err = output_paths(&target, "build").unwrap_err().to_string();
+        assert!(err.contains("invalid graph output path"));
     }
 
     #[test]

--- a/crates/once-cli/src/commands/graph/action.rs
+++ b/crates/once-cli/src/commands/graph/action.rs
@@ -132,13 +132,12 @@ fn build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -
 
 fn generic_build_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> String {
     let manifest_path = shell_quote(&format!("{}/manifest.json", build_root(target)));
+    let write_manifest = write_manifest_cmd(&manifest_path, manifest_json);
     let prepare_outputs = prepare_outputs_script(output_paths);
     format!(
         r"set -eu
 {prepare_outputs}
-cat > {manifest_path} <<'ONCE_MANIFEST'
-{manifest_json}
-ONCE_MANIFEST
+{write_manifest}
 ",
     )
 }
@@ -148,6 +147,7 @@ fn library_build_script(target: &GraphTarget, manifest_json: &str, output_paths:
     let product_text = shell_quote(&product);
     let target_text = shell_quote(&target.label.id);
     let manifest_path = shell_quote(&format!("{}/manifest.json", build_root(target)));
+    let write_manifest = write_manifest_cmd(&manifest_path, manifest_json);
     let binary_path = shell_quote(&format!("{}/{}.a", build_root(target), product));
     let swiftmodule_path = shell_quote(&format!("{}/{}.swiftmodule", build_root(target), product));
     let generated_sources_path = shell_quote(&format!("{}/generated_sources", build_root(target)));
@@ -155,9 +155,7 @@ fn library_build_script(target: &GraphTarget, manifest_json: &str, output_paths:
     format!(
         r"set -eu
 {prepare_outputs}
-cat > {manifest_path} <<'ONCE_MANIFEST'
-{manifest_json}
-ONCE_MANIFEST
+{write_manifest}
 printf 'archive for %s\n' {target_text} > {binary_path}
 printf 'swiftmodule for %s\n' {product_text} > {swiftmodule_path}
 mkdir -p {generated_sources_path}
@@ -171,6 +169,7 @@ fn framework_build_script(target: &GraphTarget, manifest_json: &str, output_path
     let target_text = shell_quote(&target.label.id);
     let root = build_root(target);
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let write_manifest = write_manifest_cmd(&manifest_path, manifest_json);
     let info_plist = shell_quote(&format!("{root}/{product}.framework/Info.plist"));
     let info_plist_content = shell_quote(&format!(
         r#"<?xml version="1.0"?><plist><dict><key>CFBundleName</key><string>{}</string></dict></plist>"#,
@@ -190,9 +189,7 @@ fn framework_build_script(target: &GraphTarget, manifest_json: &str, output_path
     format!(
         r"set -eu
 {prepare_outputs}
-cat > {manifest_path} <<'ONCE_MANIFEST'
-{manifest_json}
-ONCE_MANIFEST
+{write_manifest}
 printf '%s\n' {info_plist_content} > {info_plist}
 printf 'framework binary for %s\n' {target_text} > {binary_path}
 mkdir -p {modules_path} {dsyms_contents_path}
@@ -211,6 +208,7 @@ fn application_build_script(
     let target_text = shell_quote(&target.label.id);
     let root = build_root(target);
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let write_manifest = write_manifest_cmd(&manifest_path, manifest_json);
     let info_plist = shell_quote(&format!("{root}/{product}.app/Info.plist"));
     let info_plist_content = shell_quote(&format!(
         r#"<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{}</string></dict></plist>"#,
@@ -229,9 +227,7 @@ fn application_build_script(
     format!(
         r"set -eu
 {prepare_outputs}
-cat > {manifest_path} <<'ONCE_MANIFEST'
-{manifest_json}
-ONCE_MANIFEST
+{write_manifest}
 printf '%s\n' {info_plist_content} > {info_plist}
 printf 'app executable for %s\n' {target_text} > {binary_path}
 chmod +x {binary_path}
@@ -251,6 +247,7 @@ fn test_bundle_build_script(
     let target_text = shell_quote(&target.label.id);
     let root = build_root(target);
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let write_manifest = write_manifest_cmd(&manifest_path, manifest_json);
     let info_plist = shell_quote(&format!("{root}/{product}.xctest/Info.plist"));
     let info_plist_content = shell_quote(&format!(
         r#"<?xml version="1.0"?><plist><dict><key>CFBundleExecutable</key><string>{}</string></dict></plist>"#,
@@ -265,9 +262,7 @@ fn test_bundle_build_script(
     format!(
         r"set -eu
 {prepare_outputs}
-cat > {manifest_path} <<'ONCE_MANIFEST'
-{manifest_json}
-ONCE_MANIFEST
+{write_manifest}
 printf '%s\n' {info_plist_content} > {info_plist}
 printf 'xctest binary for %s\n' {target_text} > {binary_path}
 chmod +x {binary_path}
@@ -283,6 +278,7 @@ fn run_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> 
     let bundle = format!("{product}.app");
     let bundle_path = shell_quote(&format!("{}/{bundle}", build_root(target)));
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let write_manifest = write_manifest_cmd(&manifest_path, manifest_json);
     let run_json = shell_quote(&format!("{root}/run.json"));
     let run_record = shell_quote(
         &serde_json::json!({
@@ -297,9 +293,7 @@ fn run_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) -> 
         r"set -eu
 {prepare_outputs}
 test -d {bundle_path}
-cat > {manifest_path} <<'ONCE_MANIFEST'
-{manifest_json}
-ONCE_MANIFEST
+{write_manifest}
 printf '%s\n' {run_record} > {run_json}
 ",
     )
@@ -311,6 +305,7 @@ fn test_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) ->
     let bundle = format!("{product}.xctest");
     let bundle_path = shell_quote(&format!("{}/{bundle}", build_root(target)));
     let manifest_path = shell_quote(&format!("{root}/manifest.json"));
+    let write_manifest = write_manifest_cmd(&manifest_path, manifest_json);
     let test_json = shell_quote(&format!("{root}/test_results.json"));
     let coverage_json = shell_quote(&format!("{root}/coverage.json"));
     let test_record = shell_quote(
@@ -335,9 +330,7 @@ fn test_script(target: &GraphTarget, manifest_json: &str, output_paths: &str) ->
         r"set -eu
 {prepare_outputs}
 test -d {bundle_path}
-cat > {manifest_path} <<'ONCE_MANIFEST'
-{manifest_json}
-ONCE_MANIFEST
+{write_manifest}
 printf '%s\n' {test_record} > {test_json}
 printf '%s\n' {coverage_record} > {coverage_json}
 ",
@@ -376,6 +369,20 @@ fn product_name(target: &GraphTarget) -> String {
             _ => None,
         })
         .unwrap_or_else(|| target.label.name.clone())
+}
+
+/// Emit the command that writes the artifact manifest.
+///
+/// The manifest is single-quoted with the same escaping every other dynamic
+/// value uses, rather than embedded in a heredoc. This keeps all generated
+/// content on the quoted side of the shell: no manifest value can terminate
+/// the script body or be interpreted by the shell. `manifest_path` is already
+/// shell quoted by the caller.
+fn write_manifest_cmd(manifest_path: &str, manifest_json: &str) -> String {
+    format!(
+        "printf '%s\\n' {} > {manifest_path}",
+        shell_quote(manifest_json)
+    )
 }
 
 fn shell_quote(value: &str) -> String {
@@ -637,9 +644,34 @@ mod tests {
         } = action_for(&target, "build", &outputs).unwrap();
         assert_eq!(argv[0], "/bin/sh");
         assert_eq!(argv[1], "-c");
-        assert!(argv[2].contains("ONCE_MANIFEST"));
+        assert!(argv[2].contains("manifest.json"));
         assert_eq!(action_outputs, outputs);
         assert!(input_digest.is_none());
+    }
+
+    #[test]
+    fn manifest_is_single_quoted_not_heredoc() {
+        let target = graph_target("apple_library", "AppCore");
+        let outputs = output_paths(&target, "build").unwrap();
+        let script = action_script(&target, "build", &outputs).unwrap();
+
+        // The manifest is written through the same single-quote escaping as
+        // every other value, so no heredoc terminator can appear in the body.
+        assert!(!script.contains("ONCE_MANIFEST"));
+        assert!(!script.contains("<<"));
+        assert!(script.contains("printf '%s\\n' '"));
+        assert!(script.contains("> '.once/out/apps/ios/AppCore/manifest.json'"));
+    }
+
+    #[test]
+    fn write_manifest_cmd_single_quotes_dynamic_content() {
+        // A manifest value that would close a quoted heredoc, plus a single
+        // quote, must stay inert inside the generated command.
+        let cmd = write_manifest_cmd("'out/manifest.json'", "{\n\"k\": \"ONCE_MANIFEST'x\"\n}");
+        assert!(cmd.starts_with("printf '%s\\n' '"));
+        assert!(cmd.ends_with("> 'out/manifest.json'"));
+        // The embedded single quote is escaped via the close/escape/reopen form.
+        assert!(cmd.contains("'\"'\"'"));
     }
 
     #[test]

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -1,0 +1,311 @@
+//! Graph capability commands for build, run, and test.
+//!
+//! This module owns command orchestration: resolving a target from the
+//! workspace graph, checking the requested capability, executing it through
+//! the action cache, and rendering the result. The translation from a target
+//! and capability into a cacheable action lives in [`action`].
+
+mod action;
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::{anyhow, Context, Result};
+use once_cas::CacheProvider;
+use once_core::RunOpts;
+use once_frontend::GraphTarget;
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+
+use crate::cli::{Format, Output};
+use crate::commands::util::cache_tag;
+use crate::render;
+
+#[derive(Debug, Serialize)]
+struct CapabilityRunRecord {
+    target: String,
+    kind: String,
+    capability: String,
+    status: &'static str,
+    action_digest: String,
+    cache: &'static str,
+    output_groups: Vec<String>,
+    required_outputs: Vec<String>,
+    outputs: Vec<String>,
+}
+
+pub async fn build(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+) -> Result<ExitCode> {
+    run_capability(workspace, cache, output, target_id, "build").await
+}
+
+pub async fn test(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+) -> Result<ExitCode> {
+    let target = graph_target(workspace, target_id)?;
+    ensure_capability(&target, "test")?;
+    let _ = run_target_capability(workspace, cache, &target, "build").await?;
+    let record = run_target_capability(workspace, cache, &target, "test").await?;
+    write_record(output, &record).await?;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub async fn run(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+) -> Result<ExitCode> {
+    let target = graph_target(workspace, target_id)?;
+    ensure_capability(&target, "run")?;
+    let _ = run_target_capability(workspace, cache, &target, "build").await?;
+    let record = run_target_capability(workspace, cache, &target, "run").await?;
+    write_record(output, &record).await?;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub fn supports(workspace: &Path, target_id: &str, capability: &str) -> Result<bool> {
+    let Some(target) = find_graph_target(workspace, target_id)? else {
+        return Ok(false);
+    };
+    Ok(target
+        .capabilities
+        .iter()
+        .any(|candidate| candidate.name == capability))
+}
+
+async fn run_capability(
+    workspace: &Path,
+    cache: &CacheProvider,
+    output: Output,
+    target_id: &str,
+    capability: &str,
+) -> Result<ExitCode> {
+    let target = graph_target(workspace, target_id)?;
+    let record = run_target_capability(workspace, cache, &target, capability).await?;
+    write_record(output, &record).await?;
+    Ok(ExitCode::SUCCESS)
+}
+
+async fn run_target_capability(
+    workspace: &Path,
+    cache: &CacheProvider,
+    target: &GraphTarget,
+    capability_name: &str,
+) -> Result<CapabilityRunRecord> {
+    let capability = ensure_capability(target, capability_name)?;
+    let outputs = action::output_paths(target, capability_name)?;
+    let action = action::action_for(target, capability_name, &outputs)?;
+    let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
+        .await
+        .with_context(|| format!("executing {capability_name} for {}", target.label.id))?;
+    if outcome.result.exit_code != 0 {
+        anyhow::bail!(
+            "{} failed for {} with exit code {}",
+            capability_name,
+            target.label.id,
+            outcome.result.exit_code
+        );
+    }
+    let cache = cache_tag(outcome.cache);
+    Ok(CapabilityRunRecord {
+        target: target.label.id.clone(),
+        kind: target.kind.clone(),
+        capability: capability.name.clone(),
+        status: "completed",
+        action_digest: outcome.action.to_string(),
+        cache,
+        output_groups: capability.output_groups.clone(),
+        required_outputs: capability.requires_outputs.clone(),
+        outputs: outputs
+            .into_iter()
+            .map(|output| output.as_str().to_string())
+            .collect(),
+    })
+}
+
+fn graph_target(workspace: &Path, target_id: &str) -> Result<GraphTarget> {
+    find_graph_target(workspace, target_id)?
+        .with_context(|| format!("no target matches `{target_id}`"))
+}
+
+fn find_graph_target(workspace: &Path, target_id: &str) -> Result<Option<GraphTarget>> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    Ok(graph
+        .into_iter()
+        .find(|target| target.label.id == target_id))
+}
+
+fn ensure_capability<'a>(
+    target: &'a GraphTarget,
+    capability: &str,
+) -> Result<&'a once_frontend::Capability> {
+    target
+        .capabilities
+        .iter()
+        .find(|candidate| candidate.name == capability)
+        .ok_or_else(|| unsupported_capability(target, capability))
+}
+
+fn unsupported_capability(target: &GraphTarget, capability: &str) -> anyhow::Error {
+    let available = target
+        .capabilities
+        .iter()
+        .map(|capability| capability.name.as_str())
+        .collect::<Vec<_>>();
+    if available.is_empty() {
+        return anyhow!(
+            "{} ({}) does not expose any capabilities",
+            target.label.id,
+            target.kind
+        );
+    }
+    anyhow!(
+        "{} ({}) does not expose `{}`. Available capabilities: {}",
+        target.label.id,
+        target.kind,
+        capability,
+        available.join(", ")
+    )
+}
+
+async fn write_record(output: Output, record: &CapabilityRunRecord) -> Result<()> {
+    let body = match output.format {
+        Format::Human => render_human(record),
+        Format::Json | Format::Toon => render::structured(output.format, record)?,
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(body.as_bytes()).await?;
+    out.flush().await?;
+    Ok(())
+}
+
+fn render_human(record: &CapabilityRunRecord) -> String {
+    let groups = if record.output_groups.is_empty() {
+        "none".to_string()
+    } else {
+        record.output_groups.join(", ")
+    };
+    let mut out = format!(
+        "once: {} {} ({}) cache {}, exit=0\noutputs: {}\n",
+        record.capability, record.target, record.kind, record.cache, groups
+    );
+    if !record.required_outputs.is_empty() {
+        out.push_str("requires: ");
+        out.push_str(&record.required_outputs.join(", "));
+        out.push('\n');
+    }
+    if !record.outputs.is_empty() {
+        out.push_str("paths:\n");
+        for path in &record.outputs {
+            out.push_str("  ");
+            out.push_str(path);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use once_frontend::{Capability, TargetLabel};
+
+    fn graph_target(kind: &str, capabilities: &[&str]) -> GraphTarget {
+        GraphTarget {
+            label: TargetLabel {
+                package: "apps/ios".to_string(),
+                name: "App".to_string(),
+                id: "apps/ios/App".to_string(),
+            },
+            kind: kind.to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs: BTreeMap::new(),
+            capabilities: capabilities
+                .iter()
+                .map(|name| Capability {
+                    name: (*name).to_string(),
+                    output_groups: Vec::new(),
+                    requires_outputs: Vec::new(),
+                })
+                .collect(),
+            providers: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn ensure_capability_returns_matching_capability() {
+        let target = graph_target("apple_application", &["build", "run"]);
+        let capability = ensure_capability(&target, "run").unwrap();
+        assert_eq!(capability.name, "run");
+    }
+
+    #[test]
+    fn unsupported_capability_lists_available_capabilities() {
+        let target = graph_target("apple_application", &["build", "run"]);
+        let err = ensure_capability(&target, "test").unwrap_err().to_string();
+        assert!(err.contains("does not expose `test`"));
+        assert!(err.contains("Available capabilities: build, run"));
+    }
+
+    #[test]
+    fn unsupported_capability_reports_when_none_declared() {
+        let target = graph_target("mystery", &[]);
+        let err = ensure_capability(&target, "build").unwrap_err().to_string();
+        assert!(err.contains("does not expose any capabilities"));
+    }
+
+    #[test]
+    fn render_human_includes_requires_and_paths() {
+        let record = CapabilityRunRecord {
+            target: "apps/ios/App".to_string(),
+            kind: "apple_application".to_string(),
+            capability: "run".to_string(),
+            status: "completed",
+            action_digest: "deadbeef".to_string(),
+            cache: "miss",
+            output_groups: vec!["default".to_string()],
+            required_outputs: vec!["bundle".to_string()],
+            outputs: vec![".once/out/apps/ios/App/run".to_string()],
+        };
+
+        let rendered = render_human(&record);
+
+        assert!(rendered.contains("once: run apps/ios/App (apple_application) cache miss, exit=0"));
+        assert!(rendered.contains("outputs: default"));
+        assert!(rendered.contains("requires: bundle"));
+        assert!(rendered.contains("  .once/out/apps/ios/App/run"));
+    }
+
+    #[test]
+    fn render_human_reports_no_output_groups() {
+        let record = CapabilityRunRecord {
+            target: "apps/ios/App".to_string(),
+            kind: "apple_application".to_string(),
+            capability: "build".to_string(),
+            status: "completed",
+            action_digest: "deadbeef".to_string(),
+            cache: "hit",
+            output_groups: Vec::new(),
+            required_outputs: Vec::new(),
+            outputs: Vec::new(),
+        };
+
+        let rendered = render_human(&record);
+
+        assert!(rendered.contains("outputs: none"));
+        assert!(!rendered.contains("requires:"));
+        assert!(!rendered.contains("paths:"));
+    }
+}

--- a/crates/once-cli/src/commands/mod.rs
+++ b/crates/once-cli/src/commands/mod.rs
@@ -5,6 +5,8 @@
 pub mod auth;
 pub mod cache;
 pub mod exec;
+pub mod graph;
+pub mod query;
 pub mod run;
 pub mod runtime;
 pub mod surface;

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -1,0 +1,157 @@
+//! `once query` - inspect the typed build graph.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+
+use crate::cli::{Format, Output};
+use crate::render;
+
+#[derive(Debug, Serialize)]
+struct TargetRecord {
+    id: String,
+    package: String,
+    name: String,
+    kind: String,
+    deps: Vec<String>,
+    capabilities: Vec<String>,
+}
+
+pub async fn targets(workspace: &Path, output: Output, kind: Option<&str>) -> Result<()> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    let records = graph
+        .into_iter()
+        .filter(|target| kind.is_none_or(|kind| target.kind == kind))
+        .map(|target| TargetRecord {
+            id: target.label.id,
+            package: target.label.package,
+            name: target.label.name,
+            kind: target.kind,
+            deps: target.deps,
+            capabilities: target
+                .capabilities
+                .into_iter()
+                .map(|capability| capability.name)
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    write_body(output, || render_targets_human(&records), &records).await
+}
+
+pub async fn capabilities(workspace: &Path, output: Output, target_id: &str) -> Result<()> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    let target = graph
+        .into_iter()
+        .find(|target| target.label.id == target_id)
+        .with_context(|| format!("no target matches `{target_id}`"))?;
+    write_body(
+        output,
+        || {
+            let mut out = format!("{} ({})\n", target.label.id, target.kind);
+            if target.capabilities.is_empty() {
+                out.push_str("capabilities: none\n");
+                return out;
+            }
+            out.push_str("capabilities:\n");
+            for capability in &target.capabilities {
+                writeln!(out, "  {}", capability.name).expect("writing to string cannot fail");
+                writeln!(out, "    outputs: {}", capability.output_groups.join(", "))
+                    .expect("writing to string cannot fail");
+                if !capability.requires_outputs.is_empty() {
+                    writeln!(
+                        out,
+                        "    requires: {}",
+                        capability.requires_outputs.join(", ")
+                    )
+                    .expect("writing to string cannot fail");
+                }
+            }
+            out
+        },
+        &target,
+    )
+    .await
+}
+
+pub async fn schema(workspace: &Path, output: Output, kind: &str) -> Result<()> {
+    let _ = workspace;
+    let schema = once_frontend::built_in_rule_schema(kind)
+        .with_context(|| format!("no built-in rule schema matches `{kind}`"))?;
+    write_body(
+        output,
+        || {
+            let mut out = format!("{}: {}\n", schema.kind, schema.docs);
+            if !schema.attrs.is_empty() {
+                out.push_str("attrs:\n");
+                for attr in &schema.attrs {
+                    let required = if attr.required {
+                        "required"
+                    } else {
+                        "optional"
+                    };
+                    let configurable = if attr.configurable {
+                        ", configurable"
+                    } else {
+                        ""
+                    };
+                    writeln!(
+                        out,
+                        "  {}: {} ({required}{configurable})",
+                        attr.name, attr.ty
+                    )
+                    .expect("writing to string cannot fail");
+                }
+            }
+            if !schema.capabilities.is_empty() {
+                out.push_str("capabilities:\n");
+                for capability in &schema.capabilities {
+                    writeln!(
+                        out,
+                        "  {}: {}",
+                        capability.name,
+                        capability.output_groups.join(", ")
+                    )
+                    .expect("writing to string cannot fail");
+                }
+            }
+            out
+        },
+        &schema,
+    )
+    .await
+}
+
+fn render_targets_human(records: &[TargetRecord]) -> String {
+    if records.is_empty() {
+        return "targets: none\n".to_string();
+    }
+    let mut out = String::from("targets:\n");
+    for target in records {
+        let capabilities = if target.capabilities.is_empty() {
+            "none".to_string()
+        } else {
+            target.capabilities.join(", ")
+        };
+        writeln!(out, "  {} ({}) [{}]", target.id, target.kind, capabilities)
+            .expect("writing to string cannot fail");
+    }
+    out
+}
+
+async fn write_body<T: Serialize>(
+    output: Output,
+    human: impl FnOnce() -> String,
+    value: &T,
+) -> Result<()> {
+    let body = match output.format {
+        Format::Human => human(),
+        Format::Json | Format::Toon => render::structured(output.format, value)?,
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(body.as_bytes()).await?;
+    out.flush().await?;
+    Ok(())
+}

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -10,7 +10,7 @@ use tokio::io::AsyncWriteExt;
 use crate::cli::{Format, Output};
 use crate::render;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 struct TargetRecord {
     id: String,
     package: String,
@@ -22,7 +22,12 @@ struct TargetRecord {
 
 pub async fn targets(workspace: &Path, output: Output, kind: Option<&str>) -> Result<()> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    let records = graph
+    let records = target_records(graph, kind);
+    write_body(output, || render_targets_human(&records), &records).await
+}
+
+fn target_records(graph: Vec<once_frontend::GraphTarget>, kind: Option<&str>) -> Vec<TargetRecord> {
+    graph
         .into_iter()
         .filter(|target| kind.is_none_or(|kind| target.kind == kind))
         .map(|target| TargetRecord {
@@ -37,8 +42,7 @@ pub async fn targets(workspace: &Path, output: Output, kind: Option<&str>) -> Re
                 .map(|capability| capability.name)
                 .collect(),
         })
-        .collect::<Vec<_>>();
-    write_body(output, || render_targets_human(&records), &records).await
+        .collect::<Vec<_>>()
 }
 
 pub async fn capabilities(workspace: &Path, output: Output, target_id: &str) -> Result<()> {
@@ -78,7 +82,9 @@ pub async fn capabilities(workspace: &Path, output: Output, target_id: &str) -> 
 
 pub async fn schema(workspace: &Path, output: Output, kind: &str) -> Result<()> {
     let _ = workspace;
-    let schema = once_frontend::built_in_rule_schema(kind)
+    let schema = once_frontend::built_in_rule_schemas_result()?
+        .into_iter()
+        .find(|schema| schema.kind == kind)
         .with_context(|| format!("no built-in rule schema matches `{kind}`"))?;
     write_body(
         output,
@@ -154,4 +160,61 @@ async fn write_body<T: Serialize>(
     out.write_all(body.as_bytes()).await?;
     out.flush().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use once_frontend::{Capability, GraphTarget, TargetLabel};
+
+    use super::*;
+
+    fn target(id: &str, kind: &str, capabilities: &[&str]) -> GraphTarget {
+        let (package, name) = id.rsplit_once('/').unwrap_or(("", id));
+        GraphTarget {
+            label: TargetLabel {
+                package: package.to_string(),
+                name: name.to_string(),
+                id: id.to_string(),
+            },
+            kind: kind.to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs: BTreeMap::new(),
+            capabilities: capabilities
+                .iter()
+                .map(|name| Capability {
+                    name: (*name).to_string(),
+                    output_groups: Vec::new(),
+                    requires_outputs: Vec::new(),
+                })
+                .collect(),
+            providers: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn target_records_filters_by_kind() {
+        let records = target_records(
+            vec![
+                target("apps/ios/App", "apple_application", &["build", "run"]),
+                target("apps/ios/AppTests", "apple_test_bundle", &["build", "test"]),
+            ],
+            Some("apple_application"),
+        );
+
+        assert_eq!(
+            records,
+            vec![TargetRecord {
+                id: "apps/ios/App".to_string(),
+                package: "apps/ios".to_string(),
+                name: "App".to_string(),
+                kind: "apple_application".to_string(),
+                deps: Vec::new(),
+                capabilities: vec!["build".to_string(), "run".to_string()],
+            }]
+        );
+    }
 }

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -51,33 +51,7 @@ pub async fn capabilities(workspace: &Path, output: Output, target_id: &str) -> 
         .into_iter()
         .find(|target| target.label.id == target_id)
         .with_context(|| format!("no target matches `{target_id}`"))?;
-    write_body(
-        output,
-        || {
-            let mut out = format!("{} ({})\n", target.label.id, target.kind);
-            if target.capabilities.is_empty() {
-                out.push_str("capabilities: none\n");
-                return out;
-            }
-            out.push_str("capabilities:\n");
-            for capability in &target.capabilities {
-                writeln!(out, "  {}", capability.name).expect("writing to string cannot fail");
-                writeln!(out, "    outputs: {}", capability.output_groups.join(", "))
-                    .expect("writing to string cannot fail");
-                if !capability.requires_outputs.is_empty() {
-                    writeln!(
-                        out,
-                        "    requires: {}",
-                        capability.requires_outputs.join(", ")
-                    )
-                    .expect("writing to string cannot fail");
-                }
-            }
-            out
-        },
-        &target,
-    )
-    .await
+    write_body(output, || render_capabilities_human(&target), &target).await
 }
 
 pub async fn schema(workspace: &Path, output: Output, kind: &str) -> Result<()> {
@@ -86,48 +60,68 @@ pub async fn schema(workspace: &Path, output: Output, kind: &str) -> Result<()> 
         .into_iter()
         .find(|schema| schema.kind == kind)
         .with_context(|| format!("no built-in rule schema matches `{kind}`"))?;
-    write_body(
-        output,
-        || {
-            let mut out = format!("{}: {}\n", schema.kind, schema.docs);
-            if !schema.attrs.is_empty() {
-                out.push_str("attrs:\n");
-                for attr in &schema.attrs {
-                    let required = if attr.required {
-                        "required"
-                    } else {
-                        "optional"
-                    };
-                    let configurable = if attr.configurable {
-                        ", configurable"
-                    } else {
-                        ""
-                    };
-                    writeln!(
-                        out,
-                        "  {}: {} ({required}{configurable})",
-                        attr.name, attr.ty
-                    )
-                    .expect("writing to string cannot fail");
-                }
-            }
-            if !schema.capabilities.is_empty() {
-                out.push_str("capabilities:\n");
-                for capability in &schema.capabilities {
-                    writeln!(
-                        out,
-                        "  {}: {}",
-                        capability.name,
-                        capability.output_groups.join(", ")
-                    )
-                    .expect("writing to string cannot fail");
-                }
-            }
-            out
-        },
-        &schema,
-    )
-    .await
+    write_body(output, || render_schema_human(&schema), &schema).await
+}
+
+fn render_capabilities_human(target: &once_frontend::GraphTarget) -> String {
+    let mut out = format!("{} ({})\n", target.label.id, target.kind);
+    if target.capabilities.is_empty() {
+        out.push_str("capabilities: none\n");
+        return out;
+    }
+    out.push_str("capabilities:\n");
+    for capability in &target.capabilities {
+        writeln!(out, "  {}", capability.name).expect("writing to string cannot fail");
+        writeln!(out, "    outputs: {}", capability.output_groups.join(", "))
+            .expect("writing to string cannot fail");
+        if !capability.requires_outputs.is_empty() {
+            writeln!(
+                out,
+                "    requires: {}",
+                capability.requires_outputs.join(", ")
+            )
+            .expect("writing to string cannot fail");
+        }
+    }
+    out
+}
+
+fn render_schema_human(schema: &once_frontend::RuleSchema) -> String {
+    let mut out = format!("{}: {}\n", schema.kind, schema.docs);
+    if !schema.attrs.is_empty() {
+        out.push_str("attrs:\n");
+        for attr in &schema.attrs {
+            let required = if attr.required {
+                "required"
+            } else {
+                "optional"
+            };
+            let configurable = if attr.configurable {
+                ", configurable"
+            } else {
+                ""
+            };
+            writeln!(
+                out,
+                "  {}: {} ({required}{configurable})",
+                attr.name, attr.ty
+            )
+            .expect("writing to string cannot fail");
+        }
+    }
+    if !schema.capabilities.is_empty() {
+        out.push_str("capabilities:\n");
+        for capability in &schema.capabilities {
+            writeln!(
+                out,
+                "  {}: {}",
+                capability.name,
+                capability.output_groups.join(", ")
+            )
+            .expect("writing to string cannot fail");
+        }
+    }
+    out
 }
 
 fn render_targets_human(records: &[TargetRecord]) -> String {
@@ -193,6 +187,47 @@ mod tests {
             providers: Vec::new(),
             diagnostics: Vec::new(),
         }
+    }
+
+    #[test]
+    fn render_targets_human_reports_empty_and_populated() {
+        assert_eq!(render_targets_human(&[]), "targets: none\n");
+        let rendered = render_targets_human(&[TargetRecord {
+            id: "apps/ios/App".to_string(),
+            package: "apps/ios".to_string(),
+            name: "App".to_string(),
+            kind: "apple_application".to_string(),
+            deps: Vec::new(),
+            capabilities: vec!["build".to_string(), "run".to_string()],
+        }]);
+        assert!(rendered.contains("apps/ios/App (apple_application) [build, run]"));
+    }
+
+    #[test]
+    fn render_capabilities_human_lists_outputs_and_requires() {
+        let mut target = target("apps/ios/App", "apple_application", &["build", "run"]);
+        target.capabilities[1].output_groups = vec!["default".to_string()];
+        target.capabilities[1].requires_outputs = vec!["bundle".to_string()];
+
+        let rendered = render_capabilities_human(&target);
+
+        assert!(rendered.contains("apps/ios/App (apple_application)"));
+        assert!(rendered.contains("  run\n    outputs: default\n    requires: bundle"));
+    }
+
+    #[test]
+    fn render_capabilities_human_reports_none() {
+        let target = target("apps/ios/App", "mystery", &[]);
+        assert!(render_capabilities_human(&target).contains("capabilities: none"));
+    }
+
+    #[test]
+    fn render_schema_human_includes_attrs_and_capabilities() {
+        let schema = once_frontend::built_in_rule_schema("apple_application").unwrap();
+        let rendered = render_schema_human(&schema);
+        assert!(rendered.starts_with("apple_application: "));
+        assert!(rendered.contains("bundle_id: string (required"));
+        assert!(rendered.contains("run: default"));
     }
 
     #[test]

--- a/crates/once-cli/src/commands/run/action/script.rs
+++ b/crates/once-cli/src/commands/run/action/script.rs
@@ -242,8 +242,10 @@ mod tests {
             package: package.to_string(),
             kind: "script".to_string(),
             name: "build".to_string(),
+            deps: Vec::new(),
             srcs: vec!["scripts/build.sh".to_string(), "src/input.txt".to_string()],
             attrs: BTreeMap::new(),
+            typed_attrs: BTreeMap::new(),
         }
     }
 

--- a/crates/once-cli/src/commands/surface/model.rs
+++ b/crates/once-cli/src/commands/surface/model.rs
@@ -177,8 +177,10 @@ mod tests {
         // only surfaces at runtime as "unknown command path segment"
         // when `<subcommand> --list` is invoked.
         let invocations: &[&[&str]] = &[
+            &["once", "build", "apps/ios/App"],
             &["once", "run", "t"],
             &["once", "exec", "true"],
+            &["once", "test", "apps/ios/AppTests"],
             &["once", "cache", "stats"],
             &["once", "cache", "blob", "put", "-"],
             &[
@@ -202,6 +204,9 @@ mod tests {
                 "get",
                 "0000000000000000000000000000000000000000000000000000000000000000",
             ],
+            &["once", "query", "targets"],
+            &["once", "query", "capabilities", "apps/ios/App"],
+            &["once", "query", "schema", "apple_application"],
             &["once", "toolchain", "inspect"],
             &["once", "runtime", "rpc", "/tmp/session"],
         ];

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -55,6 +55,11 @@ async fn run_command(
 ) -> Result<ExitCode> {
     match command {
         Cmd::Auth { cmd } => run_auth_command(workspace, xdg, output, cmd).await,
+        Cmd::Build { target } => {
+            let target = resolve_required_target(workspace, target)?;
+            let cache = crate::cache_provider::resolve(workspace, xdg)?;
+            commands::graph::build(workspace, &cache, output, &target).await
+        }
         Cmd::Run {
             target,
             runtime_rpc,
@@ -100,12 +105,33 @@ async fn run_command(
             .await
         }
         Cmd::Cache { cmd } => run_cache_command(workspace, xdg, output, cmd).await,
+        Cmd::Test { target } => {
+            let target = resolve_required_target(workspace, target)?;
+            let cache = crate::cache_provider::resolve(workspace, xdg)?;
+            commands::graph::test(workspace, &cache, output, &target).await
+        }
         Cmd::Toolchain {
             cmd: Some(cli::ToolchainCmd::Inspect { platform }),
         } => commands::toolchain::inspect(workspace, output, platform.as_deref())
             .await
             .map(|()| ExitCode::SUCCESS),
         Cmd::Toolchain { cmd: None } => anyhow::bail!("toolchain subcommand required"),
+        Cmd::Query {
+            cmd: Some(cli::QueryCmd::Targets { kind }),
+        } => commands::query::targets(workspace, output, kind.as_deref())
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Cmd::Query {
+            cmd: Some(cli::QueryCmd::Capabilities { target }),
+        } => commands::query::capabilities(workspace, output, &target)
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Cmd::Query {
+            cmd: Some(cli::QueryCmd::Schema { kind }),
+        } => commands::query::schema(workspace, output, &kind)
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Cmd::Query { cmd: None } => anyhow::bail!("query subcommand required"),
         Cmd::Runtime {
             cmd:
                 Some(cli::RuntimeCmd::Rpc {
@@ -215,12 +241,23 @@ async fn dispatch_run(
     runtime_rpc_socket: Option<PathBuf>,
     remote: Option<String>,
 ) -> Result<ExitCode> {
+    let resolved_target = resolve_required_target(workspace, target.clone())?;
+    if commands::graph::supports(workspace, &resolved_target, "run")? {
+        if runtime_rpc || runtime_rpc_socket.is_some() {
+            anyhow::bail!("--runtime-rpc is only supported for executable script targets");
+        }
+        if remote.is_some() {
+            anyhow::bail!("--remote is only supported for executable script targets");
+        }
+        let cache = crate::cache_provider::resolve(workspace, xdg)?;
+        return commands::graph::run(workspace, &cache, output, &resolved_target).await;
+    }
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
     run_target_command(
         workspace,
         &cache,
         output,
-        target,
+        Some(resolved_target),
         runtime_rpc,
         runtime_rpc_socket,
         remote,

--- a/crates/once-frontend/Cargo.toml
+++ b/crates/once-frontend/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 glob.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+starlark.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 walkdir.workspace = true

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -1,0 +1,152 @@
+def attr(name, ty, required = False, default = None, docs = "", configurable = True):
+    return {
+        "name": name,
+        "ty": ty,
+        "required": required,
+        "default": default,
+        "docs": docs,
+        "configurable": configurable,
+    }
+
+def dep(name, expected_providers, docs = ""):
+    return {
+        "name": name,
+        "expected_providers": expected_providers,
+        "docs": docs,
+    }
+
+def capability(name, output_groups, requires_outputs = []):
+    return {
+        "name": name,
+        "output_groups": output_groups,
+        "requires_outputs": requires_outputs,
+    }
+
+def rule(kind, docs, attrs = [], deps = [], providers = [], capabilities = [], examples = []):
+    return {
+        "kind": kind,
+        "docs": docs,
+        "attrs": attrs,
+        "deps": deps,
+        "providers": providers,
+        "capabilities": capabilities,
+        "examples": examples,
+    }
+
+APPLE_RULES = [
+    rule(
+        kind = "apple_library",
+        docs = "Compiles Swift, Objective-C, C, and C++ sources into a linkable Apple module.",
+        attrs = [
+            attr("platform", "string", required = True, docs = "Apple platform such as ios, macos, tvos, watchos, or visionos"),
+            attr("minimum_os", "string", docs = "Minimum supported OS version"),
+            attr("module_name", "string", docs = "Compiled module name. Defaults to the target name", configurable = False),
+            attr("headers", "list<string>", default = "[]", docs = "Public or private C-family headers compiled with this target"),
+            attr("exported_headers", "list<string>", default = "[]", docs = "Headers made available to dependent targets"),
+            attr("sdk_frameworks", "list<string>", default = "[]", docs = "Apple SDK frameworks linked by name, such as UIKit or Foundation"),
+            attr("weak_sdk_frameworks", "list<string>", default = "[]", docs = "Apple SDK frameworks linked weakly"),
+            attr("sdk_dylibs", "list<string>", default = "[]", docs = "Apple SDK dynamic libraries linked by name"),
+            attr("linkopts", "list<string>", default = "[]", docs = "Extra linker flags"),
+            attr("swift_flags", "list<string>", default = "[]", docs = "Extra Swift compiler flags"),
+            attr("clang_flags", "list<string>", default = "[]", docs = "Extra Clang compiler flags"),
+            attr("enable_testing", "bool", default = "false", docs = "Compile Swift with testability enabled for dependent tests"),
+            attr("library_evolution", "bool", default = "false", docs = "Emit stable Swift module interfaces for binary compatibility"),
+        ],
+        deps = [
+            dep("deps", ["apple_linkable", "apple_resource"], "Libraries, frameworks, or resources consumed by this library"),
+        ],
+        providers = ["apple_linkable", "apple_module"],
+        capabilities = [
+            capability("build", ["default", "binary", "swiftmodule", "generated_sources"]),
+        ],
+        examples = [
+            "[[target]]\nname = \"AppKit\"\nkind = \"apple_library\"\nsrcs = [\"Sources/**/*.swift\"]\n\n[target.attrs]\nplatform = \"ios\"\nminimum_os = \"17.0\"",
+        ],
+    ),
+    rule(
+        kind = "apple_framework",
+        docs = "Builds an Apple framework product with module metadata and optional resources.",
+        attrs = [
+            attr("platform", "string", required = True, docs = "Apple platform for the framework"),
+            attr("minimum_os", "string", docs = "Minimum supported OS version"),
+            attr("bundle_id", "string", docs = "Framework bundle identifier"),
+            attr("product_name", "string", docs = "Framework product name. Defaults to the target name", configurable = False),
+            attr("headers", "list<string>", default = "[]", docs = "Headers packaged with the framework"),
+            attr("exported_headers", "list<string>", default = "[]", docs = "Headers exported to downstream consumers"),
+            attr("resources", "list<string>", default = "[]", docs = "Resource glob patterns bundled into the framework"),
+            attr("asset_catalogs", "list<string>", default = "[]", docs = "Asset catalog paths compiled into the framework bundle"),
+            attr("privacy_manifest", "string", docs = "Privacy manifest placed in the framework bundle"),
+            attr("sdk_frameworks", "list<string>", default = "[]", docs = "Apple SDK frameworks linked by name"),
+            attr("weak_sdk_frameworks", "list<string>", default = "[]", docs = "Apple SDK frameworks linked weakly"),
+        ],
+        deps = [
+            dep("deps", ["apple_linkable", "apple_resource"], "Libraries and resources linked or embedded by the framework"),
+        ],
+        providers = ["apple_linkable", "apple_framework", "apple_bundle"],
+        capabilities = [
+            capability("build", ["default", "framework", "dsyms", "swiftmodule"]),
+        ],
+        examples = [
+            "[[target]]\nname = \"AuthFramework\"\nkind = \"apple_framework\"\ndeps = [\"./AuthCore\"]\n\n[target.attrs]\nplatform = \"ios\"\nbundle_id = \"dev.once.Auth\"",
+        ],
+    ),
+    rule(
+        kind = "apple_application",
+        docs = "Builds an Apple application bundle with resources, Info.plist metadata, and signing inputs.",
+        attrs = [
+            attr("platform", "string", required = True, docs = "Apple platform for the application"),
+            attr("bundle_id", "string", required = True, docs = "Application bundle identifier"),
+            attr("minimum_os", "string", docs = "Minimum supported OS version"),
+            attr("families", "list<string>", default = "[]", docs = "Supported device families, such as iphone or ipad"),
+            attr("product_name", "string", docs = "Application product name. Defaults to the target name", configurable = False),
+            attr("resources", "list<string>", default = "[]", docs = "Resource and asset catalog glob patterns"),
+            attr("asset_catalogs", "list<string>", default = "[]", docs = "Asset catalog paths compiled into the application bundle"),
+            attr("info_plist", "string", docs = "Info.plist template path"),
+            attr("info_plist_substitutions", "map<string,string>", default = "{}", docs = "Values substituted into the generated Info.plist"),
+            attr("entitlements", "string", docs = "Entitlements plist path"),
+            attr("provisioning_profile", "string", docs = "Provisioning profile label or path used for signing"),
+            attr("signing", "string", default = "ad_hoc", docs = "Signing mode or policy name"),
+            attr("sdk_frameworks", "list<string>", default = "[]", docs = "Apple SDK frameworks linked by name"),
+            attr("weak_sdk_frameworks", "list<string>", default = "[]", docs = "Apple SDK frameworks linked weakly"),
+            attr("sdk_dylibs", "list<string>", default = "[]", docs = "Apple SDK dynamic libraries linked by name"),
+        ],
+        deps = [
+            dep("deps", ["apple_linkable", "apple_framework", "apple_resource"], "Libraries, frameworks, and resources embedded in the app"),
+        ],
+        providers = ["apple_application", "apple_bundle"],
+        capabilities = [
+            capability("build", ["default", "bundle", "dsyms"]),
+            capability("run", ["default"], requires_outputs = ["bundle"]),
+        ],
+        examples = [
+            "[[target]]\nname = \"App\"\nkind = \"apple_application\"\ndeps = [\"./AppKit\"]\n\n[target.attrs]\nplatform = \"ios\"\nbundle_id = \"dev.once.App\"\nminimum_os = \"17.0\"",
+        ],
+    ),
+    rule(
+        kind = "apple_test_bundle",
+        docs = "Builds and runs XCTest-style test bundles, including app-hosted tests when declared.",
+        attrs = [
+            attr("platform", "string", required = True, docs = "Apple platform for the tests"),
+            attr("minimum_os", "string", docs = "Minimum supported OS version"),
+            attr("test_host", "target", docs = "Application target hosting the test bundle"),
+            attr("resources", "list<string>", default = "[]", docs = "Resource glob patterns bundled into the test bundle"),
+            attr("asset_catalogs", "list<string>", default = "[]", docs = "Asset catalog paths compiled into the test bundle"),
+            attr("info_plist", "string", docs = "Info.plist template path"),
+            attr("entitlements", "string", docs = "Entitlements plist path"),
+            attr("destination", "string", docs = "Simulator, device, or local destination selector"),
+            attr("test_plan", "string", docs = "XCTest plan path"),
+            attr("test_env", "map<string,string>", default = "{}", docs = "Environment variables passed to the test runner"),
+        ],
+        deps = [
+            dep("deps", ["apple_linkable", "apple_application"], "Code under test and optional host application"),
+        ],
+        providers = ["apple_test_bundle", "apple_bundle"],
+        capabilities = [
+            capability("build", ["default", "bundle", "dsyms"]),
+            capability("test", ["default", "test_results", "coverage"], requires_outputs = ["bundle"]),
+        ],
+        examples = [
+            "[[target]]\nname = \"AppTests\"\nkind = \"apple_test_bundle\"\ndeps = [\"./AppKit\"]\n\n[target.attrs]\nplatform = \"ios\"\ntest_host = \"./App\"",
+        ],
+    ),
+]

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -11,82 +11,122 @@ use starlark::values::dict::DictRef;
 use starlark::values::list::ListRef;
 use starlark::values::Value;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::target::{AttrValue, Target};
 use crate::workspace::load_workspace;
 
+/// Fully qualified graph target label.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TargetLabel {
+    /// Package path that owns the target.
     pub package: String,
+    /// Target name inside the package manifest.
     pub name: String,
+    /// Canonical target id, formed from package and name.
     pub id: String,
 }
 
+/// Target record after manifest loading and rule metadata attachment.
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct GraphTarget {
+    /// Canonical target label.
     pub label: TargetLabel,
+    /// Rule kind such as `apple_application` or `script`.
     pub kind: String,
+    /// Canonical dependency target ids.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deps: Vec<String>,
+    /// Source file patterns declared by the target.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub srcs: Vec<String>,
+    /// Typed target attributes parsed from the manifest.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub attrs: BTreeMap<String, AttrValue>,
+    /// Operations exposed by the target's rule schema.
     pub capabilities: Vec<Capability>,
+    /// Providers emitted by this target.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub providers: Vec<String>,
+    /// Non-fatal graph loading diagnostics for this target.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<Diagnostic>,
 }
 
+/// Operation exposed by a rule, such as build, run, or test.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Capability {
+    /// Capability name.
     pub name: String,
+    /// Output groups produced by this capability.
     pub output_groups: Vec<String>,
+    /// Output groups that must already exist before this capability runs.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires_outputs: Vec<String>,
 }
 
+/// Diagnostic emitted while constructing the typed graph.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Diagnostic {
+    /// Stable diagnostic code.
     pub code: String,
+    /// Human-readable diagnostic message.
     pub message: String,
+    /// Suggested repairs that an agent can apply or present.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repairs: Vec<String>,
 }
 
+/// Rule metadata used for schema queries and graph target enrichment.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RuleSchema {
+    /// Rule kind matched by `target.kind`.
     pub kind: String,
+    /// Human-readable rule description.
     pub docs: String,
+    /// Attribute schema for this rule.
     pub attrs: Vec<AttrSchema>,
+    /// Dependency expectations for this rule.
     pub deps: Vec<DepSchema>,
+    /// Providers emitted by targets of this rule.
     pub providers: Vec<String>,
+    /// Capabilities exposed by targets of this rule.
     pub capabilities: Vec<Capability>,
+    /// Example `once.toml` declarations.
     pub examples: Vec<String>,
 }
 
+/// Attribute metadata exposed by a rule schema.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AttrSchema {
+    /// Attribute name under `[target.attrs]`.
     pub name: String,
+    /// Human-readable type name.
     pub ty: String,
+    /// Whether the attribute must be present.
     pub required: bool,
+    /// Default value rendered as rule metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<String>,
+    /// Human-readable attribute description.
     pub docs: String,
+    /// Whether the value can vary by configuration.
     pub configurable: bool,
 }
 
+/// Dependency metadata exposed by a rule schema.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DepSchema {
+    /// Dependency attribute name.
     pub name: String,
+    /// Providers accepted by this dependency edge.
     pub expected_providers: Vec<String>,
+    /// Human-readable dependency description.
     pub docs: String,
 }
 
 pub fn load_graph_workspace(root: &Path) -> Result<Vec<GraphTarget>> {
     let targets = load_workspace(root)?;
-    Ok(graph_from_targets(&targets))
+    graph_from_targets_result(&targets)
 }
 
 #[must_use]
@@ -94,11 +134,26 @@ pub fn graph_from_targets(targets: &[Target]) -> Vec<GraphTarget> {
     targets.iter().map(GraphTarget::from).collect()
 }
 
+pub fn graph_from_targets_result(targets: &[Target]) -> Result<Vec<GraphTarget>> {
+    let schemas = built_in_rule_schemas_result()?;
+    Ok(targets
+        .iter()
+        .map(|target| graph_target_from_schema(target, &schemas))
+        .collect())
+}
+
 #[must_use]
 pub fn built_in_rule_schemas() -> Vec<RuleSchema> {
-    let mut schemas = starlark_prelude_rule_schemas();
-    schemas.push(script_schema());
+    let Ok(schemas) = built_in_rule_schemas_result() else {
+        return vec![script_schema()];
+    };
     schemas
+}
+
+pub fn built_in_rule_schemas_result() -> Result<Vec<RuleSchema>> {
+    let mut schemas = starlark_prelude_rule_schemas()?;
+    schemas.push(script_schema());
+    Ok(schemas)
 }
 
 #[must_use]
@@ -110,32 +165,36 @@ pub fn built_in_rule_schema(kind: &str) -> Option<RuleSchema> {
 
 impl From<&Target> for GraphTarget {
     fn from(target: &Target) -> Self {
-        let schema = built_in_rule_schema(&target.kind);
-        let diagnostics = if schema.is_some() {
-            Vec::new()
-        } else {
-            vec![Diagnostic {
-                code: "unknown_rule_kind".to_string(),
-                message: format!("target kind `{}` has no built-in schema", target.kind),
-                repairs: Vec::new(),
-            }]
-        };
-        GraphTarget {
-            label: TargetLabel {
-                package: target.package.clone(),
-                name: target.name.clone(),
-                id: target.id(),
-            },
-            kind: target.kind.clone(),
-            deps: target.deps.clone(),
-            srcs: target.srcs.clone(),
-            attrs: graph_attrs(target),
-            capabilities: schema
-                .as_ref()
-                .map_or_else(Vec::new, |schema| schema.capabilities.clone()),
-            providers: schema.map_or_else(Vec::new, |schema| schema.providers),
-            diagnostics,
-        }
+        graph_target_from_schema(target, &built_in_rule_schemas())
+    }
+}
+
+fn graph_target_from_schema(target: &Target, schemas: &[RuleSchema]) -> GraphTarget {
+    let schema = schemas.iter().find(|schema| schema.kind == target.kind);
+    let diagnostics = if schema.is_some() {
+        Vec::new()
+    } else {
+        vec![Diagnostic {
+            code: "unknown_rule_kind".to_string(),
+            message: format!("target kind `{}` has no built-in schema", target.kind),
+            repairs: Vec::new(),
+        }]
+    };
+    GraphTarget {
+        label: TargetLabel {
+            package: target.package.clone(),
+            name: target.name.clone(),
+            id: target.id(),
+        },
+        kind: target.kind.clone(),
+        deps: target.deps.clone(),
+        srcs: target.srcs.clone(),
+        attrs: graph_attrs(target),
+        capabilities: schema
+            .as_ref()
+            .map_or_else(Vec::new, |schema| schema.capabilities.clone()),
+        providers: schema.map_or_else(Vec::new, |schema| schema.providers.clone()),
+        diagnostics,
     }
 }
 
@@ -150,25 +209,32 @@ fn graph_attrs(target: &Target) -> BTreeMap<String, AttrValue> {
         .collect()
 }
 
-fn starlark_prelude_rule_schemas() -> Vec<RuleSchema> {
+fn starlark_prelude_rule_schemas() -> Result<Vec<RuleSchema>> {
+    const PRELUDE_PATH: &str = "once//prelude/apple.star";
     let source = include_str!("../prelude/apple.star");
     Module::with_temp_heap(|module| {
-        let ast = AstModule::parse(
-            "once//prelude/apple.star",
-            source.to_string(),
-            &Dialect::Standard,
-        )
-        .expect("built-in Apple Starlark prelude should parse");
+        let ast = AstModule::parse(PRELUDE_PATH, source.to_string(), &Dialect::Standard)
+            .map_err(|error| prelude_error(PRELUDE_PATH, error))?;
         let globals = GlobalsBuilder::standard().build();
         let mut eval = Evaluator::new(&module);
         eval.eval_module(ast, &globals)
-            .expect("built-in Apple Starlark prelude should evaluate");
+            .map_err(|error| prelude_error(PRELUDE_PATH, error))?;
         let rules = module
             .get("APPLE_RULES")
-            .expect("built-in Apple Starlark prelude should export APPLE_RULES");
-        rule_schemas_from_value(rules)
-            .expect("built-in Apple Starlark prelude should produce valid rule schemas")
+            .ok_or_else(|| prelude_message(PRELUDE_PATH, "missing APPLE_RULES export"))?;
+        rule_schemas_from_value(rules).map_err(|message| prelude_message(PRELUDE_PATH, &message))
     })
+}
+
+fn prelude_error(path: &str, error: impl std::fmt::Display) -> Error {
+    prelude_message(path, &error.to_string())
+}
+
+fn prelude_message(path: &str, message: &str) -> Error {
+    Error::Eval {
+        path: path.to_string(),
+        message: message.to_string(),
+    }
 }
 
 fn rule_schemas_from_value(value: Value<'_>) -> std::result::Result<Vec<RuleSchema>, String> {

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -212,17 +212,27 @@ fn graph_attrs(target: &Target) -> BTreeMap<String, AttrValue> {
 fn starlark_prelude_rule_schemas() -> Result<Vec<RuleSchema>> {
     const PRELUDE_PATH: &str = "once//prelude/apple.star";
     let source = include_str!("../prelude/apple.star");
+    parse_rule_schemas(PRELUDE_PATH, source)
+}
+
+/// Evaluate a Starlark prelude source and read its `APPLE_RULES` export.
+///
+/// Split out from [`starlark_prelude_rule_schemas`] so the error paths
+/// (parse failure, missing export, wrong types) are reachable from tests
+/// without depending on the compiled-in prelude staying valid, and so they
+/// keep working if the prelude ever becomes user-configurable.
+fn parse_rule_schemas(path: &str, source: &str) -> Result<Vec<RuleSchema>> {
     Module::with_temp_heap(|module| {
-        let ast = AstModule::parse(PRELUDE_PATH, source.to_string(), &Dialect::Standard)
-            .map_err(|error| prelude_error(PRELUDE_PATH, error))?;
+        let ast = AstModule::parse(path, source.to_string(), &Dialect::Standard)
+            .map_err(|error| prelude_error(path, error))?;
         let globals = GlobalsBuilder::standard().build();
         let mut eval = Evaluator::new(&module);
         eval.eval_module(ast, &globals)
-            .map_err(|error| prelude_error(PRELUDE_PATH, error))?;
+            .map_err(|error| prelude_error(path, error))?;
         let rules = module
             .get("APPLE_RULES")
-            .ok_or_else(|| prelude_message(PRELUDE_PATH, "missing APPLE_RULES export"))?;
-        rule_schemas_from_value(rules).map_err(|message| prelude_message(PRELUDE_PATH, &message))
+            .ok_or_else(|| prelude_message(path, "missing APPLE_RULES export"))?;
+        rule_schemas_from_value(rules).map_err(|message| prelude_message(path, &message))
     })
 }
 
@@ -464,18 +474,73 @@ mod tests {
         let graph = graph_from_targets(&[target]);
         let app = &graph[0];
         assert_eq!(app.label.id, "apps/ios/App");
-        assert_eq!(
-            app.capabilities
-                .iter()
-                .map(|capability| capability.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["build", "run"]
-        );
+        // Assert membership rather than order: capability order is defined by
+        // the prelude and reordering it there should not break this test.
+        let mut names = app
+            .capabilities
+            .iter()
+            .map(|capability| capability.name.as_str())
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        assert_eq!(names, vec!["build", "run"]);
         assert!(app
             .capabilities
             .iter()
             .any(|capability| capability.name == "run"
                 && capability.requires_outputs == vec!["bundle"]));
+    }
+
+    #[test]
+    fn parse_rule_schemas_rejects_invalid_syntax() {
+        let err = parse_rule_schemas("test.star", "APPLE_RULES = [").unwrap_err();
+        assert!(matches!(err, Error::Eval { .. }));
+    }
+
+    #[test]
+    fn parse_rule_schemas_requires_apple_rules_export() {
+        let err = parse_rule_schemas("test.star", "OTHER = []").unwrap_err();
+        match err {
+            Error::Eval { message, .. } => assert!(message.contains("missing APPLE_RULES export")),
+            other => panic!("expected Error::Eval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rule_schemas_requires_list_export() {
+        let err = parse_rule_schemas("test.star", "APPLE_RULES = 7").unwrap_err();
+        match err {
+            Error::Eval { message, .. } => assert!(message.contains("should be a list")),
+            other => panic!("expected Error::Eval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rule_schemas_reports_missing_rule_field() {
+        let err = parse_rule_schemas("test.star", r#"APPLE_RULES = [{"kind": "x"}]"#).unwrap_err();
+        match err {
+            Error::Eval { message, .. } => assert!(message.contains("is missing")),
+            other => panic!("expected Error::Eval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rule_schemas_accepts_minimal_valid_rule() {
+        let source = r#"
+APPLE_RULES = [
+    {
+        "kind": "demo",
+        "docs": "Demo rule",
+        "attrs": [],
+        "deps": [],
+        "providers": [],
+        "capabilities": [],
+        "examples": [],
+    },
+]
+"#;
+        let schemas = parse_rule_schemas("test.star", source).unwrap();
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(schemas[0].kind, "demo");
     }
 
     #[test]

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -479,6 +479,73 @@ mod tests {
     }
 
     #[test]
+    fn unknown_kind_gets_diagnostic_and_no_capabilities() {
+        let target = Target {
+            package: "apps/ios".to_string(),
+            kind: "mystery_rule".to_string(),
+            name: "Thing".to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs: BTreeMap::new(),
+            typed_attrs: BTreeMap::new(),
+        };
+
+        let graph = graph_from_targets(&[target]);
+        let thing = &graph[0];
+        assert!(thing.capabilities.is_empty());
+        assert!(thing.providers.is_empty());
+        assert_eq!(thing.diagnostics.len(), 1);
+        assert_eq!(thing.diagnostics[0].code, "unknown_rule_kind");
+        assert!(thing.diagnostics[0]
+            .message
+            .contains("`mystery_rule` has no built-in schema"));
+    }
+
+    #[test]
+    fn graph_attrs_fall_back_to_string_attrs_when_untyped() {
+        let mut attrs = BTreeMap::new();
+        attrs.insert("platform".to_string(), "ios".to_string());
+        let target = Target {
+            package: "apps/ios".to_string(),
+            kind: "apple_library".to_string(),
+            name: "AppCore".to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs,
+            typed_attrs: BTreeMap::new(),
+        };
+
+        let graph = graph_from_targets(&[target]);
+        assert_eq!(
+            graph[0].attrs.get("platform"),
+            Some(&AttrValue::String("ios".to_string()))
+        );
+    }
+
+    #[test]
+    fn typed_attrs_take_precedence_over_string_attrs() {
+        let mut attrs = BTreeMap::new();
+        attrs.insert("enable_testing".to_string(), "true".to_string());
+        let mut typed_attrs = BTreeMap::new();
+        typed_attrs.insert("enable_testing".to_string(), AttrValue::Bool(true));
+        let target = Target {
+            package: "apps/ios".to_string(),
+            kind: "apple_library".to_string(),
+            name: "AppCore".to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs,
+            typed_attrs,
+        };
+
+        let graph = graph_from_targets(&[target]);
+        assert_eq!(
+            graph[0].attrs.get("enable_testing"),
+            Some(&AttrValue::Bool(true))
+        );
+    }
+
+    #[test]
     fn built_in_schema_contains_apple_rule_set() {
         let kinds = built_in_rule_schemas()
             .into_iter()

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -1,0 +1,432 @@
+//! Typed build graph model and built-in rule metadata.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Serialize;
+use starlark::environment::{GlobalsBuilder, Module};
+use starlark::eval::Evaluator;
+use starlark::syntax::{AstModule, Dialect};
+use starlark::values::dict::DictRef;
+use starlark::values::list::ListRef;
+use starlark::values::Value;
+
+use crate::error::Result;
+use crate::target::{AttrValue, Target};
+use crate::workspace::load_workspace;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TargetLabel {
+    pub package: String,
+    pub name: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct GraphTarget {
+    pub label: TargetLabel,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deps: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub srcs: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attrs: BTreeMap<String, AttrValue>,
+    pub capabilities: Vec<Capability>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Capability {
+    pub name: String,
+    pub output_groups: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requires_outputs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repairs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuleSchema {
+    pub kind: String,
+    pub docs: String,
+    pub attrs: Vec<AttrSchema>,
+    pub deps: Vec<DepSchema>,
+    pub providers: Vec<String>,
+    pub capabilities: Vec<Capability>,
+    pub examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AttrSchema {
+    pub name: String,
+    pub ty: String,
+    pub required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    pub docs: String,
+    pub configurable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DepSchema {
+    pub name: String,
+    pub expected_providers: Vec<String>,
+    pub docs: String,
+}
+
+pub fn load_graph_workspace(root: &Path) -> Result<Vec<GraphTarget>> {
+    let targets = load_workspace(root)?;
+    Ok(graph_from_targets(&targets))
+}
+
+#[must_use]
+pub fn graph_from_targets(targets: &[Target]) -> Vec<GraphTarget> {
+    targets.iter().map(GraphTarget::from).collect()
+}
+
+#[must_use]
+pub fn built_in_rule_schemas() -> Vec<RuleSchema> {
+    let mut schemas = starlark_prelude_rule_schemas();
+    schemas.push(script_schema());
+    schemas
+}
+
+#[must_use]
+pub fn built_in_rule_schema(kind: &str) -> Option<RuleSchema> {
+    built_in_rule_schemas()
+        .into_iter()
+        .find(|schema| schema.kind == kind)
+}
+
+impl From<&Target> for GraphTarget {
+    fn from(target: &Target) -> Self {
+        let schema = built_in_rule_schema(&target.kind);
+        let diagnostics = if schema.is_some() {
+            Vec::new()
+        } else {
+            vec![Diagnostic {
+                code: "unknown_rule_kind".to_string(),
+                message: format!("target kind `{}` has no built-in schema", target.kind),
+                repairs: Vec::new(),
+            }]
+        };
+        GraphTarget {
+            label: TargetLabel {
+                package: target.package.clone(),
+                name: target.name.clone(),
+                id: target.id(),
+            },
+            kind: target.kind.clone(),
+            deps: target.deps.clone(),
+            srcs: target.srcs.clone(),
+            attrs: graph_attrs(target),
+            capabilities: schema
+                .as_ref()
+                .map_or_else(Vec::new, |schema| schema.capabilities.clone()),
+            providers: schema.map_or_else(Vec::new, |schema| schema.providers),
+            diagnostics,
+        }
+    }
+}
+
+fn graph_attrs(target: &Target) -> BTreeMap<String, AttrValue> {
+    if !target.typed_attrs.is_empty() {
+        return target.typed_attrs.clone();
+    }
+    target
+        .attrs
+        .iter()
+        .map(|(key, value)| (key.clone(), AttrValue::String(value.clone())))
+        .collect()
+}
+
+fn starlark_prelude_rule_schemas() -> Vec<RuleSchema> {
+    let source = include_str!("../prelude/apple.star");
+    Module::with_temp_heap(|module| {
+        let ast = AstModule::parse(
+            "once//prelude/apple.star",
+            source.to_string(),
+            &Dialect::Standard,
+        )
+        .expect("built-in Apple Starlark prelude should parse");
+        let globals = GlobalsBuilder::standard().build();
+        let mut eval = Evaluator::new(&module);
+        eval.eval_module(ast, &globals)
+            .expect("built-in Apple Starlark prelude should evaluate");
+        let rules = module
+            .get("APPLE_RULES")
+            .expect("built-in Apple Starlark prelude should export APPLE_RULES");
+        rule_schemas_from_value(rules)
+            .expect("built-in Apple Starlark prelude should produce valid rule schemas")
+    })
+}
+
+fn rule_schemas_from_value(value: Value<'_>) -> std::result::Result<Vec<RuleSchema>, String> {
+    list(value, "APPLE_RULES")?
+        .iter()
+        .enumerate()
+        .map(|(index, rule)| rule_schema_from_value(rule, &format!("APPLE_RULES[{index}]")))
+        .collect()
+}
+
+fn rule_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<RuleSchema, String> {
+    Ok(RuleSchema {
+        kind: field_string(value, path, "kind")?,
+        docs: field_string(value, path, "docs")?,
+        attrs: field_list(value, path, "attrs")?
+            .iter()
+            .enumerate()
+            .map(|(index, attr)| attr_schema_from_value(attr, &format!("{path}.attrs[{index}]")))
+            .collect::<std::result::Result<Vec<_>, _>>()?,
+        deps: field_list(value, path, "deps")?
+            .iter()
+            .enumerate()
+            .map(|(index, dep)| dep_schema_from_value(dep, &format!("{path}.deps[{index}]")))
+            .collect::<std::result::Result<Vec<_>, _>>()?,
+        providers: field_string_list(value, path, "providers")?,
+        capabilities: field_list(value, path, "capabilities")?
+            .iter()
+            .enumerate()
+            .map(|(index, capability)| {
+                capability_from_value(capability, &format!("{path}.capabilities[{index}]"))
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()?,
+        examples: field_string_list(value, path, "examples")?,
+    })
+}
+
+fn attr_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<AttrSchema, String> {
+    Ok(AttrSchema {
+        name: field_string(value, path, "name")?,
+        ty: field_string(value, path, "ty")?,
+        required: field_bool(value, path, "required")?,
+        default: optional_field_string(value, path, "default")?,
+        docs: field_string(value, path, "docs")?,
+        configurable: field_bool(value, path, "configurable")?,
+    })
+}
+
+fn dep_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<DepSchema, String> {
+    Ok(DepSchema {
+        name: field_string(value, path, "name")?,
+        expected_providers: field_string_list(value, path, "expected_providers")?,
+        docs: field_string(value, path, "docs")?,
+    })
+}
+
+fn capability_from_value(value: Value<'_>, path: &str) -> std::result::Result<Capability, String> {
+    Ok(Capability {
+        name: field_string(value, path, "name")?,
+        output_groups: field_string_list(value, path, "output_groups")?,
+        requires_outputs: field_string_list(value, path, "requires_outputs")?,
+    })
+}
+
+fn field_value<'v>(
+    value: Value<'v>,
+    path: &str,
+    field: &str,
+) -> std::result::Result<Value<'v>, String> {
+    let dict = DictRef::from_value(value)
+        .ok_or_else(|| format!("{path} should be a dict, got `{}`", value.get_type()))?;
+    dict.get_str(field)
+        .ok_or_else(|| format!("{path} is missing `{field}`"))
+}
+
+fn field_string(value: Value<'_>, path: &str, field: &str) -> std::result::Result<String, String> {
+    let value = field_value(value, path, field)?;
+    value.unpack_str().map(ToOwned::to_owned).ok_or_else(|| {
+        format!(
+            "{path}.{field} should be a string, got `{}`",
+            value.get_type()
+        )
+    })
+}
+
+fn optional_field_string(
+    value: Value<'_>,
+    path: &str,
+    field: &str,
+) -> std::result::Result<Option<String>, String> {
+    let value = field_value(value, path, field)?;
+    if value.is_none() {
+        return Ok(None);
+    }
+    value
+        .unpack_str()
+        .map(|value| Some(value.to_owned()))
+        .ok_or_else(|| {
+            format!(
+                "{path}.{field} should be a string or None, got `{}`",
+                value.get_type()
+            )
+        })
+}
+
+fn field_bool(value: Value<'_>, path: &str, field: &str) -> std::result::Result<bool, String> {
+    let value = field_value(value, path, field)?;
+    value.unpack_bool().ok_or_else(|| {
+        format!(
+            "{path}.{field} should be a bool, got `{}`",
+            value.get_type()
+        )
+    })
+}
+
+fn field_list<'v>(
+    value: Value<'v>,
+    path: &str,
+    field: &str,
+) -> std::result::Result<&'v ListRef<'v>, String> {
+    let value = field_value(value, path, field)?;
+    list(value, &format!("{path}.{field}"))
+}
+
+fn field_string_list(
+    value: Value<'_>,
+    path: &str,
+    field: &str,
+) -> std::result::Result<Vec<String>, String> {
+    let field_path = format!("{path}.{field}");
+    list(field_value(value, path, field)?, &field_path)?
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            item.unpack_str().map(ToOwned::to_owned).ok_or_else(|| {
+                format!(
+                    "{field_path}[{index}] should be a string, got `{}`",
+                    item.get_type()
+                )
+            })
+        })
+        .collect()
+}
+
+fn list<'v>(value: Value<'v>, path: &str) -> std::result::Result<&'v ListRef<'v>, String> {
+    ListRef::from_value(value)
+        .ok_or_else(|| format!("{path} should be a list, got `{}`", value.get_type()))
+}
+
+fn script_schema() -> RuleSchema {
+    RuleSchema {
+        kind: "script".to_string(),
+        docs: "Migration target that wraps an annotated script action.".to_string(),
+        attrs: vec![
+            attr(
+                "script_path",
+                "string",
+                true,
+                None,
+                "Workspace-relative script path",
+                false,
+            ),
+            attr(
+                "script_runtime",
+                "string",
+                true,
+                None,
+                "Runtime parsed from the script shebang",
+                false,
+            ),
+        ],
+        deps: Vec::new(),
+        providers: vec!["script_action".to_string()],
+        capabilities: vec![capability("run", &["default"], &[])],
+        examples: Vec::new(),
+    }
+}
+
+fn attr(
+    name: &str,
+    ty: &str,
+    required: bool,
+    default: Option<&str>,
+    docs: &str,
+    configurable: bool,
+) -> AttrSchema {
+    AttrSchema {
+        name: name.to_string(),
+        ty: ty.to_string(),
+        required,
+        default: default.map(str::to_string),
+        docs: docs.to_string(),
+        configurable,
+    }
+}
+
+fn capability(name: &str, output_groups: &[&str], requires_outputs: &[&str]) -> Capability {
+    Capability {
+        name: name.to_string(),
+        output_groups: output_groups
+            .iter()
+            .map(|group| (*group).to_string())
+            .collect(),
+        requires_outputs: requires_outputs
+            .iter()
+            .map(|group| (*group).to_string())
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::target::Target;
+
+    #[test]
+    fn apple_application_exposes_build_and_run() {
+        let target = Target {
+            package: "apps/ios".to_string(),
+            kind: "apple_application".to_string(),
+            name: "App".to_string(),
+            deps: vec!["apps/ios/AppKit".to_string()],
+            srcs: Vec::new(),
+            attrs: BTreeMap::new(),
+            typed_attrs: BTreeMap::new(),
+        };
+
+        let graph = graph_from_targets(&[target]);
+        let app = &graph[0];
+        assert_eq!(app.label.id, "apps/ios/App");
+        assert_eq!(
+            app.capabilities
+                .iter()
+                .map(|capability| capability.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["build", "run"]
+        );
+        assert!(app
+            .capabilities
+            .iter()
+            .any(|capability| capability.name == "run"
+                && capability.requires_outputs == vec!["bundle"]));
+    }
+
+    #[test]
+    fn built_in_schema_contains_apple_rule_set() {
+        let kinds = built_in_rule_schemas()
+            .into_iter()
+            .map(|schema| schema.kind)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            kinds,
+            vec![
+                "apple_library",
+                "apple_framework",
+                "apple_application",
+                "apple_test_bundle",
+                "script"
+            ]
+        );
+    }
+}

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod cache_provider;
 mod error;
+mod graph;
 mod manifest;
 mod script;
 mod target;
@@ -21,11 +22,15 @@ pub use cache_provider::{
     CacheProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
 };
 pub use error::{Error, Result};
+pub use graph::{
+    built_in_rule_schema, built_in_rule_schemas, graph_from_targets, load_graph_workspace,
+    AttrSchema, Capability, DepSchema, Diagnostic, GraphTarget, RuleSchema, TargetLabel,
+};
 pub use manifest::{load_cache_provider_toml_str, load_toml_str};
 pub use script::{parse_script_annotations, ScriptAnnotations};
-pub use target::Target;
+pub use target::{AttrValue, Target};
 pub use target_ref::{
-    absolutize, normalize_cli_target, normalize_cli_target_from, target_id, validate_target_name,
-    TargetIdError,
+    absolutize, normalize_cli_target, normalize_cli_target_from, normalize_manifest_target,
+    target_id, validate_target_name, TargetIdError,
 };
 pub use workspace::{load_cache_provider, load_cache_provider_override, load_file, load_workspace};

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -23,8 +23,9 @@ pub use cache_provider::{
 };
 pub use error::{Error, Result};
 pub use graph::{
-    built_in_rule_schema, built_in_rule_schemas, graph_from_targets, load_graph_workspace,
-    AttrSchema, Capability, DepSchema, Diagnostic, GraphTarget, RuleSchema, TargetLabel,
+    built_in_rule_schema, built_in_rule_schemas, built_in_rule_schemas_result, graph_from_targets,
+    graph_from_targets_result, load_graph_workspace, AttrSchema, Capability, DepSchema, Diagnostic,
+    GraphTarget, RuleSchema, TargetLabel,
 };
 pub use manifest::{load_cache_provider_toml_str, load_toml_str};
 pub use script::{parse_script_annotations, ScriptAnnotations};

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -1,18 +1,31 @@
 //! TOML frontend for workspace configuration.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::Deserialize;
 
 use crate::cache_provider::{CacheProviderToml, InfrastructureToml};
 use crate::error::{Error, Result};
-use crate::target::Target;
+use crate::target::{AttrValue, Target};
+use crate::target_ref::{normalize_manifest_target, validate_target_name};
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 struct Manifest {
     infrastructure: InfrastructureToml,
     cache_provider: Option<CacheProviderToml>,
+    target: Vec<TargetToml>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct TargetToml {
+    name: String,
+    kind: String,
+    deps: Vec<String>,
+    srcs: Vec<String>,
+    attrs: BTreeMap<String, toml::Value>,
 }
 
 pub fn load_toml_str(path: &str, src: &str) -> Result<Vec<Target>> {
@@ -23,13 +36,17 @@ pub(crate) fn load_toml_with(
     display_name: &str,
     src: &str,
     _workspace_root: &Path,
-    _package: &str,
+    package: &str,
 ) -> Result<Vec<Target>> {
-    let _manifest: Manifest = toml::from_str(src).map_err(|source| Error::Parse {
+    let manifest: Manifest = toml::from_str(src).map_err(|source| Error::Parse {
         path: display_name.to_string(),
         message: source.to_string(),
     })?;
-    Ok(Vec::new())
+    manifest
+        .target
+        .into_iter()
+        .map(|target| target.into_target(display_name, package))
+        .collect()
 }
 
 pub fn load_cache_provider_toml_str(
@@ -47,6 +64,88 @@ pub fn load_cache_provider_toml_str(
         .cache_provider
         .map(|raw| raw.into_config(path))
         .transpose()
+}
+
+impl TargetToml {
+    fn into_target(self, display_name: &str, package: &str) -> Result<Target> {
+        if self.name.is_empty() {
+            return Err(Error::Eval {
+                path: display_name.to_string(),
+                message: "target name is required".to_string(),
+            });
+        }
+        if self.kind.is_empty() {
+            return Err(Error::Eval {
+                path: display_name.to_string(),
+                message: format!("target `{}` kind is required", self.name),
+            });
+        }
+        validate_target_name(&self.name).map_err(|source| Error::Eval {
+            path: display_name.to_string(),
+            message: source.to_string(),
+        })?;
+        let deps = self
+            .deps
+            .iter()
+            .map(|dep| {
+                normalize_manifest_target(package, dep).map_err(|source| Error::Eval {
+                    path: display_name.to_string(),
+                    message: source.to_string(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let typed_attrs = self
+            .attrs
+            .into_iter()
+            .map(|(key, value)| {
+                let string_value = toml_value_to_attr_string(&value);
+                (key, string_value, toml_value_to_attr_value(value))
+            })
+            .collect::<Vec<_>>();
+        let attrs = typed_attrs
+            .iter()
+            .map(|(key, value, _)| (key.clone(), value.clone()))
+            .collect();
+        let typed_attrs = typed_attrs
+            .into_iter()
+            .map(|(key, _, value)| (key, value))
+            .collect();
+        Ok(Target {
+            package: package.to_string(),
+            kind: self.kind,
+            name: self.name,
+            deps,
+            srcs: self.srcs,
+            attrs,
+            typed_attrs,
+        })
+    }
+}
+
+fn toml_value_to_attr_string(value: &toml::Value) -> String {
+    match value {
+        toml::Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn toml_value_to_attr_value(value: toml::Value) -> AttrValue {
+    match value {
+        toml::Value::String(value) => AttrValue::String(value),
+        toml::Value::Integer(value) => AttrValue::Integer(value),
+        toml::Value::Float(value) => AttrValue::Float(value),
+        toml::Value::Boolean(value) => AttrValue::Bool(value),
+        toml::Value::Array(values) => {
+            AttrValue::List(values.into_iter().map(toml_value_to_attr_value).collect())
+        }
+        toml::Value::Table(values) => AttrValue::Map(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, toml_value_to_attr_value(value)))
+                .collect(),
+        ),
+        toml::Value::Datetime(value) => AttrValue::String(value.to_string()),
+    }
 }
 
 #[cfg(test)]
@@ -68,5 +167,55 @@ argv = ["sh", "-c", "printf hello"]
 "#;
         let err = load_toml_str("once.toml", src).unwrap_err().to_string();
         assert!(err.contains("unknown field `script`"));
+    }
+
+    #[test]
+    fn loads_apple_target_declarations() {
+        let src = r#"
+[[target]]
+name = "App"
+kind = "apple_application"
+deps = ["apps/ios/AppKit"]
+srcs = ["Sources/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+bundle_id = "dev.once.App"
+minimum_os = "17.0"
+resources = ["Resources/**"]
+"#;
+        let targets =
+            load_toml_with("apps/ios/once.toml", src, Path::new("."), "apps/ios").unwrap();
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].id(), "apps/ios/App");
+        assert_eq!(targets[0].deps, vec!["apps/ios/AppKit"]);
+        assert_eq!(
+            targets[0].attrs.get("bundle_id").map(String::as_str),
+            Some("dev.once.App")
+        );
+        assert_eq!(
+            targets[0].attrs.get("resources").map(String::as_str),
+            Some("[\"Resources/**\"]")
+        );
+        assert_eq!(
+            targets[0].typed_attrs.get("resources"),
+            Some(&AttrValue::List(vec![AttrValue::String(
+                "Resources/**".to_string()
+            )]))
+        );
+    }
+
+    #[test]
+    fn dot_deps_are_package_relative() {
+        let src = r#"
+[[target]]
+name = "App"
+kind = "apple_application"
+deps = ["./AppKit"]
+"#;
+        let targets =
+            load_toml_with("apps/ios/once.toml", src, Path::new("."), "apps/ios").unwrap();
+        assert_eq!(targets[0].deps, vec!["apps/ios/AppKit"]);
     }
 }

--- a/crates/once-frontend/src/target.rs
+++ b/crates/once-frontend/src/target.rs
@@ -30,7 +30,7 @@ impl Target {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum AttrValue {
     String(String),
@@ -39,6 +39,20 @@ pub enum AttrValue {
     Bool(bool),
     List(Vec<AttrValue>),
     Map(BTreeMap<String, AttrValue>),
+}
+
+impl PartialEq for AttrValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::String(lhs), Self::String(rhs)) => lhs == rhs,
+            (Self::Integer(lhs), Self::Integer(rhs)) => lhs == rhs,
+            (Self::Float(lhs), Self::Float(rhs)) => lhs.to_bits() == rhs.to_bits(),
+            (Self::Bool(lhs), Self::Bool(rhs)) => lhs == rhs,
+            (Self::List(lhs), Self::List(rhs)) => lhs == rhs,
+            (Self::Map(lhs), Self::Map(rhs)) => lhs == rhs,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/once-frontend/src/target.rs
+++ b/crates/once-frontend/src/target.rs
@@ -7,15 +7,19 @@ use serde::Serialize;
 use crate::target_ref::target_id;
 
 /// A script-like target declared by a `once.toml` file.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct Target {
     pub package: String,
     pub kind: String,
     pub name: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deps: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub srcs: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub attrs: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub typed_attrs: BTreeMap<String, AttrValue>,
 }
 
 impl Target {
@@ -24,6 +28,17 @@ impl Target {
     pub fn id(&self) -> String {
         target_id(&self.package, &self.name)
     }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum AttrValue {
+    String(String),
+    Integer(i64),
+    Float(f64),
+    Bool(bool),
+    List(Vec<AttrValue>),
+    Map(BTreeMap<String, AttrValue>),
 }
 
 #[cfg(test)]
@@ -36,8 +51,10 @@ mod tests {
             package: "crates/foo".into(),
             kind: "script".into(),
             name: "bar".into(),
+            deps: vec![],
             srcs: vec![],
             attrs: BTreeMap::new(),
+            typed_attrs: BTreeMap::new(),
         };
         assert_eq!(t.id(), "crates/foo/bar");
         let root_t = Target {

--- a/crates/once-frontend/src/target_ref.rs
+++ b/crates/once-frontend/src/target_ref.rs
@@ -61,6 +61,20 @@ pub fn normalize_cli_target_from(
     }
 }
 
+pub fn normalize_manifest_target(package: &str, raw: &str) -> Result<String, TargetIdError> {
+    validate_raw(raw)?;
+    if raw.starts_with("./") || raw.starts_with("../") {
+        let base = package
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        normalize_from(&base, raw)
+    } else {
+        normalize_from(&[], raw)
+    }
+}
+
 fn validate_raw(raw: &str) -> Result<(), TargetIdError> {
     if raw.is_empty() {
         return Err(TargetIdError::Empty);
@@ -209,5 +223,21 @@ mod tests {
             normalize_cli_target_from(root.path(), outside.path(), "./hello"),
             Err(TargetIdError::CurrentDirOutsideProject { .. })
         ));
+    }
+
+    #[test]
+    fn manifest_deps_allow_root_and_package_relative_refs() {
+        assert_eq!(
+            normalize_manifest_target("apps/ios", "packages/auth/Auth").unwrap(),
+            "packages/auth/Auth"
+        );
+        assert_eq!(
+            normalize_manifest_target("apps/ios", "./AppKit").unwrap(),
+            "apps/ios/AppKit"
+        );
+        assert_eq!(
+            normalize_manifest_target("apps/ios", "../shared/Logging").unwrap(),
+            "apps/shared/Logging"
+        );
     }
 }

--- a/docs/guide/apple-graph.md
+++ b/docs/guide/apple-graph.md
@@ -1,0 +1,101 @@
+# Apple Graph
+
+Once is starting its build graph with Apple targets. The first implementation
+models target declarations, rule schemas, capabilities, and local build, run,
+and test commands. It does not invoke Xcode yet.
+
+The model is informed by:
+
+- [Bazel rules_apple](https://github.com/bazelbuild/rules_apple), where
+  application rules handle linking and bundling while Swift and Objective-C
+  compilation live in language rules.
+- [Bazel apple_binary](https://docs.bazel.build/versions/3.0.0/be/objective-c.html#apple_binary),
+  which exposes Apple binary concepts such as platform type, minimum OS
+  version, SDK frameworks, SDK dylibs, weak SDK frameworks, link options, and
+  multi-architecture outputs.
+- [Buck2 apple_library](https://buck2.build/docs/prelude/rules/apple/apple_library/),
+  [apple_binary](https://buck2.build/docs/prelude/rules/apple/apple_binary/),
+  and [apple_bundle](https://buck2.build/docs/prelude/rules/apple/apple_bundle/),
+  which separate compile inputs, Apple toolchain selection, bundle assembly,
+  resources, asset catalogs, Info.plist values, entitlements, provisioning
+  profiles, and tests.
+
+Once adapts those concepts into typed graph data instead of copying the rule
+names or macro model. Users and agents declare graph targets in `once.toml`.
+Built-in Apple rule metadata is defined in Once's Starlark prelude, then lowered
+into typed Rust graph schemas. The graph is intentionally inspectable first, so
+agents and CLI users can ask what a target can do before broad execution exists.
+
+## Targets
+
+Package manifests declare targets with one canonical shape:
+
+```toml
+[[target]]
+name = "App"
+kind = "apple_application"
+deps = ["./AppCore"]
+
+[target.attrs]
+platform = "ios"
+bundle_id = "dev.once.App"
+minimum_os = "17.0"
+families = ["iphone", "ipad"]
+resources = ["Resources/**"]
+asset_catalogs = ["Assets.xcassets"]
+info_plist = "Info.plist"
+entitlements = "App.entitlements"
+provisioning_profile = "profiles/App.mobileprovision"
+sdk_frameworks = ["UIKit"]
+```
+
+Dependency references are root-relative by default. `./` and `../` references
+resolve from the package that owns the manifest.
+
+## Built-In Apple Rules
+
+The initial built-in rules are defined in `crates/once-frontend/prelude/apple.star`:
+
+- `apple_library`: Swift, Objective-C, C, and C++ sources, headers, exported
+  headers, Swift and Clang flags, SDK frameworks, weak SDK frameworks, SDK
+  dylibs, link options, testability, and library evolution.
+- `apple_framework`: framework bundle metadata, resources, asset catalogs,
+  privacy manifests, headers, exported headers, SDK frameworks, weak SDK
+  frameworks, and debug symbol outputs.
+- `apple_application`: application bundle metadata, device families, resources,
+  asset catalogs, Info.plist substitutions, entitlements, provisioning profile,
+  signing policy, SDK frameworks, weak SDK frameworks, and SDK dylibs.
+- `apple_test_bundle`: XCTest bundle metadata, optional test host, resources,
+  asset catalogs, Info.plist, entitlements, destination, test plan, and test
+  environment.
+
+## Commands
+
+Use queries to inspect the graph:
+
+```sh
+once query targets
+once query capabilities apps/ios/App
+once query schema apple_application
+```
+
+Use capability commands to materialize the current graph contract:
+
+```sh
+once build apps/ios/App
+once run apps/ios/App
+once test apps/ios/AppTests
+```
+
+These commands run local cache-backed actions. `build` writes artifacts under
+`.once/out/<target>/`, `run` consumes the built application bundle and writes a
+run record, and `test` consumes the built test bundle and writes test results
+and coverage records. For example, an `apple_application` build produces a
+`.app` bundle and `dsyms`, while `run` depends on the `bundle` output. An
+`apple_test_bundle` test produces `test_results` and `coverage`, and also
+depends on the built bundle.
+
+Script targets still execute through `once run` and the action cache. Apple
+target execution will move from these local materialization actions to Xcode
+toolchain-backed configured graph snapshots and concrete compile, link, bundle,
+sign, install, launch, and XCTest actions in later implementations.

--- a/docs/guide/apple-graph.md
+++ b/docs/guide/apple-graph.md
@@ -1,8 +1,10 @@
 # Apple Graph
 
-Once is starting its build graph with Apple targets. The first implementation
-models target declarations, rule schemas, capabilities, and local build, run,
-and test commands. It does not invoke Xcode yet.
+Once is starting its build graph with Apple targets, following
+[RFC 0001: Once Build Graph](https://github.com/tuist/once/blob/main/rfcs/0001-build-graph.md).
+The first implementation models target declarations, rule schemas,
+capabilities, and local build, run, and test commands. It does not invoke Xcode
+yet.
 
 The model is informed by:
 
@@ -21,10 +23,12 @@ The model is informed by:
   profiles, and tests.
 
 Once adapts those concepts into typed graph data instead of copying the rule
-names or macro model. Users and agents declare graph targets in `once.toml`.
-Built-in Apple rule metadata is defined in Once's Starlark prelude, then lowered
-into typed Rust graph schemas. The graph is intentionally inspectable first, so
-agents and CLI users can ask what a target can do before broad execution exists.
+names or macro model. It is not Buck-compatible, Bazel-compatible, or a drop-in
+replacement for either tool. Users and agents declare graph targets in
+`once.toml`. Built-in Apple rule metadata is defined in Once's Starlark prelude,
+then lowered into typed Rust graph schemas. The graph is intentionally
+inspectable first, so agents and CLI users can ask what a target can do before
+broad execution exists.
 
 ## Targets
 

--- a/docs/site.js
+++ b/docs/site.js
@@ -21,6 +21,11 @@ export const site = {
     "/": [
       { text: "Why", link: "/guide/why" },
       {
+        text: "Graph",
+        collapsed: false,
+        items: [{ text: "Apple", link: "/guide/apple-graph" }],
+      },
+      {
         text: "Scripts",
         collapsed: false,
         items: [

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -1,0 +1,155 @@
+#shellcheck shell=bash
+# End-to-end specs for Apple graph targets.
+
+Describe 'apple graph'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  create_apple_workspace() {
+    mkdir -p "$WORKSPACE/apps/ios"
+    cat > "$WORKSPACE/apps/ios/once.toml" <<'EOF'
+[[target]]
+name = "AppCore"
+kind = "apple_library"
+srcs = ["Sources/AppCore/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+minimum_os = "17.0"
+headers = ["Sources/AppCore/include/AppCore.h"]
+exported_headers = ["Sources/AppCore/include/AppCore.h"]
+sdk_frameworks = ["Foundation"]
+swift_flags = ["-warnings-as-errors"]
+
+[[target]]
+name = "DesignSystem"
+kind = "apple_framework"
+deps = ["./AppCore"]
+
+[target.attrs]
+platform = "ios"
+bundle_id = "dev.once.DesignSystem"
+minimum_os = "17.0"
+resources = ["DesignSystem/Resources/**"]
+asset_catalogs = ["DesignSystem/Assets.xcassets"]
+privacy_manifest = "DesignSystem/PrivacyInfo.xcprivacy"
+
+[[target]]
+name = "App"
+kind = "apple_application"
+deps = ["./AppCore", "./DesignSystem"]
+
+[target.attrs]
+platform = "ios"
+bundle_id = "dev.once.App"
+minimum_os = "17.0"
+families = ["iphone", "ipad"]
+resources = ["Resources/**"]
+asset_catalogs = ["Assets.xcassets"]
+entitlements = "App.entitlements"
+provisioning_profile = "profiles/App.mobileprovision"
+sdk_frameworks = ["UIKit"]
+
+[[target]]
+name = "AppTests"
+kind = "apple_test_bundle"
+deps = ["./AppCore"]
+
+[target.attrs]
+platform = "ios"
+minimum_os = "17.0"
+test_host = "./App"
+test_plan = "App.xctestplan"
+EOF
+  }
+
+  It 'lists buildable Apple artifacts'
+    create_apple_workspace
+
+    When call once query targets
+    The status should be success
+    The stdout should include 'apps/ios/AppCore (apple_library) [build]'
+    The stdout should include 'apps/ios/DesignSystem (apple_framework) [build]'
+    The stdout should include 'apps/ios/App (apple_application) [build, run]'
+    The stdout should include 'apps/ios/AppTests (apple_test_bundle) [build, test]'
+  End
+
+  It 'exposes runnable Apple application artifacts'
+    create_apple_workspace
+
+    When call once --format json query capabilities apps/ios/App
+    The status should be success
+    The stdout should include '"kind":"apple_application"'
+    The stdout should include '"name":"build"'
+    The stdout should include '"output_groups":["default","bundle","dsyms"]'
+    The stdout should include '"name":"run"'
+    The stdout should include '"requires_outputs":["bundle"]'
+  End
+
+  It 'builds Apple application artifacts through the graph command'
+    create_apple_workspace
+
+    When call once --format json build apps/ios/App
+    The status should be success
+    The stdout should include '"target":"apps/ios/App"'
+    The stdout should include '"capability":"build"'
+    The stdout should include '"status":"completed"'
+    The stdout should include '"output_groups":["default","bundle","dsyms"]'
+    The stdout should include '".once/out/apps/ios/App/App.app"'
+    The path "$WORKSPACE/.once/out/apps/ios/App/App.app/Info.plist" should be file
+  End
+
+  It 'runs Apple application artifacts through the graph command'
+    create_apple_workspace
+
+    When call once --format json run apps/ios/App
+    The status should be success
+    The stdout should include '"target":"apps/ios/App"'
+    The stdout should include '"capability":"run"'
+    The stdout should include '"status":"completed"'
+    The stdout should include '"required_outputs":["bundle"]'
+    The path "$WORKSPACE/.once/out/apps/ios/App/run/run.json" should be file
+  End
+
+  It 'exposes testable Apple test bundle artifacts'
+    create_apple_workspace
+
+    When call once --format json query capabilities apps/ios/AppTests
+    The status should be success
+    The stdout should include '"kind":"apple_test_bundle"'
+    The stdout should include '"name":"build"'
+    The stdout should include '"output_groups":["default","bundle","dsyms"]'
+    The stdout should include '"name":"test"'
+    The stdout should include '"output_groups":["default","test_results","coverage"]'
+    The stdout should include '"requires_outputs":["bundle"]'
+  End
+
+  It 'tests Apple test bundle artifacts through the graph command'
+    create_apple_workspace
+
+    When call once --format json test apps/ios/AppTests
+    The status should be success
+    The stdout should include '"target":"apps/ios/AppTests"'
+    The stdout should include '"capability":"test"'
+    The stdout should include '"status":"completed"'
+    The stdout should include '"output_groups":["default","test_results","coverage"]'
+    The stdout should include '"required_outputs":["bundle"]'
+    The path "$WORKSPACE/.once/out/apps/ios/AppTests/test/test_results.json" should be file
+  End
+
+  It 'describes Apple application build and run schemas'
+    When call once query schema apple_application
+    The status should be success
+    The stdout should include 'apple_application'
+    The stdout should include 'provisioning_profile'
+    The stdout should include 'asset_catalogs'
+    The stdout should include 'run: default'
+  End
+
+  It 'describes Apple test bundle build and test schemas'
+    When call once query schema apple_test_bundle
+    The status should be success
+    The stdout should include 'apple_test_bundle'
+    The stdout should include 'test: default, test_results, coverage'
+  End
+End

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -152,4 +152,36 @@ EOF
     The stdout should include 'apple_test_bundle'
     The stdout should include 'test: default, test_results, coverage'
   End
+
+  It 'errors when building a target id that does not match'
+    create_apple_workspace
+
+    When call once build apps/ios/Missing
+    The status should not equal 0
+    The stderr should include 'no target matches'
+  End
+
+  It 'errors when a capability is not exposed by the target'
+    create_apple_workspace
+
+    When call once test apps/ios/App
+    The status should not equal 0
+    The stderr should include 'does not expose `test`'
+  End
+
+  It 'rejects --remote for graph run targets'
+    create_apple_workspace
+
+    When call once run --remote apps/ios/App
+    The status should not equal 0
+    The stderr should include '--remote is only supported for executable script targets'
+  End
+
+  It 'rejects --runtime-rpc for graph run targets'
+    create_apple_workspace
+
+    When call once run --runtime-rpc apps/ios/App
+    The status should not equal 0
+    The stderr should include '--runtime-rpc is only supported for executable script targets'
+  End
 End

--- a/spec/cli_surface_spec.sh
+++ b/spec/cli_surface_spec.sh
@@ -6,10 +6,13 @@ Describe 'once --help'
     When call "$ONCE_BIN" --help
     The status should be success
     The stdout should include 'once'
+    The stdout should include 'build'
     The stdout should include 'run'
     The stdout should include 'exec'
+    The stdout should include 'test'
     The stdout should include 'cache'
     The stdout should include 'auth'
+    The stdout should include 'query'
     The stdout should include 'runtime'
     The stdout should include '--directory'
     The stdout should include '--list'
@@ -32,9 +35,12 @@ Describe 'once --list'
     When call "$ONCE_BIN" --list
     The status should be success
     The stdout should include 'once'
+    The stdout should include 'build'
     The stdout should include 'run'
     The stdout should include 'exec'
+    The stdout should include 'test'
     The stdout should include 'auth'
+    The stdout should include 'query'
     The stdout should include 'runtime'
     The stdout should include '--list'
   End


### PR DESCRIPTION
## Summary
- Add typed frontend graph models for Apple targets, capabilities, providers, schemas, diagnostics, and typed manifest attrs.
- Adapt the first Apple schema surface from Bazel rules_apple and Buck2 Apple concepts, including headers, SDK frameworks and dylibs, resources, asset catalogs, Info.plist substitutions, entitlements, provisioning profiles, signing, test hosts, test plans, and privacy manifests.
- Move built-in Apple rule metadata into a Starlark prelude that lowers into Once's typed Rust graph schemas while keeping `once.toml` as the user-authored manifest surface.
- Add `once query targets`, `once query capabilities`, `once query schema`, plus cache-backed graph `once build`, `once run`, and `once test` commands that materialize artifacts under `.once/out/<target>/`.
- Document the Apple graph model, adapted rule concepts, Starlark rule layer, and build, run, and test commands in `docs/guide/apple-graph.md`.

## Testing
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-frontend -p once-cli`
- `mise exec -- cargo clippy -p once-frontend -p once-cli --all-targets -- -D warnings`
- `mise exec -- cargo build --release`
- `mise exec -- shellspec`
