### PR TITLE
fix(ci): stabilize Rust release graph actions

### DIFF
--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -201,21 +201,9 @@ def _rust_feature_flags(ctx):
         flags.extend(["--cfg", "feature=\"" + feature + "\""])
     return flags
 
-def _rust_response_file(ctx, name, content, identifier_suffix):
+def _rust_response_file(ctx, name, content):
     path = declare_output(_rust_declared_output(ctx, name))
-    mkdir = _shell_quote(host_which("mkdir"))
-    script = """set -eu
-__once_path={path}
-case "$__once_path" in */*) {mkdir} -p "${{__once_path%/*}}" ;; esac
-printf '%s' {content} > "$__once_path"
-""".format(path = _shell_quote(path), mkdir = mkdir, content = _shell_quote(content))
-    run_action(
-        argv = [host_which("sh"), "-c", script],
-        outputs = [path],
-        env = _rust_windows_tool_env(),
-        toolchain_identity = "once.rust.response.v1\x00" + content,
-        identifier = ctx["label"]["id"] + ":" + identifier_suffix,
-    )
+    write_path(path, content)
     return path
 
 def _rust_feature_args(ctx):
@@ -224,7 +212,7 @@ def _rust_feature_args(ctx):
         return ([], [])
     if host_os() != "windows":
         return (flags, [])
-    path = _rust_response_file(ctx, "rustc-features.rsp", "\n".join(flags) + "\n", "rustc-features")
+    path = _rust_response_file(ctx, "rustc-features.rsp", "\n".join(flags) + "\n")
     return (["@" + path], [path])
 
 def _rust_user_flags(ctx):
@@ -300,6 +288,26 @@ def _rust_tool_path(tools):
     dirs.extend(_rust_unix_tool_dirs())
     return ":".join(_unique(dirs))
 
+def _rust_path_separator():
+    return ";" if host_os() == "windows" else ":"
+
+def _rust_merge_paths(primary, fallback):
+    if not primary:
+        return fallback
+    if not fallback:
+        return primary
+    separator = _rust_path_separator()
+    return separator.join(_unique(primary.split(separator) + fallback.split(separator)))
+
+def _rust_merge_env_lower_precedence(env, fallback_env):
+    for key, value in fallback_env.items():
+        if key == "PATH":
+            path = _rust_merge_paths(env.get("PATH") or "", value)
+            if path:
+                env["PATH"] = path
+        elif key not in env:
+            env[key] = value
+
 def _rust_c_tool_env(target, host_triple):
     env = {}
     if host_os() == "windows" or target != host_triple:
@@ -370,13 +378,8 @@ def _rust_manifest_dir(ctx, manifest_dir):
 
 def _rust_compile_action_env(ctx, target, host_triple):
     env = _rust_compile_env(ctx)
-    for key, value in _rust_android_compile_env(ctx, target or host_triple).items():
-        if key not in env:
-            env[key] = value
-    c_env = _rust_c_tool_env(target or host_triple, host_triple)
-    path = c_env.get("PATH")
-    if path and "PATH" not in env:
-        env["PATH"] = path
+    _rust_merge_env_lower_precedence(env, _rust_android_compile_env(ctx, target or host_triple))
+    _rust_merge_env_lower_precedence(env, _rust_c_tool_env(target or host_triple, host_triple))
     return env
 
 def _rust_target_args(target):
@@ -542,9 +545,7 @@ def _rust_builtin_extern_args(crate_type):
 
 def _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path):
     env = _rust_compile_env(ctx)
-    for key, value in _rust_c_tool_env(target or host_triple, host_triple).items():
-        if key not in env:
-            env[key] = value
+    _rust_merge_env_lower_precedence(env, _rust_c_tool_env(target or host_triple, host_triple))
     for key, value in _rust_cfg_env(rustc, target).items():
         if key not in env:
             env[key] = value

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -192,7 +192,7 @@ def _rust_android_compile_env(ctx, target):
         env["PATH"] = path
     return env
 
-def _rust_features(ctx):
+def _rust_feature_flags(ctx):
     flags = []
     features = []
     features.extend(_rust_attr(ctx, "features", []))
@@ -200,6 +200,32 @@ def _rust_features(ctx):
     for feature in _unique(features):
         flags.extend(["--cfg", "feature=\"" + feature + "\""])
     return flags
