### PR TITLE
fix(ci): repair release packaging jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           # Restrict to the build tools needed on every matrix host.
           install_args: "rust jq"
       - if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcap-ng-dev
       - name: Cache Rust
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
@@ -157,7 +157,7 @@ jobs:
           version: ${{ env.MISE_VERSION }}
           install_args: "rust jq"
       - if: startsWith(matrix.runner, 'ubuntu-')
-        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcap-ng-dev
       - name: Cache Rust
         continue-on-error: true
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -1143,15 +1143,18 @@ def _cargo_resolver_impl(ctx):
         })
     return targets
 
+def _cargo_normalized_path(path):
+    return path.replace("\\", "/")
+
 def _cargo_package_root(package):
-    manifest = package.get("manifest_path") or ""
+    manifest = _cargo_normalized_path(package.get("manifest_path") or "")
     if manifest:
         return _parent_dir(manifest)
     return ""
 
 def _cargo_source_rel(package, target):
-    src = target.get("src_path") or ""
-    root = _cargo_package_root(package)
+    src = _cargo_normalized_path(target.get("src_path") or "")
+    root = _cargo_normalized_path(_cargo_package_root(package))
     prefix = root + "/"
     if root and src.startswith(prefix):
         return src[len(prefix):]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -534,6 +534,63 @@ fn prelude_cargo_metadata_targets_preserve_rust_target() {
 }
 
 #[test]
+fn prelude_cargo_metadata_targets_normalize_windows_build_script_paths() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+targets = _cargo_metadata_targets({{
+    "attrs": {{
+        "target": "x86_64-pc-windows-msvc",
+        "vendor_dir": "third_party/rust/vendor",
+    }},
+}}, {{
+    "packages": [{{
+        "id": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "name": "anyhow",
+        "version": "1.0.102",
+        "source": "registry+https://github.com/rust-lang/crates.io-index",
+        "manifest_path": "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index\\anyhow-1.0.102\\Cargo.toml",
+        "targets": [
+            {{
+                "name": "anyhow",
+                "kind": ["lib"],
+                "crate_types": ["lib"],
+                "src_path": "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index\\anyhow-1.0.102\\src\\lib.rs",
+                "edition": "2021",
+            }},
+            {{
+                "name": "build-script-build",
+                "kind": ["custom-build"],
+                "crate_types": ["bin"],
+                "src_path": "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index\\anyhow-1.0.102\\build.rs",
+                "edition": "2021",
+            }},
+        ],
+    }}],
+    "resolve": {{
+        "nodes": [{{
+            "id": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+            "features": [],
+            "deps": [],
+        }}],
+    }},
+}})
+by_name = {{target["name"]: target for target in targets}}
+result = repr([
+    by_name["anyhow-1.0.102"]["attrs"]["crate_root"],
+    by_name["anyhow-1.0.102"]["attrs"]["build_script"],
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+
+    assert_eq!(
+        out,
+        "[\"third_party/rust/vendor/anyhow-1.0.102/src/lib.rs\", \"third_party/rust/vendor/anyhow-1.0.102/build.rs\"]"
+    );
+}
+
+#[test]
 fn prelude_cargo_metadata_targets_split_proc_macro_host_deps() {
     let prelude = all_prelude_source();
     let source = format!(

--- a/mise/tasks/release/write-rust-release-manifests.sh
+++ b/mise/tasks/release/write-rust-release-manifests.sh
@@ -71,7 +71,14 @@ fi
 
 suffix="$(printf '%s' "${target}" | tr '.-' '__')"
 dependency_target="cargo_dependencies_${suffix}"
-release_flags='["-C", "opt-level=3", "-C", "codegen-units=1", "-C", "panic=abort"]'
+case "${target}" in
+  *-apple-ios*)
+    release_flags='["-C", "opt-level=3", "-C", "codegen-units=1"]'
+    ;;
+  *)
+    release_flags='["-C", "opt-level=3", "-C", "codegen-units=1", "-C", "panic=abort"]'
+    ;;
+esac
 
 remove_generated_blocks
 


### PR DESCRIPTION
## Summary
- Restores the Release workflow after the latest `main` push showed ARM Linux, Windows, and XCFramework jobs failing for separate release packaging reasons.
- Installs `build-essential` on Linux release runners so generated Cargo dependency build scripts have the native linker tools they need, while keeping the existing `libcap-ng-dev` setup.
- Normalizes Cargo metadata paths in the Rust prelude so Windows registry paths resolve custom build targets to `build.rs` instead of falling back to `src/lib.rs`; the new regression test covers the `anyhow` metadata shape that failed in CI.
- Keeps `panic=abort` for standard release targets but omits it for iOS staticlibs, because the XCFramework build pulls in `objc2` and that crate requires unwind panics on the iOS targets.

## Testing
- `mise exec -- cargo test -p once-frontend prelude_cargo_metadata_targets_normalize_windows_build_script_paths`
- `mise exec -- cargo test -p once-frontend prelude_cargo_metadata_targets`
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- Manual generated-manifest checks for `aarch64-apple-ios` and `x86_64-pc-windows-msvc` release flags
