### PR TITLE
feat(mcp): make Once self-describing for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,40 @@ Keep the current CLI surface centered on:
 New build graph CLI, rule, and query surfaces should be introduced
 deliberately and documented in the relevant RFC or implementation plan.
 
+## Toolchain Rules
+
+Once exposes a doc-less surface for coding agents: an agent should be
+able to discover what rules exist, pull a runnable starter, validate a
+draft, and commit an edit using MCP tool calls alone, without reading
+prose docs. When adding support for a new toolchain (Android, JVM,
+Rust, etc.), mirror the shape already established for the Apple rules
+rather than inventing a parallel surface.
+
+Every new toolchain rule should preserve these invariants:
+
+- The rule is discoverable through `once_list_rules` and its full
+  contract is fetchable through `once_query_schema`.
+- The rule ships at least one runnable starter example as a real
+  directory under `crates/once-frontend/prelude/examples/<slug>/`
+  (manifest plus sources plus a `_meta.toml` with `name` and
+  `use_when`). The Starlark `rule(examples = [...])` declaration
+  references these by slug; inline TOML strings are not allowed.
+- Every example loads under the examples integration test
+  (`crates/once-frontend/tests/examples.rs`) without emitting any
+  diagnostics. If the rule has an `impl`, the example must build.
+- User-visible failures surface through the structured `Diagnostic`
+  shape (`code`, `target`, `attribute`, `repairs`). Validation lives
+  in `target_validator`; the editor in `manifest_editor` reuses the
+  same shape so retries are single-shot for the agent.
+- Every MCP tool has a matching `once query` or `once edit` CLI
+  subcommand so a human can reproduce what an agent does from the
+  terminal.
+
+The Apple rules under `crates/once-frontend/prelude/apple.star` and
+the examples under `crates/once-frontend/prelude/examples/` are the
+reference implementation. Treat them as the template when wiring a
+new toolchain.
+
 ## SDK API And Docs
 
 The `once` crate root and `crates/once/swift/Once.swift` are public SDK

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,12 +3428,14 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "glob",
+ "include_dir",
  "serde",
  "serde_json",
  "starlark",
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
  "walkdir",
 ]
 
@@ -5566,11 +5568,17 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -5582,13 +5590,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -6675,6 +6701,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -8,12 +8,14 @@ use once_core::WorkspacePath;
 
 mod auth;
 mod cache;
+mod edit;
 mod query;
 mod runtime;
 mod toolchain;
 
 pub use auth::AuthCmd;
 pub use cache::{CacheActionCmd, CacheBlobCmd, CacheCmd};
+pub use edit::EditCmd;
 pub use query::QueryCmd;
 pub use runtime::RuntimeCmd;
 pub use toolchain::ToolchainCmd;
@@ -296,6 +298,19 @@ pub enum Cmd {
         cmd: Option<RuntimeCmd>,
     },
 
+    /// Mutate workspace manifests.
+    ///
+    /// `edit apply` runs a batch of `create` / `update` / `delete`
+    /// operations against a single `once.toml` atomically. The same
+    /// surface is exposed as the `once_apply_edit` MCP tool; the CLI
+    /// reads its input JSON from `--file` or stdin so humans can
+    /// reproduce what an agent did from the terminal.
+    #[command(arg_required_else_help = true)]
+    Edit {
+        #[command(subcommand)]
+        cmd: Option<EditCmd>,
+    },
+
     /// Expose Once's graph queries to a coding agent over MCP.
     ///
     /// Speaks the Model Context Protocol over stdio so an agent host
@@ -363,6 +378,13 @@ impl Cmd {
             }
             Self::Query { cmd } => {
                 let mut path = vec!["query"];
+                if let Some(cmd) = cmd {
+                    path.extend(cmd.surface_path());
+                }
+                path
+            }
+            Self::Edit { cmd } => {
+                let mut path = vec!["edit"];
                 if let Some(cmd) = cmd {
                     path.extend(cmd.surface_path());
                 }

--- a/crates/once-cli/src/cli/edit.rs
+++ b/crates/once-cli/src/cli/edit.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum EditCmd {
+    /// Apply a batch of operations to one `once.toml` atomically.
+    ///
+    /// Reads a JSON document matching the `once_apply_edit` MCP tool
+    /// input shape (`{ "package": "...", "operations": [...] }`) from
+    /// `--file` or, if omitted, from stdin. On success, the manifest
+    /// is rewritten and the resolved path is printed. On failure,
+    /// structured diagnostics are emitted and the manifest is left
+    /// untouched.
+    Apply {
+        /// Path to a JSON file. When omitted, the JSON document is read from stdin.
+        #[arg(long, value_name = "PATH")]
+        file: Option<PathBuf>,
+    },
+}
+
+impl EditCmd {
+    pub fn surface_path(&self) -> Vec<&'static str> {
+        match self {
+            Self::Apply { .. } => vec!["apply"],
+        }
+    }
+}

--- a/crates/once-cli/src/cli/query.rs
+++ b/crates/once-cli/src/cli/query.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Subcommand;
 
 #[derive(Subcommand)]
@@ -20,6 +22,26 @@ pub enum QueryCmd {
         /// Rule kind, e.g. `apple_application`.
         kind: String,
     },
+
+    /// List every rule kind with its one-line docs and example slugs.
+    Rules,
+
+    /// Resolve a single target's full record (kind, srcs, deps, attrs, capabilities).
+    Target {
+        /// Target id, e.g. `apps/Hello/Hello`.
+        target: String,
+    },
+
+    /// Validate a proposed `[[target]]` table against its rule schema.
+    ///
+    /// Reads a JSON document matching the `once_validate_target` MCP
+    /// tool input shape (`{ "target": { ... } }`) from `--file` or, if
+    /// omitted, from stdin.
+    ValidateTarget {
+        /// Path to a JSON file. When omitted, the JSON document is read from stdin.
+        #[arg(long, value_name = "PATH")]
+        file: Option<PathBuf>,
+    },
 }
 
 impl QueryCmd {
@@ -28,6 +50,9 @@ impl QueryCmd {
             Self::Targets { .. } => vec!["targets"],
             Self::Capabilities { .. } => vec!["capabilities"],
             Self::Schema { .. } => vec!["schema"],
+            Self::Rules => vec!["rules"],
+            Self::Target { .. } => vec!["target"],
+            Self::ValidateTarget { .. } => vec!["validate-target"],
         }
     }
 }

