### PR TITLE
fat: Support Apple app run and Swift Testing bundles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,12 @@ prose docs. When adding support for a new toolchain (Android, JVM,
 Rust, etc.), mirror the shape already established for the Apple rules
 rather than inventing a parallel surface.
 
+Rust code must stay toolchain-agnostic. Do not add Rust branches that
+recognize Apple, Android, JVM, Rust, or any other build system by name.
+Build system behavior belongs in rules. The Rust side should provide
+generic primitives, typed graph plumbing, validation surfaces, and
+execution policy that rules can compose to express their needs.
+
 Every new toolchain rule should preserve these invariants:
 
 - The rule is discoverable through `once_list_rules` and its full

--- a/blick.toml
+++ b/blick.toml
@@ -1,6 +1,6 @@
 [agent]
 kind = "opencode"
-model = "fireworks-ai/accounts/fireworks/models/kimi-k2p5"
+model = "fireworks-ai/accounts/fireworks/models/kimi-k2p7-code"
 
 [defaults]
 base = "origin/main"

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -315,7 +315,8 @@ pub enum Cmd {
     /// `once_query_targets`, `once_query_capabilities`, and
     /// `once_query_schema` as tools and get JSON back without
     /// scraping prose. Mounts inspection tools by default; pass
-    /// `--allow-run` to expose side-effectful runtime session tools.
+    /// `--allow-run` to expose side-effectful build, run, and
+    /// runtime session tools.
     Mcp {
         /// Workspace root the MCP tools resolve targets against.
         /// Defaults to the value of the global `-C/--directory` flag
@@ -323,7 +324,7 @@ pub enum Cmd {
         #[arg(long, value_name = "DIR")]
         workspace: Option<PathBuf>,
 
-        /// Advertise and allow side-effectful runtime session tools.
+        /// Advertise and allow side-effectful execution tools.
         #[arg(long)]
         allow_run: bool,
     },

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -4,11 +4,10 @@
 //! For every target the driver calls [`once_frontend::analysis::analyze_target`].
 //! When the rule has an `impl` callable the analysis returns a list of
 //! `DeclaredAction`s plus a provider record; we materialise each
-//! declared command as a cacheable `Action`, run it through
-//! `once_core::run_with_cache`, and pass the resulting provider down
-//! to consumers. When the rule has no `impl` declared in the prelude,
-//! the driver returns `None` so the caller can fall back to its generic
-//! marker action.
+//! declared command according to its cache policy and pass the resulting
+//! provider down to consumers. When the rule has no `impl` declared in
+//! the prelude, the driver returns `None` so the caller can fall back to
+//! its generic marker action.
 //!
 //! This module has no Apple-specific logic: it consults the prelude
 //! via `rule_has_impl` to know which kinds run through analysis, and

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -1,4 +1,6 @@
 use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use once_cas::{CacheProvider, Digest};
@@ -7,6 +9,7 @@ use once_core::{
 };
 use once_frontend::analysis::{AnalysisResult, DeclaredAction};
 use once_frontend::GraphTarget;
+use tokio::process::Command;
 
 use super::BuildOutcome;
 
@@ -32,6 +35,7 @@ pub(super) async fn run_declared_actions(
             .clone()
             .unwrap_or_else(|| "<anonymous>".to_string());
         all_outputs.extend(declared.outputs.iter().cloned());
+        let cacheable = declared.cacheable;
         let mut input_action_digests = dep_action_digests.to_vec();
         input_action_digests.extend(
             action_digests
@@ -46,23 +50,37 @@ pub(super) async fn run_declared_actions(
                     target.label.id,
                 )
             })?;
-        let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
-            .await
-            .with_context(|| {
-                format!(
-                    "executing action {index} for {} ({identifier_for_error})",
+        if cacheable {
+            let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
+                .await
+                .with_context(|| {
+                    format!(
+                        "executing action {index} for {} ({identifier_for_error})",
+                        target.label.id,
+                    )
+                })?;
+            let exit_code = outcome.result.exit_code;
+            if exit_code != 0 {
+                anyhow::bail!(
+                    "{identifier_for_error} ({index}) failed for {} with exit code {exit_code}",
                     target.label.id,
-                )
-            })?;
-        let exit_code = outcome.result.exit_code;
-        if exit_code != 0 {
-            anyhow::bail!(
-                "{identifier_for_error} ({index}) failed for {} with exit code {exit_code}",
-                target.label.id,
-            );
+                );
+            }
+            action_digests.push(outcome.action);
+            last_cache_tag = crate::commands::util::cache_tag(outcome.cache);
+        } else {
+            let action_digest = action.digest();
+            run_uncached_action(&action, workspace)
+                .await
+                .with_context(|| {
+                    format!(
+                        "executing action {index} for {} ({identifier_for_error})",
+                        target.label.id,
+                    )
+                })?;
+            action_digests.push(action_digest);
+            last_cache_tag = "bypass";
         }
-        action_digests.push(outcome.action);
-        last_cache_tag = crate::commands::util::cache_tag(outcome.cache);
     }
 
     Ok(BuildOutcome {
@@ -71,6 +89,49 @@ pub(super) async fn run_declared_actions(
         outputs: all_outputs,
         cache_tag: last_cache_tag,
     })
+}
+
+async fn run_uncached_action(action: &Action, workspace: &Path) -> Result<()> {
+    match action {
+        Action::RunCommand {
+            argv,
+            env,
+            cwd,
+            timeout_ms,
+            ..
+        } => {
+            let (program, rest) = argv
+                .split_first()
+                .ok_or_else(|| anyhow::anyhow!("declared action has empty argv"))?;
+            let mut command = Command::new(program);
+            command.args(rest);
+            command.env_clear();
+            for (key, value) in env {
+                command.env(key, value);
+            }
+            command.stdin(Stdio::null());
+            command.stdout(Stdio::piped());
+            command.stderr(Stdio::piped());
+            command.current_dir(
+                cwd.as_ref()
+                    .map_or_else(|| workspace.to_path_buf(), |path| path.resolve(workspace)),
+            );
+            command.kill_on_drop(true);
+
+            let output = match timeout_ms {
+                Some(ms) => tokio::time::timeout(Duration::from_millis(*ms), command.output())
+                    .await
+                    .with_context(|| format!("declared action timed out after {ms}ms"))??,
+                None => command.output().await?,
+            };
+            if !output.status.success() {
+                let code = output.status.code().unwrap_or(-1);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!("declared action exited with code {code}: {stderr}");
+            }
+            Ok(())
+        }
+    }
 }
 
 fn compose_target_action_digest(target_id: &str, action_digests: &[Digest]) -> Digest {
@@ -197,6 +258,7 @@ mod tests {
                 ".once/out/x/sub/B.meta".to_string(),
             ],
             env: BTreeMap::new(),
+            cacheable: true,
             toolchain_identity: None,
             identifier: None,
         };
@@ -209,6 +271,39 @@ mod tests {
         assert_eq!(argv, vec!["tool".to_string(), "--version".to_string()]);
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uncached_action_executes_each_time() {
+        let workspace = tempfile::tempdir().unwrap();
+        let action = Action::RunCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "printf x >> counter".to_string(),
+            ],
+            env: BTreeMap::new(),
+            cwd: None,
+            input_digest: None,
+            outputs: Vec::new(),
+            output_symlink_mode: OutputSymlinkMode::default(),
+            resources: ResourceRequest::default(),
+            timeout_ms: None,
+            remote: None,
+        };
+
+        run_uncached_action(&action, workspace.path())
+            .await
+            .unwrap();
+        run_uncached_action(&action, workspace.path())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("counter")).unwrap(),
+            "xx"
+        );
+    }
+
     #[test]
     fn input_digest_changes_with_toolchain_identity() {
         let workspace = tempfile::tempdir().unwrap();
@@ -218,6 +313,7 @@ mod tests {
             inputs: vec!["a.swift".to_string()],
             outputs: vec![".once/out/A.a".to_string()],
             env: BTreeMap::new(),
+            cacheable: true,
             toolchain_identity: Some("id-1".to_string()),
             identifier: None,
         };
@@ -239,6 +335,7 @@ mod tests {
             inputs: vec!["a.swift".to_string()],
             outputs: vec![".once/out/A.a".to_string()],
             env: BTreeMap::new(),
+            cacheable: true,
             toolchain_identity: None,
             identifier: None,
         };

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -324,6 +324,67 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uncached_action_succeeds_when_declared_output_exists() {
+        let workspace = tempfile::tempdir().unwrap();
+        let action = Action::RunCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "printf ok > .once/out/result.txt".to_string(),
+            ],
+            env: BTreeMap::new(),
+            cwd: None,
+            input_digest: None,
+            outputs: vec![WorkspacePath::try_from(".once/out/result.txt").unwrap()],
+            output_symlink_mode: OutputSymlinkMode::default(),
+            resources: ResourceRequest::default(),
+            timeout_ms: None,
+            remote: None,
+        };
+        std::fs::create_dir_all(workspace.path().join(".once/out")).unwrap();
+
+        let exit_code = run_uncached_action(&action, workspace.path())
+            .await
+            .unwrap();
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join(".once/out/result.txt")).unwrap(),
+            "ok"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uncached_action_errors_when_declared_output_is_missing() {
+        let workspace = tempfile::tempdir().unwrap();
+        let action = Action::RunCommand {
+            argv: vec!["/bin/sh".to_string(), "-c".to_string(), ":".to_string()],
+            env: BTreeMap::new(),
+            cwd: None,
+            input_digest: None,
+            outputs: vec![WorkspacePath::try_from(".once/out/missing.txt").unwrap()],
+            output_symlink_mode: OutputSymlinkMode::default(),
+            resources: ResourceRequest::default(),
+            timeout_ms: None,
+            remote: None,
+        };
+
+        let err = run_uncached_action(&action, workspace.path())
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains(
+                "declared action completed without producing output `.once/out/missing.txt`"
+            ),
+            "{err}"
+        );
+    }
+
     #[test]
     fn input_digest_changes_with_toolchain_identity() {
         let workspace = tempfile::tempdir().unwrap();

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -70,7 +70,7 @@ pub(super) async fn run_declared_actions(
             last_cache_tag = crate::commands::util::cache_tag(outcome.cache);
         } else {
             let action_digest = action.digest();
-            run_uncached_action(&action, workspace)
+            let exit_code = run_uncached_action(&action, workspace)
                 .await
                 .with_context(|| {
                     format!(
@@ -78,6 +78,12 @@ pub(super) async fn run_declared_actions(
                         target.label.id,
                     )
                 })?;
+            if exit_code != 0 {
+                anyhow::bail!(
+                    "{identifier_for_error} ({index}) failed for {} with exit code {exit_code}",
+                    target.label.id,
+                );
+            }
             action_digests.push(action_digest);
             last_cache_tag = "bypass";
         }
@@ -91,13 +97,14 @@ pub(super) async fn run_declared_actions(
     })
 }
 
