### PR TITLE
fix(graph): materialize arg files from cmd_args

### DIFF
--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -12,8 +12,8 @@ use once_core::{
     OutputSymlinkMode, PreparePathMode, ResourceRequest, RunOpts, WorkspacePath,
 };
 use once_frontend::analysis::{
-    AnalysisResult, DeclaredAction, DeclaredActionOperation, DeclaredCopyPathMode,
-    DeclaredPreparePathMode,
+    AnalysisResult, DeclaredAction, DeclaredActionOperation, DeclaredArgFile,
+    DeclaredArgFileFormat, DeclaredCopyPathMode, DeclaredPreparePathMode,
 };
 use once_frontend::GraphTarget;
 use tokio::process::Command;
@@ -167,6 +167,9 @@ async fn run_declared_action(run: DeclaredActionRun<'_>) -> Result<DeclaredActio
         outputs = declared.outputs.len(),
         "preparing declared graph action"
     );
+    materialize_declared_arg_files(workspace, &declared.arg_files).with_context(|| {
+        format!("writing arg files for action {index} for {target_id} ({identifier_for_error})")
+    })?;
     let action = declared_to_action(
         workspace,
         declared,
@@ -646,6 +649,41 @@ fn declared_to_action(
     }
 }
 
+fn materialize_declared_arg_files(workspace: &Path, arg_files: &[DeclaredArgFile]) -> Result<()> {
+    for arg_file in arg_files {
+        let path = workspace_path(&arg_file.path, "arg_files path")?;
+        let absolute = path.resolve(workspace);
+        if let Some(parent) = absolute.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("creating parent directory for arg file `{}`", path.as_str())
+            })?;
+        }
+        let content = declared_arg_file_content(arg_file)?;
+        std::fs::write(&absolute, content)
+            .with_context(|| format!("writing arg file `{}`", path.as_str()))?;
+    }
+    Ok(())
+}
+
+fn declared_arg_file_content(arg_file: &DeclaredArgFile) -> Result<Vec<u8>> {
+    match arg_file.format {
+        DeclaredArgFileFormat::LineDelimited => {
+            let mut content = Vec::new();
+            for arg in &arg_file.args {
+                if arg.contains('\n') || arg.contains('\r') {
+                    anyhow::bail!(
+                        "line-delimited arg file `{}` contains an argument with a newline",
+                        arg_file.path
+                    );
+                }
+                content.extend_from_slice(arg.as_bytes());
+                content.push(b'\n');
+            }
+            Ok(content)
+        }
+    }
+}
+
 fn operation_to_action(operation: DeclaredActionOperation, input_digest: Digest) -> Result<Action> {
     Ok(match operation {
         DeclaredActionOperation::WriteFile { path, bytes } => Action::WriteFile {
@@ -730,6 +768,9 @@ fn compose_input_digest(
     for arg in &declared.argv {
         builder.push_bytes(arg.as_bytes());
     }
+    let encoded_arg_files =
+        serde_json::to_vec(&declared.arg_files).context("serializing declared action arg files")?;
+    builder.push_bytes(&encoded_arg_files);
     for (key, value) in &declared.env {
         builder.push_bytes(key.as_bytes());
         builder.push_bytes(value.as_bytes());
@@ -774,6 +815,7 @@ mod tests {
         let declared = DeclaredAction {
             operation: None,
             argv: vec!["tool".to_string(), "--version".to_string()],
+            arg_files: Vec::new(),
             inputs: Vec::new(),
             outputs: vec![
                 ".once/out/x/A.out".to_string(),
@@ -793,6 +835,40 @@ mod tests {
             panic!("command declaration should lower to RunCommand");
         };
         assert_eq!(argv, vec!["tool".to_string(), "--version".to_string()]);
+    }
+
+    #[test]
+    fn materialize_declared_arg_files_writes_line_delimited_args() {
+        let workspace = tempfile::tempdir().unwrap();
+        let arg_files = vec![DeclaredArgFile {
+            path: ".once/out/rust/rustc-features.rsp".to_string(),
+            format: DeclaredArgFileFormat::LineDelimited,
+            args: vec!["--cfg".to_string(), "feature=\"alloc\"".to_string()],
+        }];
+
+        materialize_declared_arg_files(workspace.path(), &arg_files).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join(".once/out/rust/rustc-features.rsp"))
+                .unwrap(),
+            "--cfg\nfeature=\"alloc\"\n"
+        );
+    }
+
+    #[test]
+    fn materialize_declared_arg_files_rejects_newline_args() {
+        let workspace = tempfile::tempdir().unwrap();
+        let arg_files = vec![DeclaredArgFile {
+            path: ".once/out/rust/rustc-features.rsp".to_string(),
+            format: DeclaredArgFileFormat::LineDelimited,
+            args: vec!["feature=\"alloc\"\n--cfg".to_string()],
+        }];
+
+        let err = materialize_declared_arg_files(workspace.path(), &arg_files)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("contains an argument with a newline"), "{err}");
     }
 
     #[tokio::test]
@@ -1027,6 +1103,7 @@ mod tests {
                     "printf visible-stdout; printf visible-stderr >&2; printf ok > .once/out/one.txt"
                         .to_string(),
                 ],
+                arg_files: Vec::new(),
                 inputs: Vec::new(),
                 outputs: vec![".once/out/one.txt".to_string()],
                 env: BTreeMap::new(),
@@ -1094,6 +1171,7 @@ mod tests {
                 "-c".to_string(),
                 format!("printf {name} > .once/out/{name}.txt"),
             ],
+            arg_files: Vec::new(),
             inputs: Vec::new(),
             outputs: vec![format!(".once/out/{name}.txt")],
             env: BTreeMap::new(),
@@ -1175,6 +1253,7 @@ mod tests {
         let declared = DeclaredAction {
             operation: None,
             argv: vec!["tool".to_string()],
+            arg_files: Vec::new(),
             inputs: vec!["input.txt".to_string()],
             outputs: vec![".once/out/A.a".to_string()],
             env: BTreeMap::new(),
@@ -1192,12 +1271,46 @@ mod tests {
     }
 
     #[test]
+    fn input_digest_changes_with_declared_arg_files() {
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join("input.txt"), b"content").unwrap();
+        let declared = DeclaredAction {
+            operation: None,
+            argv: vec!["tool".to_string(), "@.once/out/args.rsp".to_string()],
+            arg_files: vec![DeclaredArgFile {
+                path: ".once/out/args.rsp".to_string(),
+                format: DeclaredArgFileFormat::LineDelimited,
+                args: vec!["--cfg".to_string(), "feature=\"alloc\"".to_string()],
+            }],
+            inputs: vec!["input.txt".to_string()],
+            outputs: vec![".once/out/A.a".to_string()],
+            env: BTreeMap::new(),
+            cacheable: true,
+            toolchain_identity: None,
+            identifier: None,
+        };
+        let one = compose_input_digest(workspace.path(), &declared, module_digest(), &[]).unwrap();
+        let declared2 = DeclaredAction {
+            arg_files: vec![DeclaredArgFile {
+                path: ".once/out/args.rsp".to_string(),
+                format: DeclaredArgFileFormat::LineDelimited,
+                args: vec!["--cfg".to_string(), "feature=\"std\"".to_string()],
+            }],
+            ..declared
+        };
+        let two = compose_input_digest(workspace.path(), &declared2, module_digest(), &[]).unwrap();
+
+        assert_ne!(one, two);
+    }
+
+    #[test]
     fn input_digest_changes_with_module_source_digest() {
         let workspace = tempfile::tempdir().unwrap();
         std::fs::write(workspace.path().join("input.txt"), b"content").unwrap();
         let declared = DeclaredAction {
             operation: None,
             argv: vec!["tool".to_string()],
+            arg_files: Vec::new(),
             inputs: vec!["input.txt".to_string()],
             outputs: vec![".once/out/A.a".to_string()],
             env: BTreeMap::new(),
@@ -1230,6 +1343,7 @@ mod tests {
         let declared = DeclaredAction {
             operation: None,
             argv: vec!["tool".to_string()],
+            arg_files: Vec::new(),
             inputs: vec!["input.txt".to_string()],
             outputs: vec![".once/out/A.a".to_string()],
             env: BTreeMap::new(),

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -14,6 +14,9 @@ def _ascii_env_key(value):
 def _rust_metadata_suffix(ctx):
     return _ascii_env_key(ctx["label"]["id"])
 
+def _rust_build_dir(ctx):
+    return ctx.get("build_dir") or (".once/out/" + ctx["label"]["id"])
+
 def _crate_name_from_label(ctx):
     return ctx["label"]["name"].replace("-", "_").replace(".", "_")
 
@@ -201,19 +204,23 @@ def _rust_feature_flags(ctx):
         flags.extend(["--cfg", "feature=\"" + feature + "\""])
     return flags
 
-def _rust_response_file(ctx, name, content):
-    path = declare_output(_rust_declared_output(ctx, name))
-    write_path(path, content)
-    return path
-
 def _rust_feature_args(ctx):
     flags = _rust_feature_flags(ctx)
     if not flags:
         return ([], [])
     if host_os() != "windows":
         return (flags, [])
-    path = _rust_response_file(ctx, "rustc-features.rsp", "\n".join(flags) + "\n")
-    return (["@" + path], [path])
+    path = _rust_build_dir(ctx) + "/" + _rust_declared_output(ctx, "rustc-features.rsp")
+    return ([
+        cmd_args(
+            args = flags,
+            use_arg_file = {
+                "path": path,
+                "format": "line-delimited",
+                "arg_format": "@{}",
+            },
+        ),
+    ], [])
 
 def _rust_user_flags(ctx):
     return _rust_attr(ctx, "rustc_flags", [])

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -206,17 +206,13 @@ def _rust_response_file(ctx, name, content):
     write_path(path, content)
     return path
 
-def _rust_response_file_arg(arg):
-    return arg.replace("\"", "\\\"")
-
 def _rust_feature_args(ctx):
     flags = _rust_feature_flags(ctx)
     if not flags:
         return ([], [])
     if host_os() != "windows":
         return (flags, [])
-    content = "\n".join([_rust_response_file_arg(flag) for flag in flags]) + "\n"
-    path = _rust_response_file(ctx, "rustc-features.rsp", content)
+    path = _rust_response_file(ctx, "rustc-features.rsp", "\n".join(flags) + "\n")
     return (["@" + path], [path])
 
 def _rust_user_flags(ctx):

--- a/crates/once-frontend/src/analysis/globals.rs
+++ b/crates/once-frontend/src/analysis/globals.rs
@@ -7,16 +7,20 @@ use sha2::Digest as ShaDigest;
 use starlark::environment::{Globals, GlobalsBuilder};
 use starlark::eval::Evaluator;
 use starlark::starlark_module;
+use starlark::values::dict::{AllocDict, DictRef};
+use starlark::values::list::ListRef;
 use starlark::values::none::NoneType;
 use starlark::values::Value;
 
 use super::store::{
     analysis_active, with_store, with_store_mut, DeclaredAction, DeclaredActionOperation,
-    DeclaredCopyPathMode, DeclaredPreparePathMode,
+    DeclaredArgFile, DeclaredArgFileFormat, DeclaredCopyPathMode, DeclaredPreparePathMode,
 };
 use super::values::{
     json_to_value, toml_value_to_starlark, unpack_byte_list, unpack_string_dict, unpack_string_list,
 };
+
+const CMD_ARGS_MARKER: &str = "_once_cmd_args";
 
 /// Globals exposed to the prelude.
 ///
@@ -192,6 +196,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
                 bytes,
             }),
             argv: Vec::new(),
+            arg_files: Vec::new(),
             inputs: Vec::new(),
             outputs: vec![path.to_string()],
             env: BTreeMap::new(),
@@ -235,6 +240,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
                 mode,
             }),
             argv: Vec::new(),
+            arg_files: Vec::new(),
             inputs,
             outputs: vec![destination.to_string()],
             env: BTreeMap::new(),
@@ -271,6 +277,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
                 mode,
             }),
             argv: Vec::new(),
+            arg_files: Vec::new(),
             inputs: Vec::new(),
             outputs,
             env: BTreeMap::new(),
@@ -315,6 +322,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
                 include_suffixes,
             }),
             argv: Vec::new(),
+            arg_files: Vec::new(),
             inputs,
             outputs: vec![output.to_string()],
             env: BTreeMap::new(),
@@ -330,11 +338,49 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
         Ok(NoneType)
     }
 
+    /// Build a structured command-line fragment. `args` is a list of
+    /// string arguments. When `use_arg_file` is set, it must be a dict
+    /// with `path` plus optional `format` and `arg_format`. The only
+    /// supported format today is `"line-delimited"`, which writes one
+    /// argument per line without shell escaping.
+    fn cmd_args<'v>(
+        args: Value<'v>,
+        use_arg_file: Option<Value<'v>>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Value<'v>> {
+        let args = unpack_string_list(args, "cmd_args.args")?;
+        let arg_file = match use_arg_file {
+            Some(value) => unpack_cmd_args_arg_file(value)?,
+            None => None,
+        };
+        if let Some(arg_file) = &arg_file {
+            validate_declared_arg_file_args(arg_file.format, &args, &arg_file.path)?;
+            apply_arg_format(&arg_file.arg_format, &arg_file.path)?;
+        }
+        let heap = eval.heap();
+        let mut pairs = vec![
+            (CMD_ARGS_MARKER.to_string(), Value::new_bool(true)),
+            ("args".to_string(), heap.alloc(args)),
+        ];
+        if let Some(arg_file) = arg_file {
+            pairs.extend([
+                ("arg_file_path".to_string(), heap.alloc(arg_file.path)),
+                (
+                    "arg_file_format".to_string(),
+                    heap.alloc(arg_file.format.as_str().to_string()),
+                ),
+                ("arg_format".to_string(), heap.alloc(arg_file.arg_format)),
+            ]);
+        }
+        Ok(heap.alloc(AllocDict(pairs)))
+    }
+
     /// Record one command action declaration. Argument shape:
-    /// `argv`: list of strings; `inputs`: list of workspace-relative
-    /// source paths to hash into the input digest; `outputs`: list of
-    /// workspace-relative paths the action produces; `env`: optional
-    /// string->string dict; `cacheable`: optional bool, default true;
+    /// `argv`: list of strings and `cmd_args` values; `inputs`: list
+    /// of workspace-relative source paths to hash into the input
+    /// digest; `outputs`: list of workspace-relative paths the action
+    /// produces; `env`: optional string->string dict; `cacheable`:
+    /// optional bool, default true;
     /// `toolchain_identity`: optional string folded into the input
     /// digest; `identifier`: optional label for diagnostics.
     fn run_action<'v>(
@@ -346,7 +392,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
         identifier: Option<String>,
         cacheable: Option<bool>,
     ) -> anyhow::Result<NoneType> {
-        let argv = unpack_string_list(argv, "argv")?;
+        let argv = unpack_action_argv(argv, "argv")?;
         let inputs = inputs
             .map(|value| unpack_string_list(value, "inputs"))
             .transpose()?
@@ -361,7 +407,8 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
             .unwrap_or_default();
         let action = DeclaredAction {
             operation: None,
-            argv,
+            argv: argv.args,
+            arg_files: argv.arg_files,
             inputs,
             outputs,
             env,
@@ -391,6 +438,25 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
     fn json_decode<'v>(src: &str, eval: &mut Evaluator<'v, '_, '_>) -> anyhow::Result<Value<'v>> {
         let value: JsonValue = serde_json::from_str(src)?;
         Ok(json_to_value(eval, &value))
+    }
+}
+
+struct ActionArgv {
+    args: Vec<String>,
+    arg_files: Vec<DeclaredArgFile>,
+}
+
+struct CmdArgsArgFile {
+    path: String,
+    format: DeclaredArgFileFormat,
+    arg_format: String,
+}
+
+impl DeclaredArgFileFormat {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::LineDelimited => "line-delimited",
+        }
     }
 }
 