--- a/crates/once-cli/src/commands/edit.rs
+++ b/crates/once-cli/src/commands/edit.rs
@@ -1,0 +1,114 @@
+//! `once edit` - mutate workspace manifests.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+
+use crate::cli::{Format, Output};
+use crate::commands::query;
+use crate::render;
+
+#[derive(Debug, Deserialize)]
+struct ApplyInput {
+    package: String,
+    operations: Vec<once_frontend::EditOperation>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ApplyResult {
+    Applied {
+        applied: bool,
+        path: String,
+    },
+    Rejected {
+        applied: bool,
+        diagnostics: Vec<once_frontend::Diagnostic>,
+    },
+}
+
+pub async fn apply(workspace: &Path, output: Output, file: Option<PathBuf>) -> Result<()> {
+    let raw = query::read_json_input(file)?;
+    let input: ApplyInput = serde_json::from_str(&raw).context(
+        "apply input is not valid JSON matching `{ \"package\": \"...\", \"operations\": [...] }`",
+    )?;
+    let package_dir = if input.package.is_empty() {
+        workspace.to_path_buf()
+    } else {
+        workspace.join(&input.package)
+    };
+    let manifest_path = package_dir.join(once_frontend::TOML_BUILD_FILE_NAME);
+    let existing = match std::fs::read_to_string(&manifest_path) {
+        Ok(src) => src,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "reading `{}`: {err}",
+                manifest_path.display()
+            ));
+        }
+    };
+    let result = match once_frontend::apply_operations(&existing, &input.operations) {
+        Ok(new_src) => {
+            std::fs::create_dir_all(&package_dir).with_context(|| {
+                format!("creating package directory `{}`", package_dir.display())
+            })?;
+            std::fs::write(&manifest_path, &new_src)
+                .with_context(|| format!("writing `{}`", manifest_path.display()))?;
+            ApplyResult::Applied {
+                applied: true,
+                path: manifest_path.to_string_lossy().into_owned(),
+            }
+        }
+        Err(diagnostics) => ApplyResult::Rejected {
+            applied: false,
+            diagnostics,
+        },
+    };
+    write_body(output, || render_apply_human(&result), &result).await
+}
+
+fn render_apply_human(result: &ApplyResult) -> String {
+    match result {
+        ApplyResult::Applied { path, .. } => format!("applied: {path}\n"),
+        ApplyResult::Rejected { diagnostics, .. } => {
+            let mut out = String::from("rejected:\n");
+            for diagnostic in diagnostics {
+                let scope = match (&diagnostic.target, &diagnostic.attribute) {
+                    (Some(t), Some(a)) => format!(" [{t}/{a}]"),
+                    (Some(t), None) => format!(" [{t}]"),
+                    (None, Some(a)) => format!(" [{a}]"),
+                    (None, None) => String::new(),
+                };
+                writeln!(
+                    out,
+                    "  {}{}: {}",
+                    diagnostic.code, scope, diagnostic.message
+                )
+                .expect("writing to string cannot fail");
+                for repair in &diagnostic.repairs {
+                    writeln!(out, "    - {repair}").expect("writing to string cannot fail");
+                }
+            }
+            out
+        }
+    }
+}
+
+async fn write_body<T: Serialize>(
+    output: Output,
+    human: impl FnOnce() -> String,
+    value: &T,
+) -> Result<()> {
+    let body = match output.format {
+        Format::Human => human(),
+        Format::Json | Format::Toon => render::structured(output.format, value)?,
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(body.as_bytes()).await?;
+    out.flush().await?;
+    Ok(())
+}

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -130,9 +130,13 @@ impl Server {
         let result = match call.name.as_str() {
             "once_query_targets" => self.tool_query_targets(&call.arguments),
             "once_query_capabilities" => self.tool_query_capabilities(&call.arguments),
-            // Schema queries don't need a workspace because they
+            "once_get_target" => self.tool_get_target(&call.arguments),
+            "once_apply_edit" => self.tool_apply_edit(&call.arguments),
+            // Rule registry queries don't need a workspace because they
             // read from the compiled-in rule prelude.
             "once_query_schema" => tool_query_schema(&call.arguments),
+            "once_list_rules" => tool_list_rules(),
+            "once_validate_target" => tool_validate_target(&call.arguments),
             other => Err(anyhow::anyhow!("unknown tool `{other}`")),
         };
         match result {
@@ -166,6 +170,33 @@ impl Server {
             .with_context(|| format!("no target matches `{target_id}`"))?;
         Ok(serde_json::to_value(CapabilityView::from(target))?)
     }
+
+    fn tool_get_target(&self, args: &Value) -> Result<Value> {
+        let target_id = args
+            .get("target")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("missing `target` argument"))?;
+        let graph =
+            once_frontend::load_graph_workspace(&self.workspace).context("loading graph")?;
+        let target = graph
+            .into_iter()
+            .find(|target| target.label.id == target_id)
+            .with_context(|| format!("no target matches `{target_id}`"))?;
+        Ok(serde_json::to_value(target)?)
+    }
+
+    fn tool_apply_edit(&self, args: &Value) -> Result<Value> {
+        let package = args
+            .get("package")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("missing `package` argument"))?;
+        let raw_ops = args
+            .get("operations")
+            .ok_or_else(|| anyhow::anyhow!("missing `operations` argument"))?;
+        let operations: Vec<once_frontend::EditOperation> = serde_json::from_value(raw_ops.clone())
+            .map_err(|err| anyhow::anyhow!("invalid `operations`: {err}"))?;
+        apply_edit_to_package(&self.workspace, package, &operations)
+    }
 }
 
 fn tool_query_schema(args: &Value) -> Result<Value> {
@@ -178,6 +209,97 @@ fn tool_query_schema(args: &Value) -> Result<Value> {
         .find(|schema| schema.kind == kind)
         .with_context(|| format!("no built-in rule schema matches `{kind}`"))?;
     Ok(serde_json::to_value(schema)?)
+}
+
+fn tool_list_rules() -> Result<Value> {
+    let schemas = once_frontend::built_in_rule_schemas_result()?;
+    let summaries: Vec<RuleSummary> = schemas.into_iter().map(RuleSummary::from).collect();
+    Ok(serde_json::to_value(summaries)?)
+}
+
+fn tool_validate_target(args: &Value) -> Result<Value> {
+    let raw_target = args
+        .get("target")
+        .ok_or_else(|| anyhow::anyhow!("missing `target` argument"))?
+        .clone();
+    let spec: once_frontend::TargetSpec = serde_json::from_value(raw_target)
+        .map_err(|err| anyhow::anyhow!("invalid `target`: {err}"))?;
+    let schemas = once_frontend::built_in_rule_schemas_result()?;
+    let diagnostics = once_frontend::validate_target(&spec, &schemas);
+    if diagnostics.is_empty() {
+        Ok(json!({ "valid": true }))
+    } else {
+        Ok(json!({ "valid": false, "diagnostics": diagnostics }))
+    }
+}
+
+fn apply_edit_to_package(
+    workspace: &std::path::Path,
+    package: &str,
+    operations: &[once_frontend::EditOperation],
+) -> Result<Value> {
+    let package_dir = if package.is_empty() {
+        workspace.to_path_buf()
+    } else {
+        workspace.join(package)
+    };
+    let manifest_path = package_dir.join(once_frontend::TOML_BUILD_FILE_NAME);
+    let existing = match std::fs::read_to_string(&manifest_path) {
+        Ok(src) => src,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "reading `{}`: {err}",
+                manifest_path.display()
+            ));
+        }
+    };
+    match once_frontend::apply_operations(&existing, operations) {
+        Ok(new_src) => {
+            std::fs::create_dir_all(&package_dir).with_context(|| {
+                format!("creating package directory `{}`", package_dir.display())
+            })?;
+            std::fs::write(&manifest_path, &new_src)
+                .with_context(|| format!("writing `{}`", manifest_path.display()))?;
+            Ok(json!({
+                "applied": true,
+                "path": manifest_path.to_string_lossy(),
+            }))
+        }
+        Err(diagnostics) => Ok(json!({ "applied": false, "diagnostics": diagnostics })),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RuleSummary {
+    kind: String,
+    docs: String,
+    examples: Vec<RuleExampleSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuleExampleSummary {
+    slug: String,
+    name: String,
+    use_when: String,
+}
+
+impl From<once_frontend::RuleSchema> for RuleSummary {
+    fn from(schema: once_frontend::RuleSchema) -> Self {
+        Self {
+            kind: schema.kind,
+            docs: schema.docs,
+            examples: schema
+                .examples
+                .into_iter()
+                .map(|example| RuleExampleSummary {
+                    slug: example.slug,
+                    name: example.name,
+                    use_when: example.use_when,
+                })
+                .collect(),
+        }
+    }
 }
 
 fn tool_error(id: Value, message: &str) -> JsonRpcResponse {
@@ -234,6 +356,7 @@ pub struct ToolDefinition {
 
 /// All tools `once mcp` exposes, in the same order they appear in
 /// `tools/list` and on the reference page.
+#[allow(clippy::too_many_lines)]
 pub fn tool_catalog() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
@@ -269,8 +392,8 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "once_query_schema",
-            description: "Return the typed contract for a rule kind: attributes, dep edges, providers, and capabilities.",
-            long_description: "Returns the rule schema (the typed contract a target of that kind must match) as `once query schema <kind> --format json` would. The record carries the rule's documentation, attribute list (with types, required flag, and whether the attribute is configurable), expected dep providers, emitted providers, and exposed capabilities.",
+            description: "Return the typed contract for a rule kind: attributes, dep edges, providers, capabilities, and runnable starter examples.",
+            long_description: "Returns the rule schema (the typed contract a target of that kind must match) as `once query schema <kind> --format json` would. The record carries the rule's documentation, attribute list (with types, required flag, and whether the attribute is configurable), expected dep providers, emitted providers, exposed capabilities, and a list of runnable starter examples. Each example bundles a slug, a one-line `use_when` hint, and the full file tree (`once.toml` plus source files) a caller would copy to get a working target.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -281,7 +404,70 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 },
                 "required": ["kind"]
             }),
-            example_return: "{\n  \"kind\": \"apple_library\",\n  \"docs\": \"Mixed Swift, Objective-C, C, and C++ static library...\",\n  \"attrs\": [\n    { \"name\": \"platform\", \"ty\": \"string\", \"required\": true, \"configurable\": true },\n    { \"name\": \"sdk_frameworks\", \"ty\": \"list<string>\", \"required\": false, \"configurable\": true }\n  ],\n  \"capabilities\": [ { \"name\": \"build\", \"output_groups\": [\"archive\"], \"requires_outputs\": [] } ],\n  \"providers\": [\"SwiftInfo\", \"CcInfo\"]\n}",
+            example_return: "{\n  \"kind\": \"apple_library\",\n  \"docs\": \"Mixed Swift, Objective-C, C, and C++ static library...\",\n  \"attrs\": [\n    { \"name\": \"platform\", \"ty\": \"string\", \"required\": true, \"configurable\": true }\n  ],\n  \"capabilities\": [ { \"name\": \"build\", \"output_groups\": [\"archive\"], \"requires_outputs\": [] } ],\n  \"providers\": [\"apple_linkable\", \"apple_module\"],\n  \"examples\": [\n    {\n      \"slug\": \"apple-library-minimal\",\n      \"name\": \"Minimal Apple library\",\n      \"use_when\": \"...\",\n      \"files\": [\n        { \"path\": \"apps/Hello/once.toml\", \"contents\": \"[[target]]\\nname = \\\"Hello\\\"\\nkind = \\\"apple_library\\\"\\n...\" }\n      ]\n    }\n  ]\n}",
+        },
+        ToolDefinition {
+            name: "once_list_rules",
+            description: "List every rule kind the registry knows about, with its one-line docs and example slugs.",
+            long_description: "Lightweight discovery entry point. Returns one entry per rule kind containing the rule's documentation and the slugs of its bundled starter examples. Use this to discover what kinds of targets are buildable in the workspace before calling `once_query_schema` for the full contract of a chosen rule.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {}
+            }),
+            example_return: "[\n  {\n    \"kind\": \"apple_library\",\n    \"docs\": \"Mixed Swift, Objective-C, C, and C++ static library...\",\n    \"examples\": [\n      { \"slug\": \"apple-library-minimal\", \"name\": \"Minimal Apple library\", \"use_when\": \"...\" }\n    ]\n  }\n]",
+        },
+        ToolDefinition {
+            name: "once_get_target",
+            description: "Return the resolved view of a single target: rule kind, srcs, deps, typed attrs, capabilities, providers.",
+            long_description: "Returns the same `GraphTarget` record `once_query_targets` emits, scoped to one target id. Includes the target's typed attribute values (with the types declared by its rule schema), the capabilities it exposes, the providers it emits, and any diagnostics emitted while loading the manifest. Use this before editing a target to learn its current shape.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Canonical target id, e.g. `apps/Hello/Hello`."
+                    }
+                },
+                "required": ["target"]
+            }),
+            example_return: "{\n  \"label\": { \"package\": \"apps/Hello\", \"name\": \"Hello\", \"id\": \"apps/Hello/Hello\" },\n  \"kind\": \"apple_library\",\n  \"srcs\": [\"Sources/**/*.swift\"],\n  \"deps\": [],\n  \"attrs\": { \"platform\": \"ios\", \"minimum_os\": \"17.0\" },\n  \"capabilities\": [ { \"name\": \"build\", \"output_groups\": [\"default\", \"binary\"], \"requires_outputs\": [] } ],\n  \"providers\": [\"apple_linkable\", \"apple_module\"]\n}",
+        },
+        ToolDefinition {
+            name: "once_validate_target",
+            description: "Validate a proposed `[[target]]` table against its rule schema. Returns structured diagnostics instead of prose.",
+            long_description: "Schema-only validation: checks that the target declares a known rule kind, every required attribute is present, every declared attribute is known to the rule and matches the rule's declared type, and the target name is well-formed. The check is local; it does not resolve dep references or read other manifests. Returns `{ valid: true }` on success or `{ valid: false, diagnostics: [...] }` where each diagnostic carries a stable `code`, the offending `target` id, the offending `attribute` when applicable, and `repairs` an agent can apply.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "object",
+                        "description": "Raw `[[target]]` table shape with `name`, `kind`, optional `deps`, `srcs`, and `attrs`."
+                    }
+                },
+                "required": ["target"]
+            }),
+            example_return: "{\n  \"valid\": false,\n  \"diagnostics\": [\n    {\n      \"code\": \"missing_required_attr\",\n      \"message\": \"rule `apple_library` requires attribute `platform`\",\n      \"target\": \"Hello\",\n      \"attribute\": \"platform\"\n    }\n  ]\n}",
+        },
+        ToolDefinition {
+            name: "once_apply_edit",
+            description: "Apply a batch of `create` / `update` / `delete` operations to one `once.toml` atomically.",
+            long_description: "Reads the manifest at `<workspace>/<package>/once.toml` (creating it if missing), applies the batch of operations against the in-memory document, and writes the result back only if every operation succeeds. Returns `{ applied: true, path: <manifest path> }` on success or `{ applied: false, diagnostics: [...] }` with the structured diagnostic shape used by `once_validate_target`. The original file is never partially modified.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "package": {
+                        "type": "string",
+                        "description": "Package directory relative to the workspace root, e.g. `apps/Hello`. Use `\"\"` for the root manifest."
+                    },
+                    "operations": {
+                        "type": "array",
+                        "description": "Ordered list of operations. Each is `{ op: \"create\", target: {...} }`, `{ op: \"update\", target_name: \"...\", set: {...} }`, or `{ op: \"delete\", target_name: \"...\" }`.",
+                        "items": { "type": "object" }
+                    }
+                },
+                "required": ["package", "operations"]
+            }),
+            example_return: "{\n  \"applied\": true,\n  \"path\": \"apps/Hello/once.toml\"\n}",
         },
     ]
 }
@@ -448,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_advertises_the_three_query_tools() {
+    fn tools_list_advertises_the_full_tool_surface() {
         let tmp = TempDir::new().unwrap();
         let response = server(tmp.path().to_path_buf()).dispatch(request("tools/list", json!({})));
         let names: Vec<String> = response.result.unwrap()["tools"]
@@ -463,6 +649,10 @@ mod tests {
                 "once_query_targets".to_string(),
                 "once_query_capabilities".to_string(),
                 "once_query_schema".to_string(),
+                "once_list_rules".to_string(),
+                "once_get_target".to_string(),
+                "once_validate_target".to_string(),
+                "once_apply_edit".to_string(),
             ]
         );
     }