+
+def _rust_response_file(ctx, name, content, identifier_suffix):
+    path = declare_output(_rust_declared_output(ctx, name))
+    mkdir = _shell_quote(host_which("mkdir"))
+    script = """set -eu
+__once_path={path}
+case "$__once_path" in */*) {mkdir} -p "${{__once_path%/*}}" ;; esac
+printf '%s' {content} > "$__once_path"
+""".format(path = _shell_quote(path), mkdir = mkdir, content = _shell_quote(content))
+    run_action(
+        argv = [host_which("sh"), "-c", script],
+        outputs = [path],
+        env = _rust_windows_tool_env(),
+        toolchain_identity = "once.rust.response.v1\x00" + content,
+        identifier = ctx["label"]["id"] + ":" + identifier_suffix,
+    )
+    return path
+
+def _rust_feature_args(ctx):
+    flags = _rust_feature_flags(ctx)
+    if not flags:
+        return ([], [])
+    if host_os() != "windows":
+        return (flags, [])
+    path = _rust_response_file(ctx, "rustc-features.rsp", "\n".join(flags) + "\n", "rustc-features")
+    return (["@" + path], [path])
 
 def _rust_user_flags(ctx):
     return _rust_attr(ctx, "rustc_flags", [])
@@ -341,6 +367,17 @@ def _rust_manifest_dir(ctx, manifest_dir):
     if package and (manifest_dir == package or manifest_dir.startswith(package + "/")):
         return manifest_dir
     return _package_relative(ctx, manifest_dir)
+
+def _rust_compile_action_env(ctx, target, host_triple):
+    env = _rust_compile_env(ctx)
+    for key, value in _rust_android_compile_env(ctx, target or host_triple).items():
+        if key not in env:
+            env[key] = value
+    c_env = _rust_c_tool_env(target or host_triple, host_triple)
+    path = c_env.get("PATH")
+    if path and "PATH" not in env:
+        env["PATH"] = path
+    return env
 
 def _rust_target_args(target):
     if target:
@@ -603,7 +640,7 @@ def _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports):
     ])
     return "\n".join(lines)
 
-def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps):
+def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps, feature_args, feature_inputs):
     build_script = _rust_attr(ctx, "build_script", "")
     if not build_script:
         return (None, [], {}, None)
@@ -621,15 +658,16 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         script_path,
         "-o", runner,
     ]
-    compile_argv.extend(_rust_features(ctx))
+    compile_argv.extend(feature_args)
     compile_argv.extend(_rust_cap_lints(ctx))
     compile_argv.extend(dep_args)
     compile_argv.extend(linker_args)
+    build_script_compile_env = _rust_compile_action_env(ctx, host_triple, host_triple)
     run_action(
         argv = compile_argv,
-        inputs = _unique([script_path] + dep_inputs + _rust_extra_inputs(ctx)),
+        inputs = _unique([script_path] + dep_inputs + feature_inputs + _rust_extra_inputs(ctx)),
         outputs = [runner],
-        env = _rust_compile_env(ctx),
+        env = build_script_compile_env,
         toolchain_identity = identity + linker_identity + "\x00build-script",
         identifier = ctx["label"]["id"] + ":build-script-rustc",
     )
@@ -646,7 +684,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         toolchain_identity = identity + "\x00build-script-run",
         identifier = ctx["label"]["id"] + ":build-script",
     )
-    compile_env = _rust_compile_env(ctx)
+    compile_env = _rust_compile_action_env(ctx, target, host_triple)
     compile_env["OUT_DIR"] = _workspace_absolute(out_dir)
     return (out_dir, [script_path, stdout], compile_env, stdout)
 
@@ -815,11 +853,9 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
         build_deps = []
     build_dep_args = _rust_dep_args(build_deps, aliases)
     build_dep_inputs = _rust_dep_inputs(build_deps)
-    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps)
-    compile_env = build_env if build_env else _rust_compile_env(ctx)
-    for key, value in _rust_android_compile_env(ctx, target).items():
-        if key not in compile_env:
-            compile_env[key] = value
+    feature_args, feature_inputs = _rust_feature_args(ctx)
+    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps, feature_args, feature_inputs)
+    compile_env = build_env if build_env else _rust_compile_action_env(ctx, target, host_triple)
     linker_args, linker_identity = _rust_linker(ctx, crate_type, target, host_triple)
     argv = [
         rustc,
@@ -831,7 +867,7 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
         "-o", output,
     ]
     argv.extend(_rust_target_args(target))
