### PR TITLE
Build release artifacts with Once

### DIFF
--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -101,6 +101,7 @@ jobs:
           cp ".once/out/${target_id}/once" target/release/once
         env:
           GH_TOKEN: ${{ github.token }}
+          ONCE_BOOTSTRAP_SOURCE: source
       - uses: actions/upload-artifact@v7
         with:
           name: once-${{ matrix.os }}

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -86,7 +86,21 @@ jobs:
           shared-key: release-build-${{ matrix.os }}
           cache-on-failure: true
           cache-bin: false
-      - run: mise exec -- cargo build --release
+      - name: Build release binary with Once
+        run: |
+          set -euo pipefail
+          once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+          host_target="$(rustc -vV | sed -n 's/^host: //p')"
+          suffix="$(printf '%s' "${host_target}" | tr '.-' '__')"
+          target_id="crates/once-cli/once_cli_${suffix}"
+          trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
+          ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${host_target}"
+          ./mise/tasks/release/write-rust-release-manifests.sh --target "${host_target}" --version 0.0.0
+          "${once_bin}" build "${target_id}" --format json --quiet
+          mkdir -p target/release
+          cp ".once/out/${target_id}/once" target/release/once
+        env:
+          GH_TOKEN: ${{ github.token }}
       - uses: actions/upload-artifact@v7
         with:
           name: once-${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         include:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - runner: macos-15-intel
             target: x86_64-apple-darwin
           - runner: macos-15
@@ -72,9 +74,8 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
-          # Restrict to rust so shellspec (no Windows binary) doesn't
-          # block the Windows job.
-          install_args: "rust"
+          # Restrict to the build tools needed on every matrix host.
+          install_args: "rust jq"
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
       - name: Cache Rust
@@ -86,6 +87,8 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - name: Package release archive
         run: mise run release:package --target "${{ matrix.target }}" --version "${{ needs.detect.outputs.next-version }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Upload release assets
         uses: actions/upload-artifact@v7
         with:
@@ -102,7 +105,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "rust"
+          install_args: "rust jq"
       - name: Cache Rust
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
@@ -111,6 +114,7 @@ jobs:
       - name: Package XCFramework
         run: mise run release:package-xcframework --version "${{ needs.detect.outputs.next-version }}"
         env:
+          GH_TOKEN: ${{ github.token }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_DEVELOPER_ID_CERTIFICATE_ENCRYPTION_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_ENCRYPTION_PASSWORD }}
           APPLE_DEVELOPER_ID_CERTIFICATE_NAME: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_NAME }}
@@ -150,7 +154,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "rust"
+          install_args: "rust jq"
       - if: startsWith(matrix.runner, 'ubuntu-')
         run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
       - name: Cache Rust
@@ -162,7 +166,9 @@ jobs:
       - name: Add Rust target
         run: rustup target add ${{ matrix.target }}
       - name: Package SDK libraries
-        run: mise run release:package-sdk-libs --target "${{ matrix.target }}"
+        run: mise run release:package-sdk-libs --target "${{ matrix.target }}" --version "${{ needs.detect.outputs.next-version }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Upload SDK libraries
         uses: actions/upload-artifact@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /.fabrik
 /.blick/runs/
 /vendor
+/third_party/rust/src/
+/third_party/rust/vendor/
 /packages/js/node_modules
 /packages/js/prebuilds
 /packages/ruby/prebuilds

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -3,7 +3,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use once_cas::{CacheProvider, Digest};
+use once_cas::{ActionResult, CacheProvider, Digest};
 use once_core::{
     Action, InputDigestBuilder, OutputSymlinkMode, ResourceRequest, RunOpts, WorkspacePath,
 };
@@ -12,6 +12,8 @@ use once_frontend::GraphTarget;
 use tokio::process::Command;
 
 use super::BuildOutcome;
+
+const FAILURE_OUTPUT_LIMIT: usize = 16 * 1024;
 
 /// Materialise each declared action through the action cache, then
 /// fold the analysis provider directly into the build outcome.
@@ -62,8 +64,16 @@ pub(super) async fn run_declared_actions(
             let exit_code = outcome.result.exit_code;
             if exit_code != 0 {
                 anyhow::bail!(
-                    "{identifier_for_error} ({index}) failed for {} with exit code {exit_code}",
-                    target.label.id,
+                    "{}",
+                    declared_action_failure_message(
+                        cache,
+                        &identifier_for_error,
+                        index,
+                        &target.label.id,
+                        exit_code,
+                        &outcome.result,
+                    )
+                    .await
                 );
             }
             action_digests.push(outcome.action);
@@ -95,6 +105,51 @@ pub(super) async fn run_declared_actions(
         outputs: all_outputs,
         cache_tag: last_cache_tag,
     })
