### PR TITLE
fix(docs): fix docs deployment domain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment:
       name: production
-      url: https://buildonce.dev
+      url: https://docs.buildonce.dev
     defaults:
       run:
         working-directory: docs
@@ -79,7 +79,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.90.1"
+          wranglerVersion: "4.100.0"
           workingDirectory: docs
           command: deploy
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -14,8 +14,51 @@ env:
   RUSTUP_MAX_RETRIES: "10"
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust_ci: ${{ steps.filter.outputs.rust_ci }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        name: classify changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [[ "$base" =~ ^0+$ ]]; then
+              base="${head}^"
+            fi
+          fi
+
+          git diff --name-only "$base" "$head" > changed-files.txt
+
+          rust_ci=false
+          while IFS= read -r path; do
+            case "$path" in
+              Cargo.toml|Cargo.lock|mise.toml|once.toml|crates/*|spec/*|mise/tasks/*|.cargo/*)
+                rust_ci=true
+                ;;
+            esac
+          done < changed-files.txt
+
+          echo "rust_ci=$rust_ci" >> "$GITHUB_OUTPUT"
+          echo "Rust CI required: $rust_ci"
+          sed 's/^/- /' changed-files.txt
+
   fmt:
     name: fmt
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -28,6 +71,8 @@ jobs:
 
   clippy:
     name: clippy
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,6 +91,8 @@ jobs:
 
   tests:
     name: tests (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -68,6 +115,8 @@ jobs:
 
   release-build:
     name: release build (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -109,7 +158,8 @@ jobs:
 
   dogfood:
     name: dogfood (${{ matrix.os }})
-    needs: release-build
+    needs: [changes, release-build]
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -132,7 +182,8 @@ jobs:
 
   shellspec:
     name: shellspec (${{ matrix.os }})
-    needs: release-build
+    needs: [changes, release-build]
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -153,6 +204,8 @@ jobs:
 
   windows-build:
     name: windows build
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -175,6 +228,8 @@ jobs:
 
   windows-cas-test:
     name: windows cas test
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Conventions for humans and AI agents contributing to this repo.
 
+## GitHub
+
+- Use Conventional Commit style for pull request titles, such as
+  `fix(docs): update deployment route`.
+- Do not prefix pull request titles with `[codex]`.
+
 ## Module Layout
 
 **Avoid monolith Rust files.** When a `lib.rs` or `main.rs` grows past

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -14,7 +14,7 @@
   },
   "routes": [
     {
-      "pattern": "once.tuist.dev",
+      "pattern": "docs.buildonce.dev",
       "custom_domain": true
     }
   ]


### PR DESCRIPTION
## Summary

- Point the docs Cloudflare Worker route at `docs.buildonce.dev`.
- Update the GitHub deployment environment URL to `https://docs.buildonce.dev`.
- Align the workflow Wrangler version with the docs package pin so the deploy action reuses `wrangler@4.100.0` instead of trying to install `4.90.1`.
- Add a cheap `once` workflow change detector so docs-only pull requests skip Rust, release-build, dogfood, shellspec, and Windows jobs.
- Document that PR titles should use Conventional Commit style without a `[codex]` prefix.

## Root Cause

Docs builds were passing, but deployment failed in `cloudflare/wrangler-action` because the workflow requested `wranglerVersion: "4.90.1"` while the project had `wrangler@4.100.0` installed. The action attempted an npm install of the older version and npm failed before deployment.

The `once` workflow also ran unconditionally on every pull request, so docs-only changes still triggered release-mode Rust builds and the downstream dogfood jobs.

## Validation

- `mise exec -- aube ci`
- `mise exec -- aube run build`
- `mise exec -- aube exec -- wrangler --version`
- `mise exec -- aube exec -- wrangler deploy --dry-run`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/once.yml"); puts "yaml ok"'`
