### PR TITLE
ci: make SDK release cache advisory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
       - if: startsWith(matrix.runner, 'ubuntu-')
         run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
       - name: Cache Rust
+        continue-on-error: true
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           shared-key: release-sdk-${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Keeps SDK library release builds from failing when the Rust cache step has a cache backend or reservation issue.
- Leaves caching enabled for speed, but makes it advisory so SDK artifacts can still be built and uploaded.
- Addresses the failed main release run where the Windows SDK prebuild job stopped in `Cache Rust` before package publishing could run.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'`
- `git diff --check`
- `rg -n "—" .github/workflows/release.yml`
