### PR TITLE
fix(ci): restore docs and release workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,11 +75,7 @@ jobs:
         run: aube run build
 
       - name: deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.100.0"
-          workingDirectory: docs
-          command: deploy
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        run: aube run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ env:
   MISE_TASK_RUN_AUTO_INSTALL: "false"
   MISE_NOT_FOUND_AUTO_INSTALL: "false"
   MISE_EXEC_AUTO_INSTALL: "false"
+  ONCE_BOOTSTRAP_SOURCE: source
 
 jobs:
   detect:

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -156,12 +156,67 @@ def _host_which_optional(name):
     path = host_command([host_which("sh"), "-c", "command -v " + _shell_quote(name) + " 2>/dev/null || true"]).strip()
     return path
 
+def _rust_host_env(keys):
+    env = {}
+    for key in keys:
+        value = host_env(key)
+        if value:
+            env[key] = value
+    return env
+
+def _rust_windows_tool_env():
+    if host_os() != "windows":
+        return {}
+    env = _rust_host_env([
+        "COMSPEC",
+        "INCLUDE",
+        "LIB",
+        "LIBPATH",
+        "PATHEXT",
+        "PROCESSOR_ARCHITECTURE",
+        "PROCESSOR_ARCHITEW6432",
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "ProgramW6432",
+        "SystemDrive",
+        "SystemRoot",
+        "TEMP",
+        "TMP",
+        "UCRTVersion",
+        "UniversalCRTSdkDir",
+        "VCINSTALLDIR",
+        "VCToolsInstallDir",
+        "VSINSTALLDIR",
+        "VSCMD_ARG_HOST_ARCH",
+        "VSCMD_ARG_TGT_ARCH",
+        "VSCMD_VER",
+        "VisualStudioVersion",
+        "WindowsSdkBinPath",
+        "WindowsSdkDir",
+        "WindowsSDKLibVersion",
+        "WindowsSdkVerBinPath",
+        "WindowsSDKVersion",
+    ])
+    path = host_env("PATH") or host_env("Path")
+    if path:
+        env["PATH"] = path
+    return env
+
+def _rust_unix_tool_dirs():
+    os = host_os()
+    if os == "macos":
+        return ["/usr/bin", "/bin", "/usr/sbin", "/sbin", "/Library/Apple/usr/bin"]
+    if os == "linux":
+        return ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+    return []
+
 def _rust_tool_path(tools):
     dirs = []
     for tool in tools:
         directory = _parent_dir(tool)
         if directory:
             dirs.append(directory)
+    dirs.extend(_rust_unix_tool_dirs())
     return ":".join(_unique(dirs))
 
 def _rust_c_tool_env(target, host_triple):
@@ -174,7 +229,13 @@ def _rust_c_tool_env(target, host_triple):
     ar = host_which("ar")
     if ar:
         env["AR"] = ar
-    path = _rust_tool_path([cc, ar, _host_which_optional("as"), _host_which_optional("ld")])
+    ranlib = _host_which_optional("ranlib")
+    if ranlib:
+        env["RANLIB"] = ranlib
+    pkg_config = _host_which_optional("pkg-config")
+    if pkg_config:
+        env["PKG_CONFIG"] = pkg_config
+    path = _rust_tool_path([cc, ar, _host_which_optional("as"), _host_which_optional("ld"), ranlib, pkg_config])
     if path:
         env["PATH"] = path
     return env
@@ -203,6 +264,9 @@ def _workspace_absolute(path):
 
 def _rust_compile_env(ctx):
     env = _rust_env(ctx)
+    for key, value in _rust_windows_tool_env().items():
+        if key not in env:
+            env[key] = value
     manifest_dir = env.get("CARGO_MANIFEST_DIR")
     if manifest_dir:
         env["CARGO_MANIFEST_DIR"] = _workspace_absolute(_rust_manifest_dir(ctx, manifest_dir))
@@ -762,19 +826,11 @@ def _cargo_resolved_metadata(ctx):
     target = _rust_target(ctx)
     _, _, host_triple = _rustc_toolchain(target)
     cargo = host_which("cargo")
-    argv = [
-        cargo,
-        "metadata",
-        "--locked",
-        "--format-version", "1",
-        "--manifest-path", _workspace_absolute(manifest),
-    ]
     filter_platform = target or host_triple
