### PR TITLE
fix(ci): repair release package builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           # Restrict to the build tools needed on every matrix host.
           install_args: "rust jq"
       - if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcap-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y binutils build-essential libcap-ng-dev
       - name: Cache Rust
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
@@ -157,7 +157,7 @@ jobs:
           version: ${{ env.MISE_VERSION }}
           install_args: "rust jq"
       - if: startsWith(matrix.runner, 'ubuntu-')
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcap-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y binutils build-essential libcap-ng-dev
       - name: Cache Rust
         continue-on-error: true
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -1,6 +1,3 @@
-def _shell_join(argv):
-    return " ".join([_shell_quote(arg) for arg in argv])
-
 def _ascii_env_key(value):
     upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     out = []
@@ -598,7 +595,6 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
 
 def _rustc_with_build_script_args(argv, stdout):
     script = """set -eu
-set -- {argv}
 while IFS= read -r line; do
   case "$line" in
     cargo:rustc-cfg=*|cargo::rustc-cfg=*)
@@ -634,8 +630,8 @@ while IFS= read -r line; do
   esac
 done < {stdout}
 exec "$@"
-""".format(argv = _shell_join(argv), stdout = _shell_quote(stdout))
-    return [host_which("sh"), "-c", script]
+""".format(stdout = _shell_quote(stdout))
+    return [host_which("sh"), "-c", script, "once-rustc"] + argv
 
 def _rust_dep_inputs(deps):
     inputs = []

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -977,6 +977,38 @@ result = repr(env.get("CARGO_ENCODED_RUSTFLAGS"))
     assert_eq!(out.unwrap(), "\"-C\\x1fopt-level=3\"");
 }
 
+#[test]
+fn prelude_rustc_wrapper_passes_initial_argv_positionally() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "sh":
+        return "/usr/bin/sh"
+    fail("unexpected host_which call: " + name)
+
+args = _rustc_with_build_script_args(
+    ["rustc", "arg with spaces", "O'Reilly"],
+    ".once/out/pkg/build script.stdout",
+)
+result = repr(args)
+"#
+    );
+
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    let values: Vec<String> = serde_json::from_str(&out).unwrap();
+
+    assert_eq!(values[0], "/usr/bin/sh");
+    assert_eq!(values[1], "-c");
+    assert_eq!(values[3], "once-rustc");
+    assert_eq!(&values[4..], ["rustc", "arg with spaces", "O'Reilly"]);
+    let script = &values[2];
+    assert_eq!(script.lines().nth(1), Some("while IFS= read -r line; do"));
+    assert!(script.contains("done < '.once/out/pkg/build script.stdout'"));
+    assert!(script.contains("exec \"$@\""));
+    assert!(!script.contains("O'Reilly"), "{script}");
+}
+
 #[cfg(unix)]
 #[test]
 fn prelude_rust_proc_macro_compile_uses_host_target() {


### PR DESCRIPTION
## Summary
- Restore the failing `Release` workflow on Linux ARM by installing `binutils` alongside the existing native build dependencies, since the latest `main` run had `cc` but failed with `collect2: fatal error: cannot find 'ld'`.
- Fix the Windows release packaging failure by passing the initial `rustc` argv to the build-script wrapper as positional arguments after `sh -c`, instead of embedding the command in shell source where Git Bash can misparse quoted values.
- Keep the build-script output handling behavior intact while adding regression coverage for quoted rustc arguments, which makes the chosen fix narrower than rewriting the generated shell wrapper entirely.

## Testing
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
