### PR TITLE
Position scripts as graph adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 # Once
 
-Once makes project scripts cacheable, observable, and remotely executable. Declare the inputs, outputs, environment, and runtime contract once, then reuse the result locally, in CI, or on a compute provider.
+Once makes repository automation graph-aware, cacheable, observable, and remotely executable. Model work as targets with capabilities that lower into content-addressed actions. Existing scripts can join the same action model immediately through `once exec` or script targets, so teams can start without rewriting the automation they already have.
 
 ## Quick Start
 
-Describe a script with `# once` annotations:
+Start by adapting an existing script. Add a small contract that names the files, outputs, environment, and working directory that shape the action:
 
 ```sh
 #!/usr/bin/env bash
@@ -25,7 +25,7 @@ Describe a script with `# once` annotations:
 npm run build-assets
 ```
 
-Run it through the cache:
+Run it as a cached action:
 
 ```sh
 once exec -- bash scripts/build-assets.sh
@@ -37,6 +37,8 @@ Scripts can also run directly with a Once shebang:
 ```sh
 #!/usr/bin/env -S once exec -- bash
 ```
+
+When the workflow needs dependencies, multiple capabilities, typed validation, or agent-editable structure, move it into the build graph and let the rule lower the target into the same action substrate.
 
 ## Documentation
 

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -78,7 +78,7 @@ pub const CLI_VERSION: &str = match option_env!("ONCE_VERSION") {
 #[command(
     name = "once",
     version = CLI_VERSION,
-    about = "Cacheable and remotely executable project scripts",
+    about = "Graph-aware, cacheable, remotely-executable repository automation",
     arg_required_else_help = true
 )]
 pub struct Cli {
@@ -131,10 +131,11 @@ pub enum Cmd {
         target: Option<String>,
     },
 
-    /// Run a declared target action.
+    /// Run a declared target.
     ///
-    /// Finds the matching target and runs it through the action cache.
-    /// Use `--remote` to ask a compute provider to execute the command.
+    /// Resolves the target id against the workspace graph and executes
+    /// its `run` capability through the action cache. Use `--remote`
+    /// to ask a compute provider to execute the command.
     #[command(arg_required_else_help = true)]
     Run {
         /// Serve a local JSON-RPC runtime control socket for this run.
@@ -171,10 +172,10 @@ pub enum Cmd {
         target: Option<String>,
     },
 
-    /// Cache and execute a literal command (substrate escape hatch).
+    /// Execute a literal action through the cache.
     ///
-    /// Bypasses the target graph and puts any argv through the action
-    /// cache. The cache key is the full argv, declared environment
+    /// Low-level action surface for direct commands and script
+    /// adapters. The cache key is the full argv, declared environment
     /// variables, optional working directory, and optional timeout. A
     /// second invocation with the same key reuses the captured stdout,
     /// stderr, and exit code. With `--script`, or when argv looks like
@@ -255,9 +256,9 @@ pub enum Cmd {
     /// Inspect the project toolchain contract.
     ///
     /// Reports the toolchains a project pins (Rust, Swift, mise) and
-    /// the resolved versions Once will use when running cacheable
-    /// scripts or graph actions. Pair with `once query schema` when
-    /// debugging "why did the cache miss?" questions where the
+    /// the resolved versions Once will use when running actions from
+    /// script adapters or graph rules. Pair with `once query schema`
+    /// when debugging "why did the cache miss?" questions where the
     /// toolchain identity is suspect.
     #[command(arg_required_else_help = true)]
     Toolchain {

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -1,10 +1,9 @@
-//! `once exec` - cache and execute a literal command or script file.
+//! `once exec` - execute a literal action through the cache.
 //!
-//! Substrate-level escape hatch: bypass the target graph and put any
-//! argv through the action cache. Useful for ad-hoc shell-outs and for
-//! exercising the cache directly. With `--script`, or when argv looks
-//! like `<runtime> <script> [args...]` and the file carries `once`
-//! headers, Once treats argv as a script execution request.
+//! Low-level action surface for direct commands, ad-hoc shell-outs, and
+//! script adapters. With `--script`, or when argv looks like `<runtime>
+//! <script> [args...]` and the file carries `once` headers, Once treats
+//! argv as a script execution request.
 //!
 //! Stdout always carries the wrapped program's stdout verbatim
 //! (transparency), regardless of `--format`. Stderr carries the

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -1,9 +1,9 @@
 //! `once exec` - execute a literal action through the cache.
 //!
 //! Low-level action surface for direct commands, ad-hoc shell-outs, and
-//! script adapters. With `--script`, or when argv looks like `<runtime>
-//! <script> [args...]` and the file carries `once` headers, Once treats
-//! argv as a script execution request.
+//! script adapters. With `--script`, or when argv names a runtime, script,
+//! and optional args and the file carries `once` headers, Once treats argv
+//! as a script execution request.
 //!
 //! Stdout always carries the wrapped program's stdout verbatim
 //! (transparency), regardless of `--format`. Stderr carries the

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -468,7 +468,7 @@ fn list<'v>(value: Value<'v>, path: &str) -> std::result::Result<&'v ListRef<'v>
 fn script_schema() -> RuleSchema {
     RuleSchema {
         kind: "script".to_string(),
-        docs: "Migration target that wraps an annotated script action.".to_string(),
+        docs: "Adapter target that wraps existing executable automation.".to_string(),
         attrs: vec![
             attr(
                 "script_path",

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -1,8 +1,8 @@
 //! Once manifest frontend.
 //!
 //! Loads declarative `once.toml` package files into a shared
-//! [`Target`] IR. TOML keeps cacheable script declarations literal
-//! and straightforward for humans and agents to patch.
+//! [`Target`] IR. TOML keeps target declarations literal and
+//! straightforward for humans and agents to patch.
 
 pub mod analysis;
 mod cache_provider;

--- a/docs/guide/cache-cli.md
+++ b/docs/guide/cache-cli.md
@@ -13,12 +13,12 @@ operating across ten parallel worktrees redoes the same codegen step
 ten times because none of the workers know the others already paid
 for it.
 
-The `once cache` CLI exposes Once's content-addressed store
-directly to those scripts so they can stop. Declare the inputs that
-determine a result, ask the cache whether you have already produced
-that result, and either skip the work or restore the artifact. The
-script stays a script. The speedup comes from the same store that Once
-uses for declared script actions.
+The `once cache` CLI exposes Once's content-addressed store directly to
+those scripts so they can stop. Declare the inputs that determine a
+result, ask the cache whether you have already produced that result, and
+either skip the work or restore the artifact. The script stays a script.
+The speedup comes from the same store used by script adapters and typed
+graph rules.
 
 The surface is small. Two caches, mirroring the shape that Bazel and
 the [Remote Execution API](https://github.com/bazelbuild/remote-apis)

--- a/docs/guide/graph/index.md
+++ b/docs/guide/graph/index.md
@@ -1,27 +1,28 @@
 # Graph
 
-The Once graph is a typed build model that sits above the cacheable
-script ramp. When teams need richer relationships than scripts can
-express, the same work moves into typed graph targets that carry
-schemas, dep edges, capabilities, and structured diagnostics.
+The Once graph is the product model for repository automation. Targets
+declare what exists in the workspace, capabilities describe what can be
+done with those targets, and rules lower each capability into
+content-addressed actions that can run locally, replay from cache, or move
+to a compute provider.
 
 ## Where the Graph Fits
 
-Once has three layers:
+Once has a small set of durable concepts:
 
-1. **Script actions**: annotated scripts that `once exec` runs through
-   the action cache. See [Scripts](/guide/scripts/).
-2. **Script targets**: declared graph targets that wrap a script
-   action so it participates alongside typed rules.
-3. **Build graph targets**: typed targets validated against a *rule
-   schema* (the contract for a kind: which attributes it accepts,
-   which providers each dep edge expects, which providers it emits,
-   and which capabilities it exposes), carrying typed attributes,
-   declared outputs, and structured diagnostics.
+1. **Targets**: named units in the workspace.
+2. **Capabilities**: operations a target exposes, such as `build`, `run`,
+   and `test`.
+3. **Actions**: concrete executable work with inputs, outputs,
+   environment, platform requirements, and cache identity.
+4. **Rules**: typed logic that validates targets and lowers capabilities
+   into actions.
+5. **Scripts**: the least typed rule-backed adapter for existing
+   executable files.
 
-Scripts are the migration ramp. Teams move into graph targets when
-they need stronger relationships, multiple capabilities, or richer
-diagnostics.
+Scripts are not outside the graph. They are the easiest way to enter it.
+Teams move from script targets into richer typed rules when they need
+stronger relationships, multiple capabilities, or structured diagnostics.
 
 ## Targets
 
@@ -70,10 +71,10 @@ that artifact and expose `run`; and a test runner rule might expose
 `test`.
 
 The CLI dispatches on capability, and every capability runs through the
-same action substrate scripts use. Build actions can replay from cache
-when their inputs match. Run and test actions may still produce cached
-outputs, but rules can declare side-effectful work that must happen for
-the requested invocation.
+same action substrate. Build actions can replay from cache when their
+inputs match. Run and test actions may still produce cached outputs, but
+rules can declare side-effectful work that must happen for the requested
+invocation.
 
 ```sh
 once query targets

--- a/docs/guide/scripts/caching.md
+++ b/docs/guide/scripts/caching.md
@@ -1,13 +1,14 @@
 # Caching
 
-Script files are the easiest way to make existing repository automation
-cacheable through Once without rewriting the implementation.
+Script files are the easiest adapter for bringing existing repository
+automation into Once's action model without rewriting the implementation.
 
 Most repositories already have a layer of shell, Node, Python, Ruby, or
 Elixir automation that does real work but lives outside the native build
 graph. Once lets those scripts stay where they are. The script file
 remains the source of truth, and Once learns just enough about it to
-cache it, inspect it, and schedule it safely.
+cache it, inspect it, and schedule it safely through the same action
+substrate typed graph rules use.
 
 ## Annotated Script Files
 

--- a/docs/guide/scripts/index.md
+++ b/docs/guide/scripts/index.md
@@ -1,8 +1,8 @@
 # Scripts
 
-Scripts are the first way Once makes cacheable actions concrete. Keep the
+Scripts are Once's adapter for existing executable automation. Keep the
 file, keep the implementation, and add a small contract that tells Once
-what the script reads, what it writes, and which host values affect the
+what the action reads, what it writes, and which host values affect the
 result.
 
 ## Why Scripts
@@ -14,12 +14,13 @@ execution model. A developer, CI job, or agent runs them again because
 there is no shared contract that says what changed.
 
 Once gives those scripts that contract without asking teams to move the
-implementation into a new build-system shape.
+implementation into a new build-system shape. A script is the least typed
+way to enter the same graph and action model that typed rules use.
 
-::: tip Scripts are the migration ramp
-Build systems can model cacheable workflows with rich dependency graphs.
-Once starts with the scripts you already have so teams can make them
-cacheable before moving the same work into typed build graph targets.
+::: tip Scripts are adapters
+Use scripts when the workflow is still one opaque executable action. Move
+the work into a typed graph rule when it needs dependencies, multiple
+capabilities, structured diagnostics, or agent-editable shape.
 :::
 
 ## How It Works

--- a/docs/guide/scripts/runtime.md
+++ b/docs/guide/scripts/runtime.md
@@ -2,7 +2,7 @@
 
 Once exposes cache primitives at runtime through the `once cache` CLI.
 That gives ordinary scripts direct access to the same content-addressed
-store and action cache that Once uses for annotated script files.
+store and action cache that every Once action uses.
 
 Most repositories have a long tail of scripts that exist next to the
 build: test runners, codegen, dependency installs, environment
@@ -19,8 +19,8 @@ for it.
 
 Declare the inputs that determine a result, ask the cache whether you
 have already produced that result, and either skip the work or restore
-the artifact. The script stays a script. The speedup comes from the
-same store that Once uses for declared script actions.
+the artifact. The script stays a script. The speedup comes from the same
+store used by script adapters and typed graph rules.
 
 The surface is small: a content-addressed store of bytes, plus a map
 from an action's input digest to the result that input produced.

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -42,10 +42,11 @@ automation workflow to one provider.
 
 Once is the [narrow waist](https://en.wikipedia.org/wiki/Hourglass_model)
 between automation needs and the infrastructure that can make those
-workflows faster. Above Once, developers and agents describe actions:
-inputs, outputs, environment, working directory, runtime metadata, and the
-provider capabilities they need. Below Once, providers can supply local
-cache storage, shared cache storage, remote compute, or future execution
+workflows faster. Above Once, developers and agents describe targets,
+capabilities, and the actions those capabilities lower into: inputs,
+outputs, environment, working directory, runtime metadata, and the provider
+capabilities they need. Below Once, providers can supply local cache
+storage, shared cache storage, remote compute, or future execution
 surfaces.
 
 Keeping that waist small matters. The action contract should be simple
@@ -53,9 +54,10 @@ enough for agents to reason about, stable enough for providers to
 implement, and flexible enough for teams to keep using the tools they
 already have.
 
-We are starting with [scripts](/guide/scripts/) because scripts are
-everywhere, and they already encode real repository knowledge. But the
-model is not limited to scripts. Once is an interface for automation needs,
-with room to grow toward build-system integrations and agent-facing
-workflows where text and voice can become the way people declare what they
-want the system to run, cache, inspect, or parallelize.
+The durable model is not a script product with a graph attached. It is a
+graph and action system with a script adapter for the automation
+repositories already have. Scripts are everywhere, and they already encode
+real repository knowledge, so Once lets them enter the model immediately.
+When that work needs richer dependencies, multiple capabilities,
+structured diagnostics, or agent-driven edits, it can move into typed graph
+targets without changing the execution substrate underneath it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "Once"
   text: "Run once. Reuse anywhere."
-  tagline: Once turns ordinary project automation into content-addressed actions with explicit inputs, outputs, environment, and runtime metadata.
+  tagline: Once turns repository automation into graph-aware, content-addressed actions with explicit inputs, outputs, environment, and runtime metadata.
   image:
     src: /logo.png
     alt: Once
@@ -16,11 +16,13 @@ hero:
       text: SDK
       link: /guide/sdk/rust
     - theme: alt
-      text: Scripts
-      link: /guide/scripts/
+      text: Graph
+      link: /guide/graph/
 features:
-  - title: Actions stay flexible
-    details: Keep existing commands, tools, and workflows in place. Add a small execution contract around the work you want to cache.
+  - title: Graph-aware automation
+    details: Model work as targets with build, run, and test capabilities that agents and humans can query before executing anything.
+  - title: Flexible action adapters
+    details: Keep existing scripts and tools in place while they lower into the same content-addressed action model as typed rules.
   - title: Deterministic cache keys
     details: Inputs, outputs, environment variables, working directories, and timeouts become part of the action contract.
   - title: Providers

--- a/docs/reference/cli/exec.md
+++ b/docs/reference/cli/exec.md
@@ -1,6 +1,6 @@
 # `once exec`
 
-Cache and execute a literal command (substrate escape hatch)
+Execute a literal action through the cache
 
 ## Synopsis
 
@@ -10,7 +10,7 @@ once exec [OPTIONS] [ARGV]
 
 ## Description
 
-Bypasses the target graph and puts any argv through the action cache. The cache key is the full argv, declared environment variables, optional working directory, and optional timeout. A second invocation with the same key reuses the captured stdout, stderr, and exit code. With `--script`, or when argv looks like `<runtime> <script> [args...]` and the file has `once` headers, Once applies script-aware parsing instead.
+Low-level action surface for direct commands and script adapters. The cache key is the full argv, declared environment variables, optional working directory, and optional timeout. A second invocation with the same key reuses the captured stdout, stderr, and exit code. With `--script`, or when argv looks like `<runtime> <script> [args...]` and the file has `once` headers, Once applies script-aware parsing instead.
 
 ## Arguments
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -8,10 +8,10 @@ Every subcommand the `once` binary exposes, with its synopsis, options, and argu
 - [`once build`](/reference/cli/build): Build a declared target
 - [`once cache`](/reference/cli/cache): Cache management
 - [`once edit`](/reference/cli/edit): Mutate workspace manifests
-- [`once exec`](/reference/cli/exec): Cache and execute a literal command (substrate escape hatch)
+- [`once exec`](/reference/cli/exec): Execute a literal action through the cache
 - [`once mcp`](/reference/cli/mcp): Expose Once's graph queries to a coding agent over MCP
 - [`once query`](/reference/cli/query): Query the typed build graph
-- [`once run`](/reference/cli/run): Run a declared target action
+- [`once run`](/reference/cli/run): Run a declared target
 - [`once runtime`](/reference/cli/runtime): Runtime session inspection and control
 - [`once test`](/reference/cli/test): Test a declared target
 - [`once toolchain`](/reference/cli/toolchain): Inspect the project toolchain contract

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -1,6 +1,6 @@
 # `once run`
 
-Run a declared target action
+Run a declared target
 
 ## Synopsis
 
@@ -10,7 +10,7 @@ once run [OPTIONS] [TARGET]
 
 ## Description
 
-Finds the matching target and runs it through the action cache. Use `--remote` to ask a compute provider to execute the command.
+Resolves the target id against the workspace graph and executes its `run` capability through the action cache. Use `--remote` to ask a compute provider to execute the command.
 
 ## Arguments
 

--- a/docs/reference/cli/toolchain.md
+++ b/docs/reference/cli/toolchain.md
@@ -10,7 +10,7 @@ once toolchain [OPTIONS] <SUBCOMMAND>
 
 ## Description
 
-Reports the toolchains a project pins (Rust, Swift, mise) and the resolved versions Once will use when running cacheable scripts or graph actions. Pair with `once query schema` when debugging "why did the cache miss?" questions where the toolchain identity is suspect.
+Reports the toolchains a project pins (Rust, Swift, mise) and the resolved versions Once will use when running actions from script adapters or graph rules. Pair with `once query schema` when debugging "why did the cache miss?" questions where the toolchain identity is suspect.
 
 ## Options
 

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,6 +1,6 @@
 export const site = {
   description:
-    "Once makes project automation cacheable, observable, and remotely executable.",
+    "Once makes repository automation graph-aware, cacheable, observable, and remotely executable.",
   nav: [
     { text: "Docs", link: "/" },
     { text: "Reference", link: "/reference/" },
@@ -62,20 +62,20 @@ export const site = {
     "/": [
       { text: "Why", link: "/guide/why" },
       {
+        text: "Graph",
+        collapsed: false,
+        items: [
+          { text: "Overview", link: "/guide/graph/" },
+          { text: "Apple", link: "/guide/graph/apple" },
+        ],
+      },
+      {
         text: "Scripts",
         collapsed: false,
         items: [
           { text: "Overview", link: "/guide/scripts/" },
           { text: "Caching", link: "/guide/scripts/caching" },
           { text: "Runtime", link: "/guide/scripts/runtime" },
-        ],
-      },
-      {
-        text: "Graph",
-        collapsed: false,
-        items: [
-          { text: "Overview", link: "/guide/graph/" },
-          { text: "Apple", link: "/guide/graph/apple" },
         ],
       },
       {

--- a/rfcs/0001-build-graph.md
+++ b/rfcs/0001-build-graph.md
@@ -2,10 +2,10 @@
 
 ## Summary
 
-Once is expanding from cacheable scripts into build-system capabilities. Scripts
-remain the migration ramp: teams can make existing automation cacheable first,
-then move the same work into a typed build graph when they need richer target
-relationships, queries, diagnostics, and agent-driven edits.
+Once is expanding around a graph and action model for repository automation.
+Scripts remain the adapter for existing work: teams can make automation
+cacheable first, then move the same work into typed graph rules when they need
+richer target relationships, queries, diagnostics, and agent-driven edits.
 
 The first product slice should focus on Apple platforms. The goal is to model
 Apple libraries, frameworks, applications, application runs, and tests well
@@ -28,8 +28,8 @@ for coding agents from the beginning.
 - Run application targets through an explicit run capability that depends on
   build outputs.
 - Run tests through an explicit test capability with structured test results.
-- Keep scripts as first-class migration targets instead of replacing the
-  existing `once exec` workflow.
+- Keep scripts as first-class adapters into the action model instead of
+  replacing the existing `once exec` workflow.
 - Give agents schema introspection, structured graph operations, structured
   diagnostics, repair suggestions, and explanation queries.
 - Preserve Once's action cache, content-addressed storage, remote execution,
@@ -46,13 +46,16 @@ for coding agents from the beginning.
 
 ## Product Model
 
-Once has three layers:
+Once has a small set of durable concepts:
 
-1. Script actions: existing scripts with `# once` annotations, runnable through
-   `once exec`.
-2. Script targets: implicit or declared graph targets that wrap script actions.
-3. Build graph targets: typed targets with rule schemas, dependencies,
-   capabilities, providers, outputs, diagnostics, and queries.
+1. Targets: named units in the workspace.
+2. Capabilities: operations a target exposes, such as `build`, `run`, and
+   `test`.
+3. Actions: concrete executable work with inputs, outputs, environment,
+   platform requirements, and cache identity.
+4. Rules: typed logic that validates targets and lowers capabilities into
+   actions.
+5. Scripts: the least typed rule-backed adapter for existing executable files.
 
 The Apple platform is the first full build graph proving ground because it
 requires the system to model real build-system complexity: compile actions,
@@ -156,8 +159,8 @@ The initial Apple rule families should be small but real:
   metadata.
 - `apple_test_bundle`: builds and runs XCTest-style test bundles, including
   app-hosted tests when needed.
-- `script`: keeps existing annotated scripts available as graph targets during
-  migration.
+- `script`: keeps existing executable automation available as graph targets
+  during migration.
 
 The RFC does not require copying Bazel or Buck rule names or attributes. It
 requires studying their Apple rules for the provider boundaries and build
@@ -351,7 +354,7 @@ Suggested order:
    diagnostic models in Rust.
 2. Load canonical `once.toml` target declarations without changing existing
    script execution.
-3. Represent implicit script targets so scripts appear in graph queries.
+3. Represent script adapter targets so scripts appear in graph queries.
 4. Add schema introspection for a small built-in Apple rule set.
 5. Add `once query targets` and `once query capabilities`.
 6. Add configured graph and action graph placeholders for Apple build, run, and

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -58,7 +58,7 @@ Describe 'apple graph'
     The stdout should include 'apps/ios/AppCore (apple_library) [build]'
     The stdout should include 'apps/ios/DesignSystem (apple_framework) [build]'
     The stdout should include 'apps/ios/App (apple_application) [build]'
-    The stdout should include 'apps/ios/AppTests (apple_test_bundle) [build]'
+    The stdout should include 'apps/ios/AppTests (apple_test_bundle) [build, test]'
   End
 
   It 'exposes build-only Apple application artifacts'
@@ -170,7 +170,7 @@ Describe 'apple graph'
     The status should be success
     The stdout should include 'apple_test_bundle'
     The stdout should include 'build: default, bundle, dsyms'
-    The stdout should not include 'test: default'
+    The stdout should include 'test: default, test_results, coverage'
   End
 
   It 'errors when building a target id that does not match'


### PR DESCRIPTION
## Summary
- Reframes Once around graph-aware repository automation and content-addressed actions instead of script-first positioning.
- Updates the graph, scripts, cache, homepage, README, and RFC docs to describe scripts as adapters into the graph/action model.
- Aligns CLI descriptions, generated reference pages, and the built-in `script` rule schema wording with the new model.

## Testing
- `mise exec -- cargo run -p once-cli -- reference --out docs/reference`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-frontend`
- `mise exec -- cargo test -p once-cli reference`
- `cd docs && mise exec -- aube ci && mise exec -- aube run build`
- `git diff --check`