-    if filter_platform:
-        argv.extend(["--filter-platform", filter_platform])
-    argv.extend(_cargo_feature_args(ctx))
-    metadata_content = host_command(argv)
-    metadata = json_decode(metadata_content)
+    metadata = _cargo_metadata_for_platform(ctx, cargo, manifest, filter_platform)
+    host_metadata = None
+    if target and target != host_triple:
+        host_metadata = _cargo_metadata_for_platform(ctx, cargo, manifest, host_triple)
     resolver_attrs = {"vendor_dir": vendor_dir}
     if target:
         resolver_attrs["target"] = target
@@ -783,8 +839,22 @@ def _cargo_resolved_metadata(ctx):
     }
     return {
         "metadata": metadata,
-        "specs": _cargo_metadata_targets(resolver_ctx, metadata),
+        "specs": _cargo_metadata_targets(resolver_ctx, metadata, host_metadata),
     }
+
+def _cargo_metadata_for_platform(ctx, cargo, manifest, platform):
+    argv = [
+        cargo,
+        "metadata",
+        "--locked",
+        "--format-version", "1",
+        "--manifest-path", _workspace_absolute(manifest),
+    ]
+    if platform:
+        argv.extend(["--filter-platform", platform])
+    argv.extend(_cargo_feature_args(ctx))
+    metadata_content = host_command(argv)
+    return json_decode(metadata_content)
 
 def _cargo_ref_name(ref):
     if ref.startswith("./"):
@@ -1133,8 +1203,10 @@ def _cargo_package_is_proc_macro(package):
 def _cargo_host_variant_name(package, duplicate_counts):
     return _cargo_target_name(package, duplicate_counts) + "-host"
 
-def _cargo_host_dependency_ids(packages, nodes):
+def _cargo_host_dependency_ids(packages, nodes, host_nodes = None):
     package_by_id, _ = _cargo_package_indexes(packages, _cargo_duplicate_counts(packages))
+    if host_nodes == None:
+        host_nodes = nodes
     needed = {}
     stack = []
     for package in packages:
@@ -1161,7 +1233,7 @@ def _cargo_host_dependency_ids(packages, nodes):
             if package == None or package.get("source") == None or package_id in needed:
                 continue
             needed[package_id] = True
-            node = nodes.get(package_id) or {}
+            node = host_nodes.get(package_id) or nodes.get(package_id) or {}
             include_build = _cargo_build_script_target(package) != None
             for dep in node.get("deps") or []:
                 if not _cargo_dep_is_runtime(dep) and not (include_build and _cargo_dep_is_build(dep)):
@@ -1205,6 +1277,26 @@ def _cargo_resolve_nodes(metadata):
     for node in resolve.get("nodes") or []:
         nodes[node.get("id")] = node
     return nodes
+
+def _cargo_merge_packages(primary, secondary):
+    out = []
+    seen = {}
+    for package in primary + secondary:
+        package_id = package.get("id")
+        key = package_id or package.get("name") + "@" + package.get("version")
+        if key in seen:
+            continue
+        seen[key] = True
+        out.append(package)
+    return out
+
+def _cargo_package_id_set(packages):
+    ids = {}
+    for package in packages:
+        package_id = package.get("id")
+        if package_id:
+            ids[package_id] = True
+    return ids
 
 def _cargo_dep_is_runtime(dep):
     saw_kind = False
@@ -1345,11 +1437,15 @@ def _cargo_metadata_target_spec(package, target, node, source_root, crate_root, 
         spec["build_deps"] = build_deps
     return spec
 
-def _cargo_metadata_targets(ctx, metadata):
-    packages = metadata.get("packages") or []
+def _cargo_metadata_targets(ctx, metadata, host_metadata = None):
+    target_packages = metadata.get("packages") or []
+    host_packages = host_metadata.get("packages") if host_metadata != None else []
+    packages = _cargo_merge_packages(target_packages, host_packages)
+    target_package_ids = _cargo_package_id_set(target_packages)
     duplicate_counts = _cargo_duplicate_counts(packages)
     nodes = _cargo_resolve_nodes(metadata)
-    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes)
+    host_nodes = _cargo_resolve_nodes(host_metadata) if host_metadata != None else nodes
+    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes, host_nodes)
     id_to_target_name, id_to_host_name = _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids)
     vendor_dir = _trim_trailing_slash(ctx["attrs"].get("vendor_dir") or "vendor")
     rust_target = ctx["attrs"].get("target") or ""