@@ -539,5 +729,157 @@ mod tests {
             .collect();
         assert!(attr_names.contains(&"platform"));
         assert!(attr_names.contains(&"sdk_frameworks"));
+    }
+
+    #[test]
+    fn query_schema_inlines_example_files() {
+        let value = tool_query_schema(&json!({ "kind": "apple_library" })).unwrap();
+        let examples = value["examples"].as_array().expect("examples is an array");
+        assert!(
+            !examples.is_empty(),
+            "apple_library should advertise at least one example"
+        );
+        let minimal = examples
+            .iter()
+            .find(|e| e["slug"] == "apple-library-minimal")
+            .expect("apple-library-minimal example present");
+        assert!(!minimal["name"].as_str().unwrap().is_empty());
+        assert!(!minimal["use_when"].as_str().unwrap().is_empty());
+        let files = minimal["files"].as_array().expect("files is an array");
+        assert!(files
+            .iter()
+            .any(|f| f["path"] == "apps/Hello/once.toml"
+                && !f["contents"].as_str().unwrap().is_empty()));
+    }
+
+    #[test]
+    fn list_rules_includes_every_known_rule() {
+        let value = tool_list_rules().unwrap();
+        let kinds: Vec<&str> = value
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|entry| entry["kind"].as_str().unwrap())
+            .collect();
+        assert!(kinds.contains(&"apple_library"));
+        assert!(kinds.contains(&"apple_application"));
+        // The list summarizes; full schema lives behind once_query_schema.
+        assert!(value.as_array().unwrap()[0].get("attrs").is_none());
+    }
+
+    #[test]
+    fn validate_target_returns_valid_for_minimal_apple_library() {
+        let value = tool_validate_target(&json!({
+            "target": {
+                "name": "Hello",
+                "kind": "apple_library",
+                "attrs": { "platform": "ios" }
+            }
+        }))
+        .unwrap();
+        assert_eq!(value["valid"], true);
+    }
+
+    #[test]
+    fn validate_target_returns_structured_diagnostics_on_failure() {
+        let value = tool_validate_target(&json!({
+            "target": {
+                "name": "Hello",
+                "kind": "apple_library"
+            }
+        }))
+        .unwrap();
+        assert_eq!(value["valid"], false);
+        let diagnostics = value["diagnostics"].as_array().unwrap();
+        let missing = diagnostics
+            .iter()
+            .find(|d| d["code"] == "missing_required_attr")
+            .expect("missing_required_attr diagnostic");
+        assert_eq!(missing["target"], "Hello");
+        assert_eq!(missing["attribute"], "platform");
+    }
+
+    #[test]
+    fn apply_edit_creates_manifest_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let result = apply_edit_to_package(
+            tmp.path(),
+            "apps/Hello",
+            &[once_frontend::EditOperation::Create {
+                target: once_frontend::TargetSpec {
+                    name: "Hello".to_string(),
+                    kind: "apple_library".to_string(),
+                    ..Default::default()
+                },
+            }],
+        )
+        .unwrap();
+        assert_eq!(result["applied"], true);
+        let written = std::fs::read_to_string(tmp.path().join("apps/Hello/once.toml")).unwrap();
+        assert!(written.contains("name = \"Hello\""));
+    }
+
+    #[test]
+    fn apply_edit_returns_diagnostics_on_failure_without_writing() {
+        let tmp = TempDir::new().unwrap();
+        let result = apply_edit_to_package(
+            tmp.path(),
+            "apps/Hello",
+            &[once_frontend::EditOperation::Delete {
+                target_name: "Missing".to_string(),
+            }],
+        )
+        .unwrap();
+        assert_eq!(result["applied"], false);
+        assert_eq!(result["diagnostics"][0]["code"], "target_not_found");
+        // Nothing should have been written when the batch failed.
+        assert!(!tmp.path().join("apps/Hello/once.toml").exists());
+    }
+
+    #[test]
+    fn get_target_returns_resolved_target_record() {
+        let tmp = TempDir::new().unwrap();
+        let pkg = tmp.path().join("apps/Hello");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("once.toml"),
+            "[[target]]\nname = \"Hello\"\nkind = \"apple_library\"\n[target.attrs]\nplatform = \"ios\"\n",
+        )
+        .unwrap();
+        let value = server(tmp.path().to_path_buf())
+            .tool_get_target(&json!({ "target": "apps/Hello/Hello" }))
+            .unwrap();
+        assert_eq!(value["label"]["id"], "apps/Hello/Hello");
+        assert_eq!(value["kind"], "apple_library");
+        assert_eq!(value["attrs"]["platform"], "ios");
+    }
+
+    #[test]
+    fn apply_edit_then_get_target_round_trips_through_disk() {
+        let tmp = TempDir::new().unwrap();
+        let server = server(tmp.path().to_path_buf());
+        // 1) Create a target via apply_edit.
+        let create = server
+            .tool_apply_edit(&json!({
+                "package": "apps/Hello",
+                "operations": [
+                    {
+                        "op": "create",
+                        "target": {
+                            "name": "Hello",
+                            "kind": "apple_library",
+                            "attrs": { "platform": "ios" }
+                        }
+                    }
+                ]
+            }))
+            .unwrap();
+        assert_eq!(create["applied"], true);
+        // 2) Read it back via get_target.
+        let target = server
+            .tool_get_target(&json!({ "target": "apps/Hello/Hello" }))
+            .unwrap();
+        assert_eq!(target["label"]["id"], "apps/Hello/Hello");
+        assert_eq!(target["kind"], "apple_library");
     }
 }

--- a/crates/once-cli/src/commands/mod.rs
+++ b/crates/once-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod auth;
 pub mod cache;
+pub mod edit;
 pub mod exec;
 pub mod graph;
 pub mod mcp;

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -1,7 +1,8 @@
 //! `once query` - inspect the typed build graph.
 
 use std::fmt::Write as _;
-use std::path::Path;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -63,6 +64,99 @@ pub async fn schema(workspace: &Path, output: Output, kind: &str) -> Result<()> 
     write_body(output, || render_schema_human(&schema), &schema).await
 }
 
