### PR TITLE
feat(cli): add per-session internal logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,21 @@ the pull request description.
 - Shellspec (`spec/*.sh`) covers the CLI's external contract end to
   end. Run `mise exec -- shellspec` after a release build.
 
+## Internal Logging
+
+Every `once` CLI invocation creates a UUIDv7 session log under the
+platform log directory. On Linux this follows XDG state directory
+conventions; on macOS logs land under `~/Library/Logs/Once` so they are
+visible from Console.app.
+
+Use `tracing` for internal execution logs instead of printing debug
+information to stdout or stderr. Log enough structured context to
+reconstruct execution: command surface, target ids, action digests,
+cache hit or miss decisions, remote provider choices, retry attempts,
+durations, and failure causes. Do not log secrets, auth tokens, full
+environment dumps, or command arguments that may contain credentials.
+Prefer fields over string interpolation so logs stay queryable.
+
 ## Toolchain
 
 The repo pins `rust = "1.88"` in `mise.toml` and the workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,6 +3247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,7 +3413,9 @@ dependencies = [
  "toml",
  "toon-rust",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
+ "uuid",
  "walkdir",
 ]
 
@@ -3714,6 +3728,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -5322,6 +5342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5470,6 +5496,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -5737,6 +5793,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5769,6 +5838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5778,12 +5857,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5962,6 +6044,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,9 @@ tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 schlussel = { git = "https://github.com/tuist/schlussel.git", rev = "80a7bc1fc0b68bdc2cd2379b16240ddbfbe0267b" }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+uuid = { version = "1", features = ["v7"] }
 walkdir = "2"
 zstd = "0.13"
 

--- a/crates/once-cli/Cargo.toml
+++ b/crates/once-cli/Cargo.toml
@@ -26,7 +26,9 @@ toml.workspace = true
 toon-rust.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tracing-appender.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/crates/once-cli/src/logging.rs
