### PR TITLE
fix(graph): encode rustc response file args

### DIFF
--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -667,20 +667,70 @@ fn materialize_declared_arg_files(workspace: &Path, arg_files: &[DeclaredArgFile
 
 fn declared_arg_file_content(arg_file: &DeclaredArgFile) -> Result<Vec<u8>> {
     match arg_file.format {
-        DeclaredArgFileFormat::LineDelimited => {
-            let mut content = Vec::new();
-            for arg in &arg_file.args {
-                if arg.contains('\n') || arg.contains('\r') {
-                    anyhow::bail!(
-                        "line-delimited arg file `{}` contains an argument with a newline",
-                        arg_file.path
-                    );
-                }
-                content.extend_from_slice(arg.as_bytes());
-                content.push(b'\n');
+        DeclaredArgFileFormat::LineDelimited => declared_arg_file_lines(arg_file, |arg| {
+            validate_arg_file_line(arg_file, arg)?;
+            Ok(arg.to_string())
+        }),
+        DeclaredArgFileFormat::RustcResponse => declared_arg_file_lines(arg_file, |arg| {
+            rustc_response_arg(arg_file, arg, cfg!(windows))
+        }),
+    }
+}
+
+fn declared_arg_file_lines(
+    arg_file: &DeclaredArgFile,
+    format: impl Fn(&str) -> Result<String>,
+) -> Result<Vec<u8>> {
+    let mut content = Vec::new();
+    for arg in &arg_file.args {
+        let line = format(arg)?;
+        content.extend_from_slice(line.as_bytes());
+        content.push(b'\n');
+    }
+    Ok(content)
+}
+
+fn rustc_response_arg(arg_file: &DeclaredArgFile, arg: &str, windows_host: bool) -> Result<String> {
+    validate_arg_file_line(arg_file, arg)?;
+    if windows_host {
+        Ok(rustc_windows_response_arg(arg))
+    } else {
+        Ok(arg.to_string())
+    }
+}
+
+fn rustc_windows_response_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "\"\"".to_string();
+    }
+    let mut escaped = String::new();
+    for character in arg.chars() {
+        match character {
+            '\\' | '"' | '\'' | ' ' | '\t' => {
+                escaped.push('\\');
+                escaped.push(character);
             }
-            Ok(content)
+            _ => escaped.push(character),
         }
+    }
+    escaped
+}
+
+fn validate_arg_file_line(arg_file: &DeclaredArgFile, arg: &str) -> Result<()> {
+    if arg.contains('\n') || arg.contains('\r') {
+        anyhow::bail!(
+            "{} arg file `{}` contains an argument with a newline",
+            declared_arg_file_format_name(arg_file.format),
+            arg_file.path
+        );
+    }
+    Ok(())
+}
+
+fn declared_arg_file_format_name(format: DeclaredArgFileFormat) -> &'static str {
+    match format {
+        DeclaredArgFileFormat::LineDelimited => "line-delimited",
+        DeclaredArgFileFormat::RustcResponse => "rustc-response",
     }
 }
 
@@ -852,6 +902,75 @@ mod tests {
             std::fs::read_to_string(workspace.path().join(".once/out/rust/rustc-features.rsp"))
                 .unwrap(),
             "--cfg\nfeature=\"alloc\"\n"
+        );
+    }
+
+    #[test]
+    fn materialize_declared_arg_files_writes_rustc_response_args() {
+        let workspace = tempfile::tempdir().unwrap();
+        let arg_files = vec![DeclaredArgFile {
+            path: ".once/out/rust/rustc-features.rsp".to_string(),
+            format: DeclaredArgFileFormat::RustcResponse,
+            args: vec!["--cfg".to_string(), "feature=\"alloc\"".to_string()],
+        }];
+
+        materialize_declared_arg_files(workspace.path(), &arg_files).unwrap();
+
+        let expected = if cfg!(windows) {
+            "--cfg\nfeature=\\\"alloc\\\"\n"
+        } else {
+            "--cfg\nfeature=\"alloc\"\n"
+        };
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join(".once/out/rust/rustc-features.rsp"))
+                .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn rustc_response_args_escape_quotes_for_windows_hosts() {
+        let arg_file = DeclaredArgFile {
+            path: ".once/out/rust/rustc-features.rsp".to_string(),
+            format: DeclaredArgFileFormat::RustcResponse,
+            args: Vec::new(),
+        };
+
+        assert_eq!(
+            rustc_response_arg(&arg_file, "feature=\"alloc\"", true).unwrap(),
+            "feature=\\\"alloc\\\""
+        );
+    }
+
+    #[test]
+    fn rustc_response_args_escape_windows_shell_characters() {
+        assert_eq!(rustc_windows_response_arg(""), "\"\"");
+        assert_eq!(
+            rustc_windows_response_arg("arg with spaces"),
+            "arg\\ with\\ spaces"
+        );
+        assert_eq!(
+            rustc_windows_response_arg("C:\\Program Files\\Rust\\rustc.exe"),
+            "C:\\\\Program\\ Files\\\\Rust\\\\rustc.exe"
+        );
+        assert_eq!(
+            rustc_windows_response_arg("feature=\\\"alloc\\\""),
+            "feature=\\\\\\\"alloc\\\\\\\""
+        );
+        assert_eq!(rustc_windows_response_arg("it's"), "it\\'s");
+    }
+
+    #[test]
+    fn rustc_response_args_keep_quotes_for_non_windows_hosts() {
+        let arg_file = DeclaredArgFile {
+            path: ".once/out/rust/rustc-features.rsp".to_string(),
+            format: DeclaredArgFileFormat::RustcResponse,
+            args: Vec::new(),
+        };
+
+        assert_eq!(
+            rustc_response_arg(&arg_file, "feature=\"alloc\"", false).unwrap(),
+            "feature=\"alloc\""
         );
     }
 

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -195,16 +195,8 @@ def _rust_android_compile_env(ctx, target):
         env["PATH"] = path
     return env
 