@@ -1367,22 +1463,24 @@ def _cargo_metadata_targets(ctx, metadata):
         rel_root = _cargo_source_rel(package, target)
         crate_root = source_root + "/" + rel_root
         node = nodes.get(package_id) or {}
+        host_node = host_nodes.get(package_id) or node
 
         if kind == "rust_proc_macro":
-            deps, aliases = _cargo_metadata_deps(node, id_to_host_name, False)
-            build_deps, build_aliases = _cargo_metadata_build_deps(node, id_to_host_name)
-            targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), ""))
+            deps, aliases = _cargo_metadata_deps(host_node, id_to_host_name, False)
+            build_deps, build_aliases = _cargo_metadata_build_deps(host_node, id_to_host_name)
+            targets.append(_cargo_metadata_target_spec(package, target, host_node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), ""))
             continue
 
-        deps, aliases = _cargo_metadata_deps(node, id_to_target_name, False)
-        build_deps, build_aliases = _cargo_metadata_build_deps(node, id_to_host_name)
-        targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), rust_target))
+        if target_package_ids.get(package_id):
+            deps, aliases = _cargo_metadata_deps(node, id_to_target_name, False)
+            build_deps, build_aliases = _cargo_metadata_build_deps(node, id_to_host_name)
+            targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), rust_target))
 
         host_name = id_to_host_name.get(package_id)
         if host_name:
-            host_deps, host_aliases = _cargo_metadata_deps(node, id_to_host_name, False)
-            host_build_deps, host_build_aliases = _cargo_metadata_build_deps(node, id_to_host_name)
-            targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, host_name, kind, host_deps, host_build_deps, _cargo_merge_aliases(host_aliases, host_build_aliases), ""))
+            host_deps, host_aliases = _cargo_metadata_deps(host_node, id_to_host_name, False)
+            host_build_deps, host_build_aliases = _cargo_metadata_build_deps(host_node, id_to_host_name)
+            targets.append(_cargo_metadata_target_spec(package, target, host_node, source_root, crate_root, host_name, kind, host_deps, host_build_deps, _cargo_merge_aliases(host_aliases, host_build_aliases), ""))
     return targets
 
 def _cargo_vendor_source_root(vendor_dir, package, target_name):

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1092,6 +1092,12 @@ _host_values = {{
 def host_env(name):
     return _host_values.get(name, "")
 
+def host_which(name):
+    fail("unexpected host_which call: " + name)
+
+def host_command(argv, env = None):
+    fail("unexpected host_command call")
+
 ctx = {{
     "label": {{
         "package": "crates/app",

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -611,6 +611,7 @@ result = repr([
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn prelude_cargo_metadata_targets_use_host_metadata_for_host_variants() {
     let prelude = all_prelude_source();
     let source = format!(

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1013,7 +1013,9 @@ result = repr([
 
     assert!(std::path::Path::new(&values[0]).is_absolute());
     assert!(std::path::Path::new(&values[1]).is_absolute());
-    assert!(std::path::Path::new(&values[2]).is_absolute());
+    if !values[2].is_empty() {
+        assert!(std::path::Path::new(&values[2]).is_absolute());
+    }
     if !values[3].is_empty() {
         assert!(std::path::Path::new(&values[3]).is_absolute());
     }
@@ -1067,6 +1069,65 @@ result = repr([
     let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 
     assert_eq!(out.unwrap(), "[None, None, None]");
+}
+
+#[test]
+fn prelude_rust_compile_env_forwards_windows_tool_env_without_overrides() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_os():
+    return "windows"
+
+_host_values = {{
+    "PATH": "C:/msvc/bin;C:/windows/system32",
+    "Path": "C:/ignored",
+    "INCLUDE": "C:/include",
+    "LIB": "C:/lib",
+    "SystemRoot": "C:/Windows",
+    "TEMP": "C:/Temp",
+    "VCINSTALLDIR": "C:/VS/VC",
+}}
+
+def host_env(name):
+    return _host_values.get(name, "")
+
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "env": {{
+            "CUSTOM": "configured",
+            "LIB": "configured-lib",
+        }},
+        "rustc_env": {{
+            "INCLUDE": "configured-include",
+        }},
+    }},
+    "srcs": [],
+}}
+env = _rust_compile_env(ctx)
+result = repr([
+    env.get("PATH"),
+    env.get("INCLUDE"),
+    env.get("LIB"),
+    env.get("SystemRoot"),
+    env.get("TEMP"),
+    env.get("VCINSTALLDIR"),
+    env.get("CUSTOM"),
+    env.get("PATHEXT"),
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+
+    assert_eq!(
+        out,
+        "[\"C:/msvc/bin;C:/windows/system32\", \"configured-include\", \"configured-lib\", \"C:/Windows\", \"C:/Temp\", \"C:/VS/VC\", \"configured\", None]"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -610,6 +610,233 @@ result = repr([
     );
 }
 
+#[test]
+fn prelude_cargo_metadata_targets_use_host_metadata_for_host_variants() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{
+    "attrs": {{
+        "target": "x86_64-apple-darwin",
+        "vendor_dir": "third_party/rust/vendor",
+    }},
+}}
+packages = [
+    {{
+        "id": "registry+https://github.com/rust-lang/crates.io-index#builder@1.0.0",
+        "name": "builder",
+        "version": "1.0.0",
+        "source": "registry+https://github.com/rust-lang/crates.io-index",
+        "manifest_path": "/workspace/vendor/builder-1.0.0/Cargo.toml",
+        "targets": [
+            {{
+                "name": "builder",
+                "kind": ["lib"],
+                "crate_types": ["lib"],
+                "src_path": "/workspace/vendor/builder-1.0.0/src/lib.rs",
+                "edition": "2021",
+            }},
+            {{
+                "name": "build-script-build",
+                "kind": ["custom-build"],
+                "crate_types": ["bin"],
+                "src_path": "/workspace/vendor/builder-1.0.0/build.rs",
+                "edition": "2021",
+            }},
+        ],
+    }},
+    {{
+        "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+        "name": "cpufeatures",
+        "version": "0.2.17",
+        "source": "registry+https://github.com/rust-lang/crates.io-index",
+        "manifest_path": "/workspace/vendor/cpufeatures-0.2.17/Cargo.toml",
+        "targets": [{{
+            "name": "cpufeatures",
+            "kind": ["lib"],
+            "crate_types": ["lib"],
+            "src_path": "/workspace/vendor/cpufeatures-0.2.17/src/lib.rs",
+            "edition": "2018",
+        }}],
+    }},
+    {{
+        "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+        "name": "libc",
+        "version": "0.2.186",
+        "source": "registry+https://github.com/rust-lang/crates.io-index",
+        "manifest_path": "/workspace/vendor/libc-0.2.186/Cargo.toml",
+        "targets": [{{
+            "name": "libc",
+            "kind": ["lib"],
+            "crate_types": ["lib"],
+            "src_path": "/workspace/vendor/libc-0.2.186/src/lib.rs",
+            "edition": "2021",
+        }}],
+    }},
+]
+target_metadata = {{
+    "packages": packages,
+    "resolve": {{
+        "nodes": [
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#builder@1.0.0",
+                "features": [],
+                "deps": [{{
+                    "name": "cpufeatures",
+                    "pkg": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+                    "dep_kinds": [{{"kind": "build"}}],
+                }}],
+            }},
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+                "features": [],
+                "deps": [],
+            }},
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+                "features": [],
+                "deps": [],
+            }},
+        ],
+    }},
+}}
+host_metadata = {{
+    "packages": packages,
+    "resolve": {{
+        "nodes": [
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#builder@1.0.0",
+                "features": [],
+                "deps": [{{
+                    "name": "cpufeatures",
+                    "pkg": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+                    "dep_kinds": [{{"kind": "build"}}],
+                }}],
+            }},
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17",
+                "features": [],
+                "deps": [{{
+                    "name": "libc",
+                    "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+                    "dep_kinds": [{{"kind": None}}],
+                }}],
+            }},
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
+                "features": [],
+                "deps": [],
+            }},
+        ],
+    }},
+}}
+targets = _cargo_metadata_targets(ctx, target_metadata, host_metadata)
+by_name = {{target["name"]: target for target in targets}}
+result = repr([
+    by_name["cpufeatures-0.2.17"]["deps"],
+    by_name["cpufeatures-0.2.17-host"]["deps"],
+    by_name["cpufeatures-0.2.17-host"]["attrs"].get("target"),
+    by_name["libc-0.2.186-host"]["attrs"].get("target"),
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+
+    assert_eq!(out, "[[], [\"./libc-0.2.186-host\"], None, None]");
+}
+
+#[test]
+fn prelude_cargo_metadata_targets_use_host_metadata_for_proc_macro_features() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{
+    "attrs": {{
+        "target": "x86_64-apple-darwin",
+        "vendor_dir": "third_party/rust/vendor",
+    }},
+}}
+packages = [
+    {{
+        "id": "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
+        "name": "document-features",
+        "version": "0.2.12",
+        "source": "registry+https://github.com/rust-lang/crates.io-index",
+        "manifest_path": "/workspace/vendor/document-features-0.2.12/Cargo.toml",
+        "targets": [{{
+            "name": "document_features",
+            "kind": ["proc-macro"],
+            "crate_types": ["proc-macro"],
+            "src_path": "/workspace/vendor/document-features-0.2.12/lib.rs",
+            "edition": "2018",
+        }}],
+    }},
+    {{
+        "id": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
+        "name": "litrs",
+        "version": "1.0.0",
+        "source": "registry+https://github.com/rust-lang/crates.io-index",
+        "manifest_path": "/workspace/vendor/litrs-1.0.0/Cargo.toml",
+        "targets": [{{
+            "name": "litrs",
+            "kind": ["lib"],
+            "crate_types": ["lib"],
+            "src_path": "/workspace/vendor/litrs-1.0.0/src/lib.rs",
+            "edition": "2021",
+        }}],
+    }},
+]
+target_metadata = {{
+    "packages": packages,
+    "resolve": {{
+        "nodes": [
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
+                "features": [],
+                "deps": [],
+            }},
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
+                "features": [],
+                "deps": [],
+            }},
+        ],
+    }},
+}}
+host_metadata = {{
+    "packages": packages,
+    "resolve": {{
+        "nodes": [
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#document-features@0.2.12",
+                "features": ["default"],
+                "deps": [{{
+                    "name": "litrs",
+                    "pkg": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
+                    "dep_kinds": [{{"kind": None}}],
+                }}],
+            }},
+            {{
+                "id": "registry+https://github.com/rust-lang/crates.io-index#litrs@1.0.0",
+                "features": [],
+                "deps": [],
+            }},
+        ],
+    }},
+}}
+targets = _cargo_metadata_targets(ctx, target_metadata, host_metadata)
+by_name = {{target["name"]: target for target in targets}}
+result = repr([
+    by_name["document-features-0.2.12"]["attrs"]["features"],
+    by_name["document-features-0.2.12"]["deps"],
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+
+    assert_eq!(out, "[[\"default\"], [\"./litrs-1.0.0-host\"]]");
+}
+
 #[cfg(unix)]
 #[test]
 fn prelude_rust_build_script_metadata_deps_are_not_duplicated() {
@@ -764,12 +991,16 @@ build_env = _rust_build_script_env(
     "third_party/rust/vendor/pkg-1.0.0/build.rs",
 )
 result = repr([
-    tool_env.get("CC"),
-    tool_env.get("AR"),
-    tool_env.get("PATH"),
-    build_env.get("CC"),
-    build_env.get("AR"),
-    build_env.get("PATH"),
+    tool_env.get("CC") or "",
+    tool_env.get("AR") or "",
+    tool_env.get("RANLIB") or "",
+    tool_env.get("PKG_CONFIG") or "",
+    tool_env.get("PATH") or "",
+    build_env.get("CC") or "",
+    build_env.get("AR") or "",
+    build_env.get("RANLIB") or "",
+    build_env.get("PKG_CONFIG") or "",
+    build_env.get("PATH") or "",
 ])
 "#
     );
@@ -781,17 +1012,60 @@ result = repr([
 
     assert!(std::path::Path::new(&values[0]).is_absolute());
     assert!(std::path::Path::new(&values[1]).is_absolute());
-    assert_eq!(values[0], values[3]);
-    assert_eq!(values[1], values[4]);
-    assert_eq!(values[2], values[5]);
-    for entry in values[2].split(':') {
+    assert!(std::path::Path::new(&values[2]).is_absolute());
+    if !values[3].is_empty() {
+        assert!(std::path::Path::new(&values[3]).is_absolute());
+    }
+    assert_eq!(values[0], values[5]);
+    assert_eq!(values[1], values[6]);
+    assert_eq!(values[2], values[7]);
+    assert_eq!(values[3], values[8]);
+    assert_eq!(values[4], values[9]);
+    for entry in values[4].split(':') {
         assert!(std::path::Path::new(entry).is_absolute());
     }
-    let cc_dir = std::path::Path::new(&values[0])
-        .parent()
-        .unwrap()
-        .to_string_lossy();
-    assert!(values[2].split(':').any(|entry| entry == cc_dir));
+    for tool in [&values[0], &values[1], &values[2], &values[3]] {
+        if tool.is_empty() {
+            continue;
+        }
+        let tool_dir = std::path::Path::new(tool)
+            .parent()
+            .unwrap()
+            .to_string_lossy();
+        assert!(values[4].split(':').any(|entry| entry == tool_dir));
+    }
+    assert!(values[4].split(':').any(|entry| entry == "/bin"));
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_rust_compile_env_does_not_forward_unix_host_path() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{}},
+    "srcs": [],
+}}
+env = _rust_compile_env(ctx)
+result = repr([
+    env.get("PATH"),
+    env.get("LIB"),
+    env.get("INCLUDE"),
+])
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "");
+
+    let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "[None, None, None]");
 }
 
 #[cfg(unix)]

