### PR TITLE
ci: fix SDK package version validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "rust ruby node"
+          install_args: "ruby node"
       - uses: 1password/load-secrets-action/configure@dafbe7cb03502b260e2b2893c753c352eee545bf
         with:
           service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/mise/tasks/release/publish-sdks.sh
+++ b/mise/tasks/release/publish-sdks.sh
@@ -17,25 +17,23 @@ while (($# > 0)); do
   esac
 done
 
+version="${version//[[:space:]]/}"
 if [[ -z "${version}" ]]; then
   echo "--version is required" >&2
   exit 1
 fi
 
-for tool in cargo gem npm; do
+if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "--version must be a semantic version" >&2
+  exit 1
+fi
+
+for tool in gem npm; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
     echo "${tool} is required" >&2
     exit 1
   fi
 done
-
-rust_pkgid="$(cargo pkgid --package once)"
-rust_version="${rust_pkgid##*#}"
-rust_version="${rust_version##*@}"
-if [[ "${rust_version}" != "${version}" ]]; then
-  echo "Rust once crate version ${rust_version} does not match release version ${version}" >&2
-  exit 1
-fi
 
 if [[ ! -d packages/js/prebuilds || ! -d packages/ruby/prebuilds ]]; then
   echo "SDK prebuilds are missing; run release:package-sdk-libs first" >&2

--- a/mise/tasks/release/publish-sdks.sh
+++ b/mise/tasks/release/publish-sdks.sh
@@ -23,7 +23,8 @@ if [[ -z "${version}" ]]; then
   exit 1
 fi
 
-if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+semver_pattern='^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)([.](0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?([+]([0-9A-Za-z-]+([.][0-9A-Za-z-]+)*))?$'
+if [[ ! "${version}" =~ ${semver_pattern} ]]; then
   echo "--version must be a semantic version" >&2
   exit 1
 fi

--- a/spec/release_sdk_spec.sh
+++ b/spec/release_sdk_spec.sh
@@ -46,25 +46,19 @@ Describe 'release SDK packaging scripts'
     The stderr should include 'unsupported SDK package target: unknown-target'
   End
 
-  It 'rejects publish versions that do not match the Rust SDK crate'
+  It 'rejects publish versions that are not semantic versions'
     setup_release_path
-    write_stub cargo \
-      '#!/usr/bin/env bash' \
-      'printf "%s\n" "path+file:///workspace/crates/once#0.2.0"'
     write_stub gem '#!/usr/bin/env bash'
     write_stub npm '#!/usr/bin/env bash'
     cd "$WORKSPACE"
 
-    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 0.1.0
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version latest
     The status should be failure
-    The stderr should include 'Rust once crate version 0.2.0 does not match release version 0.1.0'
+    The stderr should include '--version must be a semantic version'
   End
 
   It 'checks SDK prebuilds before publishing'
     setup_release_path
-    write_stub cargo \
-      '#!/usr/bin/env bash' \
-      'printf "%s\n" "path+file:///workspace/crates/once#0.1.0"'
     write_stub gem '#!/usr/bin/env bash'
     write_stub npm '#!/usr/bin/env bash'
     cd "$WORKSPACE"

--- a/spec/release_sdk_spec.sh
+++ b/spec/release_sdk_spec.sh
@@ -57,6 +57,50 @@ Describe 'release SDK packaging scripts'
     The stderr should include '--version must be a semantic version'
   End
 
+  It 'rejects publish versions with empty prerelease metadata'
+    setup_release_path
+    write_stub gem '#!/usr/bin/env bash'
+    write_stub npm '#!/usr/bin/env bash'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 1.2.3-
+    The status should be failure
+    The stderr should include '--version must be a semantic version'
+  End
+
+  It 'rejects publish versions with empty build metadata'
+    setup_release_path
+    write_stub gem '#!/usr/bin/env bash'
+    write_stub npm '#!/usr/bin/env bash'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 1.2.3+
+    The status should be failure
+    The stderr should include '--version must be a semantic version'
+  End
+
+  It 'rejects publish versions with malformed prerelease metadata'
+    setup_release_path
+    write_stub gem '#!/usr/bin/env bash'
+    write_stub npm '#!/usr/bin/env bash'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 1.2.3-+foo
+    The status should be failure
+    The stderr should include '--version must be a semantic version'
+  End
+
+  It 'accepts publish versions with prerelease and build metadata'
+    setup_release_path
+    write_stub gem '#!/usr/bin/env bash'
+    write_stub npm '#!/usr/bin/env bash'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 1.2.3-beta.1+build.5
+    The status should be failure
+    The stderr should include 'SDK prebuilds are missing'
+  End
+
   It 'checks SDK prebuilds before publishing'
     setup_release_path
     write_stub gem '#!/usr/bin/env bash'


### PR DESCRIPTION
## Summary
- Removes the invalid Rust crate version check from SDK package publishing.
- Validates the release version as semver before injecting it into npm and RubyGems packages.
- Installs only Ruby and Node in the SDK package publishing job.

## Testing
- `bash -n mise/tasks/release/publish-sdks.sh`
- `git diff --check`
- `rg -n "—" mise/tasks/release/publish-sdks.sh .github/workflows/release.yml`