+}
+
+async fn declared_action_failure_message(
+    cache: &CacheProvider,
+    identifier: &str,
+    index: usize,
+    target: &str,
+    exit_code: i32,
+    result: &ActionResult,
+) -> String {
+    let mut message =
+        format!("{identifier} ({index}) failed for {target} with exit code {exit_code}");
+    append_captured_output(cache, &mut message, "stdout", result.stdout.as_ref()).await;
+    append_captured_output(cache, &mut message, "stderr", result.stderr.as_ref()).await;
+    message
+}
+
+async fn append_captured_output(
+    cache: &CacheProvider,
+    message: &mut String,
+    name: &str,
+    digest: Option<&Digest>,
+) {
+    let Some(digest) = digest else {
+        return;
+    };
+    let Ok(bytes) = cache.get_blob(digest).await else {
+        return;
+    };
+    if bytes.is_empty() {
+        return;
+    }
+    let (prefix, slice) = if bytes.len() > FAILURE_OUTPUT_LIMIT {
+        (
+            format!("last {FAILURE_OUTPUT_LIMIT} bytes of "),
+            &bytes[bytes.len() - FAILURE_OUTPUT_LIMIT..],
+        )
+    } else {
+        (String::new(), bytes.as_slice())
+    };
+    message.push_str("\n\n");
+    message.push_str(&prefix);
+    message.push_str(name);
+    message.push_str(":\n");
+    message.push_str(&String::from_utf8_lossy(slice));
 }
 
 async fn run_uncached_action(action: &Action, workspace: &Path) -> Result<i32> {

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -131,8 +131,17 @@ async fn append_captured_output(
     let Some(digest) = digest else {
         return;
     };
-    let Ok(bytes) = cache.get_blob(digest).await else {
-        return;
+    let bytes = match cache.get_blob(digest).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            tracing::warn!(
+                output = name,
+                digest = %digest,
+                error = %err,
+                "failed to read captured declared action output"
+            );
+            return;
+        }
     };
     if bytes.is_empty() {
         return;
@@ -344,6 +353,61 @@ mod tests {
         assert!(workspace.path().join(".once/out/x/sub").is_dir());
         let Action::RunCommand { argv, .. } = action;
         assert_eq!(argv, vec!["tool".to_string(), "--version".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn declared_action_failure_message_appends_captured_output() {
+        let workspace = tempfile::tempdir().unwrap();
+        let cache = CacheProvider::Local(once_cas::Cas::open(workspace.path().join("cas")));
+        let stdout = cache.put_blob(b"visible stdout").await.unwrap();
+        let stderr = cache.put_blob(b"visible stderr").await.unwrap();
+        let result = ActionResult {
+            exit_code: 7,
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            outputs: BTreeMap::new(),
+        };
+
+        let message =
+            declared_action_failure_message(&cache, "target:action", 2, "target", 7, &result).await;
+
+        assert!(message.contains("target:action (2) failed for target with exit code 7"));
+        assert!(message.contains("stdout:\nvisible stdout"));
+        assert!(message.contains("stderr:\nvisible stderr"));
+    }
+
+    #[tokio::test]
+    async fn declared_action_failure_message_truncates_large_output() {
+        let workspace = tempfile::tempdir().unwrap();
+        let cache = CacheProvider::Local(once_cas::Cas::open(workspace.path().join("cas")));
+        let mut bytes = b"drop-me".to_vec();
+        bytes.extend(std::iter::repeat_n(b'x', FAILURE_OUTPUT_LIMIT));
+        let stdout = cache.put_blob(&bytes).await.unwrap();
+        let result = ActionResult {
+            exit_code: 1,
+            stdout: Some(stdout),
+            stderr: None,
+            outputs: BTreeMap::new(),
+        };
+
+        let message = declared_action_failure_message(&cache, "id", 0, "target", 1, &result).await;
+
+        assert!(message.contains("last 16384 bytes of stdout:\n"));
+        assert!(!message.contains("drop-me"));
+        assert!(message.ends_with(&"x".repeat(FAILURE_OUTPUT_LIMIT)));
+    }
+
+    #[tokio::test]
+    async fn append_captured_output_ignores_missing_digest_and_missing_blob() {
+        let workspace = tempfile::tempdir().unwrap();
+        let cache = CacheProvider::Local(once_cas::Cas::open(workspace.path().join("cas")));
+        let missing = Digest::of_bytes(b"missing");
+        let mut message = "base".to_string();
+
+        append_captured_output(&cache, &mut message, "stdout", None).await;
+        append_captured_output(&cache, &mut message, "stdout", Some(&missing)).await;
+
+        assert_eq!(message, "base");
     }
 
     #[cfg(unix)]

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -502,7 +502,7 @@ done < {stdout}
 """.format(metadata = _rust_dep_metadata_key_shell(prefix), stdout = _shell_quote(_workspace_absolute(stdout))))
     return ("\n".join(snippets), _unique(inputs))
 
-def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps):
+def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps):
     build_script = _rust_attr(ctx, "build_script", "")
     if not build_script:
         return (None, [], {}, None)
@@ -533,7 +533,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         identifier = ctx["label"]["id"] + ":build-script-rustc",
     )
     run_env = _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path)
-    metadata_exports, metadata_inputs = _rust_dep_metadata_exports(deps)
+    metadata_exports, metadata_inputs = _rust_dep_metadata_exports(metadata_deps)
     run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(_workspace_absolute(runner)) + " > " + _shell_quote(_workspace_absolute(stdout))
     run_action(
         argv = [host_which("sh"), "-c", run_script],
@@ -628,9 +628,14 @@ def _rust_output_extension(crate_type, target):
         return ".exe" if "windows" in os_key else ""
     return ""
 
+def _rust_effective_target(ctx, crate_type):
+    if crate_type == "proc-macro":
+        return ""
+    return _rust_target(ctx)
+
 def _rust_output_name(ctx, crate_type):
     crate_name = _rust_crate_name(ctx)
-    target = _rust_target(ctx)
+    target = _rust_effective_target(ctx, crate_type)
     if crate_type == "bin":
         return crate_name + _rust_output_extension(crate_type, target)
     if crate_type == "rlib" or crate_type == "staticlib" or crate_type == "cdylib" or crate_type == "dylib" or crate_type == "proc-macro":
@@ -643,7 +648,7 @@ def _rust_declared_output(ctx, name):
     return prefix + name
 
 def _rust_compile(ctx, crate_type, default_root, output_name):
-    target = _rust_target(ctx)
+    target = _rust_effective_target(ctx, crate_type)
     rustc, identity, host_triple = _rustc_toolchain(target)
     crate_name = _rust_crate_name(ctx)
     edition = _rust_attr(ctx, "edition", "2021")
@@ -654,7 +659,12 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
     deps = _rust_resolved_deps(ctx)
     dep_args = _rust_dep_args(deps, aliases)
     dep_inputs = _rust_dep_inputs(deps)
-    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps)
+    build_deps = ctx.get("build_deps")
+    if build_deps == None:
+        build_deps = deps
+    build_dep_args = _rust_dep_args(build_deps, aliases)
+    build_dep_inputs = _rust_dep_inputs(build_deps)
+    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps)
     compile_env = build_env if build_env else _rust_compile_env(ctx)
     linker_args, linker_identity = _rust_linker(ctx, crate_type, target, host_triple)
     argv = [
@@ -730,7 +740,7 @@ def _rust_proc_macro_impl(ctx):
 def _cargo_dependencies_impl(ctx):
     resolved = _cargo_resolved_metadata(ctx)
     deps, providers_by_name = _cargo_compile_resolved_specs(ctx, resolved["specs"])
-    workspace_deps = _cargo_workspace_deps(resolved["metadata"], providers_by_name)
+    workspace_deps = _cargo_workspace_deps(ctx, resolved["metadata"], providers_by_name)
     packages = _rust_attr(ctx, "packages", [])
     if packages:
         deps = _rust_select_dependency_set([{"deps": deps}], packages, ctx["label"]["id"])
@@ -780,8 +790,11 @@ def _cargo_resolved_metadata(ctx):
     argv.extend(_cargo_feature_args(ctx))
     metadata_content = host_command(argv)
     metadata = json_decode(metadata_content)
+    resolver_attrs = {"vendor_dir": vendor_dir}
+    if target:
+        resolver_attrs["target"] = target
     resolver_ctx = {
-        "attrs": {"vendor_dir": vendor_dir},
+        "attrs": resolver_attrs,
     }
     return {
         "metadata": metadata,
@@ -816,6 +829,7 @@ def _cargo_compile_resolved_specs(ctx, specs):
         progressed = False
         for spec in remaining:
             dep_providers = []
+            build_dep_providers = []
             ready = True
             for dep_ref in spec.get("deps") or []:
                 dep_name = _cargo_ref_name(dep_ref)
@@ -827,7 +841,17 @@ def _cargo_compile_resolved_specs(ctx, specs):
             if not ready:
                 next_remaining.append(spec)
                 continue
-            provider = _cargo_compile_resolved_spec(ctx, spec, dep_providers, metadata_inputs)
+            for dep_ref in spec.get("build_deps") or []:
+                dep_name = _cargo_ref_name(dep_ref)
+                provider = providers_by_name.get(dep_name)
+                if provider == None:
+                    ready = False
+                    break
+                build_dep_providers.append(provider)
+            if not ready:
+                next_remaining.append(spec)
+                continue
+            provider = _cargo_compile_resolved_spec(ctx, spec, dep_providers, build_dep_providers, metadata_inputs)
             providers_by_name[spec["name"]] = provider
             providers.append(provider)
             progressed = True
@@ -840,7 +864,7 @@ def _cargo_compile_resolved_specs(ctx, specs):
         fail(ctx["label"]["id"] + ": Cargo dependency graph has a cycle or missing dependency among " + ", ".join(names))
     return (providers, providers_by_name)
 
-def _cargo_compile_resolved_spec(ctx, spec, dep_providers, metadata_inputs):
+def _cargo_compile_resolved_spec(ctx, spec, dep_providers, build_dep_providers, metadata_inputs):
     attrs = _cargo_copy_attrs(spec.get("attrs") or {})
     attrs["_output_prefix"] = spec["name"] + "/"
     attrs["_extra_inputs"] = metadata_inputs
@@ -852,17 +876,19 @@ def _cargo_compile_resolved_spec(ctx, spec, dep_providers, metadata_inputs):
         },
         "attr": attrs,
         "deps": dep_providers,
+        "build_deps": build_dep_providers,
         "srcs": spec.get("srcs") or [],
     }
     if spec.get("kind") == "rust_proc_macro":
         return _rust_proc_macro_impl(spec_ctx)
     return _rust_crate_impl(spec_ctx)
 
-def _cargo_workspace_deps(metadata, providers_by_name):
+def _cargo_workspace_deps(ctx, metadata, providers_by_name):
     packages = metadata.get("packages") or []
     duplicate_counts = _cargo_duplicate_counts(packages)
-    _, id_to_target_name = _cargo_package_indexes(packages, duplicate_counts)
     nodes = _cargo_resolve_nodes(metadata)
+    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes)
+    id_to_target_name, _ = _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids)
     out = {}
     for package in packages:
         if package.get("source") != None:
@@ -1106,6 +1132,69 @@ def _cargo_kind_for_target(target):
         return "rust_proc_macro"
     return "rust_crate"
 
+def _cargo_package_is_proc_macro(package):
+    target = _cargo_library_target(package)
+    if target == None:
+        return False
+    return _cargo_kind_for_target(target) == "rust_proc_macro"
+
+def _cargo_host_variant_name(package, duplicate_counts):
+    return _cargo_target_name(package, duplicate_counts) + "-host"
+
+def _cargo_host_dependency_ids(packages, nodes):
+    package_by_id, _ = _cargo_package_indexes(packages, _cargo_duplicate_counts(packages))
+    needed = {}
+    stack = []
+    for package in packages:
+        package_id = package.get("id")
+        if package.get("source") == None or not package_id:
+            continue
+        if _cargo_package_is_proc_macro(package):
+            stack.append(package_id)
+        if _cargo_build_script_target(package) != None:
+            node = nodes.get(package_id) or {}
+            for dep in node.get("deps") or []:
+                if _cargo_dep_is_build(dep):
+                    dep_id = dep.get("pkg")
+                    dep_package = package_by_id.get(dep_id)
+                    if dep_package != None and dep_package.get("source") != None:
+                        stack.append(dep_id)
+    for _ in range(len(packages) + 1):
+        if len(stack) == 0:
+            break
+        current = stack
+        stack = []
+        for package_id in current:
+            package = package_by_id.get(package_id)
+            if package == None or package.get("source") == None or package_id in needed:
+                continue
+            needed[package_id] = True
+            node = nodes.get(package_id) or {}
+            include_build = _cargo_build_script_target(package) != None
+            for dep in node.get("deps") or []:
+                if not _cargo_dep_is_runtime(dep) and not (include_build and _cargo_dep_is_build(dep)):
+                    continue
+                dep_id = dep.get("pkg")
+                dep_package = package_by_id.get(dep_id)
+                if dep_package != None and dep_package.get("source") != None and dep_id not in needed:
+                    stack.append(dep_id)
+    return needed
+
+def _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids):
+    target_names = {}
+    host_names = {}
+    for package in packages:
+        package_id = package.get("id")
+        if package.get("source") == None or not package_id:
+            continue
+        target_name = _cargo_target_name(package, duplicate_counts)
+        target_names[package_id] = target_name
+        if _cargo_package_is_proc_macro(package):
+            host_names[package_id] = target_name
+        elif host_dependency_ids.get(package_id):
+            host_names[package_id] = _cargo_host_variant_name(package, duplicate_counts)
+    return (target_names, host_names)
+
 def _cargo_package_indexes(packages, duplicate_counts):
     by_id = {}
     id_to_target_name = {}
@@ -1139,11 +1228,13 @@ def _cargo_dep_is_build(dep):
             return True
     return False
 
-def _cargo_metadata_deps(node, id_to_target_name, include_build):
+def _cargo_metadata_dep_refs(node, id_to_target_name, include_runtime, include_build):
     deps = []
     aliases = {}
     for dep in node.get("deps") or []:
-        if not _cargo_dep_is_runtime(dep) and not (include_build and _cargo_dep_is_build(dep)):
+        runtime = include_runtime and _cargo_dep_is_runtime(dep)
+        build = include_build and _cargo_dep_is_build(dep)
+        if not runtime and not build:
             continue
         dep_id = dep.get("pkg")
         target_name = id_to_target_name.get(dep_id)
@@ -1154,6 +1245,12 @@ def _cargo_metadata_deps(node, id_to_target_name, include_build):
         if local_name:
             aliases[target_name] = local_name
     return (_unique(deps), aliases)
+
+def _cargo_metadata_deps(node, id_to_target_name, include_build):
+    return _cargo_metadata_dep_refs(node, id_to_target_name, True, include_build)
+
+def _cargo_metadata_build_deps(node, id_to_target_name):
+    return _cargo_metadata_dep_refs(node, id_to_target_name, False, True)
 
 def _cargo_version_components(version):
     build_parts = version.split("+")
@@ -1228,12 +1325,40 @@ def _cargo_metadata_resolver_impl(ctx, metadata_content):
     metadata = json_decode(metadata_content)
     return _cargo_metadata_targets(ctx, metadata)
 
+def _cargo_merge_aliases(left, right):
+    out = {}
+    for key, value in left.items():
+        out[key] = value
+    for key, value in right.items():
+        out[key] = value
+    return out
+
+def _cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, aliases, rust_target):
+    attrs = _cargo_metadata_attrs(package, target, node, source_root, crate_root, aliases)
+    if rust_target:
+        attrs["target"] = rust_target
+    checksum = package.get("checksum")
+    if checksum != None:
+        attrs["checksum"] = checksum
+    spec = {
+        "name": name,
+        "kind": kind,
+        "deps": deps,
+        "srcs": [_cargo_source_glob(source_root, crate_root)],
+        "attrs": attrs,
+    }
+    if build_deps:
+        spec["build_deps"] = build_deps
+    return spec
+
 def _cargo_metadata_targets(ctx, metadata):
     packages = metadata.get("packages") or []
     duplicate_counts = _cargo_duplicate_counts(packages)
-    package_by_id, id_to_target_name = _cargo_package_indexes(packages, duplicate_counts)
     nodes = _cargo_resolve_nodes(metadata)
+    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes)
+    id_to_target_name, id_to_host_name = _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids)
     vendor_dir = _trim_trailing_slash(ctx["attrs"].get("vendor_dir") or "vendor")
+    rust_target = ctx["attrs"].get("target") or ""
     targets = []
     for package in packages:
         if package.get("source") == None:
@@ -1241,23 +1366,29 @@ def _cargo_metadata_targets(ctx, metadata):
         target = _cargo_library_target(package)
         if target == None:
             continue
-        name = id_to_target_name.get(package.get("id")) or _cargo_target_name(package, duplicate_counts)
-        source_root = _cargo_vendor_source_root(vendor_dir, package, name)
+        package_id = package.get("id")
+        name = id_to_target_name.get(package_id) or _cargo_target_name(package, duplicate_counts)
+        kind = _cargo_kind_for_target(target)
+        source_root = _cargo_vendor_source_root(vendor_dir, package, _cargo_target_name(package, duplicate_counts))
         rel_root = _cargo_source_rel(package, target)
         crate_root = source_root + "/" + rel_root
-        node = nodes.get(package.get("id")) or {}
-        deps, aliases = _cargo_metadata_deps(node, id_to_target_name, _cargo_build_script_target(package) != None)
-        attrs = _cargo_metadata_attrs(package, target, node, source_root, crate_root, aliases)
-        checksum = package.get("checksum")
-        if checksum != None:
-            attrs["checksum"] = checksum
-        targets.append({
-            "name": name,
-            "kind": _cargo_kind_for_target(target),
-            "deps": deps,
-            "srcs": [_cargo_source_glob(source_root, crate_root)],
-            "attrs": attrs,
-        })
+        node = nodes.get(package_id) or {}
+
+        if kind == "rust_proc_macro":
+            deps, aliases = _cargo_metadata_deps(node, id_to_host_name, False)
+            build_deps, build_aliases = _cargo_metadata_build_deps(node, id_to_host_name)
+            targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), ""))
+            continue
+
+        deps, aliases = _cargo_metadata_deps(node, id_to_target_name, False)
+        build_deps, build_aliases = _cargo_metadata_build_deps(node, id_to_host_name)
+        targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), rust_target))
+
+        host_name = id_to_host_name.get(package_id)
+        if host_name:
+            host_deps, host_aliases = _cargo_metadata_deps(node, id_to_host_name, False)
+            host_build_deps, host_build_aliases = _cargo_metadata_build_deps(node, id_to_host_name)
+            targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, host_name, kind, host_deps, host_build_deps, _cargo_merge_aliases(host_aliases, host_build_aliases), ""))
     return targets
 
 def _cargo_vendor_source_root(vendor_dir, package, target_name):

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -232,6 +232,30 @@ def _rust_user_flags(ctx):
 def _rust_encoded_rustflags(ctx):
     return "\x1f".join(_rust_user_flags(ctx))
 
+def _rust_host_env_value(name):
+    if host_os() == "windows":
+        return ""
+    return host_command([host_which("sh"), "-c", "printf '%s' \"${" + name + "-}\""])
+
+def _rust_host_tool_env():
+    env = {}
+    for key in [
+        "PATH",
+        "COMPILER_PATH",
+        "LIBRARY_PATH",
+        "GCC_EXEC_PREFIX",
+        "CPATH",
+        "C_INCLUDE_PATH",
+        "CPLUS_INCLUDE_PATH",
+        "PKG_CONFIG_PATH",
+        "PKG_CONFIG_LIBDIR",
+        "PKG_CONFIG_SYSROOT_DIR",
+    ]:
+        value = _rust_host_env_value(key)
+        if value:
+            env[key] = value
+    return env
+
 def _rust_cap_lints(ctx):
     value = _rust_attr(ctx, "cap_lints", "")
     if value:
@@ -439,6 +463,9 @@ def _rust_builtin_extern_args(crate_type):
 
 def _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path):
     env = _rust_compile_env(ctx)
+    for key, value in _rust_host_tool_env().items():
+        if key not in env:
+            env[key] = value
     for key, value in _rust_cfg_env(rustc, target).items():
         if key not in env:
             env[key] = value

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -232,21 +232,16 @@ def _rust_user_flags(ctx):
 def _rust_encoded_rustflags(ctx):
     return "\x1f".join(_rust_user_flags(ctx))
 
-def _rust_target_env_keys(prefix, target):
-    keys = [prefix]
-    if target:
-        keys.append(prefix + "_" + target.replace("-", "_"))
-        keys.append(prefix + "_" + target)
-    return _unique(keys)
-
-def _rust_c_tool_env(target):
+def _rust_c_tool_env(target, host_triple):
     env = {}
-    if host_os() == "windows":
+    if host_os() == "windows" or target != host_triple:
         return env
-    for key in _rust_target_env_keys("CC", target):
-        env[key] = host_which("cc")
-    for key in _rust_target_env_keys("AR", target):
-        env[key] = host_which("ar")
+    cc = host_which("cc")
+    if cc:
+        env["CC"] = cc
+    ar = host_which("ar")
+    if ar:
+        env["AR"] = ar
     return env
 
 def _rust_cap_lints(ctx):
@@ -456,7 +451,7 @@ def _rust_builtin_extern_args(crate_type):
 
 def _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path):
     env = _rust_compile_env(ctx)
-    for key, value in _rust_c_tool_env(target or host_triple).items():
+    for key, value in _rust_c_tool_env(target or host_triple, host_triple).items():
         if key not in env:
             env[key] = value
     for key, value in _rust_cfg_env(rustc, target).items():

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -178,6 +178,9 @@ def _rust_sources(ctx, crate_root):
         srcs.append(crate_root)
     return _unique(srcs)
 
+def _rust_source_inputs(ctx):
+    return glob(ctx["srcs"])
+
 def _rust_extra_inputs(ctx):
     return _rust_attr(ctx, "_extra_inputs", [])
 
@@ -225,6 +228,9 @@ def _rust_features(ctx):
 
 def _rust_user_flags(ctx):
     return _rust_attr(ctx, "rustc_flags", [])
+
+def _rust_encoded_rustflags(ctx):
+    return "\x1f".join(_rust_user_flags(ctx))
 
 def _rust_cap_lints(ctx):
     value = _rust_attr(ctx, "cap_lints", "")
@@ -452,6 +458,8 @@ def _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path
         env["PROFILE"] = "debug"
     env["RUSTC"] = rustc
     env["TARGET"] = target or host_triple
+    if "CARGO_ENCODED_RUSTFLAGS" not in env:
+        env["CARGO_ENCODED_RUSTFLAGS"] = _rust_encoded_rustflags(ctx)
     return env
 
 def _rust_manifest_links(ctx):
@@ -534,10 +542,10 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     )
     run_env = _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path)
     metadata_exports, metadata_inputs = _rust_dep_metadata_exports(metadata_deps)
-    run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(_workspace_absolute(runner)) + " > " + _shell_quote(_workspace_absolute(stdout))
+    run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(_workspace_absolute(runner)) + " > " + _shell_quote(_workspace_absolute(stdout)) + " 2>&1"
     run_action(
         argv = [host_which("sh"), "-c", run_script],
-        inputs = _unique([runner] + metadata_inputs),
+        inputs = _unique([runner] + metadata_inputs + _rust_source_inputs(ctx)),
         outputs = [out_dir, stdout],
         env = run_env,
         toolchain_identity = identity + "\x00build-script-run",
@@ -1083,7 +1091,7 @@ def _cargo_resolver_impl(ctx):
             "name": name,
             "kind": "rust_crate",
             "deps": deps,
-            "srcs": [source_root + "/src/**/*.rs"],
+            "srcs": [_cargo_package_source_glob(source_root)],
             "attrs": attrs,
         })
     return targets
@@ -1109,6 +1117,9 @@ def _cargo_source_glob(source_root, crate_root):
         if rel_parent:
             return source_root + "/" + rel_parent + "/**/*.rs"
     return source_root + "/src/**/*.rs"
+
+def _cargo_package_source_glob(source_root):
+    return source_root + "/**"
 
 def _cargo_library_target(package):
     for target in package.get("targets") or []:
@@ -1344,7 +1355,7 @@ def _cargo_metadata_target_spec(package, target, node, source_root, crate_root, 
         "name": name,
         "kind": kind,
         "deps": deps,
-        "srcs": [_cargo_source_glob(source_root, crate_root)],
+        "srcs": [_cargo_package_source_glob(source_root)],
         "attrs": attrs,
     }
     if build_deps:

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -185,7 +185,7 @@ def _rust_extra_inputs(ctx):
     return _rust_attr(ctx, "_extra_inputs", [])
 
 def _rust_build_script_inputs(ctx):
-    return _rust_attr(ctx, "_build_script_inputs", [])
+    return glob(_rust_attr(ctx, "_build_script_inputs", []))
 
 def _rust_target(ctx):
     return _rust_target_raw(ctx)

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -232,6 +232,18 @@ def _rust_user_flags(ctx):
 def _rust_encoded_rustflags(ctx):
     return "\x1f".join(_rust_user_flags(ctx))
 
+def _host_which_optional(name):
+    path = host_command([host_which("sh"), "-c", "command -v " + _shell_quote(name) + " 2>/dev/null || true"]).strip()
+    return path
+
+def _rust_tool_path(tools):
+    dirs = []
+    for tool in tools:
+        directory = _parent_dir(tool)
+        if directory:
+            dirs.append(directory)
+    return ":".join(_unique(dirs))
+
 def _rust_c_tool_env(target, host_triple):
     env = {}
     if host_os() == "windows" or target != host_triple:
@@ -242,6 +254,9 @@ def _rust_c_tool_env(target, host_triple):
     ar = host_which("ar")
     if ar:
         env["AR"] = ar
+    path = _rust_tool_path([cc, ar, _host_which_optional("as"), _host_which_optional("ld")])
+    if path:
+        env["PATH"] = path
     return env
 
 def _rust_cap_lints(ctx):

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -542,7 +542,8 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     )
     run_env = _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path)
     metadata_exports, metadata_inputs = _rust_dep_metadata_exports(metadata_deps)
-    run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(_workspace_absolute(runner)) + " > " + _shell_quote(_workspace_absolute(stdout)) + " 2>&1"
+    stdout_abs = _shell_quote(_workspace_absolute(stdout))
+    run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(_workspace_absolute(runner)) + " > " + stdout_abs + " 2>&1 || { code=$?; " + _shell_quote(host_which("cat")) + " " + stdout_abs + " >&2; exit $code; }"
     run_action(
         argv = [host_which("sh"), "-c", run_script],
         inputs = _unique([runner] + metadata_inputs + _rust_source_inputs(ctx)),

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -232,28 +232,21 @@ def _rust_user_flags(ctx):
 def _rust_encoded_rustflags(ctx):
     return "\x1f".join(_rust_user_flags(ctx))
 
-def _rust_host_env_value(name):
-    if host_os() == "windows":
-        return ""
-    return host_command([host_which("sh"), "-c", "printf '%s' \"${" + name + "-}\""])
+def _rust_target_env_keys(prefix, target):
+    keys = [prefix]
+    if target:
+        keys.append(prefix + "_" + target.replace("-", "_"))
+        keys.append(prefix + "_" + target)
+    return _unique(keys)
 
-def _rust_host_tool_env():
+def _rust_c_tool_env(target):
     env = {}
-    for key in [
-        "PATH",
-        "COMPILER_PATH",
-        "LIBRARY_PATH",
-        "GCC_EXEC_PREFIX",
-        "CPATH",
-        "C_INCLUDE_PATH",
-        "CPLUS_INCLUDE_PATH",
-        "PKG_CONFIG_PATH",
-        "PKG_CONFIG_LIBDIR",
-        "PKG_CONFIG_SYSROOT_DIR",
-    ]:
-        value = _rust_host_env_value(key)
-        if value:
-            env[key] = value
+    if host_os() == "windows":
+        return env
+    for key in _rust_target_env_keys("CC", target):
+        env[key] = host_which("cc")
+    for key in _rust_target_env_keys("AR", target):
+        env[key] = host_which("ar")
     return env
 
 def _rust_cap_lints(ctx):
@@ -463,7 +456,7 @@ def _rust_builtin_extern_args(crate_type):
 
 def _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path):
     env = _rust_compile_env(ctx)
-    for key, value in _rust_host_tool_env().items():
+    for key, value in _rust_c_tool_env(target or host_triple).items():
         if key not in env:
             env[key] = value
     for key, value in _rust_cfg_env(rustc, target).items():

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -543,6 +543,33 @@ done < {stdout}
 """.format(metadata = _rust_dep_metadata_key_shell(prefix), stdout = _shell_quote(_workspace_absolute(stdout))))
     return ("\n".join(snippets), _unique(inputs))
 
+def _rust_build_script_output_pipeline(runner, status, stdout):
+    runner_exec = _shell_quote(_workspace_absolute(runner))
+    printf = _shell_quote(host_which("printf"))
+    tee = _shell_quote(host_which("tee"))
+    status_abs = _shell_quote(status)
+    stdout_abs = _shell_quote(_workspace_absolute(stdout))
+    status_capture = "{ " + runner_exec + " 2>&1; " + printf + " '%s' \"$?\" > " + status_abs + "; }"
+    return status_capture + " | " + tee + " " + stdout_abs
+
+def _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports):
+    status = run_env["OUT_DIR"] + "/.once-build-script-status"
+    status_abs = _shell_quote(status)
+    rm = _shell_quote(host_which("rm"))
+    lines = [
+        _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]),
+    ]
+    if metadata_exports:
+        lines.append(metadata_exports)
+    lines.extend([
+        rm + " -f " + status_abs,
+        _rust_build_script_output_pipeline(runner, status, stdout),
+        "code=$(" + _shell_quote(host_which("cat")) + " " + status_abs + ")",
+        rm + " -f " + status_abs,
+        "exit \"$code\"",
+    ])
+    return "\n".join(lines)
+
 def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps):
     build_script = _rust_attr(ctx, "build_script", "")
     if not build_script:
@@ -575,9 +602,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     )
     run_env = _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path)
     metadata_exports, metadata_inputs = _rust_dep_metadata_exports(metadata_deps)
-    stdout_abs = _shell_quote(_workspace_absolute(stdout))
-    status_abs = _shell_quote(run_env["OUT_DIR"] + "/.once-build-script-status")
-    run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(host_which("rm")) + " -f " + status_abs + "\n{ " + _shell_quote(_workspace_absolute(runner)) + " 2>&1; " + _shell_quote(host_which("printf")) + " '%s' \"$?\" > " + status_abs + "; } | " + _shell_quote(host_which("tee")) + " " + stdout_abs + "\ncode=$(" + _shell_quote(host_which("cat")) + " " + status_abs + ")\n" + _shell_quote(host_which("rm")) + " -f " + status_abs + "\nexit \"$code\""
+    run_script = _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports)
     run_action(
         argv = [host_which("sh"), "-c", run_script],
         inputs = _unique([runner] + metadata_inputs + _rust_source_inputs(ctx) + _rust_build_script_inputs(ctx)),

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -184,6 +184,9 @@ def _rust_source_inputs(ctx):
 def _rust_extra_inputs(ctx):
     return _rust_attr(ctx, "_extra_inputs", [])
 
+def _rust_build_script_inputs(ctx):
+    return _rust_attr(ctx, "_build_script_inputs", [])
+
 def _rust_target(ctx):
     return _rust_target_raw(ctx)
 
@@ -573,10 +576,11 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     run_env = _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path)
     metadata_exports, metadata_inputs = _rust_dep_metadata_exports(metadata_deps)
     stdout_abs = _shell_quote(_workspace_absolute(stdout))