-async fn run_uncached_action(action: &Action, workspace: &Path) -> Result<()> {
+async fn run_uncached_action(action: &Action, workspace: &Path) -> Result<i32> {
     match action {
         Action::RunCommand {
             argv,
             env,
             cwd,
             timeout_ms,
+            outputs,
             ..
         } => {
             let (program, rest) = argv
@@ -110,7 +117,7 @@ async fn run_uncached_action(action: &Action, workspace: &Path) -> Result<()> {
                 command.env(key, value);
             }
             command.stdin(Stdio::null());
-            command.stdout(Stdio::piped());
+            command.stdout(Stdio::null());
             command.stderr(Stdio::piped());
             command.current_dir(
                 cwd.as_ref()
@@ -129,9 +136,22 @@ async fn run_uncached_action(action: &Action, workspace: &Path) -> Result<()> {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 anyhow::bail!("declared action exited with code {code}: {stderr}");
             }
-            Ok(())
+            verify_declared_outputs(outputs, workspace)?;
+            Ok(output.status.code().unwrap_or(0))
         }
     }
+}
+
+fn verify_declared_outputs(outputs: &[WorkspacePath], workspace: &Path) -> Result<()> {
+    for output in outputs {
+        if !output.resolve(workspace).exists() {
+            anyhow::bail!(
+                "declared action completed without producing output `{}`",
+                output.as_str()
+            );
+        }
+    }
+    Ok(())
 }
 
 fn compose_target_action_digest(target_id: &str, action_digests: &[Digest]) -> Digest {

--- a/crates/once-cli/src/commands/graph/analysis/tests.rs
+++ b/crates/once-cli/src/commands/graph/analysis/tests.rs
@@ -14,6 +14,7 @@ def _impl(ctx):
             argv = ["/bin/sh", "-c", ctx["attr"]["script"], "sh", out],
             inputs = srcs,
             outputs = [out],
+            cacheable = not ("uncacheable" in ctx["attr"]),
             identifier = ctx["label"]["name"] + "-" + ctx["capability"],
         )
         return {"target": ctx["label"]["name"], "out": out}
@@ -194,6 +195,46 @@ async fn independent_dependencies_run_in_parallel() {
     assert_eq!(
         outcome.outputs,
         vec![".once/out/Root/Root-build.txt".to_string()]
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn uncacheable_declared_actions_bypass_action_cache() {
+    let workspace = tempfile::tempdir().unwrap();
+    let cache = CacheProvider::open_local(workspace.path().join(".once/cache"));
+    let graph = vec![target_with_capabilities(
+        "Root",
+        &[],
+        &[],
+        &["build"],
+        [
+            (
+                "script".to_string(),
+                AttrValue::String("printf x >> side_effect; printf run > \"$1\"".to_string()),
+            ),
+            ("uncacheable".to_string(), AttrValue::Bool(true)),
+        ],
+    )];
+    let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
+    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+
+    let first = session
+        .build_with_analysis(&graph[0])
+        .await
+        .unwrap()
+        .unwrap();
+    let second = session
+        .build_with_analysis(&graph[0])
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(first.cache_tag, "bypass");
+    assert_eq!(second.cache_tag, "bypass");
+    assert_eq!(
+        std::fs::read_to_string(workspace.path().join("side_effect")).unwrap(),
+        "xx"
     );
 }
 

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -1,9 +1,9 @@
 //! Graph capability commands for build, run, and test.
 //!
 //! This module owns command orchestration: resolving a target from the
-//! workspace graph, checking the requested capability, executing it through
-//! the action cache, and rendering the result. The translation from a target
-//! and capability into a cacheable action lives in [`action`].
+//! workspace graph, checking the requested capability, executing rule-declared
+//! or generic fallback actions, and rendering the result. The legacy
+//! capability fallback lives in [`action`].
 
 mod action;
 mod analysis;
@@ -94,10 +94,31 @@ pub async fn run(
 ) -> Result<ExitCode> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
     let target = require_target(&graph, target_id)?;
-    ensure_capability(&target, "run")?;
+    let run_capability = ensure_capability(&target, "run")?;
     let session = analysis::BuildSession::new(workspace, cache, &graph)?;
-    let _ = build_target(workspace, cache, &target, &session).await?;
-    let record = run_target_capability(workspace, cache, &target, "run").await?;
+    if !run_capability.requires_outputs.is_empty()
+        && target
+            .capabilities
+            .iter()
+            .any(|capability| capability.name == "build")
+    {
+        let _ = build_target(workspace, cache, &target, &session).await?;
+    }
+    let record = if let Some(outcome) = session.run_with_analysis(&target, "run").await? {
+        CapabilityRunRecord {
+            target: target.label.id.clone(),
+            kind: target.kind.clone(),
+            capability: run_capability.name.clone(),
+            status: "completed",
+            action_digest: outcome.action_digest.to_string(),
+            cache: outcome.cache_tag,
+            output_groups: run_capability.output_groups.clone(),
+            required_outputs: run_capability.requires_outputs.clone(),
+            outputs: outcome.outputs,
+        }
+    } else {
+        run_target_capability(workspace, cache, &target, "run").await?
+    };
     write_record(output, &record).await?;
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -388,7 +388,7 @@ fn run_test_target(workspace: &std::path::Path, target: &str) -> Result<Value> {
         .with_context(|| format!("running `{}` test `{target}`", exe.display()))?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let (record, record_parse_error) = parse_test_run_record(&stdout);
+    let (record, record_parse_error) = parse_json_record(&stdout);
     let results = crate::commands::query::test_results_value(workspace, target).ok();
     Ok(json!({
         "target": target,
@@ -423,7 +423,7 @@ fn run_graph_target_with_exe(
         .with_context(|| format!("running `{}` {capability} `{target}`", exe.display()))?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let (record, record_parse_error) = parse_test_run_record(&stdout);
+    let (record, record_parse_error) = parse_json_record(&stdout);
     Ok(json!({
         "target": target,
         "capability": capability,
@@ -435,7 +435,7 @@ fn run_graph_target_with_exe(
     }))
 }
 
-fn parse_test_run_record(stdout: &str) -> (Value, Option<String>) {
+fn parse_json_record(stdout: &str) -> (Value, Option<String>) {
     if stdout.is_empty() {
         return (Value::Null, None);
     }
@@ -1202,8 +1202,8 @@ srcs = ["other_spec.sh"]
     }
 
     #[test]
-    fn parse_test_run_record_preserves_json_error_context() {
-        let (record, error) = parse_test_run_record("{not json");
+    fn parse_json_record_preserves_error_context() {
+        let (record, error) = parse_json_record("{not json");
 
         assert_eq!(record, Value::String("{not json".to_string()));
         assert!(error.unwrap().contains("line"));

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -1,4 +1,4 @@
-//! `once mcp` — expose Once's graph queries over the Model Context
+//! `once mcp` exposes Once's graph queries over the Model Context
 //! Protocol so a coding agent can call `query_targets`,
 //! `query_capabilities`, and `query_schema` as MCP tools.
 //!
@@ -13,9 +13,10 @@
 //! tool because coding harnesses need a short discover, filter, run,
 //! inspect loop after editing files.
 //!
-//! Runtime invocation is opt-in because it is side-effectful. When enabled,
-//! tools start persisted runtime sessions and return session ids agents can use
-//! to query status, read logs, or stop the process later.
+//! Target execution is opt-in because it writes outputs and may trigger rule
+//! side effects. When enabled, tools can build, run, or start persisted runtime
+//! sessions and return session ids agents can use to query status, read logs,
+//! or stop the process later.
 
 use std::path::PathBuf;
 
@@ -143,15 +144,19 @@ impl Server {
             "once_query_affected_tests" => self.tool_query_affected_tests(&call.arguments),
             "once_run_tests" => self.tool_run_tests(&call.arguments),
             "once_query_test_results" => self.tool_query_test_results(&call.arguments),
+            "once_build_target" if self.allow_run => self.tool_build_target(&call.arguments),
+            "once_run_target" if self.allow_run => self.tool_run_target(&call.arguments),
             "once_start_target" if self.allow_run => self.tool_start_target(&call.arguments),
             "once_runtime_status" if self.allow_run => self.tool_runtime_status(&call.arguments),
             "once_runtime_logs" if self.allow_run => self.tool_runtime_logs(&call.arguments),
             "once_stop_runtime" if self.allow_run => self.tool_stop_runtime(&call.arguments),
-            "once_start_target"
+            "once_build_target"
+            | "once_run_target"
+            | "once_start_target"
             | "once_runtime_status"
             | "once_runtime_logs"
             | "once_stop_runtime" => Err(anyhow::anyhow!(
-                "runtime tools require starting `once mcp --allow-run`"
+                "execution tools require starting `once mcp --allow-run`"
             )),
             "once_apply_edit" => self.tool_apply_edit(&call.arguments),
             // Rule registry queries don't need a workspace because they
@@ -254,6 +259,16 @@ impl Server {
             runs.push(run_test_target(&self.workspace, &target)?);
         }
         Ok(json!({ "runs": runs }))
+    }
+
+    fn tool_build_target(&self, args: &Value) -> Result<Value> {
+        let args: TargetExecutionArgs = serde_json::from_value(tool_args(args))?;
+        run_graph_target(&self.workspace, "build", &args.target)
+    }
+
+    fn tool_run_target(&self, args: &Value) -> Result<Value> {
+        let args: TargetExecutionArgs = serde_json::from_value(tool_args(args))?;
+        run_graph_target(&self.workspace, "run", &args.target)
     }
 
     fn tool_start_target(&self, args: &Value) -> Result<Value> {
@@ -370,7 +385,7 @@ fn run_test_target(workspace: &std::path::Path, target: &str) -> Result<Value> {
         .arg("test")
         .arg(target)
         .output()
-        .with_context(|| format!("running `{}` test {target}`", exe.display()))?;
+        .with_context(|| format!("running `{}` test `{target}`", exe.display()))?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let (record, record_parse_error) = parse_test_run_record(&stdout);
@@ -382,6 +397,31 @@ fn run_test_target(workspace: &std::path::Path, target: &str) -> Result<Value> {
         "record": record,
         "record_parse_error": record_parse_error,
         "results": results,
+        "stderr": stderr,
+    }))
+}
+
+fn run_graph_target(workspace: &std::path::Path, capability: &str, target: &str) -> Result<Value> {
+    let exe = std::env::current_exe().context("resolving current once executable")?;
+    let output = std::process::Command::new(&exe)
+        .arg("-C")
+        .arg(workspace)
+        .arg("--format")
+        .arg("json")
+        .arg(capability)
+        .arg(target)
+        .output()
+        .with_context(|| format!("running `{}` {capability} `{target}`", exe.display()))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let (record, record_parse_error) = parse_test_run_record(&stdout);
+    Ok(json!({
+        "target": target,
+        "capability": capability,
+        "exit_code": output.status.code().unwrap_or(-1),
+        "success": output.status.success(),
+        "record": record,
+        "record_parse_error": record_parse_error,
         "stderr": stderr,
     }))
 }
@@ -402,6 +442,12 @@ fn tool_args(args: &Value) -> Value {
     } else {
         args.clone()
     }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TargetExecutionArgs {
+    target: String,
 }
 
 #[derive(Deserialize)]
@@ -549,13 +595,13 @@ fn text_content_str(text: &str) -> Value {
 }
 
 fn tool_definitions(allow_run: bool) -> Vec<Value> {
-    // The runtime `tools/list` reply is the wire projection of the
+    // The MCP `tools/list` reply is the wire projection of the
     // shared catalog; the doc generator walks the same catalog so
     // the reference page can't drift from the server's advertised
     // surface.
     tool_catalog()
         .into_iter()
-        .filter(|tool| allow_run || !is_runtime_tool(tool.name))
+        .filter(|tool| allow_run || !is_run_gated_tool(tool.name))
         .map(|tool| {
             json!({
                 "name": tool.name,
@@ -566,10 +612,15 @@ fn tool_definitions(allow_run: bool) -> Vec<Value> {
         .collect()
 }
 
-fn is_runtime_tool(name: &str) -> bool {
+fn is_run_gated_tool(name: &str) -> bool {
     matches!(
         name,
-        "once_start_target" | "once_runtime_status" | "once_runtime_logs" | "once_stop_runtime"
+        "once_build_target"
+            | "once_run_target"
+            | "once_start_target"
+            | "once_runtime_status"
+            | "once_runtime_logs"
+            | "once_stop_runtime"
     )
 }
 
@@ -621,7 +672,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 },
                 "required": ["target"]
             }),
-            example_return: "{\n  \"id\": \"apps/ios/App\",\n  \"kind\": \"apple_application\",\n  \"capabilities\": [\n    { \"name\": \"build\", \"output_groups\": [\"default\", \"bundle\", \"dsyms\"],\n      \"requires_outputs\": [] }\n  ]\n}",
+            example_return: "{\n  \"id\": \"apps/ios/App\",\n  \"kind\": \"apple_application\",\n  \"capabilities\": [\n    { \"name\": \"build\", \"output_groups\": [\"default\", \"bundle\", \"dsyms\"],\n      \"requires_outputs\": [] },\n    { \"name\": \"run\", \"output_groups\": [\"default\"],\n      \"requires_outputs\": [\"bundle\"] }\n  ]\n}",
         },
         ToolDefinition {
             name: "once_query_schema",
@@ -731,6 +782,38 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 "required": ["target"]
             }),
             example_return: "{\n  \"schema\": \"once.test_results.v1\",\n  \"target\": \"spec/cli_e2e\",\n  \"status\": \"passed\",\n  \"summary\": { \"total\": 2, \"passed\": 2, \"failed\": 0 },\n  \"cases\": []\n}",
+        },
+        ToolDefinition {
+            name: "once_build_target",
+            description: "Build a target by running its generic `build` capability.",
+            long_description: "Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`. Executes the same path as `once build <target> --format json`, so dependency traversal, rule-declared actions, cache policy, and output groups stay owned by the CLI and rule graph. The tool returns stdout parsed as JSON when possible, along with exit status and stderr. A failed build is returned as normal tool content with `success: false` so agents can inspect diagnostics.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Target id to build, e.g. `apps/ios/App` or `./App`."
+                    }
+                },
+                "required": ["target"]
+            }),
+            example_return: "{\n  \"target\": \"apps/ios/App\",\n  \"capability\": \"build\",\n  \"exit_code\": 0,\n  \"success\": true,\n  \"record\": {\n    \"target\": \"apps/ios/App\",\n    \"kind\": \"apple_application\",\n    \"capability\": \"build\",\n    \"cache\": \"miss\",\n    \"outputs\": [\".once/out/apps/ios/App/App.app\"]\n  },\n  \"stderr\": \"\"\n}",
+        },
+        ToolDefinition {
+            name: "once_run_target",
+            description: "Run a target by executing its generic `run` capability.",
+            long_description: "Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`. Executes the same path as `once run <target> --format json`, including any prerequisite build outputs declared by the target's `run` capability. Rule-declared execution policy is preserved, so uncacheable actions are executed instead of replayed from the action cache. The tool returns stdout parsed as JSON when possible, plus exit status and stderr.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Target id to run, e.g. `apps/ios/App` or `./App`."
+                    }
+                },
+                "required": ["target"]
+            }),
+            example_return: "{\n  \"target\": \"apps/ios/App\",\n  \"capability\": \"run\",\n  \"exit_code\": 0,\n  \"success\": true,\n  \"record\": {\n    \"target\": \"apps/ios/App\",\n    \"kind\": \"apple_application\",\n    \"capability\": \"run\",\n    \"cache\": \"bypass\",\n    \"outputs\": [\".once/out/apps/ios/App/run/run.json\"]\n  },\n  \"stderr\": \"\"\n}",
         },
         ToolDefinition {
             name: "once_start_target",
@@ -1053,6 +1136,8 @@ mod tests {
             .iter()
             .map(|tool| tool["name"].as_str().unwrap().to_string())
             .collect();
+        assert!(names.contains(&"once_build_target".to_string()));
+        assert!(names.contains(&"once_run_target".to_string()));
         assert!(names.contains(&"once_start_target".to_string()));
         assert!(names.contains(&"once_runtime_status".to_string()));
         assert!(names.contains(&"once_runtime_logs".to_string()));
@@ -1060,19 +1145,21 @@ mod tests {
     }
 
     #[test]
-    fn runtime_tools_require_allow_run() {
+    fn execution_tools_require_allow_run() {
         let tmp = TempDir::new().unwrap();
-        let response = server(tmp.path().to_path_buf()).dispatch(request(
-            "tools/call",
-            json!({ "name": "once_start_target", "arguments": { "target": "App" } }),
-        ));
-        let result = response.result.expect("result");
+        for tool in ["once_build_target", "once_run_target", "once_start_target"] {
+            let response = server(tmp.path().to_path_buf()).dispatch(request(
+                "tools/call",
+                json!({ "name": tool, "arguments": { "target": "App" } }),
+            ));
+            let result = response.result.expect("result");
 
-        assert_eq!(result["isError"], true);
-        assert!(result["content"][0]["text"]
-            .as_str()
-            .unwrap()
-            .contains("--allow-run"));
+            assert_eq!(result["isError"], true);
+            assert!(result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("--allow-run"));
+        }
     }
 
     #[test]

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -403,7 +403,16 @@ fn run_test_target(workspace: &std::path::Path, target: &str) -> Result<Value> {
 
 fn run_graph_target(workspace: &std::path::Path, capability: &str, target: &str) -> Result<Value> {
     let exe = std::env::current_exe().context("resolving current once executable")?;
-    let output = std::process::Command::new(&exe)
+    run_graph_target_with_exe(&exe, workspace, capability, target)
+}
+
+fn run_graph_target_with_exe(
+    exe: &std::path::Path,
+    workspace: &std::path::Path,
+    capability: &str,
+    target: &str,
+) -> Result<Value> {
+    let output = std::process::Command::new(exe)
         .arg("-C")
         .arg(workspace)
         .arg("--format")
@@ -1198,6 +1207,44 @@ srcs = ["other_spec.sh"]
 
         assert_eq!(record, Value::String("{not json".to_string()));
         assert!(error.unwrap().contains("line"));
+    }
+
+    #[cfg(unix)]
+    fn shell_literal(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\"'\"'"))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn graph_target_runner_invokes_cli_and_parses_json_record() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let exe = tmp.path().join("once-mock");
+        let args_path = tmp.path().join("args.txt");
+        let args_file = shell_literal(args_path.to_str().unwrap());
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {args_file}\nprintf '{{\"target\":\"%s\",\"capability\":\"%s\",\"status\":\"completed\"}}\\n' \"$6\" \"$5\"\n",
+        );
+        std::fs::write(&exe, script).unwrap();
+        let mut permissions = std::fs::metadata(&exe).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&exe, permissions).unwrap();
+
+        let build = run_graph_target_with_exe(&exe, tmp.path(), "build", "apps/App").unwrap();
+        assert_eq!(build["capability"], "build");
+        assert_eq!(build["success"], true);
+        assert_eq!(build["record"]["target"], "apps/App");
+        assert_eq!(build["record"]["capability"], "build");
+
+        let run = run_graph_target_with_exe(&exe, tmp.path(), "run", "apps/App").unwrap();
+        assert_eq!(run["capability"], "run");
+        assert_eq!(run["success"], true);
+        assert_eq!(run["record"]["target"], "apps/App");
+        assert_eq!(run["record"]["capability"], "run");
+
+        let args = std::fs::read_to_string(args_path).unwrap();
+        assert!(args.contains("--format\njson\nrun\napps/App\n"));
     }
 
     #[test]

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -272,11 +272,17 @@ fn render_schema_human(schema: &once_frontend::RuleSchema) -> String {
     if !schema.capabilities.is_empty() {
         out.push_str("capabilities:\n");
         for capability in &schema.capabilities {
+            let requires = if capability.requires_outputs.is_empty() {
+                String::new()
+            } else {
+                format!(" (requires: {})", capability.requires_outputs.join(", "))
+            };
             writeln!(
                 out,
-                "  {}: {}",
+                "  {}: {}{}",
                 capability.name,
-                capability.output_groups.join(", ")
+                capability.output_groups.join(", "),
+                requires
             )
             .expect("writing to string cannot fail");
         }
@@ -763,7 +769,7 @@ mod tests {
         assert!(rendered.starts_with("apple_application: "));
         assert!(rendered.contains("bundle_id: string (required"));
         assert!(rendered.contains("build: default, bundle, dsyms"));
-        assert!(!rendered.contains("run: default"));
+        assert!(rendered.contains("run: default (requires: bundle)"));
     }
 
     #[test]

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -355,6 +355,7 @@ async fn dispatch_run(
             anyhow::bail!("--remote is only supported for executable script targets");
         }
         let cache = crate::cache_provider::resolve(workspace, xdg)?;
+        // Keep dispatch_run's future below clippy's large_futures limit.
         return Box::pin(commands::graph::run(
             workspace,
             &cache,

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -355,7 +355,13 @@ async fn dispatch_run(
             anyhow::bail!("--remote is only supported for executable script targets");
         }
         let cache = crate::cache_provider::resolve(workspace, xdg)?;
-        return commands::graph::run(workspace, &cache, output, &resolved_target).await;
+        return Box::pin(commands::graph::run(
+            workspace,
+            &cache,
+            output,
+            &resolved_target,
+        ))
+        .await;
     }
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
     run_target_command(

--- a/crates/once-cli/src/reference.rs
+++ b/crates/once-cli/src/reference.rs
@@ -585,7 +585,7 @@ mod tests {
 
         let cache = std::fs::read_to_string(tmp.path().join("cache.md")).unwrap();
         assert!(cache.contains("## Subcommands"));
-        // Each child gets its own labelled link — the format-string
+        // Each child gets its own labelled link, and the format-string
         // cleanup keeps this in lockstep with the iteration variable.
         assert!(cache.contains("- [`once cache stats`](/reference/cli/cache/stats)"));
 

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -42,7 +42,7 @@ def rule(kind, docs, attrs = [], deps = [], providers = [], capabilities = [], e
 #   glob(patterns)             -> sorted, deduplicated workspace-relative file paths
 #                                 matching the patterns under the active package
 #   declare_output(name)       -> workspace-relative output path under the active build_dir
-#   run_action(argv=..., inputs=..., outputs=..., env={}, toolchain_identity=None, identifier=None)
+#   run_action(argv=..., inputs=..., outputs=..., env={}, cacheable=True, toolchain_identity=None, identifier=None)
 #
 # Each impl receives a `ctx` dict built by the Rust analysis pass with:
 #   ctx["label"]      -> {"package", "name", "id"}
@@ -546,6 +546,12 @@ def _shell_words(values):
         out.append(_shell_literal(value))
     return " ".join(out)
 
+def _json_escape(value):
+    return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+
+def _json_literal(value):
+    return "\"" + _json_escape(value) + "\""
+
 def _shellspec_test_impl(ctx):
     attrs = ctx["attr"]
     shellspec = attrs.get("shellspec") or "shellspec"
@@ -711,34 +717,6 @@ done
         specs = specs,
         target = target,
         runner_type = runner_type,
-    )
-
-def _swift_testing_package_script(product_name, package_dir, swift_srcs):
-    tests_dir = package_dir + "/Tests/" + product_name
-    copy_lines = []
-    for src in swift_srcs:
-        copy_lines.append("cp " + _shell_literal(src) + " " + _shell_literal(tests_dir + "/" + _basename(src)))
-    return """rm -rf {package_dir}
-mkdir -p {tests_dir}
-cat > {manifest} <<'EOF'
-// swift-tools-version: 6.0
-import PackageDescription
-
-let package = Package(
-    name: "{package_name}",
-    targets: [
-        .testTarget(name: "{product_name}")
-    ]
-)
-EOF
-{copy_lines}
-""".format(
-        package_dir = _shell_literal(package_dir),
-        tests_dir = _shell_literal(tests_dir),
-        manifest = _shell_literal(package_dir + "/Package.swift"),
-        package_name = product_name + "Package",
-        product_name = product_name,
-        copy_lines = "\n".join(copy_lines),
     )
 
 def _apple_test_info(ctx, runner_type, command_argv, command_env, labels, results, log, native_results):
@@ -1653,6 +1631,61 @@ def shell_quote_for_action(path):
     escaped = path.replace("'", "'\"'\"'")
     return "'" + escaped + "'"
 
+def _apple_application_run_script(label_id, platform, sdk_variant, xcrun, app_path, bundle_id, run_dir, run_record, run_log):
+    target_json = _json_literal(label_id)
+    platform_json = _json_literal(platform)
+    bundle_json = _json_literal(bundle_id)
+    app_json = _json_literal(app_path)
+    if platform == "macos" or platform == "macosx":
+        record_json = '{"schema":"once.run.v1","target":' + target_json + ',"kind":"apple_application","status":"launched","platform":' + platform_json + ',"bundle_id":' + bundle_json + ',"app_path":' + app_json + '}'
+        command = """/usr/bin/open -n {app} >> {log} 2>&1
+printf '%s\\n' {record_json} > {record}
+""".format(
+            app = _shell_literal(app_path),
+            log = _shell_literal(run_log),
+            record_json = _shell_literal(record_json),
+            record = _shell_literal(run_record),
+        )
+    elif platform == "ios" and sdk_variant == "simulator":
+        record_prefix = '{"schema":"once.run.v1","target":' + target_json + ',"kind":"apple_application","status":"launched","platform":' + platform_json + ',"sdk_variant":"simulator","bundle_id":' + bundle_json + ',"app_path":' + app_json + ',"simulator_id":"'
+        record_suffix = '"}'
+        command = """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"
+if [ -z "$simulator_id" ]; then
+  simulator_id=$({xcrun} simctl list devices booted | sed -n 's/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
+fi
+if [ -z "$simulator_id" ]; then
+  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
+fi
+if [ -z "$simulator_id" ]; then
+  echo "error: no booted or available iOS simulator found" >&2
+  exit 1
+fi
+{xcrun} simctl boot "$simulator_id" >> {log} 2>&1 || true
+{xcrun} simctl bootstatus "$simulator_id" -b >> {log} 2>&1
+{xcrun} simctl install "$simulator_id" {app} >> {log} 2>&1
+{xcrun} simctl launch "$simulator_id" {bundle_id} >> {log} 2>&1
+printf '%s%s%s\\n' {record_prefix} "$simulator_id" {record_suffix} > {record}
+""".format(
+            xcrun = _shell_literal(xcrun),
+            log = _shell_literal(run_log),
+            app = _shell_literal(app_path),
+            bundle_id = _shell_literal(bundle_id),
+            record_prefix = _shell_literal(record_prefix),
+            record_suffix = _shell_literal(record_suffix),
+            record = _shell_literal(run_record),
+        )
+    else:
+        fail(label_id + ": apple_application run supports macos and ios simulator targets")
+    return """set -eu
+mkdir -p {run_dir}
+: > {log}
+{command}
+""".format(
+        run_dir = _shell_literal(run_dir),
+        log = _shell_literal(run_log),
+        command = command,
+    )
+
 def _apple_application_impl(ctx):
     attrs = _resolve_attrs(ctx["attr"], ctx["label"]["id"], ["product_name"])
     _reject_unsupported_attrs(attrs, ctx["label"]["id"], ["resources", "asset_catalogs", "info_plist", "info_plist_substitutions", "entitlements", "provisioning_profile", "signing_identity"])
@@ -1682,6 +1715,25 @@ def _apple_application_impl(ctx):
     triple = _apple_triple(platform, target_sdk_version, sdk_variant, arch, False)
 
     app_dir = product_name + ".app"
+    app_path = ctx["build_dir"] + "/" + app_dir
+    if ctx["capability"] == "run":
+        run_dir = ctx["build_dir"] + "/run"
+        run_record = run_dir + "/run.json"
+        run_log = run_dir + "/run.log"
+        run_action(
+            argv = ["/bin/sh", "-c", _apple_application_run_script(ctx["label"]["id"], platform, sdk_variant, xcrun, app_path, bundle_id, run_dir, run_record, run_log)],
+            outputs = [run_dir, run_record, run_log],
+            env = xcrun_env,
+            cacheable = False,
+            toolchain_identity = "once.apple.application.run.v1\x00" + swiftc_identity,
+            identifier = "apple_application_run_" + product_name,
+        )
+        return {
+            "label_id": ctx["label"]["id"],
+            "app_path": app_path,
+            "bundle_id": bundle_id,
+        }
+
     executable = declare_output(app_dir + "/" + product_name)
     info_plist = declare_output(app_dir + "/Info.plist")
 
@@ -1867,7 +1919,7 @@ def _apple_application_impl(ctx):
 
     return {
         "label_id": ctx["label"]["id"],
-        "app_path": ctx["build_dir"] + "/" + app_dir,
+        "app_path": app_path,
         "bundle_id": bundle_id,
     }
 
@@ -1898,95 +1950,11 @@ def _apple_test_bundle_impl(ctx):
     action_env = {"HOME": test_dir + "/home"}
     for key in test_env:
         action_env[key] = test_env[key]
-    runner_type = "swift_testing" if swift_testing else "xctest"
-    command_argv = ["swift", "test"] if swift_testing else ["xctest", ctx["build_dir"] + "/" + product_name + ".xctest"]
-    provider = {
-        "label_id": ctx["label"]["id"],
-        "test_bundle_path": ctx["build_dir"] + "/" + product_name + ".xctest",
-        "affected_inputs": all_srcs,
-        "test_info": _apple_test_info(ctx, runner_type, command_argv, action_env, labels, results, log, native_results),
-    }
-
-    if ctx["capability"] == "test":
-        if swift_testing:
-            if platform != "macos" and platform != "macosx":
-                fail(ctx["label"]["id"] + ": swift_testing execution currently supports macos targets; simulator/device runners will use the XCTest bundle path later")
-            xcrun, sdk, swiftc_identity, xcrun_env = _xcrun_swiftc(platform, sdk_variant, xcode_developer_dir)
-            for key in xcrun_env:
-                action_env[key] = xcrun_env[key]
-            package_dir = test_dir + "/SwiftTestingPackage"
-            cases_file = test_dir + "/cases.jsonl"
-            script = """set -eu
-mkdir -p {test_dir}
-mkdir -p "$HOME"
-{package_script}
-log={log}
-results={results}
-native_results={native_results}
-: > "$native_results"
-set +e
-{command} > "$log" 2>&1
-status=$?
-set -e
-cp "$log" "$native_results"
-{cases_script}
-if [ "$status" -eq 0 ]; then run_status=passed; failed=0; passed=$total; else run_status=failed; failed=1; passed=0; fi
-{{
-  printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"swift_testing","metadata":{{}}}},"status":"%s","summary":{{"total":%s,"passed":%s,"failed":%s,"skipped":0,"flaky":0}},"cases":[' "{target}" "$run_status" "$total" "$passed" "$failed"
-  cat "$cases_file"
-  printf '],"artifacts":{{"logs":["%s"],"native_results":["%s"]}}}}\n' "$log" "$native_results"
-}} > "$results"
-exit "$status"
-""".format(
-                test_dir = _shell_literal(test_dir),
-                package_script = _swift_testing_package_script(product_name, package_dir, swift_srcs),
-                log = _shell_literal(log),
-                results = _shell_literal(results),
-                native_results = _shell_literal(native_results),
-                command = _shell_words([xcrun, "--sdk", sdk, "swift", "test", "--package-path", package_dir]),
-                cases_script = _swift_testing_cases_script(swift_srcs, cases_file, ctx["label"]["id"], "swift_testing"),
-                target = ctx["label"]["id"],
-            )
-            run_action(
-                argv = ["/bin/sh", "-c", script],
-                inputs = swift_srcs,
-                outputs = [test_dir, results, log, native_results],
-                env = action_env,
-                toolchain_identity = "once.apple.swift_testing.v1\x00" + swiftc_identity,
-                identifier = "apple_swift_testing:" + ctx["label"]["id"],
-            )
-        else:
-            script = """set -eu
-mkdir -p {test_dir}
-log={log}
-results={results}
-native_results={native_results}
-printf 'XCTest execution is not wired yet; emitted placeholder Once result for %s\n' "{target}" > "$log"
-cp "$log" "$native_results"
-printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"xctest","metadata":{{}}}},"status":"passed","summary":{{"total":0,"passed":0,"failed":0,"skipped":0,"flaky":0}},"cases":[],"artifacts":{{"logs":["%s"],"native_results":["%s"]}}}}\n' "{target}" "$log" "$native_results" > "$results"
-""".format(
-                test_dir = _shell_literal(test_dir),
-                log = _shell_literal(log),
-                results = _shell_literal(results),
-                native_results = _shell_literal(native_results),
-                target = ctx["label"]["id"],
-            )
-            run_action(
-                argv = ["/bin/sh", "-c", script],
-                inputs = [],
-                outputs = [test_dir, results, log, native_results],
-                env = action_env,
-                toolchain_identity = "once.apple.xctest.placeholder.v1",
-                identifier = "apple_xctest_placeholder:" + ctx["label"]["id"],
-            )
-        return provider
-
-    if swift_testing:
-        return provider
-
     arch = host_arch()
     xcrun, sdk, swiftc_identity, xcrun_env = _xcrun_swiftc(platform, sdk_variant, xcode_developer_dir)
     triple = _apple_triple(platform, target_sdk_version, sdk_variant, arch, False)
+    for key in xcrun_env:
+        action_env[key] = xcrun_env[key]
 
     # XCTest lives in the platform's developer-frameworks tree, not
     # the SDK's default search path. Resolve `<platform>/Developer/
@@ -1994,10 +1962,26 @@ printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"xctes
     # linker finds the framework and dyld locates it at runtime.
     platform_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-platform-path"], env = xcrun_env).strip()
     xctest_framework_dir = platform_path + "/Developer/Library/Frameworks"
+    xctest_usr_lib_dir = platform_path + "/Developer/usr/lib"
+    developer_dir = platform_path.split("/Platforms/")[0]
+    testing_macros_plugin = developer_dir + "/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib"
 
     bundle_dir = product_name + ".xctest"
-    test_binary = declare_output(bundle_dir + "/" + product_name)
-    info_plist = declare_output(bundle_dir + "/Info.plist")
+    if platform == "macos" or platform == "macosx":
+        test_binary = declare_output(bundle_dir + "/Contents/MacOS/" + product_name)
+        info_plist = declare_output(bundle_dir + "/Contents/Info.plist")
+    else:
+        test_binary = declare_output(bundle_dir + "/" + product_name)
+        info_plist = declare_output(bundle_dir + "/Info.plist")
+    test_bundle_path = ctx["build_dir"] + "/" + bundle_dir
+    runner_type = "swift_testing" if swift_testing else "xctest"
+    command_argv = [xcrun, "xctest", test_bundle_path]
+    provider = {
+        "label_id": ctx["label"]["id"],
+        "test_bundle_path": test_bundle_path,
+        "affected_inputs": all_srcs,
+        "test_info": _apple_test_info(ctx, runner_type, command_argv, action_env, labels, results, log, native_results),
+    }
 
     deps = ctx["deps"]
     (
@@ -2036,17 +2020,37 @@ printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"xctes
         "-bundle",
         "-F",
         xctest_framework_dir,
+        "-L",
+        xctest_usr_lib_dir,
         "-Xlinker",
         "-rpath",
         "-Xlinker",
         xctest_framework_dir,
+        "-Xlinker",
+        "-rpath",
+        "-Xlinker",
+        xctest_usr_lib_dir,
         "-framework",
         "XCTest",
         "-o",
         test_binary,
     ]
+    if swift_testing:
+        swift_argv.extend([
+            "-framework",
+            "Testing",
+            "-lXCTestSwiftSupport",
+            "-load-plugin-library",
+            testing_macros_plugin,
+        ])
     for d in compile_swiftmodule_dirs:
         swift_argv.extend(["-I", d])
+    for hdir in compile_header_dirs:
+        swift_argv.extend(["-Xcc", "-I", "-Xcc", hdir])
+    for mmap in dep_modulemaps:
+        swift_argv.extend(["-Xcc", "-fmodule-map-file=" + mmap])
+    for hmap in dep_hmaps:
+        swift_argv.extend(["-Xcc", "-I", "-Xcc", hmap])
     for d in framework_search_dirs:
         swift_argv.extend(["-F", d])
     for fw in framework_module_names:
@@ -2057,6 +2061,8 @@ printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"xctes
         swift_argv.extend(["-l" + dy])
     for opt in dep_linkopts:
         swift_argv.append(opt)
+    for dylib_path in plugin_dylibs:
+        swift_argv.extend(["-load-plugin-library", dylib_path])
     for flag in swift_flags:
         swift_argv.append(flag)
     for src in swift_srcs:
@@ -2071,6 +2077,9 @@ printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"xctes
     for f in dep_framework_files:
         if f not in swift_inputs:
             swift_inputs.append(f)
+    for dylib_path in plugin_dylibs:
+        if dylib_path not in swift_inputs:
+            swift_inputs.append(dylib_path)
 
     run_action(
         argv = swift_argv,
@@ -2094,7 +2103,103 @@ printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"xctes
     }
     write_file(info_plist, _render_plist(plist_entries))
 
-    provider["test_bundle_path"] = ctx["build_dir"] + "/" + bundle_dir
+    cs_xcrun, codesign_path, cs_identity, cs_env = _xcrun_codesign(xcode_developer_dir)
+    if platform == "macos" or platform == "macosx":
+        test_cs_stamp = declare_output(bundle_dir + "/Contents/_CodeSignature/CodeResources")
+    else:
+        test_cs_stamp = declare_output(bundle_dir + "/_CodeSignature/CodeResources")
+    cs_script = "set -e; " + codesign_path + " --force --sign - --timestamp=none " + shell_quote_for_action(test_bundle_path)
+    run_action(
+        argv = ["/bin/sh", "-c", cs_script],
+        inputs = [test_binary, info_plist],
+        outputs = [test_cs_stamp],
+        env = cs_env,
+        toolchain_identity = cs_identity,
+        identifier = "apple_test_bundle_codesign_" + module_name,
+    )
+
+    if ctx["capability"] == "test":
+        cases_file = test_dir + "/cases.jsonl"
+        if platform == "macos" or platform == "macosx":
+            runner_command = """DYLD_LIBRARY_PATH={usr_lib}${{DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}} DYLD_FALLBACK_FRAMEWORK_PATH={frameworks}${{DYLD_FALLBACK_FRAMEWORK_PATH:+:$DYLD_FALLBACK_FRAMEWORK_PATH}} {command}""".format(
+                usr_lib = _shell_literal(xctest_usr_lib_dir),
+                frameworks = _shell_literal(xctest_framework_dir),
+                command = _shell_words([xcrun, "xctest", test_bundle_path]),
+            )
+        elif sdk_variant == "simulator":
+            runner_command = """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"
+if [ -z "$simulator_id" ]; then
+  simulator_id=$({xcrun} simctl list devices booted | sed -n 's/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
+fi
+if [ -z "$simulator_id" ]; then
+  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
+fi
+if [ -z "$simulator_id" ]; then
+  echo "error: no booted or available iOS simulator found" >&2
+  exit 1
+fi
+{xcrun} simctl boot "$simulator_id" >/dev/null 2>&1 || true
+{xcrun} simctl bootstatus "$simulator_id" -b
+tmpdir=$(mktemp -d "${{TMPDIR:-/tmp}}/once-xctest.XXXXXX")
+trap 'rm -rf "$tmpdir"' EXIT
+cp -R {bundle} "$tmpdir/"
+chmod -R 777 "$tmpdir/{bundle_name}"
+SIMCTL_CHILD_DYLD_LIBRARY_PATH={usr_lib} SIMCTL_CHILD_DYLD_FALLBACK_FRAMEWORK_PATH={frameworks} {xcrun} simctl spawn "$simulator_id" {xctest_agent} -XCTest All "$tmpdir/{bundle_name}"
+""".format(
+                xcrun = _shell_literal(xcrun),
+                bundle = _shell_literal(test_bundle_path),
+                bundle_name = bundle_dir,
+                usr_lib = _shell_literal(xctest_usr_lib_dir),
+                frameworks = _shell_literal(xctest_framework_dir),
+                xctest_agent = _shell_literal(platform_path + "/Developer/Library/Xcode/Agents/xctest"),
+            )
+        else:
+            fail(ctx["label"]["id"] + ": apple_test_bundle execution supports macos and simulator targets; device runners need xctestrun support")
+        script = """set -eu
+mkdir -p {test_dir}
+mkdir -p "$HOME"
+log={log}
+results={results}
+native_results={native_results}
+: > "$native_results"
+set +e
+(
+{runner_command}
+) > "$log" 2>&1
+status=$?
+set -e
+cp "$log" "$native_results"
+{cases_script}
+if [ "$status" -eq 0 ]; then run_status=passed; failed=0; passed=$total; else run_status=failed; failed=1; passed=0; fi
+{{
+  printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"%s","metadata":{{}}}},"status":"%s","summary":{{"total":%s,"passed":%s,"failed":%s,"skipped":0,"flaky":0}},"cases":[' "{target}" "{runner_type}" "$run_status" "$total" "$passed" "$failed"
+  cat "$cases_file"
+  printf '],"artifacts":{{"logs":["%s"],"native_results":["%s"]}}}}\n' "$log" "$native_results"
+}} > "$results"
+exit "$status"
+""".format(
+            test_dir = _shell_literal(test_dir),
+            log = _shell_literal(log),
+            results = _shell_literal(results),
+            native_results = _shell_literal(native_results),
+            runner_command = runner_command,
+            cases_script = _swift_testing_cases_script(swift_srcs, cases_file, ctx["label"]["id"], runner_type),
+            target = ctx["label"]["id"],
+            runner_type = runner_type,
+        )
+        test_inputs = [test_binary, info_plist, test_cs_stamp]
+        for src in swift_srcs:
+            if src not in test_inputs:
+                test_inputs.append(src)
+        run_action(
+            argv = ["/bin/sh", "-c", script],
+            inputs = test_inputs,
+            outputs = [test_dir, results, log, native_results],
+            env = action_env,
+            toolchain_identity = "once.apple." + runner_type + ".runner.v1\x00" + swiftc_identity,
+            identifier = "apple_" + runner_type + ":" + ctx["label"]["id"],
+        )
+
     return provider
 
 RULES = [
@@ -2229,6 +2334,7 @@ RULES = [
         providers = ["apple_application", "apple_bundle"],
         capabilities = [
             capability("build", ["default", "bundle", "dsyms"]),
+            capability("run", ["default"], ["bundle"]),
         ],
         examples = [
             "apple-application-minimal",

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -194,6 +194,14 @@ def _xcrun_codesign(xcode_developer_dir):
     identity = "once.apple.codesign.v1\x00" + codesign_path + "\x00" + (xcode_developer_dir or "")
     return (xcrun, codesign_path, identity, env)
 
+def _swift_testing_macros_plugin(xcrun, xcrun_env):
+    swiftc_path = host_command([xcrun, "--find", "swiftc"], env = xcrun_env).strip()
+    suffix = "/usr/bin/swiftc"
+    if not _ends_with(swiftc_path, suffix):
+        fail("unable to derive Swift toolchain path from swiftc at " + swiftc_path)
+    toolchain_dir = swiftc_path[:len(swiftc_path) - len(suffix)]
+    return toolchain_dir + "/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib"
+
 def _xcrun_actool(xcode_developer_dir):
     xcrun = host_which("xcrun")
     env = _xcrun_env(xcode_developer_dir)
@@ -1974,8 +1982,7 @@ def _apple_test_bundle_impl(ctx):
     platform_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-platform-path"], env = xcrun_env).strip()
     xctest_framework_dir = platform_path + "/Developer/Library/Frameworks"
     xctest_usr_lib_dir = platform_path + "/Developer/usr/lib"
-    developer_dir = platform_path.split("/Platforms/")[0]
-    testing_macros_plugin = developer_dir + "/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib"
+    testing_macros_plugin = _swift_testing_macros_plugin(xcrun, xcrun_env)
 
     bundle_dir = product_name + ".xctest"
     if platform == "macos" or platform == "macosx":
@@ -2144,12 +2151,15 @@ def _apple_test_bundle_impl(ctx):
 tmpdir=$(mktemp -d "${{TMPDIR:-/tmp}}/once-xctest.XXXXXX")
 trap 'rm -rf "$tmpdir"' EXIT
 cp -R {bundle} "$tmpdir/"
-chmod -R 777 "$tmpdir/{bundle_name}"
+find "$tmpdir/{bundle_name}" -type d -exec chmod 755 {{}} +
+find "$tmpdir/{bundle_name}" -type f -exec chmod 644 {{}} +
+chmod 755 "$tmpdir/{bundle_name}/{binary_name}"
 SIMCTL_CHILD_DYLD_LIBRARY_PATH={usr_lib} SIMCTL_CHILD_DYLD_FALLBACK_FRAMEWORK_PATH={frameworks} {xcrun} simctl spawn "$simulator_id" {xctest_agent} -XCTest All "$tmpdir/{bundle_name}"
 """.format(
                 xcrun = _shell_literal(xcrun),
                 bundle = _shell_literal(test_bundle_path),
                 bundle_name = bundle_dir,
+                binary_name = product_name,
                 usr_lib = _shell_literal(xctest_usr_lib_dir),
                 frameworks = _shell_literal(xctest_framework_dir),
                 xctest_agent = _shell_literal(platform_path + "/Developer/Library/Xcode/Agents/xctest"),
@@ -2197,6 +2207,7 @@ exit "$status"
             inputs = test_inputs,
             outputs = [test_dir, results, log, native_results],
             env = action_env,
+            cacheable = False,
             toolchain_identity = "once.apple." + runner_type + ".runner.v1\x00" + swiftc_identity,
             identifier = "apple_" + runner_type + ":" + ctx["label"]["id"],
         )

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -552,6 +552,27 @@ def _json_escape(value):
 def _json_literal(value):
     return "\"" + _json_escape(value) + "\""
 
+_IOS_SIMULATOR_BOOTED_FILTER = "/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p"
+_IOS_SIMULATOR_SHUTDOWN_FILTER = "/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p"
+
+def _ios_simulator_selection_script(xcrun):
+    return """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"
+if [ -z "$simulator_id" ]; then
+  simulator_id=$({xcrun} simctl list devices booted | sed -n {booted_filter} | head -n 1)
+fi
+if [ -z "$simulator_id" ]; then
+  simulator_id=$({xcrun} simctl list devices available | sed -n {shutdown_filter} | head -n 1)
+fi
+if [ -z "$simulator_id" ]; then
+  echo "error: no booted or available iOS simulator found" >&2
+  exit 1
+fi
+""".format(
+        xcrun = _shell_literal(xcrun),
+        booted_filter = _shell_literal(_IOS_SIMULATOR_BOOTED_FILTER),
+        shutdown_filter = _shell_literal(_IOS_SIMULATOR_SHUTDOWN_FILTER),
+    )
+
 def _shellspec_test_impl(ctx):
     attrs = ctx["attr"]
     shellspec = attrs.get("shellspec") or "shellspec"
@@ -1649,17 +1670,7 @@ printf '%s\\n' {record_json} > {record}
     elif platform == "ios" and sdk_variant == "simulator":
         record_prefix = '{"schema":"once.run.v1","target":' + target_json + ',"kind":"apple_application","status":"launched","platform":' + platform_json + ',"sdk_variant":"simulator","bundle_id":' + bundle_json + ',"app_path":' + app_json + ',"simulator_id":"'
         record_suffix = '"}'
-        command = """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"
-if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices booted | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
-fi
-if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
-fi
-if [ -z "$simulator_id" ]; then
-  echo "error: no booted or available iOS simulator found" >&2
-  exit 1
-fi
+        command = _ios_simulator_selection_script(xcrun) + """
 {xcrun} simctl boot "$simulator_id" >> {log} 2>&1 || true
 {xcrun} simctl bootstatus "$simulator_id" -b >> {log} 2>&1
 {xcrun} simctl install "$simulator_id" {app} >> {log} 2>&1
@@ -2127,17 +2138,7 @@ def _apple_test_bundle_impl(ctx):
                 command = _shell_words([xcrun, "xctest", test_bundle_path]),
             )
         elif sdk_variant == "simulator":
-            runner_command = """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"
-if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices booted | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
-fi
-if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
-fi
-if [ -z "$simulator_id" ]; then
-  echo "error: no booted or available iOS simulator found" >&2
-  exit 1
-fi
+            runner_command = _ios_simulator_selection_script(xcrun) + """
 {xcrun} simctl boot "$simulator_id" >/dev/null 2>&1 || true
 {xcrun} simctl bootstatus "$simulator_id" -b
 tmpdir=$(mktemp -d "${{TMPDIR:-/tmp}}/once-xctest.XXXXXX")

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -560,8 +560,8 @@ def _json_escape(value):
 def _json_literal(value):
     return "\"" + _json_escape(value) + "\""
 
-_IOS_SIMULATOR_BOOTED_FILTER = "/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p"
-_IOS_SIMULATOR_SHUTDOWN_FILTER = "/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p"
+_IOS_SIMULATOR_BOOTED_FILTER = "/iPhone/ s/^.* (\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted)[[:space:]]*$/\\1/p; /iPad/ s/^.* (\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted)[[:space:]]*$/\\1/p"
+_IOS_SIMULATOR_SHUTDOWN_FILTER = "/iPhone/ s/^.* (\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown)[[:space:]]*$/\\1/p; /iPad/ s/^.* (\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown)[[:space:]]*$/\\1/p"
 
 def _ios_simulator_selection_script(xcrun):
     return """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -1651,10 +1651,10 @@ printf '%s\\n' {record_json} > {record}
         record_suffix = '"}'
         command = """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"
 if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices booted | sed -n 's/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
+  simulator_id=$({xcrun} simctl list devices booted | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
 fi
 if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
+  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
 fi
 if [ -z "$simulator_id" ]; then
   echo "error: no booted or available iOS simulator found" >&2
@@ -2129,10 +2129,10 @@ def _apple_test_bundle_impl(ctx):
         elif sdk_variant == "simulator":
             runner_command = """simulator_id="${{ONCE_APPLE_SIMULATOR_UDID:-}}"
 if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices booted | sed -n 's/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
+  simulator_id=$({xcrun} simctl list devices booted | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Booted).*/\\1/p' | head -n 1)
 fi
 if [ -z "$simulator_id" ]; then
-  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
+  simulator_id=$({xcrun} simctl list devices available | sed -n '/iPhone/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p; /iPad/ s/.*(\\([0-9A-Fa-f-][0-9A-Fa-f-]*\\)) (Shutdown).*/\\1/p' | head -n 1)
 fi
 if [ -z "$simulator_id" ]; then
   echo "error: no booted or available iOS simulator found" >&2

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -28,7 +28,7 @@ use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use starlark::environment::{Globals, GlobalsBuilder, Module};
 use starlark::eval::Evaluator;
@@ -43,7 +43,7 @@ use crate::graph::GraphTarget;
 use crate::target::AttrValue;
 
 /// A single command declared by a rule impl through `run_action`.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DeclaredAction {
     pub argv: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -51,7 +51,10 @@ pub struct DeclaredAction {
     pub outputs: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env: BTreeMap<String, String>,
-    #[serde(skip_serializing_if = "is_cacheable")]
+    #[serde(
+        default = "default_cacheable",
+        skip_serializing_if = "std::clone::Clone::clone"
+    )]
     pub cacheable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub toolchain_identity: Option<String>,
@@ -59,8 +62,8 @@ pub struct DeclaredAction {
     pub identifier: Option<String>,
 }
 
-fn is_cacheable(value: &bool) -> bool {
-    *value
+fn default_cacheable() -> bool {
+    true
 }
 
 /// Per-target collection of declared outputs, actions, and the host
@@ -434,9 +437,9 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
         inputs: Option<Value<'v>>,
         outputs: Option<Value<'v>>,
         env: Option<Value<'v>>,
-        cacheable: Option<bool>,
         toolchain_identity: Option<String>,
         identifier: Option<String>,
+        cacheable: Option<bool>,
     ) -> anyhow::Result<NoneType> {
         let argv = unpack_string_list(argv, "argv")?;
         let inputs = inputs
@@ -1195,6 +1198,24 @@ run_action(
         });
         assert_eq!(store.actions.len(), 1);
         assert!(!store.actions[0].cacheable);
+    }
+
+    #[test]
+    fn declared_action_defaults_cacheable_when_omitted() {
+        let action: DeclaredAction = serde_json::from_value(serde_json::json!({
+            "argv": ["swiftc", "App.swift"],
+            "outputs": [".once/out/App.o"]
+        }))
+        .unwrap();
+
+        assert!(action.cacheable);
+        assert_eq!(
+            serde_json::to_value(&action).unwrap(),
+            serde_json::json!({
+                "argv": ["swiftc", "App.swift"],
+                "outputs": [".once/out/App.o"]
+            })
+        );
     }
 
     #[test]

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -51,10 +51,16 @@ pub struct DeclaredAction {
     pub outputs: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "is_cacheable")]
+    pub cacheable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub toolchain_identity: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
+}
+
+fn is_cacheable(value: &bool) -> bool {
+    *value
 }
 
 /// Per-target collection of declared outputs, actions, and the host
@@ -361,6 +367,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
             inputs: Vec::new(),
             outputs: vec![path.to_string()],
             env: BTreeMap::new(),
+            cacheable: true,
             // Folding the literal content into the toolchain identity
             // keeps the digest pinned to what the file should contain,
             // so changing the content alone invalidates the action.
@@ -403,6 +410,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
             inputs: Vec::new(),
             outputs: vec![path.to_string()],
             env: BTreeMap::new(),
+            cacheable: true,
             toolchain_identity: Some(format!("once.write_bytes.v1\0{encoded}")),
             identifier: Some(format!("write_bytes:{path}")),
         };
@@ -418,14 +426,15 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
     /// `argv`: list of strings; `inputs`: list of workspace-relative
     /// source paths to hash into the input digest; `outputs`: list of
     /// workspace-relative paths the action produces; `env`: optional
-    /// string->string dict; `toolchain_identity`: optional string
-    /// folded into the input digest; `identifier`: optional label for
-    /// diagnostics.
+    /// string->string dict; `cacheable`: optional bool, default true;
+    /// `toolchain_identity`: optional string folded into the input
+    /// digest; `identifier`: optional label for diagnostics.
     fn run_action<'v>(
         argv: Value<'v>,
         inputs: Option<Value<'v>>,
         outputs: Option<Value<'v>>,
         env: Option<Value<'v>>,
+        cacheable: Option<bool>,
         toolchain_identity: Option<String>,
         identifier: Option<String>,
     ) -> anyhow::Result<NoneType> {
@@ -447,6 +456,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
             inputs,
             outputs,
             env,
+            cacheable: cacheable.unwrap_or(true),
             toolchain_identity,
             identifier,
         };
@@ -1166,6 +1176,25 @@ run_action(
             store.actions[0].identifier.as_deref(),
             Some("swift_compile")
         );
+        assert!(store.actions[0].cacheable);
+    }
+
+    #[test]
+    fn run_action_can_mark_declarations_uncacheable() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_for(tmp.path(), "apps/ios/App");
+        let (store, ()) = with_active_store(store, || {
+            run(r#"
+run_action(
+    argv = ["open", ".once/out/apps/ios/App/App.app"],
+    outputs = [".once/out/apps/ios/App/run/run.json"],
+    cacheable = False,
+)
+"#)
+            .unwrap();
+        });
+        assert_eq!(store.actions.len(), 1);
+        assert!(!store.actions[0].cacheable);
     }
 
     #[test]

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1128,6 +1128,7 @@ mod tests {
     use super::*;
     use starlark::environment::Module;
     use starlark::syntax::{AstModule, Dialect};
+    use std::process::Command;
     use tempfile::TempDir;
 
     fn run(source: &str) -> starlark::Result<()> {
@@ -1658,6 +1659,43 @@ RULES = [
         })
     }
 
+    fn eval_prelude_string_function(
+        function_name: &str,
+        call_source: &str,
+    ) -> std::result::Result<String, String> {
+        let prelude = include_str!("../prelude/apple.star");
+        let source = format!("{prelude}\nresult = {function_name}{call_source}\n");
+        Module::with_temp_heap(|module| {
+            let ast = AstModule::parse("test.star", source, &Dialect::Standard)
+                .map_err(|error| format!("parse: {error:?}"))?;
+            let globals = globals_for_prelude();
+            let mut eval = Evaluator::new(&module);
+            eval.eval_module(ast, &globals)
+                .map_err(|error| format!("eval: {error:?}"))?;
+            let result = module
+                .get("result")
+                .ok_or_else(|| "missing result".to_string())?;
+            Ok(result
+                .unpack_str()
+                .ok_or_else(|| "result was not a string".to_string())?
+                .to_string())
+        })
+    }
+
+    fn starlark_string_literal(value: &str) -> String {
+        serde_json::to_string(value).unwrap()
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::write(path, contents).unwrap();
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
     #[test]
     fn prelude_resolve_select_picks_matching_branch() {
         let out = eval_prelude_function(
@@ -1700,17 +1738,165 @@ RULES = [
 
     #[test]
     fn prelude_ios_simulator_selection_filters_to_iphone_and_ipad() {
-        let out = eval_prelude_function("_ios_simulator_selection_script", r#"("/usr/bin/xcrun")"#)
-            .unwrap();
+        let out = eval_prelude_string_function(
+            "_ios_simulator_selection_script",
+            r#"("/usr/bin/xcrun")"#,
+        )
+        .unwrap();
 
         assert!(out.contains("ONCE_APPLE_SIMULATOR_UDID"), "{out}");
         assert!(out.contains("simctl list devices booted"), "{out}");
         assert!(out.contains("simctl list devices available"), "{out}");
-        assert!(out.contains("/iPhone/ s/.*"), "{out}");
-        assert!(out.contains("/iPad/ s/.*"), "{out}");
-        assert!(out.contains("(Booted)"), "{out}");
-        assert!(out.contains("(Shutdown)"), "{out}");
+        assert!(out.contains("/iPhone/ s/^.*"), "{out}");
+        assert!(out.contains("/iPad/ s/^.*"), "{out}");
+        assert!(out.contains("(Booted)[[:space:]]*$"), "{out}");
+        assert!(out.contains("(Shutdown)[[:space:]]*$"), "{out}");
         assert!(!out.contains("sed -n 's/.*"), "{out}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_ios_simulator_selection_script_picks_booted_ios_device() {
+        let tmp = TempDir::new().unwrap();
+        let xcrun = tmp.path().join("xcrun");
+        write_executable(
+            &xcrun,
+            r#"#!/bin/sh
+if [ "${1:-}" = "simctl" ] && [ "${2:-}" = "list" ] && [ "${3:-}" = "devices" ] && [ "${4:-}" = "booted" ]; then
+  printf '%s\n' '    Apple TV (AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA) (Booted)'
+  printf '%s\n' '    iPhone Preview (BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB) (Extra) (Booted)'
+  printf '%s\n' '    iPhone 15 Pro (11111111-1111-1111-1111-111111111111) (Booted)'
+  exit 0
+fi
+if [ "${1:-}" = "simctl" ] && [ "${2:-}" = "list" ] && [ "${3:-}" = "devices" ] && [ "${4:-}" = "available" ]; then
+  printf '%s\n' '    iPad Pro (22222222-2222-2222-2222-222222222222) (Shutdown)'
+  exit 0
+fi
+exit 1
+"#,
+        );
+        let call = format!(
+            "({})",
+            starlark_string_literal(&xcrun.display().to_string())
+        );
+        let selection_script =
+            eval_prelude_string_function("_ios_simulator_selection_script", &call).unwrap();
+        let output = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!("{selection_script}\nprintf '%s' \"$simulator_id\""))
+            .output()
+            .unwrap();
+
+        assert!(output.status.success(), "{output:?}");
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            "11111111-1111-1111-1111-111111111111"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_ios_simulator_selection_script_errors_without_ios_device() {
+        let tmp = TempDir::new().unwrap();
+        let xcrun = tmp.path().join("xcrun");
+        write_executable(
+            &xcrun,
+            r#"#!/bin/sh
+if [ "${1:-}" = "simctl" ] && [ "${2:-}" = "list" ] && [ "${3:-}" = "devices" ]; then
+  printf '%s\n' '    Apple TV (AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA) (Booted)'
+  exit 0
+fi
+exit 1
+"#,
+        );
+        let call = format!(
+            "({})",
+            starlark_string_literal(&xcrun.display().to_string())
+        );
+        let selection_script =
+            eval_prelude_string_function("_ios_simulator_selection_script", &call).unwrap();
+        let output = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!("{selection_script}\nprintf '%s' \"$simulator_id\""))
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success(), "{output:?}");
+        assert!(String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("no booted or available iOS simulator found"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_swift_testing_macros_plugin_uses_swift_toolchain_path() {
+        let tmp = TempDir::new().unwrap();
+        let xcrun = tmp.path().join("xcrun");
+        let swiftc = tmp
+            .path()
+            .join("Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc");
+        std::fs::create_dir_all(swiftc.parent().unwrap()).unwrap();
+        write_executable(
+            &xcrun,
+            &format!(
+                r#"#!/bin/sh
+if [ "${{1:-}}" = "--find" ] && [ "${{2:-}}" = "swiftc" ]; then
+  printf '%s\n' {}
+  exit 0
+fi
+exit 1
+"#,
+                starlark_string_literal(&swiftc.display().to_string())
+            ),
+        );
+        let store = store_for(tmp.path(), "");
+        let call = format!(
+            "({}, {{}})",
+            starlark_string_literal(&xcrun.display().to_string())
+        );
+
+        let (_, out) = with_active_store(store, || {
+            eval_prelude_string_function("_swift_testing_macros_plugin", &call)
+        });
+
+        assert_eq!(
+            out.unwrap(),
+            tmp.path()
+                .join("Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib")
+                .display()
+                .to_string()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_swift_testing_macros_plugin_rejects_unexpected_swiftc_path() {
+        let tmp = TempDir::new().unwrap();
+        let xcrun = tmp.path().join("xcrun");
+        write_executable(
+            &xcrun,
+            r#"#!/bin/sh
+if [ "${1:-}" = "--find" ] && [ "${2:-}" = "swiftc" ]; then
+  printf '%s\n' '/tmp/swiftc'
+  exit 0
+fi
+exit 1
+"#,
+        );
+        let store = store_for(tmp.path(), "");
+        let call = format!(
+            "({}, {{}})",
+            starlark_string_literal(&xcrun.display().to_string())
+        );
+
+        let (_, err) = with_active_store(store, || {
+            eval_prelude_string_function("_swift_testing_macros_plugin", &call).unwrap_err()
+        });
+
+        assert!(
+            err.contains("unable to derive Swift toolchain path"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1698,6 +1698,33 @@ RULES = [
         assert!(err.contains("no branch matching"), "{err}");
     }
 
+    #[test]
+    fn prelude_ios_simulator_selection_filters_to_iphone_and_ipad() {
+        let out = eval_prelude_function("_ios_simulator_selection_script", r#"("/usr/bin/xcrun")"#)
+            .unwrap();
+
+        assert!(out.contains("ONCE_APPLE_SIMULATOR_UDID"), "{out}");
+        assert!(out.contains("simctl list devices booted"), "{out}");
+        assert!(out.contains("simctl list devices available"), "{out}");
+        assert!(out.contains("/iPhone/ s/.*"), "{out}");
+        assert!(out.contains("/iPad/ s/.*"), "{out}");
+        assert!(out.contains("(Booted)"), "{out}");
+        assert!(out.contains("(Shutdown)"), "{out}");
+        assert!(!out.contains("sed -n 's/.*"), "{out}");
+    }
+
+    #[test]
+    fn prelude_ios_simulator_selection_helper_feeds_run_and_test_scripts() {
+        let source = include_str!("../prelude/apple.star");
+
+        assert_eq!(
+            source
+                .matches("_ios_simulator_selection_script(xcrun) +")
+                .count(),
+            2
+        );
+    }
+
     /// The prelude `_serialize_hmap` helper must lay out the
     /// header-map byte sequence correctly: 4-byte magic, version 1,
     /// reserved 0, the rest of the header, a power-of-two bucket

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -51,10 +51,7 @@ pub struct DeclaredAction {
     pub outputs: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env: BTreeMap<String, String>,
-    #[serde(
-        default = "default_cacheable",
-        skip_serializing_if = "std::clone::Clone::clone"
-    )]
+    #[serde(default = "default_cacheable", skip_serializing_if = "is_true")]
     pub cacheable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub toolchain_identity: Option<String>,
@@ -64,6 +61,11 @@ pub struct DeclaredAction {
 
 fn default_cacheable() -> bool {
     true
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_true(value: &bool) -> bool {
+    *value
 }
 
 /// Per-target collection of declared outputs, actions, and the host

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -538,7 +538,7 @@ mod tests {
     use crate::target::Target;
 
     #[test]
-    fn apple_application_exposes_build() {
+    fn apple_application_exposes_build_and_run() {
         let target = Target {
             package: "apps/ios".to_string(),
             kind: "apple_application".to_string(),
@@ -560,7 +560,7 @@ mod tests {
             .map(|capability| capability.name.as_str())
             .collect::<Vec<_>>();
         names.sort_unstable();
-        assert_eq!(names, vec!["build"]);
+        assert_eq!(names, vec!["build", "run"]);
     }
 
     #[test]

--- a/docs/guide/graph/apple.md
+++ b/docs/guide/graph/apple.md
@@ -12,7 +12,8 @@ automatically. The bundle, app, and test-host kinds
 [`apple_application`](/reference/prelude/apple_application),
 [`apple_test_bundle`](/reference/prelude/apple_test_bundle)) are
 implemented as Starlark graph rules that declare cacheable build
-actions.
+actions. Runtime effects, such as launching an app, are also declared
+by rules and can opt out of action-cache replay.
 
 For the per-rule attribute, dep, provider, and capability tables see
 the [Prelude reference](/reference/prelude/).
@@ -63,19 +64,20 @@ pages list the exact paths each rule emits.
 
 ## Running Apps
 
-`apple_application` produces an `.app` bundle. It is a build target, not
-a runtime selector. Simulator and device knowledge should live in Apple
-prelude rules that consume the app bundle provider and expose `run`, not
-in Once's core CLI.
+`apple_application` produces an `.app` bundle and exposes `run`.
+`once run` first materializes the required bundle output, then executes
+the launch action declared by the Apple rule. That launch action is not
+cacheable, so each `once run` attempts a fresh launch instead of
+replaying an action-cache hit.
 
-That keeps the graph shape explicit. The app rule answers "how do I
-build this bundle?" A future Apple runner rule can answer "how do I take
-that bundle and run it in this Apple runtime?" Once only dispatches the
-generic capability:
+The Apple rule owns the platform behavior. macOS apps are launched with
+the host app launcher. iOS simulator apps use `simctl` to pick or boot a
+simulator, install the bundle, and launch the bundle identifier. Device
+launch support is not implemented yet.
 
 ```sh
 once build apps/ios/App
-once run tools/ios/LaunchApp
+once run apps/ios/App
 ```
 
 ## Configurable attributes

--- a/docs/guide/graph/index.md
+++ b/docs/guide/graph/index.md
@@ -131,16 +131,16 @@ once mcp
 ```
 
 Running is side-effectful. It can build code, write outputs, install
-software, or launch a process, so Once only advertises runtime session
+software, or launch a process, so Once only advertises execution
 tools when the server is started with an explicit opt-in:
 
 ```sh
 once mcp --allow-run
 ```
 
-With that opt-in, agents can call `once_start_target` with the same
-target id the CLI accepts. The call returns a runtime session id
-immediately, then the agent can use `once_runtime_status`,
-`once_runtime_logs`, and `once_stop_runtime` to follow or stop the run.
-Without it, the MCP surface remains read-oriented and the runtime tools
-are not listed.
+With that opt-in, agents can call `once_build_target`,
+`once_run_target`, or `once_start_target` with the same target id the
+CLI accepts. The start call returns a runtime session id immediately,
+then the agent can use `once_runtime_status`, `once_runtime_logs`, and
+`once_stop_runtime` to follow or stop the run. Without it, the MCP
+surface remains read-oriented and the execution tools are not listed.

--- a/docs/reference/cli/mcp.md
+++ b/docs/reference/cli/mcp.md
@@ -10,14 +10,14 @@ once mcp [OPTIONS]
 
 ## Description
 
-Speaks the Model Context Protocol over stdio so an agent host (Claude Desktop, an IDE plug-in, the Anthropic SDK) can call `once_query_targets`, `once_query_capabilities`, and `once_query_schema` as tools and get JSON back without scraping prose. Mounts inspection tools by default; pass `--allow-run` to expose side-effectful runtime session tools.
+Speaks the Model Context Protocol over stdio so an agent host (Claude Desktop, an IDE plug-in, the Anthropic SDK) can call `once_query_targets`, `once_query_capabilities`, and `once_query_schema` as tools and get JSON back without scraping prose. Mounts inspection tools by default; pass `--allow-run` to expose side-effectful build, run, and runtime session tools.
 
 ## Options
 
 | Flag | Value | Default | Description |
 | --- | --- | --- | --- |
 | `--workspace` | `<DIR>` |  | Workspace root the MCP tools resolve targets against. Defaults to the value of the global `-C/--directory` flag (or the current directory) |
-| `--allow-run` | (flag) | `false` | Advertise and allow side-effectful runtime session tools |
+| `--allow-run` | (flag) | `false` | Advertise and allow side-effectful execution tools |
 | `-C, --directory` | `<DIR>` |  | Project root. Defaults to the current directory; the cache lives under `<project>/.once/`. Mirrors `make -C` |
 | `--format` | `<FORMAT>` | `human` | Output format for Once's structured data (`cache stats`, `run`/`exec` trailers). Defaults to a human-readable rendering; pass `json` or `toon` to get machine-parseable output for scripting and for agent consumers |
 | `-v, --verbose` | (flag) | `0` | Increase log verbosity. Repeat for more (-v: info, -vv: debug, -vvv: trace). Overridden by `RUST_LOG` |

--- a/docs/reference/mcp/tools.md
+++ b/docs/reference/mcp/tools.md
@@ -65,7 +65,9 @@ Returns the same record `once query capabilities <target> --format json` emits: 
   "kind": "apple_application",
   "capabilities": [
     { "name": "build", "output_groups": ["default", "bundle", "dsyms"],
-      "requires_outputs": [] }
+      "requires_outputs": [] },
+    { "name": "run", "output_groups": ["default"],
+      "requires_outputs": ["bundle"] }
   ]
 }
 ```
@@ -331,6 +333,90 @@ Reads the normalized result file produced by the target's `test` capability. Thi
   "status": "passed",
   "summary": { "total": 2, "passed": 2, "failed": 0 },
   "cases": []
+}
+```
+
+## `once_build_target`
+
+Build a target by running its generic `build` capability.
+
+Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`. Executes the same path as `once build <target> --format json`, so dependency traversal, rule-declared actions, cache policy, and output groups stay owned by the CLI and rule graph. The tool returns stdout parsed as JSON when possible, along with exit status and stderr. A failed build is returned as normal tool content with `success: false` so agents can inspect diagnostics.
+
+**Input schema**
+
+```json
+{
+  "properties": {
+    "target": {
+      "description": "Target id to build, e.g. `apps/ios/App` or `./App`.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "target"
+  ],
+  "type": "object"
+}
+```
+
+**Example return**
+
+```json
+{
+  "target": "apps/ios/App",
+  "capability": "build",
+  "exit_code": 0,
+  "success": true,
+  "record": {
+    "target": "apps/ios/App",
+    "kind": "apple_application",
+    "capability": "build",
+    "cache": "miss",
+    "outputs": [".once/out/apps/ios/App/App.app"]
+  },
+  "stderr": ""
+}
+```
+
+## `once_run_target`
+
+Run a target by executing its generic `run` capability.
+
+Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`. Executes the same path as `once run <target> --format json`, including any prerequisite build outputs declared by the target's `run` capability. Rule-declared execution policy is preserved, so uncacheable actions are executed instead of replayed from the action cache. The tool returns stdout parsed as JSON when possible, plus exit status and stderr.
+
+**Input schema**
+
+```json
+{
+  "properties": {
+    "target": {
+      "description": "Target id to run, e.g. `apps/ios/App` or `./App`.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "target"
+  ],
+  "type": "object"
+}
+```
+
+**Example return**
+
+```json
+{
+  "target": "apps/ios/App",
+  "capability": "run",
+  "exit_code": 0,
+  "success": true,
+  "record": {
+    "target": "apps/ios/App",
+    "kind": "apple_application",
+    "capability": "run",
+    "cache": "bypass",
+    "outputs": [".once/out/apps/ios/App/run/run.json"]
+  },
+  "stderr": ""
 }
 ```
 

--- a/docs/reference/prelude/apple_application.md
+++ b/docs/reference/prelude/apple_application.md
@@ -5,7 +5,9 @@ Apple application bundle.
 ## Description
 
 Builds an Apple application bundle with a generated Info.plist,
-linked dependencies, embedded frameworks, and ad-hoc signing.
+linked dependencies, embedded frameworks, and ad-hoc signing. The
+`run` capability builds the required bundle and then executes a
+rule-declared launch action that bypasses the action cache.
 
 ## Attributes
 
@@ -43,11 +45,21 @@ The target emits `apple_application` and `apple_bundle`.
 | Capability | Output groups | Requires |
 | --- | --- | --- |
 | `build` | `default`, `bundle`, `dsyms` |  |
+| `run` | `default` | `bundle` |
+
+## Running
+
+`once run` launches macOS apps with the host app launcher and iOS
+simulator apps with `simctl` boot, install, and launch. The launch
+action writes a run record under the target's output directory and is
+marked uncacheable by the rule, so repeated runs execute the launch
+again instead of replaying an action-cache hit. Device launch support
+is not implemented yet.
 
 ## Limitations
 
 Resource bundling, asset catalogs, custom Info.plist templates,
 entitlements, provisioning profiles, signing identities, and non-ad-hoc signing are
 declared in the schema for graph compatibility but are not implemented
-yet. Non-empty values for those attrs fail analysis instead of being
-ignored.
+yet. Device launch support is also not implemented yet. Non-empty
+values for unsupported attrs fail analysis instead of being ignored.

--- a/docs/reference/prelude/apple_test_bundle.md
+++ b/docs/reference/prelude/apple_test_bundle.md
@@ -4,7 +4,10 @@ Apple test bundle.
 
 ## Description
 
-Builds Apple test targets and can run Swift Testing tests through the generic Once test capability.
+Builds Apple test targets and can run XCTest or Swift Testing tests
+through the generic Once test capability. Swift Testing sources compile
+into the same `.xctest` bundle shape as XCTest tests; Once does not
+generate a Swift package wrapper for them.
 
 ## Attributes
 
@@ -46,5 +49,5 @@ App-hosted tests, resource bundling, asset catalogs, custom Info.plist
 templates, entitlements, destinations, and test plans are declared in
 the schema for graph compatibility but are not implemented yet.
 Non-empty values for those attrs fail analysis instead of being
-ignored. Swift Testing execution currently supports macOS logic tests;
-simulator and device runners will use the XCTest bundle path later.
+ignored. Test execution currently supports macOS logic tests and iOS
+simulator bundles. Device runners still need xctestrun support.

--- a/fixtures/apple_swift_testing/apps/macos/Sources/AppTests/AppTests.swift
+++ b/fixtures/apple_swift_testing/apps/macos/Sources/AppTests/AppTests.swift
@@ -1,5 +1,6 @@
+import AppCore
 import Testing
 
 @Test func examplePasses() {
-    #expect(true)
+    #expect(AppCore.name == "AppCore")
 }

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -50,6 +50,85 @@ Describe 'apple graph'
     cp -R "$REPO_ROOT/fixtures/apple_swift_testing/." "$WORKSPACE/"
   }
 
+  create_mock_apple_run_fixture() {
+    mkdir -p "$WORKSPACE/bin" "$WORKSPACE/apps/ios/Sources/App"
+    cat > "$WORKSPACE/apps/ios/Sources/App/App.swift" <<'SWIFT'
+@main
+struct App {
+    static func main() {}
+}
+SWIFT
+    cat > "$WORKSPACE/apps/ios/once.toml" <<'TOML'
+[[target]]
+name = "App"
+kind = "apple_application"
+srcs = ["Sources/App/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+sdk_variant = "simulator"
+bundle_id = "dev.once.App"
+minimum_os = "17.0"
+TOML
+    cat > "$WORKSPACE/bin/codesign" <<'SH'
+#!/bin/sh
+app=""
+for arg do
+  app="$arg"
+done
+mkdir -p "$app/_CodeSignature"
+: > "$app/_CodeSignature/CodeResources"
+SH
+    chmod +x "$WORKSPACE/bin/codesign"
+    cat > "$WORKSPACE/bin/xcrun" <<SH
+#!/bin/sh
+log='$WORKSPACE/xcrun.log'
+if [ "\${1:-}" = "--sdk" ]; then
+  shift 2
+fi
+case "\${1:-}" in
+  --find)
+    case "\${2:-}" in
+      swiftc) printf '%s\\n' "\$0" ;;
+      codesign) printf '%s\\n' '$WORKSPACE/bin/codesign' ;;
+      *) printf '%s\\n' "\$0" ;;
+    esac
+    ;;
+  swiftc)
+    if [ "\${2:-}" = "--version" ]; then
+      printf '%s\\n' 'Apple Swift version mock'
+      exit 0
+    fi
+    out=''
+    while [ "\$#" -gt 0 ]; do
+      if [ "\$1" = "-o" ]; then
+        shift
+        out="\${1:-}"
+        break
+      fi
+      shift
+    done
+    [ -n "\$out" ] || exit 2
+    mkdir -p "\$(dirname "\$out")"
+    printf '%s\\n' '#!/bin/sh' 'exit 0' > "\$out"
+    chmod 755 "\$out"
+    ;;
+  simctl)
+    printf '%s\\n' "\$*" >> "\$log"
+    if [ "\${2:-}" = "list" ] && [ "\${3:-}" = "devices" ] && [ "\${4:-}" = "booted" ]; then
+      printf '%s\\n' '    Apple TV (TV-DEVICE) (Booted)'
+      printf '%s\\n' '    iPhone 15 (11111111-1111-1111-1111-111111111111) (Booted)'
+    fi
+    ;;
+  *)
+    printf '%s\\n' "unexpected xcrun invocation: \$*" >&2
+    exit 1
+    ;;
+esac
+SH
+    chmod +x "$WORKSPACE/bin/xcrun"
+  }
+
   It 'lists buildable Apple artifacts'
     copy_apple_graph_fixture
 
@@ -87,6 +166,20 @@ Describe 'apple graph'
     The path "$WORKSPACE/.once/out/apps/ios/App/App.app/App" should be file
     The path "$WORKSPACE/.once/out/apps/ios/App/App.app/Info.plist" should be file
     The path "$WORKSPACE/.once/out/apps/ios/App/App.app/Frameworks/DesignSystem.framework/DesignSystem" should be file
+  End
+
+  It 'runs Apple application artifacts through the simulator launch path'
+    create_mock_apple_run_fixture
+
+    When call env PATH="$WORKSPACE/bin:$PATH" "$ONCE_BIN" -C "$WORKSPACE" --format json run apps/ios/App
+    The status should be success
+    The stdout should include '"target":"apps/ios/App"'
+    The stdout should include '"capability":"run"'
+    The stdout should include '"cache":"bypass"'
+    The path "$WORKSPACE/.once/out/apps/ios/App/run/run.json" should be file
+    The contents of file "$WORKSPACE/.once/out/apps/ios/App/run/run.json" should include '"status":"launched"'
+    The contents of file "$WORKSPACE/.once/out/apps/ios/App/run/run.json" should include '"simulator_id":"11111111-1111-1111-1111-111111111111"'
+    The contents of file "$WORKSPACE/xcrun.log" should include 'simctl launch 11111111-1111-1111-1111-111111111111 dev.once.App'
   End
 
   It 'exposes testable Apple test bundle artifacts'

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -57,11 +57,11 @@ Describe 'apple graph'
     The status should be success
     The stdout should include 'apps/ios/AppCore (apple_library) [build]'
     The stdout should include 'apps/ios/DesignSystem (apple_framework) [build]'
-    The stdout should include 'apps/ios/App (apple_application) [build]'
+    The stdout should include 'apps/ios/App (apple_application) [build, run]'
     The stdout should include 'apps/ios/AppTests (apple_test_bundle) [build, test]'
   End
 
-  It 'exposes build-only Apple application artifacts'
+  It 'exposes runnable Apple application artifacts'
     copy_apple_graph_fixture
 
     When call once --format json query capabilities apps/ios/App
@@ -69,8 +69,8 @@ Describe 'apple graph'
     The stdout should include '"kind":"apple_application"'
     The stdout should include '"name":"build"'
     The stdout should include '"output_groups":["default","bundle","dsyms"]'
-    The stdout should not include '"name":"run"'
-    The stdout should not include '"requires_outputs":["bundle"]'
+    The stdout should include '"name":"run"'
+    The stdout should include '"requires_outputs":["bundle"]'
   End
 
   It 'builds Apple application artifacts through the graph command'
@@ -87,14 +87,6 @@ Describe 'apple graph'
     The path "$WORKSPACE/.once/out/apps/ios/App/App.app/App" should be file
     The path "$WORKSPACE/.once/out/apps/ios/App/App.app/Info.plist" should be file
     The path "$WORKSPACE/.once/out/apps/ios/App/App.app/Frameworks/DesignSystem.framework/DesignSystem" should be file
-  End
-
-  It 'rejects running Apple application artifacts through the graph command'
-    copy_apple_graph_fixture
-
-    When call once --format json run apps/ios/App
-    The status should not equal 0
-    The stderr should include 'running `apple_application` targets is not yet supported'
   End
 
   It 'exposes testable Apple test bundle artifacts'
@@ -162,7 +154,7 @@ Describe 'apple graph'
     The stdout should include 'provisioning_profile'
     The stdout should include 'asset_catalogs'
     The stdout should include 'build: default, bundle, dsyms'
-    The stdout should not include 'run: default'
+    The stdout should include 'run: default (requires: bundle)'
   End
 
   It 'describes Apple test bundle build schema'
@@ -189,20 +181,20 @@ Describe 'apple graph'
     The stderr should include 'does not expose `test`'
   End
 
-  It 'rejects --remote for non-runnable graph targets'
+  It 'rejects --remote for graph run targets before execution'
     copy_apple_graph_fixture
 
     When call once run --remote apps/ios/App
     The status should not equal 0
-    The stderr should include 'running `apple_application` targets is not yet supported'
+    The stderr should include '--remote is only supported for executable script targets'
   End
 
-  It 'rejects --runtime-rpc for non-runnable graph targets'
+  It 'rejects --runtime-rpc for graph run targets before execution'
     copy_apple_graph_fixture
 
     When call once run --runtime-rpc apps/ios/App
     The status should not equal 0
-    The stderr should include 'running `apple_application` targets is not yet supported'
+    The stderr should include '--runtime-rpc is only supported for executable script targets'
   End
 
   Describe 'apple_library swiftc compile'

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -129,6 +129,90 @@ SH
     chmod +x "$WORKSPACE/bin/xcrun"
   }
 
+  create_mock_apple_test_fixture() {
+    mkdir -p "$WORKSPACE/toolchain/usr/bin" "$WORKSPACE/bin" "$WORKSPACE/apps/ios/Tests/AppTests" "$WORKSPACE/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks" "$WORKSPACE/Platforms/iPhoneSimulator.platform/Developer/usr/lib"
+    cat > "$WORKSPACE/apps/ios/Tests/AppTests/AppTests.swift" <<'SWIFT'
+import Testing
+
+@Test func examplePasses() {}
+SWIFT
+    cat > "$WORKSPACE/apps/ios/once.toml" <<'TOML'
+[[target]]
+name = "AppTests"
+kind = "apple_test_bundle"
+srcs = ["Tests/AppTests/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+sdk_variant = "simulator"
+minimum_os = "17.0"
+TOML
+    cat > "$WORKSPACE/bin/codesign" <<'SH'
+#!/bin/sh
+app=""
+for arg do
+  app="$arg"
+done
+mkdir -p "$app/_CodeSignature"
+: > "$app/_CodeSignature/CodeResources"
+SH
+    chmod +x "$WORKSPACE/bin/codesign"
+    cat > "$WORKSPACE/toolchain/usr/bin/xcrun" <<SH
+#!/bin/sh
+log='$WORKSPACE/xcrun.log'
+swiftc_path='$WORKSPACE/toolchain/usr/bin/swiftc'
+platform_path='$WORKSPACE/Platforms/iPhoneSimulator.platform'
+if [ "\${1:-}" = "--sdk" ]; then
+  shift 2
+fi
+case "\${1:-}" in
+  --find)
+    case "\${2:-}" in
+      swiftc) printf '%s\\n' "\$swiftc_path" ;;
+      codesign) printf '%s\\n' '$WORKSPACE/bin/codesign' ;;
+      *) printf '%s\\n' "\$0" ;;
+    esac
+    ;;
+  --show-sdk-platform-path)
+    printf '%s\\n' "\$platform_path"
+    ;;
+  swiftc)
+    if [ "\${2:-}" = "--version" ]; then
+      printf '%s\\n' 'Apple Swift version mock'
+      exit 0
+    fi
+    out=''
+    while [ "\$#" -gt 0 ]; do
+      if [ "\$1" = "-o" ]; then
+        shift
+        out="\${1:-}"
+        break
+      fi
+      shift
+    done
+    [ -n "\$out" ] || exit 2
+    mkdir -p "\$(dirname "\$out")"
+    printf '%s\\n' '#!/bin/sh' 'exit 0' > "\$out"
+    chmod 755 "\$out"
+    ;;
+  simctl)
+    printf '%s\\n' "\$*" >> "\$log"
+    if [ "\${2:-}" = "list" ] && [ "\${3:-}" = "devices" ] && [ "\${4:-}" = "booted" ]; then
+      printf '%s\\n' '    iPhone 15 (11111111-1111-1111-1111-111111111111) (Booted)'
+    fi
+    if [ "\${2:-}" = "list" ] && [ "\${3:-}" = "devices" ] && [ "\${4:-}" = "available" ]; then
+      printf '%s\\n' '    iPad Pro (22222222-2222-2222-2222-222222222222) (Shutdown)'
+    fi
+    ;;
+  *)
+    printf '%s\\n' "unexpected xcrun invocation: \$*" >&2
+    exit 1
+    ;;
+esac
+SH
+    chmod +x "$WORKSPACE/toolchain/usr/bin/xcrun"
+  }
+
   It 'lists buildable Apple artifacts'
     copy_apple_graph_fixture
 
@@ -192,6 +276,19 @@ SH
     The stdout should include '"output_groups":["default","bundle","dsyms"]'
     The stdout should include '"name":"test"'
     The stdout should include '"output_groups":["default","test_results","coverage"]'
+  End
+
+  It 're-runs Apple test runner actions without using the action cache'
+    create_mock_apple_test_fixture
+
+    When call env PATH="$WORKSPACE/toolchain/usr/bin:$PATH" /bin/sh -c '"$1" -C "$2" --format json test apps/ios/AppTests
+"$1" -C "$2" --format json test apps/ios/AppTests
+printf "spawn_count=%s\n" "$(grep -c "simctl spawn" "$2/xcrun.log")"' sh "$ONCE_BIN" "$WORKSPACE"
+    The status should be success
+    The stdout should include '"target":"apps/ios/AppTests"'
+    The stdout should include '"capability":"test"'
+    The stdout should include '"cache":"bypass"'
+    The stdout should include 'spawn_count=2'
   End
 
   It 'tests Apple test bundle artifacts through the graph command'


### PR DESCRIPTION
## Summary
- Adds generic rule-declared uncacheable actions so launch side effects bypass action-cache replay while Rust stays toolchain-agnostic.
- Implements Apple app run for macOS and iOS simulators, and compiles Swift Testing tests into `.xctest` bundles with dependency wiring.
- Adds MCP `once_build_target` and `once_run_target` behind `--allow-run`.
- Updates Blick to Fireworks Kimi K2.7 Code.

## Testing
- `mise exec -- cargo fmt --all`
- `mise exec -- cargo test -p once-frontend -p once-cli`
- `mise exec -- cargo build --release -p once-cli && mise exec -- shellspec spec/apple_spec.sh`
- MCP `tools/list` smoke checks with and without `--allow-run`
- `git diff --check`