-def _rust_string_literal(value):
-    hashes = "#"
-    for _ in range(len(value) + 1):
-        if "\"" + hashes not in value:
-            return "r" + hashes + "\"" + value + "\"" + hashes
-        hashes += "#"
-    fail("could not quote Rust string literal")
-
 def _rust_feature_cfg(feature):
-    return "feature=" + _rust_string_literal(feature)
+    return "feature=\"" + feature + "\""
 
 def _rust_feature_flags(ctx):
     flags = []
@@ -227,7 +219,7 @@ def _rust_feature_args(ctx):
             args = flags,
             use_arg_file = {
                 "path": path,
-                "format": "line-delimited",
+                "format": "rustc-response",
                 "arg_format": "@{}",
             },
         ),

--- a/crates/once-frontend/src/analysis/globals.rs
+++ b/crates/once-frontend/src/analysis/globals.rs
@@ -340,9 +340,8 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
 
     /// Build a structured command-line fragment. `args` is a list of
     /// string arguments. When `use_arg_file` is set, it must be a dict
-    /// with `path` plus optional `format` and `arg_format`. The only
-    /// supported format today is `"line-delimited"`, which writes one
-    /// argument per line without shell escaping.
+    /// with `path` plus optional `format` and `arg_format`. Supported
+    /// formats are `"line-delimited"` and `"rustc-response"`.
     fn cmd_args<'v>(
         args: Value<'v>,
         use_arg_file: Option<Value<'v>>,
@@ -456,6 +455,7 @@ impl DeclaredArgFileFormat {
     fn as_str(self) -> &'static str {
         match self {
             Self::LineDelimited => "line-delimited",
+            Self::RustcResponse => "rustc-response",
         }
     }
 }