-    run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(_workspace_absolute(runner)) + " > " + stdout_abs + " 2>&1 || { code=$?; " + _shell_quote(host_which("cat")) + " " + stdout_abs + " >&2; exit $code; }"
+    status_abs = _shell_quote(run_env["OUT_DIR"] + "/.once-build-script-status")
+    run_script = _shell_quote(host_which("mkdir")) + " -p " + _shell_quote(run_env["OUT_DIR"]) + " && cd " + _shell_quote(run_env["CARGO_MANIFEST_DIR"]) + "\n" + metadata_exports + "\n" + _shell_quote(host_which("rm")) + " -f " + status_abs + "\n{ " + _shell_quote(_workspace_absolute(runner)) + " 2>&1; " + _shell_quote(host_which("printf")) + " '%s' \"$?\" > " + status_abs + "; } | " + _shell_quote(host_which("tee")) + " " + stdout_abs + "\ncode=$(" + _shell_quote(host_which("cat")) + " " + status_abs + ")\n" + _shell_quote(host_which("rm")) + " -f " + status_abs + "\nexit \"$code\""
     run_action(
         argv = [host_which("sh"), "-c", run_script],
-        inputs = _unique([runner] + metadata_inputs + _rust_source_inputs(ctx)),
+        inputs = _unique([runner] + metadata_inputs + _rust_source_inputs(ctx) + _rust_build_script_inputs(ctx)),
         outputs = [out_dir, stdout],
         env = run_env,
         toolchain_identity = identity + "\x00build-script-run",
@@ -700,7 +704,7 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
     dep_inputs = _rust_dep_inputs(deps)
     build_deps = ctx.get("build_deps")
     if build_deps == None:
-        build_deps = deps
+        build_deps = []
     build_dep_args = _rust_dep_args(build_deps, aliases)
     build_dep_inputs = _rust_dep_inputs(build_deps)
     build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps)
@@ -1122,7 +1126,7 @@ def _cargo_resolver_impl(ctx):
             "name": name,
             "kind": "rust_crate",
             "deps": deps,
-            "srcs": [_cargo_package_source_glob(source_root)],
+            "srcs": _cargo_package_source_globs(source_root),
             "attrs": attrs,
         })
     return targets
@@ -1149,8 +1153,12 @@ def _cargo_source_glob(source_root, crate_root):
             return source_root + "/" + rel_parent + "/**/*.rs"
     return source_root + "/src/**/*.rs"
 
-def _cargo_package_source_glob(source_root):
-    return source_root + "/**"
+def _cargo_package_source_globs(source_root):
+    return [
+        source_root + "/Cargo.toml",
+        source_root + "/build.rs",
+        source_root + "/src/**/*.rs",
+    ]
 
 def _cargo_library_target(package):
     for target in package.get("targets") or []:
@@ -1382,11 +1390,13 @@ def _cargo_metadata_target_spec(package, target, node, source_root, crate_root, 
     checksum = package.get("checksum")
     if checksum != None:
         attrs["checksum"] = checksum
+    if attrs.get("build_script"):
+        attrs["_build_script_inputs"] = [source_root + "/**"]
     spec = {
         "name": name,
         "kind": kind,
         "deps": deps,
-        "srcs": [_cargo_package_source_glob(source_root)],
+        "srcs": _cargo_package_source_globs(source_root),
         "attrs": attrs,
     }
     if build_deps:

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1877,6 +1877,53 @@ result = repr([
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn prelude_rust_build_script_env_uses_absolute_c_tool_paths() {
+        let prelude = format!(
+            "{}\n{}",
+            include_str!("../prelude/apple.star"),
+            include_str!("../prelude/rust.star")
+        );
+        let source = format!(
+            r#"{prelude}
+rustc, _identity, host_triple = _rustc_toolchain("")
+ctx = {{
+    "label": {{
+        "package": "third_party/rust/vendor/pkg-1.0.0",
+        "name": "pkg",
+        "id": "third_party/rust/vendor/pkg-1.0.0",
+    }},
+    "attr": {{}},
+    "srcs": [],
+}}
+env = _rust_build_script_env(
+    ctx,
+    rustc,
+    host_triple,
+    host_triple,
+    ".once/out/pkg/build",
+    "third_party/rust/vendor/pkg-1.0.0/build.rs",
+)
+result = repr([
+    env.get("CC"),
+    env.get("CC_" + host_triple.replace("-", "_")),
+    env.get("CC_" + host_triple),
+    env.get("AR"),
+])
+"#
+        );
+        let store = store_for(TempDir::new().unwrap().path(), "");
+
+        let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+        let values: Vec<String> = serde_json::from_str(&out.unwrap()).unwrap();
+
+        assert_eq!(values[0], values[1]);
+        assert_eq!(values[0], values[2]);
+        assert!(std::path::Path::new(&values[0]).is_absolute());
+        assert!(std::path::Path::new(&values[3]).is_absolute());
+    }
+
     #[test]
     fn prelude_ios_simulator_selection_filters_to_iphone_and_ipad() {
         let out = eval_prelude_string_function(

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1909,8 +1909,10 @@ build_env = _rust_build_script_env(
 result = repr([
     tool_env.get("CC"),
     tool_env.get("AR"),
+    tool_env.get("PATH"),
     build_env.get("CC"),
     build_env.get("AR"),
+    build_env.get("PATH"),
 ])
 "#
         );
@@ -1921,8 +1923,17 @@ result = repr([
 
         assert!(std::path::Path::new(&values[0]).is_absolute());
         assert!(std::path::Path::new(&values[1]).is_absolute());
-        assert_eq!(values[0], values[2]);
-        assert_eq!(values[1], values[3]);
+        assert_eq!(values[0], values[3]);
+        assert_eq!(values[1], values[4]);
+        assert_eq!(values[2], values[5]);
+        for entry in values[2].split(':') {
+            assert!(std::path::Path::new(entry).is_absolute());
+        }
+        let cc_dir = std::path::Path::new(&values[0])
+            .parent()
+            .unwrap()
+            .to_string_lossy();
+        assert!(values[2].split(':').any(|entry| entry == cc_dir));
     }
 
     #[cfg(unix)]
@@ -1945,6 +1956,7 @@ env = _rust_c_tool_env(target, host_triple)
 result = repr([
     env.get("CC"),
     env.get("AR"),
+    env.get("PATH"),
     env.get("CC_" + target.replace("-", "_")),
     env.get("CC_" + target),
 ])
@@ -1954,7 +1966,7 @@ result = repr([
 
         let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 
-        assert_eq!(out.unwrap(), "[None, None, None, None]");
+        assert_eq!(out.unwrap(), "[None, None, None, None, None]");
     }
 
     #[test]

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1897,7 +1897,8 @@ ctx = {{
     "attr": {{}},
     "srcs": [],
 }}
-env = _rust_build_script_env(
+tool_env = _rust_c_tool_env(host_triple, host_triple)
+build_env = _rust_build_script_env(
     ctx,
     rustc,
     host_triple,
@@ -1906,10 +1907,10 @@ env = _rust_build_script_env(
     "third_party/rust/vendor/pkg-1.0.0/build.rs",
 )
 result = repr([
-    env.get("CC"),
-    env.get("CC_" + host_triple.replace("-", "_")),
-    env.get("CC_" + host_triple),
-    env.get("AR"),
+    tool_env.get("CC"),
+    tool_env.get("AR"),
+    build_env.get("CC"),
+    build_env.get("AR"),
 ])
 "#
         );
@@ -1918,10 +1919,42 @@ result = repr([
         let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
         let values: Vec<String> = serde_json::from_str(&out.unwrap()).unwrap();
 
-        assert_eq!(values[0], values[1]);
-        assert_eq!(values[0], values[2]);
         assert!(std::path::Path::new(&values[0]).is_absolute());
-        assert!(std::path::Path::new(&values[3]).is_absolute());
+        assert!(std::path::Path::new(&values[1]).is_absolute());
+        assert_eq!(values[0], values[2]);
+        assert_eq!(values[1], values[3]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_rust_build_script_env_does_not_use_host_c_tool_for_cross_target() {
+        let prelude = format!(
+            "{}\n{}",
+            include_str!("../prelude/apple.star"),
+            include_str!("../prelude/rust.star")
+        );
+        let source = format!(
+            r#"{prelude}
+_rustc, _identity, host_triple = _rustc_toolchain("")
+def other_target(host_triple):
+    if host_triple == "aarch64-unknown-linux-gnu":
+        return "x86_64-unknown-linux-gnu"
+    return "aarch64-unknown-linux-gnu"
+target = other_target(host_triple)
+env = _rust_c_tool_env(target, host_triple)
+result = repr([
+    env.get("CC"),
+    env.get("AR"),
+    env.get("CC_" + target.replace("-", "_")),
+    env.get("CC_" + target),
+])
+"#
+        );
+        let store = store_for(TempDir::new().unwrap().path(), "");
+
+        let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+        assert_eq!(out.unwrap(), "[None, None, None, None]");
     }
 
     #[test]

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1579,12 +1579,24 @@ RULES = [
         function_name: &str,
         call_source: &str,
     ) -> std::result::Result<String, String> {
+        let prelude = include_str!("../prelude/apple.star");
+        eval_prelude_function_in(prelude, function_name, call_source)
+    }
+
+    fn eval_prelude_function_in(
+        prelude: &str,
+        function_name: &str,
+        call_source: &str,
+    ) -> std::result::Result<String, String> {
+        let source = format!("{prelude}\nresult = repr({function_name}{call_source})\n");
+        eval_prelude_source_to_repr(source)
+    }
+
+    fn eval_prelude_source_to_repr(source: String) -> std::result::Result<String, String> {
         // Build a Starlark module that splices the prelude's source
         // inline and invokes the requested helper. Returning the
         // result as a string via `repr()` keeps the test independent
         // of starlark Value plumbing details.
-        let prelude = include_str!("../prelude/apple.star");
-        let source = format!("{prelude}\nresult = repr({function_name}{call_source})\n");
         Module::with_temp_heap(|module| {
             let ast = AstModule::parse("test.star", source, &Dialect::Standard)
                 .map_err(|error| format!("parse: {error:?}"))?;
@@ -1644,6 +1656,131 @@ RULES = [
         )
         .unwrap_err();
         assert!(err.contains("no branch matching"), "{err}");
+    }
+
+    #[test]
+    fn prelude_cargo_metadata_targets_preserve_rust_target() {
+        let prelude = format!(
+            "{}\n{}",
+            include_str!("../prelude/apple.star"),
+            include_str!("../prelude/rust.star")
+        );
+        let out = eval_prelude_function_in(
+            &prelude,
+            "_cargo_metadata_targets",
+            r###"({
+                "attrs": {
+                    "target": "x86_64-apple-darwin",
+                    "vendor_dir": "third_party/rust/vendor",
+                },
+            }, {
+                "packages": [{
+                    "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+                    "name": "cpufeatures",
+                    "version": "0.2.17",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "manifest_path": "/workspace/vendor/cpufeatures-0.2.17/Cargo.toml",
+                    "targets": [{
+                        "name": "cpufeatures",
+                        "kind": ["lib"],
+                        "crate_types": ["lib"],
+                        "src_path": "/workspace/vendor/cpufeatures-0.2.17/src/lib.rs",
+                        "edition": "2018",
+                    }],
+                }],
+                "resolve": {
+                    "nodes": [{
+                        "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+                        "features": [],
+                        "deps": [],
+                    }],
+                },
+            })"###,
+        )
+        .unwrap();
+
+        assert!(out.contains("\"target\": \"x86_64-apple-darwin\""), "{out}");
+    }
+
+    #[test]
+    fn prelude_cargo_metadata_targets_split_proc_macro_host_deps() {
+        let prelude = format!(
+            "{}\n{}",
+            include_str!("../prelude/apple.star"),
+            include_str!("../prelude/rust.star")
+        );
+        let source = format!(
+            r###"{prelude}
+targets = _cargo_metadata_targets({{
+    "attrs": {{
+        "target": "x86_64-apple-darwin",
+        "vendor_dir": "third_party/rust/vendor",
+    }},
+}}, {{
+    "packages": [
+        {{
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+            "name": "quote",
+            "version": "1.0.45",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "manifest_path": "/workspace/vendor/quote-1.0.45/Cargo.toml",
+            "targets": [{{
+                "name": "quote",
+                "kind": ["lib"],
+                "crate_types": ["lib"],
+                "src_path": "/workspace/vendor/quote-1.0.45/src/lib.rs",
+                "edition": "2018",
+            }}],
+        }},
+        {{
+            "id": "registry+https://github.com/rust-lang/crates.io-index#linktime-proc-macro@0.2.0",
+            "name": "linktime-proc-macro",
+            "version": "0.2.0",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "manifest_path": "/workspace/vendor/linktime-proc-macro-0.2.0/Cargo.toml",
+            "targets": [{{
+                "name": "linktime_proc_macro",
+                "kind": ["proc-macro"],
+                "crate_types": ["proc-macro"],
+                "src_path": "/workspace/vendor/linktime-proc-macro-0.2.0/src/lib.rs",
+                "edition": "2021",
+            }}],
+        }},
+    ],
+    "resolve": {{
+        "nodes": [
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+                "features": [],
+                "deps": [],
+            }},
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#linktime-proc-macro@0.2.0",
+                "features": [],
+                "deps": [{{
+                    "name": "quote",
+                    "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.45",
+                    "dep_kinds": [{{"kind": None}}],
+                }}],
+            }},
+        ],
+    }},
+}})
+by_name = {{target["name"]: target for target in targets}}
+result = repr([
+    by_name["quote-1.0.45"]["attrs"].get("target"),
+    by_name["quote-1.0.45-host"]["attrs"].get("target"),
+    by_name["linktime-proc-macro-0.2.0"]["attrs"].get("target"),
+    by_name["linktime-proc-macro-0.2.0"]["deps"],
+])
+"###
+        );
+        let out = eval_prelude_source_to_repr(source).unwrap();
+
+        assert_eq!(
+            out,
+            "[\"x86_64-apple-darwin\", None, None, [\"./quote-1.0.45-host\"]]"
+        );
     }
 
     /// The prelude `_serialize_hmap` helper must lay out the

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1791,7 +1791,7 @@ RULES = [
 
         assert!(out.contains("\"target\": \"x86_64-apple-darwin\""), "{out}");
         assert!(
-            out.contains("\"srcs\": [\"third_party/rust/vendor/cpufeatures-0.2.17/**\"]"),
+            out.contains("\"srcs\": [\"third_party/rust/vendor/cpufeatures-0.2.17/Cargo.toml\", \"third_party/rust/vendor/cpufeatures-0.2.17/build.rs\", \"third_party/rust/vendor/cpufeatures-0.2.17/src/**/*.rs\"]"),
             "{out}"
         );
     }
@@ -1874,6 +1874,144 @@ result = repr([
         assert_eq!(
             out,
             "[\"x86_64-apple-darwin\", None, None, [\"./quote-1.0.45-host\"]]"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_rust_build_script_metadata_deps_are_not_duplicated() {
+        let prelude = format!(
+            "{}\n{}",
+            include_str!("../prelude/apple.star"),
+            include_str!("../prelude/rust.star")
+        );
+        let source = format!(
+            r#"{prelude}
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "build_script": "build.rs",
+        "crate_root": "src/lib.rs",
+    }},
+    "deps": [{{
+        "label_id": "third_party/rust/native",
+        "crate_name": "native",
+        "rlib": ".once/out/native/libnative.rlib",
+        "links": "native",
+        "build_script_stdout": ".once/out/native/build-script.stdout",
+    }}],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
+result = repr("ok")
+"#
+        );
+        let workspace = TempDir::new().unwrap();
+        let store = store_for(workspace.path(), "crates/app/app");
+
+        let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+        assert_eq!(out.unwrap(), "\"ok\"");
+        let script = store
+            .actions
+            .iter()
+            .find(|action| action.identifier.as_deref() == Some("crates/app/app:build-script"))
+            .and_then(|action| action.argv.get(2))
+            .unwrap();
+        assert_eq!(script.matches("done <").count(), 1, "{script}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_rust_build_script_env_encodes_rustflags() {
+        let prelude = format!(
+            "{}\n{}",
+            include_str!("../prelude/apple.star"),
+            include_str!("../prelude/rust.star")
+        );
+        let source = format!(
+            r#"{prelude}
+rustc, _identity, host_triple = _rustc_toolchain("")
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "rustc_flags": ["-C", "opt-level=3"],
+    }},
+    "deps": [],
+    "srcs": [],
+}}
+env = _rust_build_script_env(
+    ctx,
+    rustc,
+    host_triple,
+    host_triple,
+    ".once/out/app/build",
+    "crates/app/build.rs",
+)
+result = repr(env.get("CARGO_ENCODED_RUSTFLAGS"))
+"#
+        );
+        let store = store_for(TempDir::new().unwrap().path(), "crates/app/app");
+
+        let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+        assert_eq!(out.unwrap(), "\"-C\\x1fopt-level=3\"");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prelude_rust_proc_macro_compile_uses_host_target() {
+        let prelude = format!(
+            "{}\n{}",
+            include_str!("../prelude/apple.star"),
+            include_str!("../prelude/rust.star")
+        );
+        let source = format!(
+            r#"{prelude}
+_rustc, _identity, host_triple = _rustc_toolchain("")
+def other_target(host_triple):
+    if host_triple == "aarch64-unknown-linux-gnu":
+        return "x86_64-unknown-linux-gnu"
+    return "aarch64-unknown-linux-gnu"
+ctx = {{
+    "label": {{
+        "package": "macros/stringify",
+        "name": "stringify",
+        "id": "macros/stringify",
+    }},
+    "attr": {{
+        "target": other_target(host_triple),
+        "crate_root": "src/lib.rs",
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "proc-macro", "src/lib.rs", "libstringify.so")
+result = repr("ok")
+"#
+        );
+        let store = store_for(TempDir::new().unwrap().path(), "macros/stringify");
+
+        let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+        assert_eq!(out.unwrap(), "\"ok\"");
+        let action = &store.actions[0];
+        assert!(
+            !action.argv.iter().any(|arg| arg == "--target"),
+            "{:?}",
+            action.argv
+        );
+        assert_eq!(
+            action.outputs,
+            vec![".once/out/macros/stringify/libstringify.so".to_string()]
         );
     }
 

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1758,7 +1758,7 @@ RULES = [
         let out = eval_prelude_function_in(
             &prelude,
             "_cargo_metadata_targets",
-            r###"({
+            r#"({
                 "attrs": {
                     "target": "x86_64-apple-darwin",
                     "vendor_dir": "third_party/rust/vendor",
@@ -1785,11 +1785,15 @@ RULES = [
                         "deps": [],
                     }],
                 },
-            })"###,
+            })"#,
         )
         .unwrap();
 
         assert!(out.contains("\"target\": \"x86_64-apple-darwin\""), "{out}");
+        assert!(
+            out.contains("\"srcs\": [\"third_party/rust/vendor/cpufeatures-0.2.17/**\"]"),
+            "{out}"
+        );
     }
 
     #[test]
@@ -1800,7 +1804,7 @@ RULES = [
             include_str!("../prelude/rust.star")
         );
         let source = format!(
-            r###"{prelude}
+            r#"{prelude}
 targets = _cargo_metadata_targets({{
     "attrs": {{
         "target": "x86_64-apple-darwin",
@@ -1863,7 +1867,7 @@ result = repr([
     by_name["linktime-proc-macro-0.2.0"]["attrs"].get("target"),
     by_name["linktime-proc-macro-0.2.0"]["deps"],
 ])
-"###
+"#
         );
         let out = eval_prelude_source_to_repr(source).unwrap();
 

--- a/crates/once-frontend/src/analysis.rs
+++ b/crates/once-frontend/src/analysis.rs
@@ -1959,7 +1959,8 @@ env = _rust_build_script_env(
 result = repr(env.get("CARGO_ENCODED_RUSTFLAGS"))
 "#
         );
-        let store = store_for(TempDir::new().unwrap().path(), "crates/app/app");
+        let workspace = TempDir::new().unwrap();
+        let store = store_for(workspace.path(), "crates/app/app");
 
         let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 
@@ -1998,7 +1999,8 @@ _rust_compile(ctx, "proc-macro", "src/lib.rs", "libstringify.so")
 result = repr("ok")
 "#
         );
-        let store = store_for(TempDir::new().unwrap().path(), "macros/stringify");
+        let workspace = TempDir::new().unwrap();
+        let store = store_for(workspace.path(), "macros/stringify");
 
         let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 
@@ -2054,7 +2056,8 @@ result = repr([
 ])
 "#
         );
-        let store = store_for(TempDir::new().unwrap().path(), "");
+        let workspace = TempDir::new().unwrap();
+        let store = store_for(workspace.path(), "");
 
         let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
         let values: Vec<String> = serde_json::from_str(&out.unwrap()).unwrap();
@@ -2100,7 +2103,8 @@ result = repr([
 ])
 "#
         );
-        let store = store_for(TempDir::new().unwrap().path(), "");
+        let workspace = TempDir::new().unwrap();
+        let store = store_for(workspace.path(), "");
 
         let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 

--- a/mise/tasks/release/bootstrap-once.sh
+++ b/mise/tasks/release/bootstrap-once.sh
@@ -50,7 +50,7 @@ latest_release() {
 
 fallback_cargo_build() {
   echo "falling back to a Cargo-built bootstrap Once for this host" >&2
-  cargo build --locked --release --package once-cli >&2
+  mise exec -- cargo build --locked --release --package once-cli >&2
   case "$(uname -s)" in
     MINGW* | MSYS* | CYGWIN*)
       printf '%s\n' "target/release/once.exe"
@@ -59,6 +59,21 @@ fallback_cargo_build() {
       printf '%s\n' "target/release/once"
       ;;
   esac
+}
+
+verify_checksum() {
+  local dir="$1"
+  local checksum_file="$2"
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "${dir}" && sha256sum -c "${checksum_file}" >&2)
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "${dir}" && shasum -a 256 -c "${checksum_file}" >&2)
+    return
+  fi
+  echo "sha256sum or shasum is required to verify the Once release archive" >&2
+  return 1
 }
 
 if [[ -n "${ONCE_BIN:-}" ]]; then
@@ -108,12 +123,17 @@ fi
 mkdir -p "${cache_dir}"
 asset="once-${version}-${target}.tar.gz"
 archive="${cache_dir}/${asset}"
+checksum="${cache_dir}/${asset}.sha256"
 url="https://github.com/tuist/once/releases/download/${version}/${asset}"
 if command -v curl >/dev/null 2>&1 && curl -fL "${url}" -o "${archive}" >&2; then
-  tar -C "${cache_dir}" -xzf "${archive}"
-  if [[ -x "${binary}" ]]; then
-    printf '%s\n' "${binary}"
-    exit 0
+  if curl -fL "${url}.sha256" -o "${checksum}" >&2 && verify_checksum "${cache_dir}" "${asset}.sha256"; then
+    tar -C "${cache_dir}" -xzf "${archive}"
+    if [[ -x "${binary}" ]]; then
+      printf '%s\n' "${binary}"
+      exit 0
+    fi
+  else
+    echo "could not verify Once release archive checksum" >&2
   fi
 fi
 

--- a/mise/tasks/release/bootstrap-once.sh
+++ b/mise/tasks/release/bootstrap-once.sh
@@ -70,6 +70,19 @@ if [[ -n "${ONCE_BIN:-}" ]]; then
   exit 0
 fi
 
+case "${ONCE_BOOTSTRAP_SOURCE:-release}" in
+  release)
+    ;;
+  source)
+    fallback_cargo_build
+    exit 0
+    ;;
+  *)
+    echo "ONCE_BOOTSTRAP_SOURCE must be 'release' or 'source'" >&2
+    exit 1
+    ;;
+esac
+
 target="$(host_triple)"
 version="$(latest_release)"
 version="${version#v}"

--- a/mise/tasks/release/bootstrap-once.sh
+++ b/mise/tasks/release/bootstrap-once.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#MISE description="Resolve a released Once binary for bootstrapping graph builds"
+set -euo pipefail
+
+host_triple() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "${os}:${arch}" in
+    Darwin:arm64 | Darwin:aarch64)
+      printf '%s\n' "aarch64-apple-darwin"
+      ;;
+    Darwin:x86_64)
+      printf '%s\n' "x86_64-apple-darwin"
+      ;;
+    Linux:x86_64)
+      printf '%s\n' "x86_64-unknown-linux-gnu"
+      ;;
+    Linux:arm64 | Linux:aarch64)
+      printf '%s\n' "aarch64-unknown-linux-gnu"
+      ;;
+    MINGW*:x86_64 | MSYS*:x86_64 | CYGWIN*:x86_64)
+      printf '%s\n' "x86_64-pc-windows-msvc"
+      ;;
+    *)
+      echo "unsupported bootstrap host: ${os} ${arch}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+latest_release() {
+  if [[ -n "${ONCE_BOOTSTRAP_VERSION:-}" ]]; then
+    printf '%s\n' "${ONCE_BOOTSTRAP_VERSION}"
+    return
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    gh release view --repo tuist/once --json tagName --jq .tagName
+    return
+  fi
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL https://api.github.com/repos/tuist/once/releases/latest |
+      sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+      head -n 1
+    return
+  fi
+  echo "gh or curl is required to resolve the latest Once release" >&2
+  exit 1
+}
+
+fallback_cargo_build() {
+  echo "falling back to a Cargo-built bootstrap Once for this host" >&2
+  cargo build --locked --release --package once-cli >&2
+  case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*)
+      printf '%s\n' "target/release/once.exe"
+      ;;
+    *)
+      printf '%s\n' "target/release/once"
+      ;;
+  esac
+}
+
+if [[ -n "${ONCE_BIN:-}" ]]; then
+  if [[ ! -x "${ONCE_BIN}" ]]; then
+    echo "ONCE_BIN is not executable: ${ONCE_BIN}" >&2
+    exit 1
+  fi
+  printf '%s\n' "${ONCE_BIN}"
+  exit 0
+fi
+
+target="$(host_triple)"
+version="$(latest_release)"
+version="${version#v}"
+if [[ -z "${version}" ]]; then
+  echo "could not determine latest Once release" >&2
+  exit 1
+fi
+
+exe="once"
+case "${target}" in
+  *-windows-*)
+    exe="once.exe"
+    ;;
+esac
+
+cache_dir="target/once-bootstrap/${version}-${target}"
+binary="${cache_dir}/${exe}"
+if [[ -x "${binary}" ]]; then
+  printf '%s\n' "${binary}"
+  exit 0
+fi
+
+mkdir -p "${cache_dir}"
+asset="once-${version}-${target}.tar.gz"
+archive="${cache_dir}/${asset}"
+url="https://github.com/tuist/once/releases/download/${version}/${asset}"
+if command -v curl >/dev/null 2>&1 && curl -fL "${url}" -o "${archive}" >&2; then
+  tar -C "${cache_dir}" -xzf "${archive}"
+  if [[ -x "${binary}" ]]; then
+    printf '%s\n' "${binary}"
+    exit 0
+  fi
+fi
+
+fallback_cargo_build