--- a/mise/tasks/release/prepare-rust-graph-deps.sh
+++ b/mise/tasks/release/prepare-rust-graph-deps.sh
@@ -29,15 +29,45 @@ for tool in jq mise; do
   fi
 done
 
+export CARGO_NET_RETRY="${CARGO_NET_RETRY:-10}"
+
+retry_command() {
+  local description="$1"
+  shift
+
+  local attempt=1
+  local max_attempts=3
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if ((attempt >= max_attempts)); then
+      return 1
+    fi
+    echo "${description} failed; retrying (${attempt}/${max_attempts})" >&2
+    sleep $((attempt * 5))
+    attempt=$((attempt + 1))
+  done
+}
+
+cargo_vendor() {
+  mise exec -- cargo vendor --locked --versioned-dirs third_party/rust/vendor >/tmp/once-cargo-vendor-config
+}
+
 rm -rf third_party/rust/vendor
 mkdir -p third_party/rust
-mise exec -- cargo vendor --locked --versioned-dirs third_party/rust/vendor >/tmp/once-cargo-vendor-config
+retry_command "cargo vendor" cargo_vendor
 
 metadata_args=(metadata --locked --format-version 1)
 if [[ -n "${target}" ]]; then
   metadata_args+=(--filter-platform "${target}")
 fi