+++ b/crates/once-cli/src/logging.rs
@@ -81,9 +81,10 @@ fn file_writer(
 }
 
 fn file_filter() -> EnvFilter {
-    EnvFilter::try_from_env("ONCE_LOG")
-        .or_else(|_| EnvFilter::try_from_default_env())
-        .unwrap_or_else(|_| EnvFilter::new(INTERNAL_DEFAULT_FILTER))
+    file_filter_from_env(
+        env::var("ONCE_LOG").ok().as_deref(),
+        env::var("RUST_LOG").ok().as_deref(),
+    )
 }
 
 fn stderr_filter(verbose: u8) -> EnvFilter {
@@ -93,42 +94,176 @@ fn stderr_filter(verbose: u8) -> EnvFilter {
         2 => "debug",
         _ => "trace",
     };
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default))
+    stderr_filter_from_env(env::var("RUST_LOG").ok().as_deref(), default)
+}
+
+fn file_filter_from_env(once_log: Option<&str>, rust_log: Option<&str>) -> EnvFilter {
+    once_log
+        .and_then(|filter| EnvFilter::try_new(filter).ok())
+        .or_else(|| rust_log.and_then(|filter| EnvFilter::try_new(filter).ok()))
+        .unwrap_or_else(|| EnvFilter::new(INTERNAL_DEFAULT_FILTER))
+}
+
+fn stderr_filter_from_env(rust_log: Option<&str>, default: &str) -> EnvFilter {
+    rust_log
+        .and_then(|filter| EnvFilter::try_new(filter).ok())
+        .unwrap_or_else(|| EnvFilter::new(default))
 }
 
 fn log_dir() -> std::io::Result<PathBuf> {
-    platform_log_dir().ok_or_else(|| {
+    log_dir_from(platform_log_dir())
+}
+
+fn log_dir_from(platform_dir: Option<PathBuf>) -> std::io::Result<PathBuf> {
+    platform_dir.ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::NotFound, "no platform log directory")
     })
 }
 
 #[cfg(target_os = "macos")]
 fn platform_log_dir() -> Option<PathBuf> {
-    home_dir().map(|home| home.join("Library").join("Logs").join("Once"))
+    platform_log_dir_from(home_dir())
+}
+
+#[cfg(target_os = "macos")]
+fn platform_log_dir_from(home: Option<PathBuf>) -> Option<PathBuf> {
+    home.map(|home| home.join("Library").join("Logs").join("Once"))
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn platform_log_dir() -> Option<PathBuf> {
-    xdg_state_home()
-        .or_else(|| home_dir().map(|home| home.join(".local").join("state")))
+    platform_log_dir_from(xdg_state_home(), home_dir())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn platform_log_dir_from(xdg_state: Option<PathBuf>, home: Option<PathBuf>) -> Option<PathBuf> {
+    xdg_state
+        .or_else(|| home.map(|home| home.join(".local").join("state")))
         .map(|state| state.join("once").join("logs"))
 }
 
 #[cfg(windows)]
 fn platform_log_dir() -> Option<PathBuf> {
-    env::var_os("LOCALAPPDATA")
-        .map(PathBuf::from)
-        .map(|local| local.join("Once").join("Logs"))
+    platform_log_dir_from(env::var_os("LOCALAPPDATA").map(PathBuf::from))
+}
+
+#[cfg(windows)]
+fn platform_log_dir_from(local_app_data: Option<PathBuf>) -> Option<PathBuf> {
+    local_app_data.map(|local| local.join("Once").join("Logs"))
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn xdg_state_home() -> Option<PathBuf> {
-    env::var_os("XDG_STATE_HOME")
-        .map(PathBuf::from)
-        .filter(|path| path.is_absolute())
+    xdg_state_home_from(env::var_os("XDG_STATE_HOME").map(PathBuf::from))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn xdg_state_home_from(raw: Option<PathBuf>) -> Option<PathBuf> {
+    raw.filter(|path| path.is_absolute())
 }
 
 #[cfg(unix)]
 fn home_dir() -> Option<PathBuf> {
     env::var_os("HOME").map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::filter::LevelFilter;
+
+    #[test]
+    fn file_filter_prefers_once_log_over_rust_log() {
+        let filter = file_filter_from_env(Some("once=trace"), Some("once=warn"));
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::TRACE));
+    }
+
+    #[test]
+    fn file_filter_falls_back_to_rust_log() {
+        let filter = file_filter_from_env(None, Some("once=info"));
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::INFO));
+    }
+
+    #[test]
+    fn file_filter_uses_internal_default() {
+        let filter = file_filter_from_env(None, None);
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::DEBUG));
+    }
+
+    #[test]
+    fn stderr_filter_prefers_rust_log_over_verbose_default() {
+        let filter = stderr_filter_from_env(Some("once=trace"), "warn");
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::TRACE));
+    }
+
+    #[test]
+    fn stderr_filter_uses_verbose_default() {
+        let filter = stderr_filter_from_env(None, "info");
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::INFO));
+    }
+
+    #[test]
+    fn log_dir_errors_without_platform_directory() {
+        let error = log_dir_from(None).expect_err("missing log dir should error");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn log_dir_returns_platform_directory() {
+        let expected = PathBuf::from("/tmp/once-logs");
+        assert_eq!(log_dir_from(Some(expected.clone())).unwrap(), expected);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn platform_log_dir_uses_macos_library_logs() {
+        assert_eq!(
+            platform_log_dir_from(Some(PathBuf::from("/Users/test"))).unwrap(),
+            PathBuf::from("/Users/test/Library/Logs/Once")
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn platform_log_dir_uses_xdg_state_home() {
+        assert_eq!(
+            platform_log_dir_from(
+                Some(PathBuf::from("/state")),
+                Some(PathBuf::from("/home/test"))
+            )
+            .unwrap(),
+            PathBuf::from("/state/once/logs")
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn platform_log_dir_falls_back_to_home_state() {
+        assert_eq!(
+            platform_log_dir_from(None, Some(PathBuf::from("/home/test"))).unwrap(),
+            PathBuf::from("/home/test/.local/state/once/logs")
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn xdg_state_home_requires_absolute_path() {
+        assert_eq!(
+            xdg_state_home_from(Some(PathBuf::from("relative/state"))),
+            None
+        );
+        assert_eq!(
+            xdg_state_home_from(Some(PathBuf::from("/absolute/state"))).unwrap(),
+            PathBuf::from("/absolute/state")
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn platform_log_dir_uses_local_app_data() {
+        assert_eq!(
+            platform_log_dir_from(Some(PathBuf::from(r"C:\Users\test\AppData\Local"))).unwrap(),
+            PathBuf::from(r"C:\Users\test\AppData\Local\Once\Logs")
+        );
+    }
 }

--- a/crates/once-cli/src/logging.rs
+++ b/crates/once-cli/src/logging.rs
@@ -1,0 +1,134 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+use uuid::Uuid;
+
+const INTERNAL_DEFAULT_FILTER: &str =
+    "once=debug,once_cli=debug,once_core=debug,once_cas=debug,once_frontend=debug,warn";
+
+pub struct Logging {
+    session_id: Uuid,
+    log_path: Option<PathBuf>,
+    _guard: Option<WorkerGuard>,
+}
+
+impl Logging {
+    pub fn session_id(&self) -> Uuid {
+        self.session_id
+    }
+
+    pub fn log_path(&self) -> Option<&Path> {
+        self.log_path.as_deref()
+    }
+}
+
+pub fn init(verbose: u8) -> Logging {
+    let session_id = Uuid::now_v7();
+    let stderr_filter = stderr_filter(verbose);
+
+    if let Ok((dir, (writer, guard))) =
+        log_dir().and_then(|dir| file_writer(&dir, session_id).map(|writer| (dir, writer)))
+    {
+        let log_path = dir.join(format!("{session_id}.log"));
+        let file_filter = file_filter();
+        let file_layer = fmt::layer()
+            .json()
+            .with_ansi(false)
+            .with_current_span(true)
+            .with_span_list(true)
+            .with_target(true)
+            .with_thread_ids(true)
+            .with_thread_names(true)
+            .with_writer(writer)
+            .with_filter(file_filter);
+        let stderr_layer = fmt::layer()
+            .with_writer(std::io::stderr)
+            .with_filter(stderr_filter);
+
+        tracing_subscriber::registry()
+            .with(file_layer)
+            .with(stderr_layer)
+            .init();
+
+        return Logging {
+            session_id,
+            log_path: Some(log_path),
+            _guard: Some(guard),
+        };
+    }
+
+    fmt()
+        .with_env_filter(stderr_filter)
+        .with_writer(std::io::stderr)
+        .init();
+
+    Logging {
+        session_id,
+        log_path: None,
+        _guard: None,
+    }
+}
+
+fn file_writer(
+    dir: &Path,
+    session_id: Uuid,
+) -> std::io::Result<(tracing_appender::non_blocking::NonBlocking, WorkerGuard)> {
+    std::fs::create_dir_all(dir)?;
+    let appender = tracing_appender::rolling::never(dir, format!("{session_id}.log"));
+    Ok(tracing_appender::non_blocking(appender))
+}
+
+fn file_filter() -> EnvFilter {
+    EnvFilter::try_from_env("ONCE_LOG")
+        .or_else(|_| EnvFilter::try_from_default_env())
+        .unwrap_or_else(|_| EnvFilter::new(INTERNAL_DEFAULT_FILTER))
+}
+
+fn stderr_filter(verbose: u8) -> EnvFilter {
+    let default = match verbose {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default))
+}
+
+fn log_dir() -> std::io::Result<PathBuf> {
+    platform_log_dir().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "no platform log directory")
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn platform_log_dir() -> Option<PathBuf> {
+    home_dir().map(|home| home.join("Library").join("Logs").join("Once"))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn platform_log_dir() -> Option<PathBuf> {
+    xdg_state_home()
+        .or_else(|| home_dir().map(|home| home.join(".local").join("state")))
+        .map(|state| state.join("once").join("logs"))
+}
+
+#[cfg(windows)]
+fn platform_log_dir() -> Option<PathBuf> {
+    env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .map(|local| local.join("Once").join("Logs"))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn xdg_state_home() -> Option<PathBuf> {
+    env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+}
+
+#[cfg(unix)]
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME").map(PathBuf::from)
+}

--- a/crates/once-cli/src/main.rs
+++ b/crates/once-cli/src/main.rs
@@ -6,40 +6,71 @@ mod cache_provider;
 mod cli;
 mod commands;
 mod dispatch;
+mod logging;
 mod reference;
 mod render;
 
 use std::process::ExitCode;
 
 use clap::Parser;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing::Instrument;
 
 use cli::Cli;
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    let cli = Cli::parse();
-    init_tracing(cli.verbose);
-    match Box::pin(dispatch::dispatch(cli)).await {
-        Ok(code) => code,
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => return handle_parse_error(&e),
+    };
+    let command = cli.surface_path().join(" ");
+    let logging = logging::init(cli.verbose);
+    let session_id = logging.session_id();
+    let log_path = log_path(&logging);
+    let session = tracing::info_span!("once_session", session_id = %session_id);
+    tracing::info!(
+        session_id = %session_id,
+        command = if command.is_empty() {
+            "help"
+        } else {
+            command.as_str()
+        },
+        log_path,
+        "session started"
+    );
+
+    match Box::pin(dispatch::dispatch(cli).instrument(session)).await {
+        Ok(code) => {
+            tracing::info!(session_id = %session_id, exit_code = ?code, "session finished");
+            code
+        }
         Err(e) => {
+            tracing::error!(session_id = %session_id, error = %e, "session failed");
             eprintln!("once: {e:#}");
             ExitCode::from(2)
         }
     }
 }
 
-fn init_tracing(verbose: u8) {
-    // RUST_LOG always wins; otherwise -v sets the floor.
-    let default = match verbose {
-        0 => "warn",
-        1 => "info",
-        2 => "debug",
-        _ => "trace",
-    };
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default));
-    fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .init();
+fn handle_parse_error(e: &clap::Error) -> ExitCode {
+    let logging = logging::init(0);
+    let log_path = log_path(&logging);
+    let code = cli::exit_from(e.exit_code());
+    tracing::info!(
+        session_id = %logging.session_id(),
+        log_path,
+        exit_code = ?code,
+        "argument parsing stopped"
+    );
+    if let Err(print_error) = e.print() {
+        tracing::error!(error = %print_error, "failed to print clap error");
+    }
+    code
+}
+
+fn log_path(logging: &logging::Logging) -> String {
+    logging.log_path().map_or_else(
+        || "unavailable".to_string(),
+        |path| path.display().to_string(),
+    )
 }

--- a/spec/cli_surface_spec.sh
+++ b/spec/cli_surface_spec.sh
@@ -79,4 +79,15 @@ Describe 'once exec -e'
     The status should not equal 0
     The stderr should include 'KEY=VALUE'
   End
+
+  It 'logs argument parsing failures to an internal session log'
+    When call once exec -e MALFORMED -- /bin/sh -c 'true'
+    The status should not equal 0
+    The stderr should include 'KEY=VALUE'
+    log_dir="$(once_log_dir)"
+    log_file="$(find "$log_dir" -type f -name '*.log' | sort | head -n 1)"
+    The path "$log_file" should be file
+    The contents of file "$log_file" should include '"message":"argument parsing stopped"'
+    The contents of file "$log_file" should include '"session_id"'
+  End
 End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -24,8 +24,10 @@ setup_workspace() {
   XDG_DATA_HOME="$WORKSPACE/.xdg/data"
   XDG_CONFIG_HOME="$WORKSPACE/.xdg/config"
   XDG_RUNTIME_DIR="$WORKSPACE/.xdg/runtime"
-  mkdir -p "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_RUNTIME_DIR"
-  export WORKSPACE XDG_CACHE_HOME XDG_STATE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_RUNTIME_DIR
+  SPEC_ORIGINAL_HOME="${HOME:-}"
+  HOME="$WORKSPACE/.home"
+  mkdir -p "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_RUNTIME_DIR" "$HOME"
+  export WORKSPACE XDG_CACHE_HOME XDG_STATE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_RUNTIME_DIR HOME SPEC_ORIGINAL_HOME
 }
 
 cleanup_workspace() {
@@ -33,11 +35,28 @@ cleanup_workspace() {
     rm -rf "$WORKSPACE"
     unset WORKSPACE
   fi
-  unset XDG_CACHE_HOME XDG_STATE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_RUNTIME_DIR
+  if [ -n "${SPEC_ORIGINAL_HOME:-}" ]; then
+    HOME="$SPEC_ORIGINAL_HOME"
+    export HOME
+  else
+    unset HOME
+  fi
+  unset XDG_CACHE_HOME XDG_STATE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_RUNTIME_DIR SPEC_ORIGINAL_HOME
 }
 
 once() {
   "$ONCE_BIN" -C "$WORKSPACE" "$@"
+}
+
+once_log_dir() {
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s\n' "$HOME/Library/Logs/Once"
+      ;;
+    *)
+      printf '%s\n' "$XDG_STATE_HOME/once/logs"
+      ;;
+  esac
 }
 
 microsandbox_specs_disabled() {


### PR DESCRIPTION
## Summary
- Adds a per-invocation internal tracing session with a UUIDv7 log file, using non-blocking JSONL writes so diagnostic logging stays off stdout and stderr.
- Stores session logs in platform log locations: XDG state directories on Linux, `~/Library/Logs/Once` on macOS for Console.app visibility, and `LOCALAPPDATA` on Windows.
- Preserves existing stderr verbosity behavior while adding internal startup, completion, failure, and argument-parse early-exit events.
- Documents what contributors and agents should log, including cache decisions, action digests, provider choices, retries, durations, and failure causes without secrets.

## Testing
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo check -p once-cli`
- `mise exec -- cargo clippy -p once-cli --all-targets -- -D warnings`
- `mise exec -- env HOME=<temporary directory> cargo run -q -p once-cli -- --list`
- `mise exec -- env HOME=<temporary directory> cargo run -q -p once-cli -- --help`