--- a/mise/tasks/release/package-sdk-libs.sh
+++ b/mise/tasks/release/package-sdk-libs.sh
@@ -4,6 +4,8 @@
 #USAGE flag "--version <version>" help="Version number to embed in the shared library"
 set -euo pipefail
 
+release_tasks_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 target=""
 version="0.0.0"
 while (($# > 0)); do
@@ -64,13 +66,13 @@ target_suffix() {
 }
 
 cleanup() {
-  ./mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true
+  "${release_tasks_dir}/write-rust-release-manifests.sh" --clear >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
-./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
-./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version "${version}"
+once_bin="$("${release_tasks_dir}/bootstrap-once.sh")"
+"${release_tasks_dir}/prepare-rust-graph-deps.sh" --target "${target}"
+"${release_tasks_dir}/write-rust-release-manifests.sh" --target "${target}" --version "${version}"
 
 suffix="$(target_suffix "${target}")"
 target_id="crates/once/once_cdylib_${suffix}"

--- a/mise/tasks/release/package-sdk-libs.sh
+++ b/mise/tasks/release/package-sdk-libs.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 #MISE description="Build shared Once SDK libraries for Ruby and JavaScript packages"
 #USAGE flag "--target <target>" help="Rust target triple to compile"
+#USAGE flag "--version <version>" help="Version number to embed in the shared library"
 set -euo pipefail
 
 target=""
+version="0.0.0"
 while (($# > 0)); do
   case "$1" in
     --target)
       target="${2}"
+      shift 2
+      ;;
+    --version)
+      version="${2}"
       shift 2
       ;;
     *)
@@ -48,9 +54,29 @@ case "${target}" in
     ;;
 esac
 
-cargo build --locked --release --package once --target "${target}"
+if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "--version must be a semantic version" >&2
+  exit 1
+fi
 
-source="target/${target}/release/${library}"
+target_suffix() {
+  printf '%s' "$1" | tr '.-' '__'
+}
+
+cleanup() {
+  ./mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
+./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version "${version}"
+
+suffix="$(target_suffix "${target}")"
+target_id="crates/once/once_cdylib_${suffix}"
+"${once_bin}" build "${target_id}" --format json --quiet
+
+source=".once/out/${target_id}/${library}"
 if [[ ! -f "${source}" ]]; then
   echo "expected shared library does not exist: ${source}" >&2
   exit 1

--- a/mise/tasks/release/package-xcframework.sh
+++ b/mise/tasks/release/package-xcframework.sh
@@ -3,6 +3,8 @@
 #USAGE flag "--version <version>" help="Version number to validate the release input"
 set -Eeuo pipefail
 
+release_tasks_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 version=""
 while (($# > 0)); do
   case "$1" in
@@ -82,7 +84,7 @@ build_target() {
   local suffix target_id
   suffix="$(target_suffix "${target}")"
   target_id="crates/once/once_staticlib_${suffix}"
-  ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version "${version}"
+  "${release_tasks_dir}/write-rust-release-manifests.sh" --target "${target}" --version "${version}"
   if ! "${once_bin}" build "${target_id}" --format json --quiet; then
     echo "once build failed for ${target}" >&2
     exit 1
@@ -105,7 +107,7 @@ stage_dir=""
 keychain_path=""
 certificate_path=""
 cleanup() {
-  ./mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true
+  "${release_tasks_dir}/write-rust-release-manifests.sh" --clear >/dev/null 2>&1 || true
   if [[ -n "${certificate_path}" ]]; then
     rm -f "${certificate_path}"
   fi
@@ -119,8 +121,8 @@ cleanup() {
 trap cleanup EXIT
 
 rustup target add "${targets[@]}"
-once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
-./mise/tasks/release/prepare-rust-graph-deps.sh
+once_bin="$("${release_tasks_dir}/bootstrap-once.sh")"
+"${release_tasks_dir}/prepare-rust-graph-deps.sh"
 
 for target in "${targets[@]}"; do
   build_target "${target}"

--- a/mise/tasks/release/package-xcframework.sh
+++ b/mise/tasks/release/package-xcframework.sh
@@ -66,10 +66,25 @@ require_lipo_archs() {
   done
 }
 
+target_suffix() {
+  printf '%s' "$1" | tr '.-' '__'
+}
+
+staticlib_path() {
+  local target="$1"
+  local suffix
+  suffix="$(target_suffix "${target}")"
+  printf '.once/out/crates/once/once_staticlib_%s/libonce.a\n' "${suffix}"
+}
+
 build_target() {
   local target="$1"
-  if ! cargo build --locked --release --package once --target "${target}"; then
-    echo "cargo build failed for ${target}" >&2
+  local suffix target_id
+  suffix="$(target_suffix "${target}")"
+  target_id="crates/once/once_staticlib_${suffix}"
+  ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version "${version}"
+  if ! "${once_bin}" build "${target_id}" --format json --quiet; then
+    echo "once build failed for ${target}" >&2
     exit 1
   fi
 }
@@ -86,20 +101,11 @@ targets=(
   x86_64-apple-ios
 )
 
-rustup target add "${targets[@]}"
-
-for target in "${targets[@]}"; do
-  build_target "${target}"
-done
-
-for target in "${targets[@]}"; do
-  require_file "target/${target}/release/libonce.a"
-done
-
 stage_dir=""
 keychain_path=""
 certificate_path=""
 cleanup() {
+  ./mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true
   if [[ -n "${certificate_path}" ]]; then
     rm -f "${certificate_path}"
   fi
@@ -110,8 +116,21 @@ cleanup() {
     rm -rf "${stage_dir}"
   fi
 }
-stage_dir="$(mktemp -d)"
 trap cleanup EXIT
+
+rustup target add "${targets[@]}"
+once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+./mise/tasks/release/prepare-rust-graph-deps.sh
+
+for target in "${targets[@]}"; do
+  build_target "${target}"
+done
+
+for target in "${targets[@]}"; do
+  require_file "$(staticlib_path "${target}")"
+done
+
+stage_dir="$(mktemp -d)"
 
 mkdir -p "${stage_dir}/macos" "${stage_dir}/ios-simulator" dist
 
@@ -170,16 +189,16 @@ if [[ -n "${APPLE_DEVELOPER_ID_CERTIFICATE_ENCRYPTION_PASSWORD:-}" ]]; then
 fi
 
 lipo -create \
-  "target/aarch64-apple-darwin/release/libonce.a" \
-  "target/x86_64-apple-darwin/release/libonce.a" \
+  "$(staticlib_path aarch64-apple-darwin)" \
+  "$(staticlib_path x86_64-apple-darwin)" \
   -output "${stage_dir}/macos/libonce.a"
 require_lipo_archs "${stage_dir}/macos/libonce.a" arm64 x86_64
 
 lipo -create \
-  "target/aarch64-apple-ios-sim/release/libonce.a" \
-  "target/x86_64-apple-ios/release/libonce.a" \
+  "$(staticlib_path aarch64-apple-ios-sim)" \
+  "$(staticlib_path x86_64-apple-ios)" \
   -output "${stage_dir}/ios-simulator/libonce.a"
-require_lipo_archs "target/aarch64-apple-ios/release/libonce.a" arm64
+require_lipo_archs "$(staticlib_path aarch64-apple-ios)" arm64
 require_lipo_archs "${stage_dir}/ios-simulator/libonce.a" arm64 x86_64
 
 release_dir="${stage_dir}/release"
@@ -188,7 +207,7 @@ mkdir -p "${release_dir}"
 rm -rf "${release_dir}/Once.xcframework"
 xcodebuild -create-xcframework \
   -library "${stage_dir}/macos/libonce.a" -headers "crates/once/include/Once" \
-  -library "target/aarch64-apple-ios/release/libonce.a" -headers "crates/once/include/Once" \
+  -library "$(staticlib_path aarch64-apple-ios)" -headers "crates/once/include/Once" \
   -library "${stage_dir}/ios-simulator/libonce.a" -headers "crates/once/include/Once" \
   -output "${release_dir}/Once.xcframework"
 

--- a/mise/tasks/release/package.sh
+++ b/mise/tasks/release/package.sh
@@ -28,8 +28,28 @@ if [[ -z "${target}" || -z "${version}" ]]; then
   exit 1
 fi
 
+if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "--version must be a semantic version" >&2
+  exit 1
+fi
+
+target_suffix() {
+  printf '%s' "$1" | tr '.-' '__'
+}
+
+stage_dir=""
+cleanup() {
+  ./mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true
+  if [[ -n "${stage_dir}" ]]; then
+    rm -rf "${stage_dir}"
+  fi
+}
+trap cleanup EXIT
+
 mkdir -p dist
-ONCE_VERSION="${version}" cargo build --locked --release --target "${target}"
+once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
+./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version "${version}"
 
 # Windows uses the .exe suffix; everything else ships a bare binary.
 case "${target}" in
@@ -41,9 +61,17 @@ case "${target}" in
     ;;
 esac
 
+suffix="$(target_suffix "${target}")"
+target_id="crates/once-cli/once_cli_${suffix}"
+"${once_bin}" build "${target_id}" --format json --quiet
+source=".once/out/${target_id}/${bin_name}"
+if [[ ! -f "${source}" ]]; then
+  echo "expected binary does not exist: ${source}" >&2
+  exit 1
+fi
+
 stage_dir="$(mktemp -d)"
-trap 'rm -rf "${stage_dir}"' EXIT
-cp "target/${target}/release/${bin_name}" "${stage_dir}/${bin_name}"
+cp "${source}" "${stage_dir}/${bin_name}"
 
 # tar.gz everywhere, modern Windows ships tar(1) and `mise install`'s
 # ubi backend handles either format. Keeping one extension across

--- a/mise/tasks/release/package.sh
+++ b/mise/tasks/release/package.sh
@@ -4,6 +4,8 @@
 #USAGE flag "--version <version>" help="Version number to embed in the binary and asset name"
 set -euo pipefail
 
+release_tasks_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 target=""
 version=""
 while (($# > 0)); do
@@ -39,7 +41,7 @@ target_suffix() {
 
 stage_dir=""
 cleanup() {
-  ./mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true
+  "${release_tasks_dir}/write-rust-release-manifests.sh" --clear >/dev/null 2>&1 || true
   if [[ -n "${stage_dir}" ]]; then
     rm -rf "${stage_dir}"
   fi
@@ -47,9 +49,9 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p dist
-once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
-./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
-./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version "${version}"
+once_bin="$("${release_tasks_dir}/bootstrap-once.sh")"
+"${release_tasks_dir}/prepare-rust-graph-deps.sh" --target "${target}"
+"${release_tasks_dir}/write-rust-release-manifests.sh" --target "${target}" --version "${version}"
 
 # Windows uses the .exe suffix; everything else ships a bare binary.
 case "${target}" in

--- a/mise/tasks/release/prepare-rust-graph-deps.sh
+++ b/mise/tasks/release/prepare-rust-graph-deps.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#MISE description="Materialize Cargo-resolved Rust dependencies for Once graph builds"
+#USAGE flag "--target <target>" help="Optional Rust target triple for metadata resolution"
+set -euo pipefail
+
+target=""
+while (($# > 0)); do
+  case "$1" in
+    --target)
+      target="${2}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "${target}" && ! "${target}" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+  echo "--target must be a Rust target triple" >&2
+  exit 1
+fi
+
+for tool in cargo jq; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "${tool} is required" >&2
+    exit 1
+  fi
+done
+
+rm -rf third_party/rust/vendor
+mkdir -p third_party/rust
+cargo vendor --locked --versioned-dirs third_party/rust/vendor >/tmp/once-cargo-vendor-config
+
+metadata_args=(metadata --locked --format-version 1)
+if [[ -n "${target}" ]]; then
+  metadata_args+=(--filter-platform "${target}")
+fi
+metadata="$(cargo "${metadata_args[@]}")"
+schlussel_manifest="$(
+  jq -r '
+    .packages[]
+    | select(.name == "schlussel")
+    | select(.source | startswith("git+"))
+    | .manifest_path
+  ' <<<"${metadata}" | head -n 1
+)"
+
+rm -rf third_party/rust/src/formulas
+if [[ -n "${schlussel_manifest}" && "${schlussel_manifest}" != "null" ]]; then
+  schlussel_root="$(cd "$(dirname "${schlussel_manifest}")/../.." && pwd)"
+  if [[ -d "${schlussel_root}/src/formulas" ]]; then
+    mkdir -p third_party/rust/src
+    cp -R "${schlussel_root}/src/formulas" third_party/rust/src/formulas
+  fi
+fi

--- a/mise/tasks/release/prepare-rust-graph-deps.sh
+++ b/mise/tasks/release/prepare-rust-graph-deps.sh
@@ -22,7 +22,7 @@ if [[ -n "${target}" && ! "${target}" =~ ^[A-Za-z0-9_.-]+$ ]]; then
   exit 1
 fi
 
-for tool in cargo jq; do
+for tool in jq mise; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
     echo "${tool} is required" >&2
     exit 1
@@ -31,13 +31,13 @@ done
 
 rm -rf third_party/rust/vendor
 mkdir -p third_party/rust
-cargo vendor --locked --versioned-dirs third_party/rust/vendor >/tmp/once-cargo-vendor-config
+mise exec -- cargo vendor --locked --versioned-dirs third_party/rust/vendor >/tmp/once-cargo-vendor-config
 
 metadata_args=(metadata --locked --format-version 1)
 if [[ -n "${target}" ]]; then
   metadata_args+=(--filter-platform "${target}")
 fi
-metadata="$(cargo "${metadata_args[@]}")"
+metadata="$(mise exec -- cargo "${metadata_args[@]}")"
 schlussel_manifest="$(
   jq -r '
     .packages[]

--- a/mise/tasks/release/write-rust-release-manifests.sh
+++ b/mise/tasks/release/write-rust-release-manifests.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#MISE description="Inject or clear temporary Once release graph targets"
+#USAGE flag "--target <target>" help="Rust target triple to compile"
+#USAGE flag "--version <version>" help="Version number to embed in final artifacts"
+#USAGE flag "--clear" help="Remove generated release targets"
+set -euo pipefail
+
+target=""
+version="0.0.0"
+clear=false
+while (($# > 0)); do
+  case "$1" in
+    --target)
+      target="${2}"
+      shift 2
+      ;;
+    --version)
+      version="${2}"
+      shift 2
+      ;;
+    --clear)
+      clear=true
+      shift
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+manifest_files=(
+  once.toml
+  crates/once-cas/once.toml
+  crates/once-core/once.toml
+  crates/once-frontend/once.toml
+  crates/once/once.toml
+  crates/once-cli/once.toml
+)
+
+remove_generated_blocks() {
+  local file tmp
+  for file in "${manifest_files[@]}"; do
+    tmp="$(mktemp)"
+    awk '
+      /^# once release generated targets start$/ { skip = 1; next }
+      /^# once release generated targets end$/ { skip = 0; next }
+      skip != 1 { print }
+    ' "${file}" >"${tmp}"
+    mv "${tmp}" "${file}"
+  done
+}
+
+if [[ "${clear}" == true ]]; then
+  remove_generated_blocks
+  exit 0
+fi
+
+if [[ -z "${target}" ]]; then
+  echo "--target is required" >&2
+  exit 1
+fi
+if [[ ! "${target}" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+  echo "--target must be a Rust target triple" >&2
+  exit 1
+fi
+if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "--version must be a semantic version" >&2
+  exit 1
+fi
+
+suffix="$(printf '%s' "${target}" | tr '.-' '__')"
+dependency_target="cargo_dependencies_${suffix}"
+release_flags='["-C", "opt-level=3", "-C", "codegen-units=1", "-C", "panic=abort"]'
+
+remove_generated_blocks
+
+cat >>once.toml <<EOF
+# once release generated targets start
+[[target]]
+name = "${dependency_target}"
+kind = "cargo_dependencies"
+srcs = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "crates/*/Cargo.toml",
+  "third_party/rust/src/formulas/**",
+]
+
+[target.attrs]
+manifest = "Cargo.toml"
+lockfile = "Cargo.lock"
+vendor_dir = "third_party/rust/vendor"
+target = "${target}"
+# once release generated targets end
+EOF
+
+cat >>crates/once-cas/once.toml <<EOF
+# once release generated targets start
+[[target]]
+name = "once_cas_${suffix}"
+kind = "rust_library"
+deps = ["${dependency_target}"]
+srcs = ["src/**/*.rs"]
+
+[target.attrs]
+crate_name = "once_cas"
+crate_root = "src/lib.rs"
+edition = "2021"
+target = "${target}"
+rustc_flags = ${release_flags}
+cargo_package = "once-cas"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once-cas"
+CARGO_PKG_NAME = "once-cas"
+CARGO_PKG_VERSION = "${version}"
+# once release generated targets end
+EOF
+
+cat >>crates/once-core/once.toml <<EOF
+# once release generated targets start
+[[target]]
+name = "once_core_${suffix}"
+kind = "rust_library"
+deps = [
+  "crates/once-cas/once_cas_${suffix}",
+  "${dependency_target}",
+]
+srcs = ["src/**/*.rs"]
+
+[target.attrs]
+crate_name = "once_core"
+crate_root = "src/lib.rs"
+edition = "2021"
+features = ["default", "remote-microsandbox"]
+target = "${target}"
+rustc_flags = ${release_flags}
+cargo_package = "once-core"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once-core"
+CARGO_PKG_NAME = "once-core"
+CARGO_PKG_VERSION = "${version}"
+# once release generated targets end
+EOF
+
+cat >>crates/once-frontend/once.toml <<EOF
+# once release generated targets start
+[[target]]
+name = "once_frontend_${suffix}"
+kind = "rust_library"
+deps = ["${dependency_target}"]
+srcs = ["src/**/*.rs", "prelude/**/*.star", "prelude/examples/**"]
+
+[target.attrs]
+crate_name = "once_frontend"
+crate_root = "src/lib.rs"
+edition = "2021"
+target = "${target}"
+rustc_flags = ${release_flags}
+cargo_package = "once-frontend"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once-frontend"
+CARGO_PKG_NAME = "once-frontend"
+CARGO_PKG_VERSION = "${version}"
+# once release generated targets end
+EOF
+
+cat >>crates/once/once.toml <<EOF
+# once release generated targets start
+[[target]]
+name = "once_cdylib_${suffix}"
+kind = "rust_library"
+deps = [
+  "crates/once-cas/once_cas_${suffix}",
+  "crates/once-core/once_core_${suffix}",
+  "${dependency_target}",
+]
+srcs = ["src/**/*.rs", "include/**/*", "swift/**/*.swift"]
+
+[target.attrs]
+crate_name = "once"
+crate_root = "src/lib.rs"
+edition = "2021"
+crate_type = "cdylib"
+target = "${target}"
+rustc_flags = ${release_flags}
+cargo_package = "once"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once"
+CARGO_PKG_NAME = "once"
+CARGO_PKG_VERSION = "${version}"
+
+[[target]]
+name = "once_staticlib_${suffix}"
+kind = "rust_library"
+deps = [
+  "crates/once-cas/once_cas_${suffix}",
+  "crates/once-core/once_core_${suffix}",
+  "${dependency_target}",
+]
+srcs = ["src/**/*.rs", "include/**/*", "swift/**/*.swift"]
+
+[target.attrs]
+crate_name = "once"
+crate_root = "src/lib.rs"
+edition = "2021"
+crate_type = "staticlib"
+target = "${target}"
+rustc_flags = ${release_flags}
+cargo_package = "once"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once"
+CARGO_PKG_NAME = "once"
+CARGO_PKG_VERSION = "${version}"
+# once release generated targets end
+EOF
+
+cat >>crates/once-cli/once.toml <<EOF
+# once release generated targets start
+[[target]]
+name = "once_cli_${suffix}"
+kind = "rust_binary"
+deps = [
+  "crates/once-cas/once_cas_${suffix}",
+  "crates/once-core/once_core_${suffix}",
+  "crates/once-frontend/once_frontend_${suffix}",
+  "${dependency_target}",
+]
+srcs = ["src/**/*.rs"]
+
+[target.attrs]
+crate_name = "once"
+crate_root = "src/main.rs"
+edition = "2021"
+target = "${target}"
+rustc_flags = ${release_flags}
+cargo_package = "once-cli"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once-cli"
+CARGO_PKG_NAME = "once-cli"
+CARGO_PKG_VERSION = "0.0.0"
+ONCE_VERSION = "${version}"
+# once release generated targets end
+EOF

--- a/once.toml
+++ b/once.toml
@@ -15,7 +15,6 @@ srcs = [
   "Cargo.toml",
   "Cargo.lock",
   "crates/*/Cargo.toml",
-  "third_party/rust/src/formulas/**",
 ]
 
 [target.attrs]

--- a/once.toml
+++ b/once.toml
@@ -15,6 +15,7 @@ srcs = [
   "Cargo.toml",
   "Cargo.lock",
   "crates/*/Cargo.toml",
+  "third_party/rust/src/formulas/**",
 ]
 
 [target.attrs]

--- a/spec/release_sdk_spec.sh
+++ b/spec/release_sdk_spec.sh
@@ -18,16 +18,48 @@ Describe 'release SDK packaging scripts'
     chmod +x "$path"
   }
 
+  setup_release_graph_workspace() {
+    mkdir -p \
+      "$WORKSPACE/crates/once-cas" \
+      "$WORKSPACE/crates/once-core" \
+      "$WORKSPACE/crates/once-frontend" \
+      "$WORKSPACE/crates/once" \
+      "$WORKSPACE/crates/once-cli"
+    touch \
+      "$WORKSPACE/Cargo.toml" \
+      "$WORKSPACE/Cargo.lock" \
+      "$WORKSPACE/once.toml" \
+      "$WORKSPACE/crates/once-cas/once.toml" \
+      "$WORKSPACE/crates/once-core/once.toml" \
+      "$WORKSPACE/crates/once-frontend/once.toml" \
+      "$WORKSPACE/crates/once/once.toml" \
+      "$WORKSPACE/crates/once-cli/once.toml"
+  }
+
   It 'copies a built shared library into each SDK prebuild directory'
     setup_release_path
+    setup_release_graph_workspace
     write_stub cargo \
       '#!/usr/bin/env bash' \
-      'mkdir -p target/x86_64-unknown-linux-gnu/release' \
-      'printf library > target/x86_64-unknown-linux-gnu/release/libonce.so'
+      'case "$1" in' \
+      '  vendor)' \
+      '    mkdir -p third_party/rust/vendor' \
+      '    ;;' \
+      '  metadata)' \
+      '    printf "%s\n" "{\"packages\":[]}"' \
+      '    ;;' \
+      'esac'
+    write_stub jq \
+      '#!/usr/bin/env bash'
+    write_stub once \
+      '#!/usr/bin/env bash' \
+      'target_id="$2"' \
+      'mkdir -p ".once/out/${target_id}"' \
+      'printf library > ".once/out/${target_id}/libonce.so"'
     mkdir -p "$WORKSPACE/packages/js" "$WORKSPACE/packages/ruby"
     cd "$WORKSPACE"
 
-    When call "$REPO_ROOT/mise/tasks/release/package-sdk-libs.sh" --target x86_64-unknown-linux-gnu
+    When call env ONCE_BIN="$WORKSPACE/bin/once" "$REPO_ROOT/mise/tasks/release/package-sdk-libs.sh" --target x86_64-unknown-linux-gnu
     The status should be success
     The contents of file "$WORKSPACE/packages/js/prebuilds/linux-x64/libonce.so" should equal 'library'
     The contents of file "$WORKSPACE/packages/ruby/prebuilds/linux-x64/libonce.so" should equal 'library'

--- a/spec/release_sdk_spec.sh
+++ b/spec/release_sdk_spec.sh
@@ -49,6 +49,13 @@ Describe 'release SDK packaging scripts'
       '    printf "%s\n" "{\"packages\":[]}"' \
       '    ;;' \
       'esac'
+    write_stub mise \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = exec ] && [ "$2" = -- ]; then' \
+      '  shift 2' \
+      '  exec "$@"' \
+      'fi' \
+      'exit 2'
     write_stub jq \
       '#!/usr/bin/env bash'
     write_stub once \

--- a/spec/rust_graph_spec.sh
+++ b/spec/rust_graph_spec.sh
@@ -1,0 +1,47 @@
+#shellcheck shell=bash
+# End-to-end specs for Rust graph targets.
+
+Describe 'rust graph'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  create_failing_build_script_fixture() {
+    mkdir -p "$WORKSPACE/crates/failing/src"
+    cat > "$WORKSPACE/once.toml" <<'TOML'
+[workspace]
+include = ["crates/*/once.toml"]
+TOML
+    cat > "$WORKSPACE/crates/failing/once.toml" <<'TOML'
+[[target]]
+name = "failing"
+kind = "rust_library"
+srcs = ["src/**/*.rs"]
+
+[target.attrs]
+crate_name = "failing"
+crate_root = "src/lib.rs"
+build_script = "build.rs"
+edition = "2021"
+TOML
+    printf 'pub fn value() -> i32 { 1 }\n' > "$WORKSPACE/crates/failing/src/lib.rs"
+    cat > "$WORKSPACE/crates/failing/build.rs" <<'RS'
+fn main() {
+    println!("build script stdout is visible");
+    eprintln!("build script stderr is visible");
+    std::process::exit(7);
+}
+RS
+  }
+
+  It 'surfaces captured build script output when a declared action fails'
+    create_failing_build_script_fixture
+
+    When call once build crates/failing/failing
+    The status should be failure
+    The stderr should include 'crates/failing/failing:build-script'
+    The stderr should include 'stdout:'
+    The stderr should include 'build script stdout is visible'
+    The stderr should include 'build script stderr is visible'
+    The stderr should not include 'last 16384 bytes of stderr'
+  End
+End


### PR DESCRIPTION
## Summary
- Split Cargo-resolved Rust dependency graphs into target and host variants so proc macros and build-script dependencies compile for the correct platform.
- Add release helpers that bootstrap a released Once binary, prepare Cargo-resolved dependency sources, and materialize temporary per-target release graph manifests.
- Switch release archives, SDK shared libraries, XCFramework static libraries, and the release-build workflow to build artifacts through Once while Cargo remains the dependency resolver.
- Add an arm64 Linux release archive slice to the release matrix.

## Testing
- `mise exec -- cargo test -p once-frontend prelude_cargo_metadata_targets -- --nocapture`
- `bash -n mise/tasks/release/bootstrap-once.sh mise/tasks/release/prepare-rust-graph-deps.sh mise/tasks/release/write-rust-release-manifests.sh mise/tasks/release/package.sh mise/tasks/release/package-sdk-libs.sh mise/tasks/release/package-xcframework.sh`
- `git diff --check`
- `mise exec -- cargo build --release --package once-cli`
- `./mise/tasks/release/package.sh --target aarch64-apple-darwin --version 0.22.0`
- `./mise/tasks/release/package-sdk-libs.sh --target aarch64-apple-darwin --version 0.22.0`
- `ONCE_BIN=target/release/once ./mise/tasks/release/package-xcframework.sh --version 0.22.0` failed after building `aarch64-apple-darwin` and `x86_64-apple-darwin`; `aarch64-apple-ios` failed at `crates/once/once_staticlib_aarch64_apple_ios:rustc`.