-metadata="$(mise exec -- cargo "${metadata_args[@]}")"
+
+cargo_metadata() {
+  mise exec -- cargo "${metadata_args[@]}"
+}
+
+metadata="$(retry_command "cargo metadata" cargo_metadata)"
 schlussel_manifest="$(
   jq -r '
     .packages[]


### PR DESCRIPTION
## Summary
- Fixes the docs deploy failure by running the repository's deploy script, so CI uses the Wrangler version pinned by the docs package instead of installing a mismatched action version.
- Repairs release graph cross builds by collecting Cargo metadata for both target and host platforms, so host build scripts and proc macros keep the correct dependencies and features.
- Keeps release packaging on the source-built `once` binary in CI, which makes the workflow exercise the prelude from this branch, and adds retries around Cargo vendor and metadata calls to absorb transient registry fetch failures.
- The final approach keeps the generic Rust graph model intact instead of special-casing failing crates, with focused prelude tests for the host metadata cases reproduced from main.

## Testing
- `git diff --check`
- `bash -n mise/tasks/release/prepare-rust-graph-deps.sh`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- aube run build`
- `mise/tasks/release/prepare-rust-graph-deps.sh --target x86_64-unknown-linux-gnu`
- `mise exec -- cargo build --locked --release --package once-cli`
- `target/release/once build crates/once/once_staticlib_x86_64_apple_darwin --format json --quiet`
