### PR TITLE
refactor(rust): improve graph schema caching and CAS boundaries

### DIFF
--- a/crates/once-cas/src/error.rs
+++ b/crates/once-cas/src/error.rs
@@ -1,0 +1,31 @@
+use std::io;
+use std::path::PathBuf;
+
+use crate::Digest;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("corrupt action result at {0}: {1}")]
+    Corrupt(PathBuf, serde_json::Error),
+    #[error("blob not found: {0}")]
+    BlobNotFound(Digest),
+    #[error("cache provider `{provider}` is misconfigured: {message}")]
+    InvalidConfig {
+        provider: &'static str,
+        message: String,
+    },
+    #[error("cache provider `{provider}` failed during `{operation}`: {message}")]
+    Remote {
+        provider: &'static str,
+        operation: &'static str,
+        message: String,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/once-cas/src/lib.rs
+++ b/crates/once-cas/src/lib.rs
@@ -15,70 +15,24 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use serde::{Deserialize, Serialize};
 use tokio::fs::{self, File};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
 mod blob;
 mod digest;
+mod error;
+mod model;
 mod provider;
 mod tuist;
 
 pub use digest::Digest;
+pub use error::{Error, Result};
+pub use model::{ActionResult, Stats};
 pub use provider::CacheProvider;
 pub use tuist::{
     TuistAuth, TuistAuthPrompt, TuistCacheConfig, TUIST_APP_OAUTH_CLIENT_ID,
     TUIST_OAUTH_CLIENT_ID_ENV,
 };
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("io error at {path}: {source}")]
-    Io {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("corrupt action result at {0}: {1}")]
-    Corrupt(PathBuf, serde_json::Error),
-    #[error("blob not found: {0}")]
-    BlobNotFound(Digest),
-    #[error("cache provider `{provider}` is misconfigured: {message}")]
-    InvalidConfig {
-        provider: &'static str,
-        message: String,
-    },
-    #[error("cache provider `{provider}` failed during `{operation}`: {message}")]
-    Remote {
-        provider: &'static str,
-        operation: &'static str,
-        message: String,
-    },
-}
-
-pub type Result<T> = std::result::Result<T, Error>;
-
-/// Cached result of a single action execution.
-///
-/// `outputs` records each declared output file the action produced
-/// (workspace-relative path -> blob digest). On a cache hit, the runner
-/// restores these blobs from the CAS to their declared paths so a
-/// dependent action sees the file it expected, even if the producing
-/// action did not actually run on this machine.
-///
-/// `stdout` and `stderr` are optional: a caller that did not capture
-/// output (or had nothing worth recording) simply leaves them unset
-/// rather than materialising an empty blob.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ActionResult {
-    pub exit_code: i32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stdout: Option<Digest>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stderr: Option<Digest>,
-    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
-    pub outputs: std::collections::BTreeMap<String, Digest>,
-}
 
 /// Local content-addressed store rooted at a workspace `.once/`
 /// directory.
@@ -355,14 +309,6 @@ impl Cas {
             action_bytes: actions.1,
         })
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Stats {
-    pub blob_count: u64,
-    pub blob_bytes: u64,
-    pub action_count: u64,
-    pub action_bytes: u64,
 }
 
 /// Buffer size for [`Cas::put_stream`]. Bounds per-stream memory use.

--- a/crates/once-cas/src/model.rs
+++ b/crates/once-cas/src/model.rs
@@ -1,0 +1,35 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Digest;
+
+/// Cached result of a single action execution.
+///
+/// `outputs` records each declared output file the action produced
+/// (workspace-relative path -> blob digest). On a cache hit, the runner
+/// restores these blobs from the CAS to their declared paths so a
+/// dependent action sees the file it expected, even if the producing
+/// action did not actually run on this machine.
+///
+/// `stdout` and `stderr` are optional: a caller that did not capture
+/// output (or had nothing worth recording) simply leaves them unset
+/// rather than materialising an empty blob.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionResult {
+    pub exit_code: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<Digest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<Digest>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub outputs: BTreeMap<String, Digest>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Stats {
+    pub blob_count: u64,
+    pub blob_bytes: u64,
+    pub action_count: u64,
+    pub action_bytes: u64,
+}

