### PR TITLE
ci(release): set HOME for Windows mise setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v6
+      - name: Set HOME for mise templates
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '"HOME=$env:USERPROFILE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append'
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
@@ -152,6 +156,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v6
+      - name: Set HOME for mise templates
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '"HOME=$env:USERPROFILE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append'
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}


### PR DESCRIPTION
## Summary
- Fixes the new main `Release` failure where Windows jobs fail during `jdx/mise-action` setup because mise cannot render `{{env.HOME}}` templates from `mise.toml`.
- Adds a Windows-only step before the release build and SDK library matrix `mise-action` steps to export `HOME=$USERPROFILE` through `GITHUB_ENV`.
- Keeps the change scoped to the Windows release jobs that failed, leaving non-Windows release jobs untouched.

## Testing
- `env -u HOME USERPROFILE=/tmp/once-userprofile HOME=/tmp/once-userprofile MISE_TRUSTED_CONFIG_PATHS="$PWD:/Users/pepicrft/.config/mise/config.toml" mise env --json | jq -r '.KOTLIN_NATIVE_HOME, .ANDROID_NDK_HOME'`
- `git diff --check`