-    argv.extend(_rust_features(ctx))
+    argv.extend(feature_args)
     argv.extend(_rust_user_flags(ctx))
     argv.extend(_rust_cap_lints(ctx))
     argv.extend(_rust_builtin_extern_args(crate_type))
@@ -842,7 +878,7 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
         argv = _rustc_with_build_script_args(argv, build_stdout)
     run_action(
         argv = argv,
-        inputs = _unique(srcs + dep_inputs + build_inputs + _rust_extra_inputs(ctx)),
+        inputs = _unique(srcs + dep_inputs + build_inputs + feature_inputs + _rust_extra_inputs(ctx)),
         outputs = [output],
         env = compile_env,
         toolchain_identity = identity + linker_identity,

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1712,6 +1712,85 @@ result = repr(args)
     assert!(!script.contains("O'Reilly"), "{script}");
 }
 
+#[test]
+fn prelude_rust_windows_feature_cfgs_use_response_file() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_os():
+    return "windows"
+
+def host_env(name):
+    return ""
+
+def host_which(name):
+    if name == "sh":
+        return "C:/Program Files/Git/usr/bin/sh.exe"
+    if name == "mkdir":
+        return "C:/Program Files/Git/usr/bin/mkdir.exe"
+    fail("unexpected host_which call: " + name)
+
+def host_command(argv, env = None):
+    fail("unexpected host_command call")
+
+def _rustc_toolchain(target):
+    return ("C:/Rust/bin/rustc.exe", "rustc-test", "x86_64-pc-windows-msvc")
+
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "target": "x86_64-pc-windows-msvc",
+        "crate_root": "src/lib.rs",
+        "features": ["default", "std"],
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    assert_eq!(store.actions.len(), 2);
+    let response = &store.actions[0];
+    assert_eq!(
+        response.identifier.as_deref(),
+        Some("crates/app/app:rustc-features")
+    );
+    assert_eq!(
+        response.outputs,
+        vec![".once/out/crates/app/app/rustc-features.rsp"]
+    );
+    let script = &response.argv[2];
+    assert!(script.contains("feature=\"default\""), "{script}");
+    assert!(script.contains("feature=\"std\""), "{script}");
+
+    let rustc = &store.actions[1];
+    assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));
+    assert!(rustc
+        .argv
+        .iter()
+        .any(|arg| arg == "@.once/out/crates/app/app/rustc-features.rsp"));
+    assert!(rustc
+        .inputs
+        .iter()
+        .any(|input| input == ".once/out/crates/app/app/rustc-features.rsp"));
+    assert!(
+        !rustc.argv.iter().any(|arg| arg.contains("feature=\"")),
+        "{:?}",
+        rustc.argv
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn prelude_rust_proc_macro_compile_uses_host_target() {
@@ -1830,6 +1909,84 @@ result = repr([
         assert!(values[4].split(':').any(|entry| entry == tool_dir));
     }
     assert!(values[4].split(':').any(|entry| entry == "/bin"));
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_rust_build_script_compile_action_gets_sanitized_c_tool_path() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "build_script": "build.rs",
+        "crate_root": "src/lib.rs",
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    let action = store
+        .actions
+        .iter()
+        .find(|action| action.identifier.as_deref() == Some("crates/app/app:build-script-rustc"))
+        .expect("build script rustc action");
+    let path = action.env.get("PATH").expect("host linker PATH");
+    assert!(path.split(':').any(|entry| entry == "/bin"), "{path}");
+    for entry in path.split(':') {
+        assert!(std::path::Path::new(entry).is_absolute(), "{path}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_rust_host_compile_actions_get_sanitized_c_tool_path() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+rustc, _identity, host_triple = _rustc_toolchain("")
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "target": host_triple,
+        "crate_root": "src/main.rs",
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "bin", "src/main.rs", "app")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    let path = store.actions[0].env.get("PATH").expect("host linker PATH");
+    assert!(path.split(':').any(|entry| entry == "/bin"), "{path}");
+    for entry in path.split(':') {
+        assert!(std::path::Path::new(entry).is_absolute(), "{path}");
+    }
 }
 
 #[cfg(unix)]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1724,10 +1724,6 @@ def host_env(name):
     return ""
 
 def host_which(name):
-    if name == "sh":
-        return "C:/Program Files/Git/usr/bin/sh.exe"
-    if name == "mkdir":
-        return "C:/Program Files/Git/usr/bin/mkdir.exe"
     fail("unexpected host_which call: " + name)
 
 def host_command(argv, env = None):
@@ -1736,6 +1732,7 @@ def host_command(argv, env = None):
 def _rustc_toolchain(target):
     return ("C:/Rust/bin/rustc.exe", "rustc-test", "x86_64-pc-windows-msvc")
 
+features = ["default", "std"] + ["feature_" + str(i) for i in range(400)]
 ctx = {{
     "label": {{
         "package": "crates/app",
@@ -1745,7 +1742,7 @@ ctx = {{
     "attr": {{
         "target": "x86_64-pc-windows-msvc",
         "crate_root": "src/lib.rs",
-        "features": ["default", "std"],
+        "features": features,
     }},
     "deps": [],
     "srcs": ["src/**/*.rs"],
@@ -1764,15 +1761,26 @@ result = repr("ok")
     let response = &store.actions[0];
     assert_eq!(
         response.identifier.as_deref(),
-        Some("crates/app/app:rustc-features")
+        Some("write_path:.once/out/crates/app/app/rustc-features.rsp")
     );
     assert_eq!(
         response.outputs,
         vec![".once/out/crates/app/app/rustc-features.rsp"]
     );
-    let script = &response.argv[2];
-    assert!(script.contains("feature=\"default\""), "{script}");
-    assert!(script.contains("feature=\"std\""), "{script}");
+    assert!(response.argv.is_empty());
+    let DeclaredActionOperation::WriteFile { path, bytes } = response
+        .operation
+        .as_ref()
+        .expect("write response file action")
+    else {
+        panic!("expected write file action");
+    };
+    assert_eq!(path, ".once/out/crates/app/app/rustc-features.rsp");
+    let content = String::from_utf8(bytes.clone()).unwrap();
+    assert!(content.len() > 4096);
+    assert!(content.contains("feature=\"default\""), "{content}");
+    assert!(content.contains("feature=\"std\""), "{content}");
+    assert!(content.contains("feature=\"feature_399\""), "{content}");
 
     let rustc = &store.actions[1];
     assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));
@@ -1786,6 +1794,133 @@ result = repr("ok")
         .any(|input| input == ".once/out/crates/app/app/rustc-features.rsp"));
     assert!(
         !rustc.argv.iter().any(|arg| arg.contains("feature=\"")),
+        "{:?}",
+        rustc.argv
+    );
+}
+
+#[test]
+fn prelude_rust_non_windows_feature_cfgs_stay_inline() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_os():
+    return "linux"
+
+def host_env(name):
+    return ""
+
+def host_which(name):
+    fail("unexpected host_which call: " + name)
+
+def host_command(argv, env = None):
+    fail("unexpected host_command call")
+
+def _rustc_toolchain(target):
+    return ("rustc", "rustc-test", "x86_64-unknown-linux-gnu")
+
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "target": "wasm32-unknown-unknown",
+        "crate_root": "src/lib.rs",
+        "features": ["default", "std"],
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    assert_eq!(store.actions.len(), 1);
+    let rustc = &store.actions[0];
+    assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));
+    assert!(rustc
+        .argv
+        .windows(2)
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"default\""));
+    assert!(rustc
+        .argv
+        .windows(2)
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"std\""));
+    assert!(
+        !rustc.argv.iter().any(|arg| arg.starts_with('@')),
+        "{:?}",
+        rustc.argv
+    );
+    assert!(rustc
+        .operation
+        .as_ref()
+        .is_none_or(|operation| !matches!(operation, DeclaredActionOperation::WriteFile { .. })));
+}
+
+#[test]
+fn prelude_rust_empty_feature_list_emits_no_response_file() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_os():
+    return "windows"
+
+def host_env(name):
+    return ""
+
+def host_which(name):
+    fail("unexpected host_which call: " + name)
+
+def host_command(argv, env = None):
+    fail("unexpected host_command call")
+
+def _rustc_toolchain(target):
+    return ("C:/Rust/bin/rustc.exe", "rustc-test", "x86_64-pc-windows-msvc")
+
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "target": "x86_64-pc-windows-msvc",
+        "crate_root": "src/lib.rs",
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    assert_eq!(store.actions.len(), 1);
+    let rustc = &store.actions[0];
+    assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));
+    assert!(
+        !rustc.argv.iter().any(|arg| arg.starts_with('@')),
+        "{:?}",
+        rustc.argv
+    );
+    assert!(
+        !rustc
+            .argv
+            .windows(2)
+            .any(|pair| pair[0] == "--cfg" && pair[1].starts_with("feature=")),
         "{:?}",
         rustc.argv
     );
