### PR TITLE
fix(graph): format rust feature cfg values as literals

### DIFF
--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -195,13 +195,24 @@ def _rust_android_compile_env(ctx, target):
         env["PATH"] = path
     return env
 
+def _rust_string_literal(value):
+    hashes = "#"
+    for _ in range(len(value) + 1):
+        if "\"" + hashes not in value:
+            return "r" + hashes + "\"" + value + "\"" + hashes
+        hashes += "#"
+    fail("could not quote Rust string literal")
+
+def _rust_feature_cfg(feature):
+    return "feature=" + _rust_string_literal(feature)
+
 def _rust_feature_flags(ctx):
     flags = []
     features = []
     features.extend(_rust_attr(ctx, "features", []))
     features.extend(_rust_attr(ctx, "crate_features", []))
     for feature in _unique(features):
-        flags.extend(["--cfg", "feature=\"" + feature + "\""])
+        flags.extend(["--cfg", _rust_feature_cfg(feature)])
     return flags
 
 def _rust_feature_args(ctx):

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1294,6 +1294,96 @@ result = repr([
 }
 
 #[test]
+fn prelude_cargo_metadata_windows_features_escape_response_file_cfgs() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_os():
+    return "windows"
+
+def host_env(name):
+    return ""
+
+def host_which(name):
+    fail("unexpected host_which call: " + name)
+
+def host_command(argv, env = None):
+    fail("unexpected host_command call")
+
+def _rustc_toolchain(target):
+    return ("C:/Rust/bin/rustc.exe", "rustc-test", "x86_64-pc-windows-msvc")
+
+targets = _cargo_metadata_targets({{
+    "attrs": {{
+        "target": "x86_64-pc-windows-msvc",
+        "vendor_dir": "third_party/rust/vendor",
+    }},
+}}, {{
+    "packages": [{{
+        "id": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+        "name": "anyhow",
+        "version": "1.0.102",
+        "source": "registry+https://github.com/rust-lang/crates.io-index",
+        "manifest_path": "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index\\anyhow-1.0.102\\Cargo.toml",
+        "targets": [{{
+            "name": "anyhow",
+            "kind": ["lib"],
+            "crate_types": ["lib"],
+            "src_path": "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index\\anyhow-1.0.102\\src\\lib.rs",
+            "edition": "2021",
+        }}],
+    }}],
+    "resolve": {{
+        "nodes": [{{
+            "id": "registry+https://github.com/rust-lang/crates.io-index#anyhow@1.0.102",
+            "features": ["default"],
+            "deps": [],
+        }}],
+    }},
+}})
+target = {{target["name"]: target for target in targets}}["anyhow-1.0.102"]
+ctx = {{
+    "label": {{
+        "package": "cargo_dependencies_x86_64_pc_windows_msvc",
+        "name": target["name"],
+        "id": "cargo_dependencies_x86_64_pc_windows_msvc/" + target["name"],
+    }},
+    "attr": target["attrs"],
+    "deps": [],
+    "srcs": target["srcs"],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libanyhow.rlib")
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(
+        workspace.path(),
+        "cargo_dependencies_x86_64_pc_windows_msvc/anyhow-1.0.102",
+    );
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    let rustc = store
+        .actions
+        .iter()
+        .find(|action| {
+            action.identifier.as_deref()
+                == Some("cargo_dependencies_x86_64_pc_windows_msvc/anyhow-1.0.102:rustc")
+        })
+        .expect("rustc action");
+    assert_eq!(rustc.arg_files.len(), 1);
+    let arg_file = &rustc.arg_files[0];
+    assert!(arg_file
+        .args
+        .windows(2)
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=r#\"default\"#"));
+    assert!(!arg_file.args.iter().any(|arg| arg == "feature=default"));
+    assert!(!arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
+}
+
+#[test]
 fn prelude_cargo_metadata_targets_split_proc_macro_host_deps() {
     let prelude = all_prelude_source();
     let source = format!(
@@ -1773,13 +1863,17 @@ result = repr("ok")
     assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc-features.rsp");
     assert_eq!(arg_file.format, DeclaredArgFileFormat::LineDelimited);
     assert!(arg_file.args.len() > 800);
-    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
-    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"std\""));
     assert!(arg_file
         .args
         .iter()
-        .any(|arg| arg == "feature=\"feature_399\""));
-    assert!(!arg_file.args.iter().any(|arg| arg.contains("\\\"")));
+        .any(|arg| arg == "feature=r#\"default\"#"));
+    assert!(arg_file.args.iter().any(|arg| arg == "feature=r#\"std\"#"));
+    assert!(arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "feature=r#\"feature_399\"#"));
+    assert!(!arg_file.args.iter().any(|arg| arg == "feature=default"));
+    assert!(!arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
     assert!(
         !rustc.argv.iter().any(|arg| arg.contains("feature=\"")),
         "{:?}",
@@ -1837,11 +1931,11 @@ result = repr("ok")
     assert!(rustc
         .argv
         .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"default\""));
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=r#\"default\"#"));
     assert!(rustc
         .argv
         .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"std\""));
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=r#\"std\"#"));
     assert!(
         !rustc.argv.iter().any(|arg| arg.starts_with('@')),
         "{:?}",


### PR DESCRIPTION
## What changed

- Formats Rust feature configuration values as raw Rust string literals when the Rust prelude lowers `features` and `crate_features` into `rustc --cfg` arguments.
- Keeps generated Cargo dependency targets on the same managed Rust prelude path, so rule authors still write `features = [...]` instead of hand-formatting compiler arguments.
- Adds a regression test for the generated Windows Cargo dependency target shape that failed in the release workflow.

## Why

The main release workflow is failing in the Windows release jobs while compiling generated Cargo dependency targets. The failing target is `cargo_dependencies_x86_64_pc_windows_msvc/anyhow-1.0.102:rustc`, which gets feature configuration from Cargo metadata rather than from a first-party release manifest.

## Root cause

`rustc --cfg` requires feature values to be Rust string literals. The previous lowering relied on normal quoted values, which is fragile around response-file boundaries on Windows. The release job surfaced this as `feature=default`, which `rustc` rejects because the value is no longer a string literal.

## Approach

The Rust prelude now owns the full feature configuration format by emitting values like `feature=r#"default"#`. This is still a Rust string literal, works when passed directly, and works in line-delimited `rustc` response files without shell-style quote preservation.

## Impact

There is no rule authoring change. `features = [...]` and `crate_features = [...]` remain the ergonomic public surface, while the prelude handles the compiler-specific formatting detail consistently for hand-written Rust targets and generated Cargo dependency targets.

## Validation

- `mise exec -- cargo test -p once-frontend --test prelude prelude_cargo_metadata_windows_features_escape_response_file_cfgs`
- `mise exec -- cargo test -p once-frontend --test prelude prelude_rust_windows_feature_cfgs_use_response_file`
- `mise exec -- cargo test -p once-frontend --test prelude prelude_rust_non_windows_feature_cfgs_stay_inline`
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo test -p once-frontend`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- `mise exec -- cargo clippy -p once-frontend --all-targets -- -D warnings`
