### PR TITLE
ci: set Apple deployment targets for XCFramework

### DIFF
--- a/mise/tasks/release/package-xcframework.sh
+++ b/mise/tasks/release/package-xcframework.sh
@@ -33,6 +33,9 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 1
 fi
 
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
+export IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-13.0}"
+
 require_tool() {
   local tool="$1"
   if ! command -v "${tool}" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Sets explicit Apple deployment targets for XCFramework packaging.
- Fixes the `aarch64-apple-ios` link failure in the release workflow where native objects were built for a newer iOS SDK while the final link targeted iOS 10.0.
- Keeps existing environment overrides respected by only providing defaults.

## Testing
- `bash -n mise/tasks/release/package-xcframework.sh`
- `git diff --check`
- `rg -n "—" mise/tasks/release/package-xcframework.sh`
- `MACOSX_DEPLOYMENT_TARGET=11.0 IPHONEOS_DEPLOYMENT_TARGET=13.0 mise exec -- cargo build --locked --release --package once --target aarch64-apple-ios`
