### PR TITLE
fix(ci): escape Windows rustc cfg response args

### DIFF
--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -206,13 +206,17 @@ def _rust_response_file(ctx, name, content):
     write_path(path, content)
     return path
 
+def _rust_response_file_arg(arg):
+    return arg.replace("\"", "\\\"")
+
 def _rust_feature_args(ctx):
     flags = _rust_feature_flags(ctx)
     if not flags:
         return ([], [])
     if host_os() != "windows":
         return (flags, [])
-    path = _rust_response_file(ctx, "rustc-features.rsp", "\n".join(flags) + "\n")
+    content = "\n".join([_rust_response_file_arg(flag) for flag in flags]) + "\n"
+    path = _rust_response_file(ctx, "rustc-features.rsp", content)
     return (["@" + path], [path])
 
 def _rust_user_flags(ctx):

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1778,9 +1778,9 @@ result = repr("ok")
     assert_eq!(path, ".once/out/crates/app/app/rustc-features.rsp");
     let content = String::from_utf8(bytes.clone()).unwrap();
     assert!(content.len() > 4096);
-    assert!(content.contains("feature=\"default\""), "{content}");
-    assert!(content.contains("feature=\"std\""), "{content}");
-    assert!(content.contains("feature=\"feature_399\""), "{content}");
+    assert!(content.contains(r#"feature=\"default\""#), "{content}");
+    assert!(content.contains(r#"feature=\"std\""#), "{content}");
+    assert!(content.contains(r#"feature=\"feature_399\""#), "{content}");
 
     let rustc = &store.actions[1];
     assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));


### PR DESCRIPTION
## Summary

The release workflow on `main` is still failing in the Windows package jobs after the previous HOME setup fix. Those jobs now reach the Once Rust graph, but `rustc` rejects the generated cfg argument because the Windows response file parses `feature="default"` as `feature=default` unless the embedded quotes are escaped.

This keeps the existing response-file approach for Windows feature cfgs, since it avoids command-line length and shell quoting issues, and narrows the follow-up to the serialization boundary that was still losing quotes. Non-Windows Rust feature args continue to be passed inline, so the working Unix behavior is unchanged.

The regression test now asserts the response file contains escaped quote characters, which matches the form `rustc` suggests for preserving a quoted cfg value.

## Testing

- `mise exec -- cargo test -p once-frontend --test prelude prelude_rust_windows_feature_cfgs_use_response_file`
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
