### PR TITLE
ci: publish SDK packages during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,10 +216,10 @@ jobs:
         with:
           version: ${{ env.MISE_VERSION }}
           install_args: "rust ruby node"
-      - uses: 1password/load-secrets-action/configure@v3
+      - uses: 1password/load-secrets-action/configure@dafbe7cb03502b260e2b2893c753c352eee545bf
         with:
           service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      - uses: 1password/load-secrets-action@v3
+      - uses: 1password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf
         with:
           export-env: true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,53 @@ jobs:
           name: Once.xcframework
           path: dist/*
 
+  build-sdk-libs:
+    name: Build SDK libraries ${{ matrix.target }}
+    needs: detect
+    if: needs.detect.outputs.should-release == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - runner: macos-15
+            target: aarch64-apple-darwin
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "rust"
+      - if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          shared-key: release-sdk-${{ matrix.target }}
+          cache-on-failure: true
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+      - name: Package SDK libraries
+        run: mise run release:package-sdk-libs --target "${{ matrix.target }}"
+      - name: Upload SDK libraries
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-libs-${{ matrix.target }}
+          path: |
+            packages/js/prebuilds/*
+            packages/ruby/prebuilds/*
+
   publish:
     name: Publish GitHub release
     needs:
@@ -150,3 +197,39 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: mise run release:publish --version "${{ needs.detect.outputs.next-version }}" --notes release-notes.md --dist dist
+
+  publish-sdks:
+    name: Publish RubyGems and npm packages
+    needs:
+      - detect
+      - publish
+      - build-sdk-libs
+    if: needs.detect.outputs.should-release == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: sdk-libs-*
+          merge-multiple: true
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "rust ruby node"
+      - uses: 1password/load-secrets-action/configure@v3
+        with:
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      - uses: 1password/load-secrets-action@v3
+        with:
+          export-env: true
+        env:
+          RUBYGEMS_API_KEY: op://once/RubyGems API Key/api_key
+          NPM_TOKEN: op://once/npm Automation Token/token
+      - name: Configure package registries
+        run: |
+          printf '%s\n' "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          chmod 0600 ~/.npmrc
+      - name: Publish SDK packages
+        run: |
+          export GEM_HOST_API_KEY="${RUBYGEMS_API_KEY}"
+          mise run release:publish-sdks --version "${{ needs.detect.outputs.next-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,8 @@ jobs:
           NPM_TOKEN: op://once/npm Automation Token/token
       - name: Configure package registries
         run: |
+          echo "::add-mask::${RUBYGEMS_API_KEY}"
+          echo "::add-mask::${NPM_TOKEN}"
           printf '%s\n' "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           chmod 0600 ~/.npmrc
       - name: Publish SDK packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           version: ${{ env.MISE_VERSION }}
           install_args: "rust"
-      - if: runner.os == 'Linux'
+      - if: startsWith(matrix.runner, 'ubuntu-')
         run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
       - name: Cache Rust
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
@@ -204,7 +204,7 @@ jobs:
       - detect
       - publish
       - build-sdk-libs
-    if: needs.detect.outputs.should-release == 'true'
+    if: needs.detect.outputs.should-release == 'true' && needs.publish.result == 'success' && needs.build-sdk-libs.result == 'success'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Adds SDK native-library packaging jobs to the release workflow for Linux, macOS, and Windows prebuilds.
- Adds a release publish job for the `buildonce` RubyGems and npm packages after the GitHub release succeeds.
- Loads RubyGems and npm tokens from the `once` 1Password vault using `OP_SERVICE_ACCOUNT_TOKEN`.
- Leaves the current GitHub release packaging path intact and keeps SDK package publishing gated on releasable changes.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'`
- `git diff --check`
- `rg -n "—" .github/workflows/release.yml`

## Notes
- The current main release workflow does not call `release:package-sdk-libs` or `release:publish-sdks`, so RubyGems and npm publishing will not happen until this workflow change lands.
- The repository does not currently expose a repo-level `OP_SERVICE_ACCOUNT_TOKEN` secret. Add that GitHub secret with a 1Password service account token that can read the `once` vault before relying on this publish job.