+#[derive(Debug, Serialize)]
+struct RuleSummary {
+    kind: String,
+    docs: String,
+    examples: Vec<RuleExampleSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuleExampleSummary {
+    slug: String,
+    name: String,
+    use_when: String,
+}
+
+impl From<once_frontend::RuleSchema> for RuleSummary {
+    fn from(schema: once_frontend::RuleSchema) -> Self {
+        Self {
+            kind: schema.kind,
+            docs: schema.docs,
+            examples: schema
+                .examples
+                .into_iter()
+                .map(|example| RuleExampleSummary {
+                    slug: example.slug,
+                    name: example.name,
+                    use_when: example.use_when,
+                })
+                .collect(),
+        }
+    }
+}
+
+pub async fn rules(output: Output) -> Result<()> {
+    let schemas = once_frontend::built_in_rule_schemas_result()?;
+    let summaries: Vec<RuleSummary> = schemas.into_iter().map(RuleSummary::from).collect();
+    write_body(output, || render_rules_human(&summaries), &summaries).await
+}
+
+pub async fn target(workspace: &Path, output: Output, target_id: &str) -> Result<()> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    let target = graph
+        .into_iter()
+        .find(|target| target.label.id == target_id)
+        .with_context(|| format!("no target matches `{target_id}`"))?;
+    write_body(output, || render_target_human(&target), &target).await
+}
+
+pub async fn validate_target(output: Output, file: Option<PathBuf>) -> Result<()> {
+    let raw = read_json_input(file)?;
+    let input: ValidateTargetInput = serde_json::from_str(&raw)
+        .context("validate-target input is not valid JSON matching `{ \"target\": { ... } }`")?;
+    let schemas = once_frontend::built_in_rule_schemas_result()?;
+    let diagnostics = once_frontend::validate_target(&input.target, &schemas);
+    let result = if diagnostics.is_empty() {
+        ValidateResult::Valid { valid: true }
+    } else {
+        ValidateResult::Invalid {
+            valid: false,
+            diagnostics,
+        }
+    };
+    write_body(output, || render_validate_human(&result), &result).await
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ValidateTargetInput {
+    target: once_frontend::TargetSpec,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ValidateResult {
+    Valid {
+        valid: bool,
+    },
+    Invalid {
+        valid: bool,
+        diagnostics: Vec<once_frontend::Diagnostic>,
+    },
+}
+
+pub(crate) fn read_json_input(file: Option<PathBuf>) -> Result<String> {
+    if let Some(path) = file {
+        std::fs::read_to_string(&path).with_context(|| format!("reading `{}`", path.display()))
+    } else {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("reading JSON from stdin")?;
+        Ok(buf)
+    }
+}
+
 fn render_capabilities_human(target: &once_frontend::GraphTarget) -> String {
     let mut out = format!("{} ({})\n", target.label.id, target.kind);
     if target.capabilities.is_empty() {
@@ -122,6 +216,78 @@ fn render_schema_human(schema: &once_frontend::RuleSchema) -> String {
         }
     }
     out
+}
+
+fn render_rules_human(rules: &[RuleSummary]) -> String {
+    if rules.is_empty() {
+        return "rules: none\n".to_string();
+    }
+    let mut out = String::from("rules:\n");
+    for rule in rules {
+        writeln!(out, "  {}: {}", rule.kind, rule.docs).expect("writing to string cannot fail");
+        for example in &rule.examples {
+            writeln!(out, "    {} - {}", example.slug, example.use_when)
+                .expect("writing to string cannot fail");
+        }
+    }
+    out
+}
+
+fn render_target_human(target: &once_frontend::GraphTarget) -> String {
+    let mut out = format!("{} ({})\n", target.label.id, target.kind);
+    if !target.srcs.is_empty() {
+        writeln!(out, "srcs: {}", target.srcs.join(", ")).expect("writing to string cannot fail");
+    }
+    if !target.deps.is_empty() {
+        writeln!(out, "deps: {}", target.deps.join(", ")).expect("writing to string cannot fail");
+    }
+    if !target.attrs.is_empty() {
+        out.push_str("attrs:\n");
+        for (key, value) in &target.attrs {
+            writeln!(out, "  {key} = {value:?}").expect("writing to string cannot fail");
+        }
+    }
+    if !target.capabilities.is_empty() {
+        out.push_str("capabilities: ");
+        let names: Vec<&str> = target
+            .capabilities
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        out.push_str(&names.join(", "));
+        out.push('\n');
+    }
+    out
+}
+
+fn render_validate_human(result: &ValidateResult) -> String {
+    match result {
+        ValidateResult::Valid { .. } => "valid\n".to_string(),
+        ValidateResult::Invalid { diagnostics, .. } => {
+            let mut out = String::from("invalid:\n");
+            for diagnostic in diagnostics {
+                let scope = match (&diagnostic.target, &diagnostic.attribute) {
+                    (Some(t), Some(a)) => format!(" [{t}/{a}]"),
+                    (Some(t), None) => format!(" [{t}]"),
+                    (None, Some(a)) => format!(" [{a}]"),
+                    (None, None) => String::new(),
+                };
+                writeln!(
+                    out,
+                    "  {} ({}){}: {}",
+                    diagnostic.code,
+                    scope.trim(),
+                    scope,
+                    diagnostic.message
+                )
+                .expect("writing to string cannot fail");
+                for repair in &diagnostic.repairs {
+                    writeln!(out, "    - {repair}").expect("writing to string cannot fail");
+                }
+            }
+            out
+        }
+    }
 }
 
 fn render_targets_human(records: &[TargetRecord]) -> String {

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -112,6 +112,7 @@ async fn run_command(
         }
         Cmd::Toolchain { cmd } => run_toolchain_command(workspace, output, cmd).await,
         Cmd::Query { cmd } => run_query_command(workspace, output, cmd).await,
+        Cmd::Edit { cmd } => run_edit_command(workspace, output, cmd).await,
         Cmd::Runtime { cmd } => run_runtime_command(cmd).await,
         Cmd::Mcp {
             workspace: workspace_override,
@@ -159,7 +160,33 @@ async fn run_query_command(
         Some(cli::QueryCmd::Schema { kind }) => commands::query::schema(workspace, output, &kind)
             .await
             .map(|()| ExitCode::SUCCESS),
+        Some(cli::QueryCmd::Rules) => commands::query::rules(output)
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Some(cli::QueryCmd::Target { target }) => {
+            commands::query::target(workspace, output, &target)
+                .await
+                .map(|()| ExitCode::SUCCESS)
+        }
+        Some(cli::QueryCmd::ValidateTarget { file }) => {
+            commands::query::validate_target(output, file)
+                .await
+                .map(|()| ExitCode::SUCCESS)
+        }
         None => anyhow::bail!("query subcommand required"),
+    }
+}
+
+async fn run_edit_command(
+    workspace: &Path,
+    output: Output,
+    command: Option<cli::EditCmd>,
+) -> Result<ExitCode> {
+    match command {
+        Some(cli::EditCmd::Apply { file }) => commands::edit::apply(workspace, output, file)
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        None => anyhow::bail!("edit subcommand required"),
     }
 }
 

--- a/crates/once-frontend/Cargo.toml
+++ b/crates/once-frontend/Cargo.toml
@@ -9,11 +9,13 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 glob.workspace = true
+include_dir = "0.7"
 serde.workspace = true
 serde_json.workspace = true
 starlark.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+toml_edit = "0.22"
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -636,7 +636,8 @@ APPLE_RULES = [
             capability("build", ["default", "binary", "swiftmodule", "generated_sources"]),
         ],
         examples = [
-            "[[target]]\nname = \"AppKit\"\nkind = \"apple_library\"\nsrcs = [\"Sources/**/*.swift\"]\n\n[target.attrs]\nplatform = \"ios\"\nminimum_os = \"17.0\"",
+            "apple-library-minimal",
+            "apple-library-with-objc",
         ],
     ),
     rule(
@@ -662,9 +663,7 @@ APPLE_RULES = [
         capabilities = [
             capability("build", ["default", "framework", "dsyms", "swiftmodule"]),
         ],
-        examples = [
-            "[[target]]\nname = \"AuthFramework\"\nkind = \"apple_framework\"\ndeps = [\"./AuthCore\"]\n\n[target.attrs]\nplatform = \"ios\"\nbundle_id = \"dev.once.Auth\"",
-        ],
+        examples = [],
     ),
     rule(
         kind = "apple_application",
@@ -695,7 +694,7 @@ APPLE_RULES = [
             capability("run", ["default"], requires_outputs = ["bundle"]),
         ],
         examples = [
-            "[[target]]\nname = \"App\"\nkind = \"apple_application\"\ndeps = [\"./AppKit\"]\n\n[target.attrs]\nplatform = \"ios\"\nbundle_id = \"dev.once.App\"\nminimum_os = \"17.0\"",
+            "apple-application-minimal",
         ],
     ),
     rule(
@@ -721,8 +720,6 @@ APPLE_RULES = [
             capability("build", ["default", "bundle", "dsyms"]),
             capability("test", ["default", "test_results", "coverage"], requires_outputs = ["bundle"]),
         ],
-        examples = [
-            "[[target]]\nname = \"AppTests\"\nkind = \"apple_test_bundle\"\ndeps = [\"./AppKit\"]\n\n[target.attrs]\nplatform = \"ios\"\ntest_host = \"./App\"",
-        ],
+        examples = [],
     ),
 ]

--- a/crates/once-frontend/prelude/examples/apple-application-minimal/_meta.toml
+++ b/crates/once-frontend/prelude/examples/apple-application-minimal/_meta.toml
@@ -1,0 +1,2 @@
+name = "Minimal iOS application"
+use_when = "You want the smallest viable iOS app target wired into a Once workspace."

--- a/crates/once-frontend/prelude/examples/apple-application-minimal/apps/Hello/Sources/HelloApp.swift
+++ b/crates/once-frontend/prelude/examples/apple-application-minimal/apps/Hello/Sources/HelloApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+@main
+struct HelloApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}

--- a/crates/once-frontend/prelude/examples/apple-application-minimal/apps/Hello/once.toml
+++ b/crates/once-frontend/prelude/examples/apple-application-minimal/apps/Hello/once.toml
@@ -1,0 +1,10 @@
+[[target]]
+name = "Hello"
+kind = "apple_application"
+srcs = ["Sources/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+bundle_id = "dev.once.Hello"
+minimum_os = "17.0"
+families = ["iphone"]

--- a/crates/once-frontend/prelude/examples/apple-library-minimal/_meta.toml
+++ b/crates/once-frontend/prelude/examples/apple-library-minimal/_meta.toml
@@ -1,0 +1,2 @@
+name = "Minimal Apple library"
+use_when = "You want a Swift static library targeting iOS or macOS with no extra resources or mixed-language sources."

--- a/crates/once-frontend/prelude/examples/apple-library-minimal/apps/Hello/Sources/Hello.swift
+++ b/crates/once-frontend/prelude/examples/apple-library-minimal/apps/Hello/Sources/Hello.swift
@@ -1,0 +1,5 @@
+public enum Hello {
+    public static func greeting(for name: String) -> String {
+        "Hello, \(name)!"
+    }
+}

--- a/crates/once-frontend/prelude/examples/apple-library-minimal/apps/Hello/once.toml
+++ b/crates/once-frontend/prelude/examples/apple-library-minimal/apps/Hello/once.toml
@@ -1,0 +1,8 @@
+[[target]]
+name = "Hello"
+kind = "apple_library"
+srcs = ["Sources/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+minimum_os = "17.0"

--- a/crates/once-frontend/prelude/examples/apple-library-with-objc/_meta.toml
+++ b/crates/once-frontend/prelude/examples/apple-library-with-objc/_meta.toml
@@ -1,0 +1,2 @@
+name = "Apple library with mixed Swift and Objective-C"
+use_when = "Your library exposes Swift APIs that call into an existing Objective-C codebase through a bridging header."

--- a/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Bridge.h
+++ b/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Bridge.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Bridge : NSObject
++ (NSString * _Nullable)formatGreeting:(NSString *)name;
+@end

--- a/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Bridge.m
+++ b/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Bridge.m
@@ -1,0 +1,10 @@
+#import "Bridge.h"
+
+@implementation Bridge
++ (NSString * _Nullable)formatGreeting:(NSString *)name {
+    if (name.length == 0) {
+        return nil;
+    }
+    return [NSString stringWithFormat:@"Hello, %@!", name];
+}
+@end

--- a/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Greeting.swift
+++ b/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Greeting.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum Greeting {
+    public static func formatted(for name: String) -> String {
+        let raw = Bridge.formatGreeting(name)
+        return raw ?? "Hello, \(name)!"
+    }
+}

--- a/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Hello-Bridging-Header.h
+++ b/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/Sources/Hello-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "Bridge.h"

--- a/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/once.toml
+++ b/crates/once-frontend/prelude/examples/apple-library-with-objc/apps/Hello/once.toml
@@ -1,0 +1,10 @@
+[[target]]
+name = "Hello"
+kind = "apple_library"
+srcs = ["Sources/**/*.swift", "Sources/**/*.m"]
+
+[target.attrs]
+platform = "ios"
+minimum_os = "17.0"
+bridging_header = "Sources/Hello-Bridging-Header.h"
+exported_headers = ["Sources/Bridge.h"]

--- a/crates/once-frontend/src/examples.rs
+++ b/crates/once-frontend/src/examples.rs
@@ -1,0 +1,122 @@
+//! Rule example bundles. Each example is a real on-disk workspace
+//! under `prelude/examples/<slug>/`; we bake the tree into the binary
+//! with `include_dir!` so MCP and CLI consumers get the same files a
+//! human browsing the repo would see.
+//!
+//! Each example directory contains a `_meta.toml` (`name`, `use_when`)
+//! plus the files that make up the runnable workspace. The meta file
+//! is metadata only and never appears in the file bundle returned to
+//! callers.
+
+use include_dir::{include_dir, Dir};
+use serde::Deserialize;
+
+use crate::graph::{RuleExample, RuleExampleFile};
+
+static EXAMPLES_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/prelude/examples");
+
+const META_FILE_NAME: &str = "_meta.toml";
+
+#[derive(Debug, Deserialize)]
+struct ExampleMeta {
+    name: String,
+    use_when: String,
+}
+
+/// Load a single example by slug. Returns `None` if no example with
+/// that slug is bundled, or if the example's `_meta.toml` is missing
+/// or malformed.
+#[must_use]
+pub fn load_example(slug: &str) -> Option<RuleExample> {
+    let dir = EXAMPLES_DIR.get_dir(slug)?;
+    let meta_path = format!("{slug}/{META_FILE_NAME}");
+    let meta_file = EXAMPLES_DIR.get_file(&meta_path)?;
+    let raw_meta = meta_file.contents_utf8()?;
+    let meta: ExampleMeta = toml::from_str(raw_meta).ok()?;
+
+    let mut files = Vec::new();
+    collect_files(dir, slug, &mut files);
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+
+    Some(RuleExample {
+        name: meta.name,
+        slug: slug.to_string(),
+        use_when: meta.use_when,
+        files,
+    })
+}
+
+/// List every example slug bundled in the binary, sorted.
+#[must_use]
+pub fn list_example_slugs() -> Vec<String> {
+    let mut slugs: Vec<String> = EXAMPLES_DIR
+        .dirs()
+        .filter_map(|dir| dir.path().file_name()?.to_str().map(str::to_string))
+        .collect();
+    slugs.sort();
+    slugs
+}
+
+fn collect_files(dir: &Dir<'_>, slug: &str, out: &mut Vec<RuleExampleFile>) {
+    for file in dir.files() {
+        let path = file.path();
+        if path.file_name().and_then(|name| name.to_str()) == Some(META_FILE_NAME) {
+            continue;
+        }
+        let relative = path.strip_prefix(slug).unwrap_or(path);
+        let contents = file.contents_utf8().unwrap_or_default().to_string();
+        out.push(RuleExampleFile {
+            path: relative.to_string_lossy().to_string(),
+            contents,
+        });
+    }
+    for sub in dir.dirs() {
+        collect_files(sub, slug, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_example_returns_apple_library_minimal() {
+        let example = load_example("apple-library-minimal").expect("example loads");
+        assert_eq!(example.slug, "apple-library-minimal");
+        assert!(!example.name.is_empty());
+        assert!(!example.use_when.is_empty());
+        // The example must include at least the manifest and one source file.
+        assert!(example
+            .files
+            .iter()
+            .any(|f| f.path == "apps/Hello/once.toml"));
+        assert!(example
+            .files
+            .iter()
+            .any(|f| f.path == "apps/Hello/Sources/Hello.swift"));
+        // _meta.toml must never leak into the file bundle.
+        assert!(!example.files.iter().any(|f| f.path.ends_with("_meta.toml")));
+    }
+
+    #[test]
+    fn load_example_returns_none_for_unknown_slug() {
+        assert!(load_example("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn list_example_slugs_returns_every_bundled_example() {
+        let slugs = list_example_slugs();
+        assert!(slugs.contains(&"apple-library-minimal".to_string()));
+        assert!(slugs.contains(&"apple-library-with-objc".to_string()));
+        assert!(slugs.contains(&"apple-application-minimal".to_string()));
+    }
+
+    #[test]
+    fn collect_files_sorts_paths_deterministically() {
+        let example = load_example("apple-library-with-objc").expect("example loads");
+        let paths: Vec<&str> = example.files.iter().map(|f| f.path.as_str()).collect();
+        let mut sorted = paths.clone();
+        sorted.sort_unstable();
+        assert_eq!(paths, sorted);
+    }
+}

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -71,6 +71,12 @@ pub struct Diagnostic {
     pub code: String,
     /// Human-readable diagnostic message.
     pub message: String,
+    /// Canonical target id this diagnostic is scoped to, when applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// Attribute name this diagnostic is scoped to, when applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribute: Option<String>,
     /// Suggested repairs that an agent can apply or present.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repairs: Vec<String>,
@@ -91,8 +97,34 @@ pub struct RuleSchema {
     pub providers: Vec<String>,
     /// Capabilities exposed by targets of this rule.
     pub capabilities: Vec<Capability>,
-    /// Example `once.toml` declarations.
-    pub examples: Vec<String>,
+    /// Runnable starter workspaces. Each example bundles the files an
+    /// agent or human needs to copy to get a working target of this
+    /// rule kind, along with a one-line "use this when..." hint.
+    pub examples: Vec<RuleExample>,
+}
+
+/// A runnable starter workspace for a rule. Resolved from the
+/// `prelude/examples/<slug>/` directory bundled into the binary.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuleExample {
+    /// Human-readable example title.
+    pub name: String,
+    /// Stable identifier used to reference this example.
+    pub slug: String,
+    /// One-line "use this when..." hint that helps callers choose
+    /// between examples for the same rule kind.
+    pub use_when: String,
+    /// Every file in the example bundle, sorted by path.
+    pub files: Vec<RuleExampleFile>,
+}
+
+/// A single file inside a [`RuleExample`].
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuleExampleFile {
+    /// Path relative to the example workspace root.
+    pub path: String,
+    /// File contents as a UTF-8 string.
+    pub contents: String,
 }
 
 /// Attribute metadata exposed by a rule schema.
@@ -177,6 +209,8 @@ fn graph_target_from_schema(target: &Target, schemas: &[RuleSchema]) -> GraphTar
         vec![Diagnostic {
             code: "unknown_rule_kind".to_string(),
             message: format!("target kind `{}` has no built-in schema", target.kind),
+            target: Some(target.id()),
+            attribute: None,
             repairs: Vec::new(),
         }]
     };
@@ -259,6 +293,16 @@ fn rule_schemas_from_value(value: Value<'_>) -> std::result::Result<Vec<RuleSche
 }
 
 fn rule_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<RuleSchema, String> {
+    let example_slugs = field_string_list(value, path, "examples")?;
+    let examples = example_slugs
+        .into_iter()
+        .enumerate()
+        .map(|(index, slug)| {
+            crate::examples::load_example(&slug).ok_or_else(|| {
+                format!("{path}.examples[{index}] references unknown example slug `{slug}`")
+            })
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
     Ok(RuleSchema {
         kind: field_string(value, path, "kind")?,
         docs: field_string(value, path, "docs")?,
@@ -280,7 +324,7 @@ fn rule_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<R
                 capability_from_value(capability, &format!("{path}.capabilities[{index}]"))
             })
             .collect::<std::result::Result<Vec<_>, _>>()?,
-        examples: field_string_list(value, path, "examples")?,
+        examples,
     })
 }
 

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -7,11 +7,14 @@
 pub mod analysis;
 mod cache_provider;
 mod error;
+mod examples;
 mod graph;
 mod manifest;
+mod manifest_editor;
 mod script;
 mod target;
 mod target_ref;
+mod target_validator;
 mod workspace;
 
 /// The declarative per-package manifest file.
@@ -23,16 +26,19 @@ pub use cache_provider::{
     CacheProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
 };
 pub use error::{Error, Result};
+pub use examples::{list_example_slugs, load_example};
 pub use graph::{
     built_in_rule_schema, built_in_rule_schemas, built_in_rule_schemas_result, graph_from_targets,
     graph_from_targets_result, load_graph_workspace, AttrSchema, Capability, DepSchema, Diagnostic,
-    GraphTarget, RuleSchema, TargetLabel,
+    GraphTarget, RuleExample, RuleExampleFile, RuleSchema, TargetLabel,
 };
 pub use manifest::{load_cache_provider_toml_str, load_toml_str};
+pub use manifest_editor::{apply_operations, EditOperation, TargetSpec, TargetUpdate};
 pub use script::{parse_script_annotations, ScriptAnnotations};
 pub use target::{AttrValue, Target};
 pub use target_ref::{
     absolutize, normalize_cli_target, normalize_cli_target_from, normalize_manifest_target,
     target_id, validate_target_name, TargetIdError,
 };
+pub use target_validator::validate_target;
 pub use workspace::{load_cache_provider, load_cache_provider_override, load_file, load_workspace};

--- a/crates/once-frontend/src/manifest_editor.rs
+++ b/crates/once-frontend/src/manifest_editor.rs
@@ -1,0 +1,672 @@
+//! Atomic editor for `once.toml` manifests.
+//!
+//! Callers describe their edit as a list of [`EditOperation`]s
+//! (`create`, `update`, `delete`) against a single manifest source
+//! string. [`apply_operations`] runs the whole list through
+//! `toml_edit`, preserving formatting and comments where it can, and
+//! returns either the new manifest body or a list of structured
+//! [`Diagnostic`]s explaining what went wrong.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, Value};
+
+use crate::graph::Diagnostic;
+
+/// One mutation against the `[[target]]` array in a `once.toml`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum EditOperation {
+    /// Append a new `[[target]]` block. Fails if a target with the
+    /// same name already exists in the manifest.
+    Create { target: TargetSpec },
+    /// Replace the named fields of an existing `[[target]]`. Fields
+    /// left unset (`None`) are preserved as-is.
+    Update {
+        target_name: String,
+        #[serde(default)]
+        set: TargetUpdate,
+    },
+    /// Remove the named `[[target]]`.
+    Delete { target_name: String },
+}
+
+/// Full description of a target as the editor will write it.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct TargetSpec {
+    pub name: String,
+    pub kind: String,
+    #[serde(default)]
+    pub deps: Vec<String>,
+    #[serde(default)]
+    pub srcs: Vec<String>,
+    #[serde(default)]
+    pub attrs: JsonMap<String, JsonValue>,
+}
+
+/// Partial update for an existing target. Any field left as `None`
+/// keeps its current value; setting `attrs` to `Some(map)` replaces
+/// the whole attrs table (callers needing a merge must read, merge,
+/// then call update with the merged map).
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct TargetUpdate {
+    pub name: Option<String>,
+    pub kind: Option<String>,
+    pub deps: Option<Vec<String>>,
+    pub srcs: Option<Vec<String>>,
+    pub attrs: Option<JsonMap<String, JsonValue>>,
+}
+
+/// Apply the operations against `toml_src` and return the resulting
+/// manifest body. Any operation failure aborts the whole batch and
+/// returns diagnostics; the input string is never partially modified.
+pub fn apply_operations(
+    toml_src: &str,
+    operations: &[EditOperation],
+) -> Result<String, Vec<Diagnostic>> {
+    let mut doc: DocumentMut = toml_src.parse().map_err(|err: toml_edit::TomlError| {
+        vec![Diagnostic {
+            code: "toml_parse_error".to_string(),
+            message: format!("could not parse `once.toml`: {err}"),
+            target: None,
+            attribute: None,
+            repairs: Vec::new(),
+        }]
+    })?;
+
+    ensure_target_array(&mut doc)?;
+
+    for op in operations {
+        apply_one(&mut doc, op)?;
+    }
+    Ok(doc.to_string())
+}
+
+fn ensure_target_array(doc: &mut DocumentMut) -> Result<(), Vec<Diagnostic>> {
+    if !doc.contains_key("target") {
+        doc.insert("target", Item::ArrayOfTables(ArrayOfTables::new()));
+        return Ok(());
+    }
+    if doc["target"].as_array_of_tables().is_none() {
+        return Err(vec![Diagnostic {
+            code: "invalid_target_section".to_string(),
+            message: "the top-level `target` key must be an array of tables (`[[target]]`)"
+                .to_string(),
+            target: None,
+            attribute: None,
+            repairs: vec!["delete the conflicting `target` value and let the editor re-create it as `[[target]]`".to_string()],
+        }]);
+    }
+    Ok(())
+}
+
+fn apply_one(doc: &mut DocumentMut, op: &EditOperation) -> Result<(), Vec<Diagnostic>> {
+    match op {
+        EditOperation::Create { target } => create(doc, target),
+        EditOperation::Update { target_name, set } => update(doc, target_name, set),
+        EditOperation::Delete { target_name } => delete(doc, target_name),
+    }
+}
+
+fn create(doc: &mut DocumentMut, spec: &TargetSpec) -> Result<(), Vec<Diagnostic>> {
+    if spec.name.trim().is_empty() {
+        return Err(vec![Diagnostic {
+            code: "target_name_required".to_string(),
+            message: "`create` operations must declare a non-empty `name`".to_string(),
+            target: None,
+            attribute: Some("name".to_string()),
+            repairs: Vec::new(),
+        }]);
+    }
+    if spec.kind.trim().is_empty() {
+        return Err(vec![Diagnostic {
+            code: "target_kind_required".to_string(),
+            message: "`create` operations must declare a non-empty `kind`".to_string(),
+            target: Some(spec.name.clone()),
+            attribute: Some("kind".to_string()),
+            repairs: Vec::new(),
+        }]);
+    }
+    if find_target_index(doc, &spec.name).is_some() {
+        return Err(vec![Diagnostic {
+            code: "target_already_exists".to_string(),
+            message: format!("a target named `{}` already exists", spec.name),
+            target: Some(spec.name.clone()),
+            attribute: None,
+            repairs: vec![format!(
+                "rename the new target, or `update` the existing `{}`",
+                spec.name
+            )],
+        }]);
+    }
+
+    let table = build_target_table(spec)?;
+    targets_mut(doc).push(table);
+    Ok(())
+}
+
+fn update(
+    doc: &mut DocumentMut,
+    target_name: &str,
+    set: &TargetUpdate,
+) -> Result<(), Vec<Diagnostic>> {
+    let Some(index) = find_target_index(doc, target_name) else {
+        return Err(vec![Diagnostic {
+            code: "target_not_found".to_string(),
+            message: format!("no target named `{target_name}` in this manifest"),
+            target: Some(target_name.to_string()),
+            attribute: None,
+            repairs: Vec::new(),
+        }]);
+    };
+
+    if let Some(new_name) = set.name.as_deref() {
+        if new_name.trim().is_empty() {
+            return Err(vec![Diagnostic {
+                code: "target_name_required".to_string(),
+                message: "`update.set.name` must be non-empty when present".to_string(),
+                target: Some(target_name.to_string()),
+                attribute: Some("name".to_string()),
+                repairs: Vec::new(),
+            }]);
+        }
+        if new_name != target_name && find_target_index(doc, new_name).is_some() {
+            return Err(vec![Diagnostic {
+                code: "target_already_exists".to_string(),
+                message: format!("renaming to `{new_name}` would clash with an existing target"),
+                target: Some(target_name.to_string()),
+                attribute: Some("name".to_string()),
+                repairs: Vec::new(),
+            }]);
+        }
+    }
+
+    let table = targets_mut(doc)
+        .get_mut(index)
+        .expect("find_target_index returned a valid index");
+    apply_update(table, set, target_name)
+}
+
+fn delete(doc: &mut DocumentMut, target_name: &str) -> Result<(), Vec<Diagnostic>> {
+    let Some(index) = find_target_index(doc, target_name) else {
+        return Err(vec![Diagnostic {
+            code: "target_not_found".to_string(),
+            message: format!("no target named `{target_name}` to delete"),
+            target: Some(target_name.to_string()),
+            attribute: None,
+            repairs: Vec::new(),
+        }]);
+    };
+    targets_mut(doc).remove(index);
+    Ok(())
+}
+
+fn apply_update(
+    table: &mut Table,
+    set: &TargetUpdate,
+    original_name: &str,
+) -> Result<(), Vec<Diagnostic>> {
+    if let Some(new_name) = &set.name {
+        table.insert("name", Item::Value(Value::from(new_name.as_str())));
+    }
+    if let Some(new_kind) = &set.kind {
+        if new_kind.trim().is_empty() {
+            return Err(vec![Diagnostic {
+                code: "target_kind_required".to_string(),
+                message: "`update.set.kind` must be non-empty when present".to_string(),
+                target: Some(original_name.to_string()),
+                attribute: Some("kind".to_string()),
+                repairs: Vec::new(),
+            }]);
+        }
+        table.insert("kind", Item::Value(Value::from(new_kind.as_str())));
+    }
+    if let Some(deps) = &set.deps {
+        table.insert("deps", Item::Value(Value::Array(string_array(deps))));
+    }
+    if let Some(srcs) = &set.srcs {
+        table.insert("srcs", Item::Value(Value::Array(string_array(srcs))));
+    }
+    if let Some(attrs) = &set.attrs {
+        let attrs_table = build_attrs_table(attrs, original_name)?;
+        table.insert("attrs", Item::Table(attrs_table));
+    }
+    Ok(())
+}
+
+fn build_target_table(spec: &TargetSpec) -> Result<Table, Vec<Diagnostic>> {
+    let mut table = Table::new();
+    table.set_implicit(false);
+    table.insert("name", Item::Value(Value::from(spec.name.as_str())));
+    table.insert("kind", Item::Value(Value::from(spec.kind.as_str())));
+    if !spec.deps.is_empty() {
+        table.insert("deps", Item::Value(Value::Array(string_array(&spec.deps))));
+    }
+    if !spec.srcs.is_empty() {
+        table.insert("srcs", Item::Value(Value::Array(string_array(&spec.srcs))));
+    }
+    if !spec.attrs.is_empty() {
+        let attrs_table = build_attrs_table(&spec.attrs, &spec.name)?;
+        table.insert("attrs", Item::Table(attrs_table));
+    }
+    Ok(table)
+}
+
+fn build_attrs_table(
+    attrs: &JsonMap<String, JsonValue>,
+    target_name: &str,
+) -> Result<Table, Vec<Diagnostic>> {
+    let mut attrs_table = Table::new();
+    attrs_table.set_implicit(false);
+    let mut sorted: BTreeMap<&String, &JsonValue> = BTreeMap::new();
+    for (key, value) in attrs {
+        sorted.insert(key, value);
+    }
+    for (key, value) in sorted {
+        let item = json_to_item(value).map_err(|err| {
+            vec![Diagnostic {
+                code: "attr_unrepresentable".to_string(),
+                message: format!("attribute `{key}` cannot be written to TOML: {err}"),
+                target: Some(target_name.to_string()),
+                attribute: Some(key.clone()),
+                repairs: Vec::new(),
+            }]
+        })?;
+        attrs_table.insert(key, item);
+    }
+    Ok(attrs_table)
+}
+
+fn string_array(values: &[String]) -> Array {
+    let mut array = Array::new();
+    for value in values {
+        array.push(value.as_str());
+    }
+    array
+}
+
+fn json_to_item(value: &JsonValue) -> Result<Item, String> {
+    Ok(match value {
+        JsonValue::Null => return Err("`null` has no TOML representation".to_string()),
+        JsonValue::Bool(b) => Item::Value(Value::from(*b)),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Item::Value(Value::from(i))
+            } else if let Some(f) = n.as_f64() {
+                Item::Value(Value::from(f))
+            } else {
+                return Err(format!("number `{n}` is out of range"));
+            }
+        }
+        JsonValue::String(s) => Item::Value(Value::from(s.as_str())),
+        JsonValue::Array(items) => {
+            let mut array = Array::new();
+            for item in items {
+                let nested = json_to_value(item)?;
+                array.push(nested);
+            }
+            Item::Value(Value::Array(array))
+        }
+        JsonValue::Object(map) => {
+            let mut table = toml_edit::InlineTable::new();
+            for (key, value) in map {
+                let nested = json_to_value(value)?;
+                table.insert(key, nested);
+            }
+            Item::Value(Value::InlineTable(table))
+        }
+    })
+}
+
+fn json_to_value(value: &JsonValue) -> Result<Value, String> {
+    match json_to_item(value)? {
+        Item::Value(v) => Ok(v),
+        _ => Err("expected scalar or inline value".to_string()),
+    }
+}
+
+fn find_target_index(doc: &DocumentMut, name: &str) -> Option<usize> {
+    let targets = doc.get("target")?.as_array_of_tables()?;
+    targets.iter().position(|t| {
+        t.get("name")
+            .and_then(Item::as_str)
+            .is_some_and(|n| n == name)
+    })
+}
+
+fn targets_mut(doc: &mut DocumentMut) -> &mut ArrayOfTables {
+    doc["target"]
+        .as_array_of_tables_mut()
+        .expect("ensure_target_array guarantees the array exists")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn target(name: &str, kind: &str) -> TargetSpec {
+        TargetSpec {
+            name: name.to_string(),
+            kind: kind.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn create_appends_target_to_empty_manifest() {
+        let out = apply_operations(
+            "",
+            &[EditOperation::Create {
+                target: target("Hello", "apple_library"),
+            }],
+        )
+        .expect("create");
+        assert!(out.contains("[[target]]"));
+        assert!(out.contains("name = \"Hello\""));
+        assert!(out.contains("kind = \"apple_library\""));
+    }
+
+    #[test]
+    fn create_preserves_existing_targets() {
+        let src = r#"
+[[target]]
+name = "Existing"
+kind = "apple_library"
+"#;
+        let out = apply_operations(
+            src,
+            &[EditOperation::Create {
+                target: target("Hello", "apple_library"),
+            }],
+        )
+        .expect("create");
+        assert!(out.contains("name = \"Existing\""));
+        assert!(out.contains("name = \"Hello\""));
+    }
+
+    #[test]
+    fn create_serializes_attrs_in_sorted_order() {
+        let mut spec = target("Hello", "apple_library");
+        spec.attrs.insert("platform".to_string(), json!("ios"));
+        spec.attrs.insert("minimum_os".to_string(), json!("17.0"));
+        let out = apply_operations("", &[EditOperation::Create { target: spec }]).expect("create");
+        let min = out.find("minimum_os").expect("minimum_os present");
+        let plat = out.find("platform").expect("platform present");
+        // Sorted: minimum_os comes before platform alphabetically.
+        assert!(
+            min < plat,
+            "attrs should serialize in sorted order, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn create_rejects_duplicate_target_names() {
+        let src = r#"
+[[target]]
+name = "Hello"
+kind = "apple_library"
+"#;
+        let diagnostics = apply_operations(
+            src,
+            &[EditOperation::Create {
+                target: target("Hello", "apple_library"),
+            }],
+        )
+        .expect_err("duplicate must fail");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "target_already_exists");
+        assert_eq!(diagnostics[0].target.as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn create_rejects_empty_name() {
+        let diagnostics = apply_operations(
+            "",
+            &[EditOperation::Create {
+                target: target("", "apple_library"),
+            }],
+        )
+        .expect_err("missing name must fail");
+        assert_eq!(diagnostics[0].code, "target_name_required");
+        assert_eq!(diagnostics[0].attribute.as_deref(), Some("name"));
+    }
+
+    #[test]
+    fn update_replaces_only_set_fields() {
+        let src = r#"
+[[target]]
+name = "Hello"
+kind = "apple_library"
+srcs = ["Sources/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+"#;
+        let out = apply_operations(
+            src,
+            &[EditOperation::Update {
+                target_name: "Hello".to_string(),
+                set: TargetUpdate {
+                    deps: Some(vec!["./Other".to_string()]),
+                    ..Default::default()
+                },
+            }],
+        )
+        .expect("update");
+        assert!(out.contains("deps = [\"./Other\"]"));
+        assert!(out.contains("srcs = [\"Sources/**/*.swift\"]"));
+        assert!(out.contains("platform = \"ios\""));
+    }
+
+    #[test]
+    fn update_can_rename_target() {
+        let src = r#"
+[[target]]
+name = "Old"
+kind = "apple_library"
+"#;
+        let out = apply_operations(
+            src,
+            &[EditOperation::Update {
+                target_name: "Old".to_string(),
+                set: TargetUpdate {
+                    name: Some("New".to_string()),
+                    ..Default::default()
+                },
+            }],
+        )
+        .expect("update rename");
+        assert!(out.contains("name = \"New\""));
+        assert!(!out.contains("name = \"Old\""));
+    }
+
+    #[test]
+    fn update_replaces_attrs_table_when_set() {
+        let src = r#"
+[[target]]
+name = "Hello"
+kind = "apple_library"
+
+[target.attrs]
+platform = "ios"
+minimum_os = "17.0"
+"#;
+        let out = apply_operations(
+            src,
+            &[EditOperation::Update {
+                target_name: "Hello".to_string(),
+                set: TargetUpdate {
+                    attrs: Some({
+                        let mut m = JsonMap::new();
+                        m.insert("platform".to_string(), json!("macos"));
+                        m
+                    }),
+                    ..Default::default()
+                },
+            }],
+        )
+        .expect("update attrs");
+        assert!(out.contains("platform = \"macos\""));
+        assert!(!out.contains("minimum_os"));
+    }
+
+    #[test]
+    fn update_rejects_renaming_into_existing_target() {
+        let src = r#"
+[[target]]
+name = "A"
+kind = "apple_library"
+
+[[target]]
+name = "B"
+kind = "apple_library"
+"#;
+        let diagnostics = apply_operations(
+            src,
+            &[EditOperation::Update {
+                target_name: "A".to_string(),
+                set: TargetUpdate {
+                    name: Some("B".to_string()),
+                    ..Default::default()
+                },
+            }],
+        )
+        .expect_err("rename clash must fail");
+        assert_eq!(diagnostics[0].code, "target_already_exists");
+    }
+
+    #[test]
+    fn update_target_not_found_diagnoses_with_scope() {
+        let diagnostics = apply_operations(
+            "",
+            &[EditOperation::Update {
+                target_name: "Missing".to_string(),
+                set: TargetUpdate::default(),
+            }],
+        )
+        .expect_err("missing target must fail");
+        assert_eq!(diagnostics[0].code, "target_not_found");
+        assert_eq!(diagnostics[0].target.as_deref(), Some("Missing"));
+    }
+
+    #[test]
+    fn delete_removes_target() {
+        let src = r#"
+[[target]]
+name = "Hello"
+kind = "apple_library"
+
+[[target]]
+name = "Keep"
+kind = "apple_library"
+"#;
+        let out = apply_operations(
+            src,
+            &[EditOperation::Delete {
+                target_name: "Hello".to_string(),
+            }],
+        )
+        .expect("delete");
+        assert!(!out.contains("name = \"Hello\""));
+        assert!(out.contains("name = \"Keep\""));
+    }
+
+    #[test]
+    fn delete_target_not_found_diagnoses() {
+        let diagnostics = apply_operations(
+            "",
+            &[EditOperation::Delete {
+                target_name: "Missing".to_string(),
+            }],
+        )
+        .expect_err("delete missing must fail");
+        assert_eq!(diagnostics[0].code, "target_not_found");
+    }
+
+    #[test]
+    fn rejects_non_array_target_key() {
+        let src = "target = \"oops\"";
+        let diagnostics = apply_operations(
+            src,
+            &[EditOperation::Create {
+                target: target("Hello", "apple_library"),
+            }],
+        )
+        .expect_err("non-array target must fail");
+        assert_eq!(diagnostics[0].code, "invalid_target_section");
+    }
+
+    #[test]
+    fn batch_operations_apply_in_order() {
+        let src = r#"
+[[target]]
+name = "Old"
+kind = "apple_library"
+"#;
+        let out = apply_operations(
+            src,
+            &[
+                EditOperation::Delete {
+                    target_name: "Old".to_string(),
+                },
+                EditOperation::Create {
+                    target: target("New", "apple_library"),
+                },
+            ],
+        )
+        .expect("batch");
+        assert!(!out.contains("name = \"Old\""));
+        assert!(out.contains("name = \"New\""));
+    }
+
+    #[test]
+    fn batch_failure_does_not_partially_mutate_the_input() {
+        // Note: apply_operations returns either Ok(new_string) or Err; we
+        // never see a partial mutation because the caller still holds the
+        // original `toml_src`. This test pins that behavior.
+        let src = r#"
+[[target]]
+name = "Hello"
+kind = "apple_library"
+"#;
+        let diagnostics = apply_operations(
+            src,
+            &[
+                EditOperation::Delete {
+                    target_name: "Hello".to_string(),
+                },
+                EditOperation::Delete {
+                    target_name: "Hello".to_string(),
+                },
+            ],
+        )
+        .expect_err("second delete fails");
+        assert_eq!(diagnostics[0].code, "target_not_found");
+    }
+
+    #[test]
+    fn deserializes_edit_operation_from_json() {
+        let raw = json!({
+            "op": "create",
+            "target": {
+                "name": "Hello",
+                "kind": "apple_library",
+                "srcs": ["Sources/**/*.swift"],
+                "attrs": { "platform": "ios" }
+            }
+        });
+        let op: EditOperation = serde_json::from_value(raw).expect("deserialize");
+        match op {
+            EditOperation::Create { target } => {
+                assert_eq!(target.name, "Hello");
+                assert_eq!(target.kind, "apple_library");
+                assert_eq!(target.srcs, vec!["Sources/**/*.swift".to_string()]);
+                assert_eq!(target.attrs.get("platform"), Some(&json!("ios")));
+            }
+            other => panic!("expected Create, got {other:?}"),
+        }
+    }
+}

--- a/crates/once-frontend/src/target_validator.rs
+++ b/crates/once-frontend/src/target_validator.rs
@@ -1,0 +1,343 @@
+//! Schema-only validation for a single `[[target]]` table.
+//!
+//! Given a [`TargetSpec`] (the shape the editor produces) and the
+//! workspace's rule registry, [`validate_target`] returns a list of
+//! [`Diagnostic`]s. An empty list means the target shape matches the
+//! rule's declared contract. The check is local: it does not resolve
+//! dep references or read other manifests.
+
+use serde_json::Value as JsonValue;
+
+use crate::graph::{AttrSchema, Diagnostic, RuleSchema};
+use crate::manifest_editor::TargetSpec;
+use crate::target_ref::validate_target_name;
+
+/// Validate `target` against `schemas`. Returns an empty `Vec` if the
+/// target's shape is acceptable to its rule kind.
+#[must_use]
+pub fn validate_target(target: &TargetSpec, schemas: &[RuleSchema]) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    if target.name.trim().is_empty() {
+        diagnostics.push(Diagnostic {
+            code: "target_name_required".to_string(),
+            message: "target `name` must not be empty".to_string(),
+            target: None,
+            attribute: Some("name".to_string()),
+            repairs: Vec::new(),
+        });
+    } else if let Err(err) = validate_target_name(&target.name) {
+        diagnostics.push(Diagnostic {
+            code: "invalid_target_name".to_string(),
+            message: err.to_string(),
+            target: Some(target.name.clone()),
+            attribute: Some("name".to_string()),
+            repairs: Vec::new(),
+        });
+    }
+
+    if target.kind.trim().is_empty() {
+        diagnostics.push(Diagnostic {
+            code: "target_kind_required".to_string(),
+            message: "target `kind` must not be empty".to_string(),
+            target: Some(target.name.clone()),
+            attribute: Some("kind".to_string()),
+            repairs: Vec::new(),
+        });
+        return diagnostics;
+    }
+
+    let Some(schema) = schemas.iter().find(|s| s.kind == target.kind) else {
+        diagnostics.push(Diagnostic {
+            code: "unknown_rule_kind".to_string(),
+            message: format!("rule kind `{}` is not registered", target.kind),
+            target: Some(target.name.clone()),
+            attribute: Some("kind".to_string()),
+            repairs: vec![suggest_known_kinds(schemas)],
+        });
+        return diagnostics;
+    };
+
+    for attr_schema in &schema.attrs {
+        if attr_schema.required && !target.attrs.contains_key(&attr_schema.name) {
+            diagnostics.push(Diagnostic {
+                code: "missing_required_attr".to_string(),
+                message: format!(
+                    "rule `{}` requires attribute `{}`",
+                    schema.kind, attr_schema.name
+                ),
+                target: Some(target.name.clone()),
+                attribute: Some(attr_schema.name.clone()),
+                repairs: Vec::new(),
+            });
+        }
+    }
+
+    for (attr_name, attr_value) in &target.attrs {
+        let Some(attr_schema) = schema.attrs.iter().find(|a| &a.name == attr_name) else {
+            diagnostics.push(Diagnostic {
+                code: "unknown_attr".to_string(),
+                message: format!(
+                    "rule `{}` does not declare attribute `{}`",
+                    schema.kind, attr_name
+                ),
+                target: Some(target.name.clone()),
+                attribute: Some(attr_name.clone()),
+                repairs: vec![suggest_known_attrs(schema)],
+            });
+            continue;
+        };
+        if let Err(err) = check_type(attr_value, &attr_schema.ty) {
+            diagnostics.push(Diagnostic {
+                code: "attr_type_mismatch".to_string(),
+                message: format!(
+                    "attribute `{}` expects type `{}`: {}",
+                    attr_name, attr_schema.ty, err
+                ),
+                target: Some(target.name.clone()),
+                attribute: Some(attr_name.clone()),
+                repairs: Vec::new(),
+            });
+        }
+    }
+
+    diagnostics
+}
+
+fn check_type(value: &JsonValue, ty: &str) -> Result<(), String> {
+    let ty = ty.trim();
+    if let Some(inner) = strip_wrapper(ty, "list<") {
+        let JsonValue::Array(items) = value else {
+            return Err(format!("expected an array, got {}", json_type(value)));
+        };
+        for (index, item) in items.iter().enumerate() {
+            check_type(item, inner).map_err(|err| format!("element [{index}]: {err}"))?;
+        }
+        return Ok(());
+    }
+    if let Some(inner) = strip_wrapper(ty, "map<") {
+        let JsonValue::Object(entries) = value else {
+            return Err(format!("expected a table, got {}", json_type(value)));
+        };
+        let (key_ty, value_ty) = split_map_params(inner)?;
+        if key_ty != "string" {
+            return Err(format!(
+                "map key type `{key_ty}` is not supported; TOML keys are always strings",
+            ));
+        }
+        for (key, sub) in entries {
+            check_type(sub, value_ty).map_err(|err| format!("entry `{key}`: {err}"))?;
+        }
+        return Ok(());
+    }
+    match ty {
+        "string" | "target" => match value {
+            JsonValue::String(_) => Ok(()),
+            _ => Err(format!("expected a string, got {}", json_type(value))),
+        },
+        "bool" => match value {
+            JsonValue::Bool(_) => Ok(()),
+            _ => Err(format!("expected a bool, got {}", json_type(value))),
+        },
+        "int" | "integer" => match value {
+            JsonValue::Number(n) if n.is_i64() => Ok(()),
+            _ => Err(format!("expected an integer, got {}", json_type(value))),
+        },
+        other => Err(format!(
+            "unknown attribute type `{other}` declared by rule schema"
+        )),
+    }
+}
+
+fn strip_wrapper<'a>(ty: &'a str, prefix: &str) -> Option<&'a str> {
+    let rest = ty.strip_prefix(prefix)?;
+    rest.strip_suffix('>')
+}
+
+fn split_map_params(inner: &str) -> Result<(&str, &str), String> {
+    let mut parts = inner.splitn(2, ',');
+    let key = parts
+        .next()
+        .ok_or_else(|| "missing map key type".to_string())?
+        .trim();
+    let value = parts
+        .next()
+        .ok_or_else(|| format!("map type `map<{inner}>` is missing the value type"))?
+        .trim();
+    Ok((key, value))
+}
+
+fn json_type(value: &JsonValue) -> &'static str {
+    match value {
+        JsonValue::Null => "null",
+        JsonValue::Bool(_) => "bool",
+        JsonValue::Number(_) => "number",
+        JsonValue::String(_) => "string",
+        JsonValue::Array(_) => "array",
+        JsonValue::Object(_) => "table",
+    }
+}
+
+fn suggest_known_kinds(schemas: &[RuleSchema]) -> String {
+    let kinds: Vec<&str> = schemas.iter().map(|s| s.kind.as_str()).collect();
+    format!("known rule kinds: {}", kinds.join(", "))
+}
+
+fn suggest_known_attrs(schema: &RuleSchema) -> String {
+    if schema.attrs.is_empty() {
+        return format!("rule `{}` declares no attributes", schema.kind);
+    }
+    let names: Vec<&str> = schema
+        .attrs
+        .iter()
+        .map(|a: &AttrSchema| a.name.as_str())
+        .collect();
+    format!(
+        "attributes declared by rule `{}`: {}",
+        schema.kind,
+        names.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::built_in_rule_schemas;
+    use serde_json::json;
+    use serde_json::Map as JsonMap;
+
+    fn schema_named(kind: &str) -> RuleSchema {
+        built_in_rule_schemas()
+            .into_iter()
+            .find(|s| s.kind == kind)
+            .expect("rule kind exists")
+    }
+
+    fn target(name: &str, kind: &str) -> TargetSpec {
+        TargetSpec {
+            name: name.to_string(),
+            kind: kind.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn missing_required_attr_produces_diagnostic_with_attribute_scope() {
+        let schemas = vec![schema_named("apple_library")];
+        // apple_library requires `platform`.
+        let target = target("Hello", "apple_library");
+        let diagnostics = validate_target(&target, &schemas);
+        let missing = diagnostics
+            .iter()
+            .find(|d| {
+                d.code == "missing_required_attr" && d.attribute.as_deref() == Some("platform")
+            })
+            .expect("missing platform diagnostic");
+        assert_eq!(missing.target.as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn unknown_kind_produces_diagnostic_with_repair() {
+        let schemas = built_in_rule_schemas();
+        let target = target("Hello", "mystery_rule");
+        let diagnostics = validate_target(&target, &schemas);
+        let unknown = diagnostics
+            .iter()
+            .find(|d| d.code == "unknown_rule_kind")
+            .expect("unknown_rule_kind diagnostic");
+        assert!(!unknown.repairs.is_empty());
+        assert!(unknown.repairs[0].contains("apple_library"));
+    }
+
+    #[test]
+    fn unknown_attr_lists_known_attrs_as_repair() {
+        let schemas = built_in_rule_schemas();
+        let mut t = target("Hello", "apple_library");
+        t.attrs.insert("platform".to_string(), json!("ios"));
+        t.attrs.insert("wat".to_string(), json!("nope"));
+        let diagnostics = validate_target(&t, &schemas);
+        let unknown = diagnostics
+            .iter()
+            .find(|d| d.code == "unknown_attr" && d.attribute.as_deref() == Some("wat"))
+            .expect("unknown wat diagnostic");
+        assert!(unknown.repairs[0].contains("platform"));
+    }
+
+    #[test]
+    fn type_mismatch_diagnoses_with_scope() {
+        let schemas = built_in_rule_schemas();
+        let mut t = target("Hello", "apple_library");
+        // platform should be a string; pass a number.
+        t.attrs.insert("platform".to_string(), json!(42));
+        let diagnostics = validate_target(&t, &schemas);
+        let mismatch = diagnostics
+            .iter()
+            .find(|d| d.code == "attr_type_mismatch" && d.attribute.as_deref() == Some("platform"))
+            .expect("mismatch diagnostic");
+        assert!(mismatch.message.contains("string"));
+        assert!(mismatch.message.contains("number"));
+    }
+
+    #[test]
+    fn list_of_strings_validates_each_element() {
+        let schemas = built_in_rule_schemas();
+        let mut t = target("Hello", "apple_library");
+        t.attrs.insert("platform".to_string(), json!("ios"));
+        // sdk_frameworks is list<string>. Pass a list with one bad entry.
+        t.attrs
+            .insert("sdk_frameworks".to_string(), json!(["UIKit", 42]));
+        let diagnostics = validate_target(&t, &schemas);
+        let mismatch = diagnostics
+            .iter()
+            .find(|d| d.attribute.as_deref() == Some("sdk_frameworks"))
+            .expect("mismatch diagnostic");
+        assert!(mismatch.message.contains("element [1]"));
+    }
+
+    #[test]
+    fn map_validates_value_type() {
+        let schemas = built_in_rule_schemas();
+        let mut t = target("Hello", "apple_application");
+        t.attrs.insert("platform".to_string(), json!("ios"));
+        t.attrs.insert("bundle_id".to_string(), json!("dev.once.X"));
+        // info_plist_substitutions is map<string,string>. Pass a bool value.
+        let mut subs = JsonMap::new();
+        subs.insert("KEY".to_string(), json!(true));
+        t.attrs.insert(
+            "info_plist_substitutions".to_string(),
+            JsonValue::Object(subs),
+        );
+        let diagnostics = validate_target(&t, &schemas);
+        let mismatch = diagnostics
+            .iter()
+            .find(|d| d.attribute.as_deref() == Some("info_plist_substitutions"))
+            .expect("mismatch diagnostic");
+        assert!(mismatch.message.contains("entry `KEY`"));
+    }
+
+    #[test]
+    fn valid_minimal_apple_library_returns_no_diagnostics() {
+        let schemas = built_in_rule_schemas();
+        let mut t = target("Hello", "apple_library");
+        t.attrs.insert("platform".to_string(), json!("ios"));
+        let diagnostics = validate_target(&t, &schemas);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics, got: {diagnostics:?}",
+        );
+    }
+
+    #[test]
+    fn empty_name_diagnoses_with_attribute_scope_only() {
+        let schemas = built_in_rule_schemas();
+        let mut t = target("", "apple_library");
+        t.attrs.insert("platform".to_string(), json!("ios"));
+        let diagnostics = validate_target(&t, &schemas);
+        let name_diag = diagnostics
+            .iter()
+            .find(|d| d.code == "target_name_required")
+            .expect("name diagnostic");
+        assert_eq!(name_diag.attribute.as_deref(), Some("name"));
+        assert!(name_diag.target.is_none());
+    }
+}

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -1,0 +1,125 @@
+//! Integration tests that materialize every bundled `RuleExample` and
+//! load it as a real workspace. This is the rot-prevention invariant
+//! the doc-less foundation depends on: if a rule schema changes in a
+//! way that breaks one of the starter examples, this test fails and
+//! the example has to be updated alongside the rule.
+//!
+//! Scope: parse + diagnostic check (cheap, runs anywhere). End-to-end
+//! build verification for examples whose rule has an `impl` is
+//! intentional follow-up work; it needs an Apple toolchain in the test
+//! environment and a configured cache provider.
+
+use std::fs;
+use std::path::Path;
+
+use once_frontend::{built_in_rule_schemas_result, list_example_slugs, load_example};
+use tempfile::TempDir;
+
+#[test]
+fn every_bundled_example_resolves() {
+    let slugs = list_example_slugs();
+    assert!(!slugs.is_empty(), "no bundled examples found");
+    for slug in &slugs {
+        assert!(
+            load_example(slug).is_some(),
+            "example slug `{slug}` advertised by list_example_slugs but does not resolve",
+        );
+    }
+}
+
+#[test]
+fn every_schema_example_loads_without_diagnostics() {
+    let schemas = built_in_rule_schemas_result().expect("built-in rule schemas load");
+    for schema in &schemas {
+        for example in &schema.examples {
+            let tmp = TempDir::new().expect("tempdir");
+            materialize(tmp.path(), example);
+            let graph = once_frontend::load_graph_workspace(tmp.path()).unwrap_or_else(|err| {
+                panic!(
+                    "example `{}` (rule `{}`) failed to load: {err}",
+                    example.slug, schema.kind
+                )
+            });
+            assert!(
+                !graph.is_empty(),
+                "example `{}` (rule `{}`) declared no targets",
+                example.slug,
+                schema.kind
+            );
+            for target in &graph {
+                assert!(
+                    target.diagnostics.is_empty(),
+                    "example `{}` target `{}` emitted diagnostics: {:?}",
+                    example.slug,
+                    target.label.id,
+                    target.diagnostics
+                );
+            }
+            let example_targets = graph
+                .iter()
+                .filter(|target| target.kind == schema.kind)
+                .count();
+            assert!(
+                example_targets > 0,
+                "example `{}` declares no target of rule `{}`",
+                example.slug,
+                schema.kind
+            );
+        }
+    }
+}
+
+#[test]
+fn every_schema_example_carries_meta() {
+    let schemas = built_in_rule_schemas_result().expect("built-in rule schemas load");
+    for schema in &schemas {
+        for example in &schema.examples {
+            assert!(
+                !example.name.is_empty(),
+                "example `{}` (rule `{}`) has an empty `name`",
+                example.slug,
+                schema.kind
+            );
+            assert!(
+                !example.use_when.is_empty(),
+                "example `{}` (rule `{}`) has an empty `use_when`",
+                example.slug,
+                schema.kind
+            );
+            assert!(
+                !example.files.is_empty(),
+                "example `{}` (rule `{}`) has no files",
+                example.slug,
+                schema.kind
+            );
+            assert!(
+                example.files.iter().any(|f| f.path.ends_with("once.toml")),
+                "example `{}` (rule `{}`) ships no once.toml manifest",
+                example.slug,
+                schema.kind
+            );
+        }
+    }
+}
+
+fn materialize(root: &Path, example: &once_frontend::RuleExample) {
+    for file in &example.files {
+        let path = root.join(&file.path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap_or_else(|err| {
+                panic!(
+                    "creating {} for example `{}`: {err}",
+                    parent.display(),
+                    example.slug
+                )
+            });
+        }
+        fs::write(&path, &file.contents).unwrap_or_else(|err| {
+            panic!(
+                "writing {} for example `{}`: {err}",
+                path.display(),
+                example.slug
+            )
+        });
+    }
+}

--- a/spec/graph_edit_spec.sh
+++ b/spec/graph_edit_spec.sh
@@ -1,0 +1,167 @@
+#shellcheck shell=bash
+# End-to-end specs for the agent-facing graph discovery and editing
+# CLI surface: `once query rules`, `once query target`,
+# `once query validate-target`, and `once edit apply`. These commands
+# mirror the MCP tool surface; the MCP tests cover the protocol layer,
+# these specs pin the CLI contract (exit codes, --format handling,
+# stdin and --file input).
+
+Describe 'once query rules'
+  It 'lists every rule kind with its example slugs in human mode'
+    When call "$ONCE_BIN" query rules
+    The status should be success
+    The stdout should include 'apple_library'
+    The stdout should include 'apple_application'
+    The stdout should include 'apple-library-minimal'
+    The stdout should include 'apple-application-minimal'
+  End
+
+  It 'emits structured JSON under --format json'
+    When call "$ONCE_BIN" --format json query rules
+    The status should be success
+    The stdout should include '"kind":"apple_library"'
+    The stdout should include '"slug":"apple-library-minimal"'
+    The stdout should include '"use_when"'
+  End
+End
+
+Describe 'once query target'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  seed_apple_library_target() {
+    mkdir -p "$WORKSPACE/apps/Hello"
+    cat > "$WORKSPACE/apps/Hello/once.toml" <<'EOF'
+[[target]]
+name = "Hello"
+kind = "apple_library"
+srcs = ["Sources/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+minimum_os = "17.0"
+EOF
+  }
+
+  It 'resolves a target by id and prints its kind and attrs'
+    seed_apple_library_target
+    When call once query target apps/Hello/Hello
+    The status should be success
+    The stdout should include 'apps/Hello/Hello (apple_library)'
+    The stdout should include 'platform'
+    The stdout should include 'ios'
+  End
+
+  It 'emits a structured record under --format json'
+    seed_apple_library_target
+    When call once --format json query target apps/Hello/Hello
+    The status should be success
+    The stdout should include '"id":"apps/Hello/Hello"'
+    The stdout should include '"kind":"apple_library"'
+    The stdout should include '"platform":"ios"'
+  End
+
+  It 'fails when the target id does not resolve'
+    seed_apple_library_target
+    When call once query target apps/Hello/Missing
+    The status should not equal 0
+    The stderr should include 'no target matches'
+  End
+End
+
+Describe 'once query validate-target'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  It 'returns valid for a minimal apple_library draft via stdin'
+    Data
+      #|{"target":{"name":"Hello","kind":"apple_library","attrs":{"platform":"ios"}}}
+    End
+    When call "$ONCE_BIN" --format json query validate-target
+    The status should be success
+    The stdout should include '"valid":true'
+  End
+
+  It 'returns structured diagnostics for a missing required attr'
+    Data
+      #|{"target":{"name":"Hello","kind":"apple_library"}}
+    End
+    When call "$ONCE_BIN" --format json query validate-target
+    The status should be success
+    The stdout should include '"valid":false'
+    The stdout should include '"code":"missing_required_attr"'
+    The stdout should include '"attribute":"platform"'
+    The stdout should include '"target":"Hello"'
+  End
+
+  It 'accepts the JSON document from --file instead of stdin'
+    cat > "$WORKSPACE/draft.json" <<'EOF'
+{"target":{"name":"Hello","kind":"apple_library","attrs":{"platform":"ios"}}}
+EOF
+    When call "$ONCE_BIN" --format json query validate-target --file "$WORKSPACE/draft.json"
+    The status should be success
+    The stdout should include '"valid":true'
+  End
+
+  It 'fails with context when the JSON does not match the expected shape'
+    Data
+      #|{"wrong":"shape"}
+    End
+    When call "$ONCE_BIN" --format json query validate-target
+    The status should not equal 0
+    The stderr should include 'validate-target input'
+  End
+End
+
+Describe 'once edit apply'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  It 'creates the manifest from nothing using a create operation via stdin'
+    Data
+      #|{"package":"apps/Hello","operations":[{"op":"create","target":{"name":"Hello","kind":"apple_library","attrs":{"platform":"ios"}}}]}
+    End
+    When call "$ONCE_BIN" -C "$WORKSPACE" --format json edit apply
+    The status should be success
+    The stdout should include '"applied":true'
+    The path "$WORKSPACE/apps/Hello/once.toml" should be file
+  End
+
+  It 'reads the operation batch from --file instead of stdin'
+    cat > "$WORKSPACE/edit.json" <<'EOF'
+{"package":"apps/Hello","operations":[{"op":"create","target":{"name":"Hello","kind":"apple_library","attrs":{"platform":"ios"}}}]}
+EOF
+    When call "$ONCE_BIN" -C "$WORKSPACE" --format json edit apply --file "$WORKSPACE/edit.json"
+    The status should be success
+    The stdout should include '"applied":true'
+    The path "$WORKSPACE/apps/Hello/once.toml" should be file
+  End
+
+  It 'returns structured diagnostics and leaves the file untouched on failure'
+    mkdir -p "$WORKSPACE/apps/Hello"
+    cat > "$WORKSPACE/apps/Hello/once.toml" <<'EOF'
+[[target]]
+name = "Hello"
+kind = "apple_library"
+EOF
+    original_sha="$(shasum "$WORKSPACE/apps/Hello/once.toml" | awk '{print $1}')"
+    Data
+      #|{"package":"apps/Hello","operations":[{"op":"delete","target_name":"Missing"}]}
+    End
+    When call "$ONCE_BIN" -C "$WORKSPACE" --format json edit apply
+    The status should be success
+    The stdout should include '"applied":false'
+    The stdout should include '"code":"target_not_found"'
+    new_sha="$(shasum "$WORKSPACE/apps/Hello/once.toml" | awk '{print $1}')"
+    The variable new_sha should equal "$original_sha"
+  End
+
+  It 'rejects input that does not match the expected JSON shape'
+    Data
+      #|not a json object
+    End
+    When call "$ONCE_BIN" -C "$WORKSPACE" --format json edit apply
+    The status should not equal 0
+    The stderr should include 'apply input'
+  End
+End


### PR DESCRIPTION
## Summary

- A coding agent can now go from "create me an iOS library" to a built target without reading docs: `once_list_rules` advertises every rule kind with example slugs, `once_query_schema` returns runnable starter examples inline (real files, not snippets), and `once_apply_edit` writes the manifest atomically. `once_validate_target` and `once_get_target` round out the read/draft/commit loop.
- Rule schema examples are now real directories under `prelude/examples/<slug>/` bundled with `include_dir!`. Three migrated this round (`apple-library-minimal`, `apple-library-with-objc`, `apple-application-minimal`); a new integration test materializes every bundled example into a tempdir and asserts it loads without diagnostics, so a rule change that breaks an example fails CI.
- `Diagnostic` now carries optional `target` and `attribute` scoping plus `repairs`. A new `manifest_editor` round-trips through `toml_edit` for atomic create/update/delete on `[[target]]` blocks; a new `target_validator` covers required attrs, unknown kinds/attrs, and type mismatches (including `list<X>` and `map<string,V>`).
- CLI mirrors every new MCP tool: `once query rules`, `once query target <id>`, `once query validate-target [--file]`, and a new top-level `once edit apply [--file]` (reads JSON from stdin when `--file` is omitted) so humans can reproduce what an agent does from the terminal.

## Testing

- `cargo test --workspace` (345 passed)
- `cargo clippy --workspace --all-targets` (clean)
- `cargo fmt --check` (clean)
- End-to-end smoke: piped `{"package":"apps/Hello","operations":[{"op":"create","target":{...}}]}` through `once edit apply`, read it back with `once query target`, and exercised `once query validate-target` against a draft missing a required attr.
- `once reference --out /tmp/once-ref` regenerated `mcp/tools.md`; verified all seven tools land there.