@@ -1987,6 +2122,126 @@ result = repr("ok")
     for entry in path.split(':') {
         assert!(std::path::Path::new(entry).is_absolute(), "{path}");
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_rust_compile_action_env_merges_c_tool_env_with_existing_path() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+rustc, _identity, host_triple = _rustc_toolchain("")
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "target": host_triple,
+        "crate_root": "src/lib.rs",
+        "env": {{
+            "PATH": "/custom/bin",
+            "CC": "/custom/cc",
+        }},
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    let action = &store.actions[0];
+    let path = action.env.get("PATH").expect("merged linker PATH");
+    let entries = path.split(':').collect::<Vec<_>>();
+    assert_eq!(entries[0], "/custom/bin");
+    assert!(entries.iter().any(|entry| *entry == "/bin"), "{path}");
+    assert_eq!(action.env.get("CC").map(String::as_str), Some("/custom/cc"));
+    assert!(action
+        .env
+        .get("AR")
+        .is_some_and(|ar| std::path::Path::new(ar).is_absolute()));
+}
+
+#[test]
+fn prelude_rust_compile_action_env_uses_target_for_c_tool_env() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_os():
+    return "linux"
+
+def host_env(name):
+    return ""
+
+def host_command(argv, env = None):
+    fail("unexpected host_command call")
+
+def host_which(name):
+    fail("unexpected host_which call: " + name)
+
+def _rustc_toolchain(target):
+    return ("rustc", "rustc-test", "x86_64-unknown-linux-gnu")
+
+def _rust_c_tool_env(target, host_triple):
+    if target != "thumbv7em-none-eabihf":
+        fail("unexpected c tool target: " + target)
+    if host_triple != "x86_64-unknown-linux-gnu":
+        fail("unexpected host triple: " + host_triple)
+    return {{
+        "CC": "/opt/thumb/bin/thumbv7em-none-eabihf-cc",
+        "AR": "/opt/thumb/bin/thumbv7em-none-eabihf-ar",
+        "PATH": "/opt/thumb/bin:/opt/thumb/libexec",
+    }}
+
+ctx = {{
+    "label": {{
+        "package": "crates/app",
+        "name": "app",
+        "id": "crates/app/app",
+    }},
+    "attr": {{
+        "target": "thumbv7em-none-eabihf",
+        "crate_root": "src/lib.rs",
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    let action = &store.actions[0];
+    assert_eq!(
+        action.env.get("CC").map(String::as_str),
+        Some("/opt/thumb/bin/thumbv7em-none-eabihf-cc")
+    );
+    assert_eq!(
+        action.env.get("AR").map(String::as_str),
+        Some("/opt/thumb/bin/thumbv7em-none-eabihf-ar")
+    );
+    let path = action.env.get("PATH").expect("target c tool PATH");
+    assert!(
+        path.split(':').any(|entry| entry == "/opt/thumb/bin"),
+        "{path}"
+    );
+    assert!(
+        path.split(':').any(|entry| entry == "/opt/thumb/libexec"),
+        "{path}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -2162,7 +2162,7 @@ result = repr("ok")
     let path = action.env.get("PATH").expect("merged linker PATH");
     let entries = path.split(':').collect::<Vec<_>>();
     assert_eq!(entries[0], "/custom/bin");
-    assert!(entries.iter().any(|entry| *entry == "/bin"), "{path}");
+    assert!(entries.contains(&"/bin"), "{path}");
     assert_eq!(action.env.get("CC").map(String::as_str), Some("/custom/cc"));
     assert!(action
         .env


### PR DESCRIPTION
## Summary
- Main release CI was still failing after the first fix: Linux ARM release jobs could not find `ld` while compiling host Rust actions, and Windows release jobs malformed `--cfg feature="..."` for cargo dependency builds.
- Thread the sanitized C tool `PATH` into Unix host rustc compile actions and build-script rustc actions, so GCC can find `ld` without forwarding the full host environment into every compile action.
- On Windows hosts, write Rust feature cfg flags to a small rustc response file and pass `@rustc-features.rsp`, avoiding nested quote parsing in the Windows process command line while keeping the existing direct argv path on other hosts.
- Add focused prelude tests for the Linux linker path regression and the Windows feature cfg response-file path. This keeps the fix in the Rust target-kind prelude instead of changing the generic action runner.

## Testing
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