@@ -436,6 +502,162 @@ fn parse_prepare_path_mode(kind: &str) -> Result<DeclaredPreparePathMode> {
             "expected `kind` to be `remove` or `directory`, got `{other}`"
         )),
     }
+}
+
+fn unpack_action_argv(value: Value<'_>, field: &str) -> anyhow::Result<ActionArgv> {
+    let list = ListRef::from_value(value).ok_or_else(|| {
+        anyhow!(
+            "expected `{field}` to be a list of strings or cmd_args values, got `{}`",
+            value.get_type()
+        )
+    })?;
+    let mut argv = ActionArgv {
+        args: Vec::new(),
+        arg_files: Vec::new(),
+    };
+    for (index, item) in list.iter().enumerate() {
+        unpack_action_argv_item(item, field, index, &mut argv)?;
+    }
+    Ok(argv)
+}
+
+fn unpack_action_argv_item(
+    value: Value<'_>,
+    field: &str,
+    index: usize,
+    argv: &mut ActionArgv,
+) -> anyhow::Result<()> {
+    if let Some(arg) = value.unpack_str() {
+        argv.args.push(arg.to_string());
+        return Ok(());
+    }
+    if let Some(dict) = DictRef::from_value(value) {
+        if dict
+            .get_str(CMD_ARGS_MARKER)
+            .and_then(Value::unpack_bool)
+            .unwrap_or(false)
+        {
+            return unpack_cmd_args_value(&dict, field, index, argv);
+        }
+    }
+    Err(anyhow!(
+        "expected `{field}` entries to be strings or cmd_args values, got `{}`",
+        value.get_type()
+    ))
+}
+
+fn unpack_cmd_args_value(
+    dict: &DictRef<'_>,
+    field: &str,
+    index: usize,
+    argv: &mut ActionArgv,
+) -> anyhow::Result<()> {
+    let fragment_args = dict
+        .get_str("args")
+        .ok_or_else(|| anyhow!("expected `{field}` entry {index} cmd_args to contain `args`"))
+        .and_then(|value| unpack_string_list(value, "cmd_args.args"))?;
+    let Some(path) = optional_string_field(dict, "arg_file_path")? else {
+        argv.args.extend(fragment_args);
+        return Ok(());
+    };
+    let format = parse_arg_file_format(
+        optional_string_field(dict, "arg_file_format")?
+            .unwrap_or_else(|| "line-delimited".to_string())
+            .as_str(),
+        "cmd_args.use_arg_file.format",
+    )?;
+    validate_declared_arg_file_args(format, &fragment_args, &path)?;
+    let arg_format =
+        optional_string_field(dict, "arg_format")?.unwrap_or_else(|| "@{}".to_string());
+    argv.args.push(apply_arg_format(&arg_format, &path)?);
+    argv.arg_files.push(DeclaredArgFile {
+        path,
+        format,
+        args: fragment_args,
+    });
+    Ok(())
+}
+
+fn unpack_cmd_args_arg_file(value: Value<'_>) -> anyhow::Result<Option<CmdArgsArgFile>> {
+    if value.is_none() {
+        return Ok(None);
+    }
+    let dict = DictRef::from_value(value).ok_or_else(|| {
+        anyhow!(
+            "expected `cmd_args.use_arg_file` to be a dict, got `{}`",
+            value.get_type()
+        )
+    })?;
+    let path = required_string_field(&dict, "cmd_args.use_arg_file", "path")?;
+    let format = parse_arg_file_format(
+        optional_string_field(&dict, "format")?
+            .unwrap_or_else(|| "line-delimited".to_string())
+            .as_str(),
+        "cmd_args.use_arg_file.format",
+    )?;
+    let arg_format =
+        optional_string_field(&dict, "arg_format")?.unwrap_or_else(|| "@{}".to_string());
+    Ok(Some(CmdArgsArgFile {
+        path,
+        format,
+        arg_format,
+    }))
+}
+
+fn parse_arg_file_format(value: &str, field: &str) -> anyhow::Result<DeclaredArgFileFormat> {
+    match value {
+        "line-delimited" => Ok(DeclaredArgFileFormat::LineDelimited),
+        other => Err(anyhow!(
+            "expected `{field}` to be `line-delimited`, got `{other}`"
+        )),
+    }
+}
+
+fn validate_declared_arg_file_args(
+    format: DeclaredArgFileFormat,
+    args: &[String],
+    path: &str,
+) -> anyhow::Result<()> {
+    match format {
+        DeclaredArgFileFormat::LineDelimited => {
+            for arg in args {
+                if arg.contains('\n') || arg.contains('\r') {
+                    return Err(anyhow!(
+                        "line-delimited arg file `{path}` contains an argument with a newline"
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn apply_arg_format(format: &str, path: &str) -> anyhow::Result<String> {
+    if format.matches("{}").count() != 1 {
+        return Err(anyhow!(
+            "expected `cmd_args.use_arg_file.arg_format` to contain exactly one `{{}}` placeholder"
+        ));
+    }
+    Ok(format.replace("{}", path))
+}
+
+fn required_string_field(dict: &DictRef<'_>, field: &str, name: &str) -> anyhow::Result<String> {
+    dict.get_str(name)
+        .ok_or_else(|| anyhow!("expected `{field}` to contain `{name}`"))?
+        .unpack_str()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("expected `{field}.{name}` to be a string"))
+}
+
+fn optional_string_field(dict: &DictRef<'_>, name: &str) -> anyhow::Result<Option<String>> {
+    dict.get_str(name)
+        .map(|value| {
+            value
+                .unpack_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| anyhow!("expected `{name}` to be a string"))
+        })
+        .transpose()
 }
 
 fn file_sha256_hex(path: &Path) -> Result<String> {

--- a/crates/once-frontend/src/analysis/mod.rs
+++ b/crates/once-frontend/src/analysis/mod.rs
@@ -22,8 +22,8 @@ use crate::target::AttrValue;
 pub use engine::{analyze_target, target_kind_has_impl, AnalysisEngine, AnalysisResult};
 pub use globals::globals_for_prelude;
 pub use store::{
-    with_active_store, AnalysisStore, DeclaredAction, DeclaredActionOperation,
-    DeclaredCopyPathMode, DeclaredPreparePathMode,
+    with_active_store, AnalysisStore, DeclaredAction, DeclaredActionOperation, DeclaredArgFile,
+    DeclaredArgFileFormat, DeclaredCopyPathMode, DeclaredPreparePathMode,
 };
 
 /// If `value` is the canonical select-shape Map (`{ "select": { ... }

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -53,6 +53,8 @@ pub struct DeclaredAction {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub argv: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub arg_files: Vec<DeclaredArgFile>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inputs: Vec<String>,
     pub outputs: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -63,6 +65,19 @@ pub struct DeclaredAction {
     pub toolchain_identity: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DeclaredArgFile {
+    pub path: String,
+    pub format: DeclaredArgFileFormat,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeclaredArgFileFormat {
+    LineDelimited,
 }
 
 fn default_cacheable() -> bool {

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -178,7 +178,74 @@ fn run_action_rejects_non_string_argv_entries() {
         run(r#"run_action(argv = [1, "tool"])"#).unwrap_err()
     });
     let message = format!("{err:?}");
-    assert!(message.contains("entries to be strings"), "{message}");
+    assert!(message.contains("strings or cmd_args values"), "{message}");
+}
+
+#[test]
+fn run_action_flattens_cmd_args_with_arg_file() {
+    let tmp = TempDir::new().unwrap();
+    let store = store_for(tmp.path(), "p");
+    let (store, ()) = with_active_store(store, || {
+        run(r#"
+run_action(
+    argv = [
+        "rustc",
+        cmd_args(
+            args = ["--cfg", "feature=\"alloc\""],
+            use_arg_file = {
+                "path": ".once/out/p/rustc-features.rsp",
+                "format": "line-delimited",
+                "arg_format": "@{}",
+            },
+        ),
+    ],
+    outputs = [".once/out/p/lib.rlib"],
+)
+"#)
+        .unwrap();
+    });
+
+    assert_eq!(store.actions.len(), 1);
+    let action = &store.actions[0];
+    assert_eq!(
+        action.argv,
+        vec![
+            "rustc".to_string(),
+            "@.once/out/p/rustc-features.rsp".to_string()
+        ]
+    );
+    assert_eq!(action.arg_files.len(), 1);
+    let arg_file = &action.arg_files[0];
+    assert_eq!(arg_file.path, ".once/out/p/rustc-features.rsp");
+    assert_eq!(arg_file.format, DeclaredArgFileFormat::LineDelimited);
+    assert_eq!(
+        arg_file.args,
+        vec!["--cfg".to_string(), "feature=\"alloc\"".to_string()]
+    );
+}
+
+#[test]
+fn run_action_rejects_line_delimited_arg_file_newlines() {
+    let tmp = TempDir::new().unwrap();
+    let store = store_for(tmp.path(), "p");
+    let (_, err) = with_active_store(store, || {
+        run(r#"
+run_action(
+    argv = [
+        cmd_args(
+            args = ["--cfg", "feature=\"alloc\"\n--cfg"],
+            use_arg_file = {"path": ".once/out/p/rustc-features.rsp"},
+        ),
+    ],
+)
+"#)
+        .unwrap_err()
+    });
+    let message = format!("{err:?}");
+    assert!(
+        message.contains("contains an argument with a newline"),
+        "{message}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use once_frontend::analysis::{
     globals_for_prelude, target_kind_has_impl, with_active_store, AnalysisStore,
-    DeclaredActionOperation, DeclaredCopyPathMode, DeclaredPreparePathMode,
+    DeclaredActionOperation, DeclaredArgFileFormat, DeclaredCopyPathMode, DeclaredPreparePathMode,
 };
 use once_frontend::{built_in_target_kind_schema, graph_from_targets, Target};
 use starlark::environment::Module;
@@ -1757,41 +1757,29 @@ result = repr("ok")
     let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 
     assert_eq!(out.unwrap(), "\"ok\"");
-    assert_eq!(store.actions.len(), 2);
-    let response = &store.actions[0];
-    assert_eq!(
-        response.identifier.as_deref(),
-        Some("write_path:.once/out/crates/app/app/rustc-features.rsp")
-    );
-    assert_eq!(
-        response.outputs,
-        vec![".once/out/crates/app/app/rustc-features.rsp"]
-    );
-    assert!(response.argv.is_empty());
-    let DeclaredActionOperation::WriteFile { path, bytes } = response
-        .operation
-        .as_ref()
-        .expect("write response file action")
-    else {
-        panic!("expected write file action");
-    };
-    assert_eq!(path, ".once/out/crates/app/app/rustc-features.rsp");
-    let content = String::from_utf8(bytes.clone()).unwrap();
-    assert!(content.len() > 4096);
-    assert!(content.contains("feature=\"default\""), "{content}");
-    assert!(content.contains("feature=\"std\""), "{content}");
-    assert!(content.contains("feature=\"feature_399\""), "{content}");
-
-    let rustc = &store.actions[1];
+    assert_eq!(store.actions.len(), 1);
+    let rustc = &store.actions[0];
     assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));
     assert!(rustc
         .argv
         .iter()
         .any(|arg| arg == "@.once/out/crates/app/app/rustc-features.rsp"));
-    assert!(rustc
+    assert!(!rustc
         .inputs
         .iter()
         .any(|input| input == ".once/out/crates/app/app/rustc-features.rsp"));
+    assert_eq!(rustc.arg_files.len(), 1);
+    let arg_file = &rustc.arg_files[0];
+    assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc-features.rsp");
+    assert_eq!(arg_file.format, DeclaredArgFileFormat::LineDelimited);
+    assert!(arg_file.args.len() > 800);
+    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
+    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"std\""));
+    assert!(arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "feature=\"feature_399\""));
+    assert!(!arg_file.args.iter().any(|arg| arg.contains("\\\"")));
     assert!(
         !rustc.argv.iter().any(|arg| arg.contains("feature=\"")),
         "{:?}",

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1778,9 +1778,9 @@ result = repr("ok")
     assert_eq!(path, ".once/out/crates/app/app/rustc-features.rsp");
     let content = String::from_utf8(bytes.clone()).unwrap();
     assert!(content.len() > 4096);
-    assert!(content.contains(r#"feature=\"default\""#), "{content}");
-    assert!(content.contains(r#"feature=\"std\""#), "{content}");
-    assert!(content.contains(r#"feature=\"feature_399\""#), "{content}");
+    assert!(content.contains("feature=\"default\""), "{content}");
+    assert!(content.contains("feature=\"std\""), "{content}");
+    assert!(content.contains("feature=\"feature_399\""), "{content}");
 
     let rustc = &store.actions[1];
     assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -192,6 +192,13 @@ The Rust executor exposes generic primitives only:
   sorted workspace-relative file paths.
 - `declare_output(name)` reserves an output under the target build
   directory.
+- `cmd_args(args, use_arg_file = None)` creates a structured
+  command-line fragment. `args` is a list of strings. When
+  `use_arg_file` is set, it is a dictionary with `path` plus optional
+  `format` and `arg_format`. The supported `format` is
+  `line-delimited`, which writes one argument per line without shell
+  escaping. `arg_format` defaults to `@{}` and must contain exactly one
+  `{}` placeholder.
 - `run_action(...)` records a command action for the executor.
 - `write_path(path, content)` materializes generated text or byte-list
   files through normal actions.
@@ -215,7 +222,7 @@ compiler flags, provider conventions, and action layout.
 
 `run_action` accepts:
 
-- `argv`: command and arguments.
+- `argv`: command and arguments as strings or `cmd_args` fragments.
 - `inputs`: workspace-relative files and directories hashed into the
   action digest.
 - `outputs`: workspace-relative outputs the action must produce.


### PR DESCRIPTION
## What changed

This moves generated response-file handling into the graph action layer instead of leaving each target kind to hand-write files and keep them synchronized with `argv`.

- Added `cmd_args(args, use_arg_file = ...)` as a structured Starlark command-line fragment.
- Extended declared actions with generated argument-file metadata that the Rust executor materializes before running the action.
- Included generated argument-file metadata in the declared action digest so cache keys change when the generated arguments change.
- Switched the Rust target kind to pass Windows rustc feature flags through `cmd_args(..., use_arg_file = { "format": "line-delimited" })`.
- Updated the Starlark module reference and tests for the new command-line contract.

## Why

The Windows release failure showed that response-file formatting is easy to get subtly wrong when each rule writes file contents directly. The rule author should state the command-line intent, while the Rust layer should own validation, materialization, and cache-key behavior for generated argument files.

## Root cause

rustc reads `@path` files as line-oriented argument files. Each line becomes one argument without shell parsing. Escaping the embedded quotes produced arguments like `feature=\"alloc\"`, and rustc rejected the preserved backslashes.

## Approach

The new `cmd_args` fragment keeps the command-line pointer and generated file contents together. `run_action` flattens strings and `cmd_args` values, records generated argument files on the declared action, and the executor writes them as line-delimited files before lowering the action.

For line-delimited files, the Rust parser rejects arguments containing newline characters. The executor repeats that validation when materializing serialized declared actions. That makes the response-file format a graph primitive rather than a Rust-prelude convention.

## Impact

Existing `run_action(argv = ["tool", "arg"])` calls continue to work. Rule authors can now use a structured command-line fragment when a tool needs an argument file, without manually adding a separate `write_path` action or listing the generated file as a normal input.

For the current Rust release issue, Windows rustc feature flags still use a response file to avoid long command lines, but the file now contains literal arguments such as `feature="alloc"`, which matches rustc's expected format.

## Validation

- `mise exec -- cargo test -p once-frontend analysis::tests::run_action_flattens_cmd_args_with_arg_file`
- `mise exec -- cargo test -p once-cli commands::graph::analysis::actions::tests::materialize_declared_arg_files_writes_line_delimited_args`
- `mise exec -- cargo test -p once-frontend analysis::tests::run_action_rejects_line_delimited_arg_file_newlines`
- `mise exec -- cargo test -p once-frontend --test prelude prelude_rust_windows_feature_cfgs_use_response_file`
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo test -p once-cli commands::graph::analysis::actions`
- `mise exec -- cargo test -p once-frontend analysis::tests::`
- `mise exec -- cargo test -p once-frontend`
- `mise exec -- cargo test -p once-cli commands::graph::analysis`
- `mise exec -- cargo test -p once-cli`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- `mise exec -- cargo clippy -p once-frontend -p once-cli --all-targets -- -D warnings`