@@ -607,8 +607,9 @@ fn unpack_cmd_args_arg_file(value: Value<'_>) -> anyhow::Result<Option<CmdArgsAr
 fn parse_arg_file_format(value: &str, field: &str) -> anyhow::Result<DeclaredArgFileFormat> {
     match value {
         "line-delimited" => Ok(DeclaredArgFileFormat::LineDelimited),
+        "rustc-response" => Ok(DeclaredArgFileFormat::RustcResponse),
         other => Err(anyhow!(
-            "expected `{field}` to be `line-delimited`, got `{other}`"
+            "expected `{field}` to be `line-delimited` or `rustc-response`, got `{other}`"
         )),
     }
 }
@@ -619,11 +620,12 @@ fn validate_declared_arg_file_args(
     path: &str,
 ) -> anyhow::Result<()> {
     match format {
-        DeclaredArgFileFormat::LineDelimited => {
+        DeclaredArgFileFormat::LineDelimited | DeclaredArgFileFormat::RustcResponse => {
             for arg in args {
                 if arg.contains('\n') || arg.contains('\r') {
                     return Err(anyhow!(
-                        "line-delimited arg file `{path}` contains an argument with a newline"
+                        "{} arg file `{path}` contains an argument with a newline",
+                        format.as_str()
                     ));
                 }
             }

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -78,6 +78,7 @@ pub struct DeclaredArgFile {
 #[serde(rename_all = "kebab-case")]
 pub enum DeclaredArgFileFormat {
     LineDelimited,
+    RustcResponse,
 }
 
 fn default_cacheable() -> bool {

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -225,6 +225,49 @@ run_action(
 }
 
 #[test]
+fn run_action_flattens_cmd_args_with_rustc_response_arg_file() {
+    let tmp = TempDir::new().unwrap();
+    let store = store_for(tmp.path(), "p");
+    let (store, ()) = with_active_store(store, || {
+        run(r#"
+run_action(
+    argv = [
+        "rustc",
+        cmd_args(
+            args = ["--cfg", "feature=\"alloc\""],
+            use_arg_file = {
+                "path": ".once/out/p/rustc-features.rsp",
+                "format": "rustc-response",
+                "arg_format": "@{}",
+            },
+        ),
+    ],
+    outputs = [".once/out/p/lib.rlib"],
+)
+"#)
+        .unwrap();
+    });
+
+    assert_eq!(store.actions.len(), 1);
+    let action = &store.actions[0];
+    assert_eq!(
+        action.argv,
+        vec![
+            "rustc".to_string(),
+            "@.once/out/p/rustc-features.rsp".to_string()
+        ]
+    );
+    assert_eq!(action.arg_files.len(), 1);
+    let arg_file = &action.arg_files[0];
+    assert_eq!(arg_file.path, ".once/out/p/rustc-features.rsp");
+    assert_eq!(arg_file.format, DeclaredArgFileFormat::RustcResponse);
+    assert_eq!(
+        arg_file.args,
+        vec!["--cfg".to_string(), "feature=\"alloc\"".to_string()]
+    );
+}
+
+#[test]
 fn run_action_rejects_line_delimited_arg_file_newlines() {
     let tmp = TempDir::new().unwrap();
     let store = store_for(tmp.path(), "p");

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1375,12 +1375,17 @@ result = repr("ok")
         .expect("rustc action");
     assert_eq!(rustc.arg_files.len(), 1);
     let arg_file = &rustc.arg_files[0];
+    assert_eq!(arg_file.format, DeclaredArgFileFormat::RustcResponse);
     assert!(arg_file
         .args
         .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=r#\"default\"#"));
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"default\""));
     assert!(!arg_file.args.iter().any(|arg| arg == "feature=default"));
-    assert!(!arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
+    assert!(!arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "feature=\\\"default\\\""));
+    assert!(!arg_file.args.iter().any(|arg| arg == "feature=r#default#"));
 }
 
 #[test]
@@ -1861,19 +1866,20 @@ result = repr("ok")
     assert_eq!(rustc.arg_files.len(), 1);
     let arg_file = &rustc.arg_files[0];
     assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc-features.rsp");
-    assert_eq!(arg_file.format, DeclaredArgFileFormat::LineDelimited);
+    assert_eq!(arg_file.format, DeclaredArgFileFormat::RustcResponse);
     assert!(arg_file.args.len() > 800);
+    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
+    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"std\""));
     assert!(arg_file
         .args
         .iter()
-        .any(|arg| arg == "feature=r#\"default\"#"));
-    assert!(arg_file.args.iter().any(|arg| arg == "feature=r#\"std\"#"));
-    assert!(arg_file
-        .args
-        .iter()
-        .any(|arg| arg == "feature=r#\"feature_399\"#"));
+        .any(|arg| arg == "feature=\"feature_399\""));
     assert!(!arg_file.args.iter().any(|arg| arg == "feature=default"));
-    assert!(!arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
+    assert!(!arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "feature=\\\"default\\\""));
+    assert!(!arg_file.args.iter().any(|arg| arg == "feature=r#default#"));
     assert!(
         !rustc.argv.iter().any(|arg| arg.contains("feature=\"")),
         "{:?}",
@@ -1931,11 +1937,11 @@ result = repr("ok")
     assert!(rustc
         .argv
         .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=r#\"default\"#"));
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"default\""));
     assert!(rustc
         .argv
         .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=r#\"std\"#"));
+        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"std\""));
     assert!(
         !rustc.argv.iter().any(|arg| arg.starts_with('@')),
         "{:?}",

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -195,10 +195,12 @@ The Rust executor exposes generic primitives only:
 - `cmd_args(args, use_arg_file = None)` creates a structured
   command-line fragment. `args` is a list of strings. When
   `use_arg_file` is set, it is a dictionary with `path` plus optional
-  `format` and `arg_format`. The supported `format` is
+  `format` and `arg_format`. The supported `format` values are
   `line-delimited`, which writes one argument per line without shell
-  escaping. `arg_format` defaults to `@{}` and must contain exactly one
-  `{}` placeholder.
+  escaping, and `rustc-response`, which writes one `rustc` argument per
+  line and applies the host-specific quote escaping expected by
+  `rustc @path` files. `arg_format` defaults to `@{}` and must contain
+  exactly one `{}` placeholder.
 - `run_action(...)` records a command action for the executor.
 - `write_path(path, content)` materializes generated text or byte-list
   files through normal actions.


### PR DESCRIPTION
## What changed

This adds a `rustc-response` argument-file format to `cmd_args` and teaches the executor to encode those files for the host before writing them. The Rust target kind now keeps feature flags as normal `rustc` arguments such as `feature="default"`, then asks the materializer for the `rustc-response` format when Windows needs a response file.

The change also updates the Starlark module reference and adds coverage for the generic `cmd_args` format, Windows response-file encoding, and the generated Rust feature response file.

## Why

The main release workflow is still failing in the Windows release packaging jobs. The previous fix made feature values valid as direct `rustc` arguments, but response-file parsing on Windows consumed the raw string delimiter quotes before `rustc` validated `--cfg`.

## Root cause

The failed jobs reached `cargo_dependencies_x86_64_pc_windows_msvc/anyhow-1.0.102:rustc` and reported `feature=r#default#`. That means the response file contained a value that looked valid as a direct Rust string literal, but Windows response-file parsing removed the double quotes inside it.

## Approach

This keeps the rule authoring surface ergonomic. Target kinds declare the arguments they intend `rustc` to receive, and the executor owns the format-specific response-file encoding. `line-delimited` remains a literal format, while `rustc-response` applies the host-specific escaping needed by `rustc @path` files.

## Impact

Rule authors do not need to know how to escape `rustc` response files for Windows. Existing direct `rustc` invocations stay unchanged, and Windows response files now preserve feature values with quoted string literals.

## Validation

- `mise exec -- cargo test -p once-frontend --test prelude prelude_cargo_metadata_windows_features_escape_response_file_cfgs`
- `mise exec -- cargo test -p once-frontend --test prelude prelude_rust_windows_feature_cfgs_use_response_file`
- `mise exec -- cargo test -p once-frontend run_action_flattens_cmd_args_with_rustc_response_arg_file`
- `mise exec -- cargo test -p once-cli rustc_response_args_escape_quotes_for_windows_hosts`
- `mise exec -- cargo test -p once-cli commands::graph::analysis::actions::tests::rustc_response_args_escape_windows_shell_characters`
- `mise exec -- cargo test -p once-cli commands::graph::analysis::actions::tests`
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo test -p once-frontend`
- `mise exec -- cargo test -p once-cli`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- `mise exec -- cargo clippy -p once-cli -p once-frontend --all-targets -- -D warnings`
- `mise exec -- cargo test --workspace`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