--- a/crates/once-core/src/plan.rs
+++ b/crates/once-core/src/plan.rs
@@ -388,6 +388,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn independent_leaves_run_in_parallel() {
         let (_tmp, runner) = ws();
+        let runner = runner.with_max_concurrency(6);
         let mut plan = Plan::new();
         for i in 0..6u32 {
             plan.push(PlanNode {

--- a/crates/once-core/tests/runner.rs
+++ b/crates/once-core/tests/runner.rs
@@ -37,6 +37,7 @@ fn cmd(script: &str) -> Action {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn many_independent_actions_execute_concurrently() {
     let (_tmp, runner) = ws();
+    let runner = runner.with_max_concurrency(8);
     let actions: Vec<Action> = (0..8u32)
         .map(|i| cmd(&format!("sleep 0.2; printf {i}")))
         .collect();

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use serde::Serialize;
 use starlark::environment::Module;
@@ -194,7 +195,8 @@ pub fn load_graph_workspace(root: &Path) -> Result<Vec<GraphTarget>> {
 
 #[must_use]
 pub fn graph_from_targets(targets: &[Target]) -> Vec<GraphTarget> {
-    targets.iter().map(GraphTarget::from).collect()
+    let schemas = built_in_target_kind_schemas();
+    graph_from_targets_with_schemas(targets, &schemas)
 }
 
 pub fn graph_from_targets_result(targets: &[Target]) -> Result<Vec<GraphTarget>> {
@@ -355,10 +357,18 @@ fn parent_dir(path: &str) -> String {
 }
 
 fn starlark_prelude_target_kind_schemas() -> Result<Vec<TargetKindSchema>> {
-    parse_target_kind_schemas(
+    static BUILT_IN_TARGET_KIND_SCHEMAS: OnceLock<Vec<TargetKindSchema>> = OnceLock::new();
+
+    if let Some(schemas) = BUILT_IN_TARGET_KIND_SCHEMAS.get() {
+        return Ok(schemas.clone());
+    }
+
+    let schemas = parse_target_kind_schemas(
         crate::modules::BUILT_IN_MODULE_PATH,
         crate::modules::built_in_module_source(),
-    )
+    )?;
+    let _ = BUILT_IN_TARGET_KIND_SCHEMAS.set(schemas.clone());
+    Ok(schemas)
 }
 
 /// Evaluate a Starlark module source and read its exported target kind symbols.
@@ -980,6 +990,31 @@ demo_kind = target_kind(
             graph[0].attrs.get("mode"),
             Some(&AttrValue::String("debug".to_string()))
         );
+    }
+
+    #[test]
+    fn graph_from_targets_attaches_built_in_schema_to_each_target() {
+        let targets = ["ToolA", "ToolB"].map(|name| Target {
+            package: "tools".to_string(),
+            kind: "script".to_string(),
+            name: name.to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs: BTreeMap::new(),
+            typed_attrs: BTreeMap::new(),
+        });
+
+        let graph = graph_from_targets(&targets);
+
+        assert_eq!(graph.len(), 2);
+        for target in graph {
+            assert!(target.diagnostics.is_empty());
+            assert_eq!(target.providers, vec!["script_action"]);
+            assert!(target
+                .capabilities
+                .iter()
+                .any(|capability| capability.name == "run"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Cache built-in target kind schemas with `OnceLock` and reuse one schema set across batch graph construction.
- Add a regression test that verifies built-in schema enrichment for multiple targets.
- Move `once-cas` public errors and cache result/stat models into focused modules while preserving existing re-exports.

## Testing
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test --workspace`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise exec -- cargo build --release`
- `mise exec -- shellspec` (147 examples, 0 failures, 1 expected skip)
