### PR TITLE
fix(graph): stabilize windows rustc response handling

### DIFF
--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -264,22 +264,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          dump_rustc_feature_response_files() {
-            if [ ! -d .once/out ]; then
-              return 0
-            fi
-            local printed=0
-            while IFS= read -r file; do
-              printf '::group::%s\n' "$file"
-              sed -n '1,20p' "$file"
-              printf '::endgroup::\n'
-              printed=$((printed + 1))
-              if [ "$printed" -ge 5 ]; then
-                break
-              fi
-            done < <(find .once/out -path '*/rustc-features.rsp' -print | sort)
-          }
-
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
           target="x86_64-pc-windows-msvc"
           suffix="$(printf '%s' "${target}" | tr '.-' '__')"
@@ -287,10 +271,7 @@ jobs:
           trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
           ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
           ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version 0.0.0
-          if ! "${once_bin}" build "${target_id}" --format json --quiet; then
-            dump_rustc_feature_response_files
-            exit 1
-          fi
+          "${once_bin}" build "${target_id}" --format json --quiet
           test -f ".once/out/${target_id}/once.exe"
 
   windows-cas-test:

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -226,6 +226,53 @@ jobs:
           cargo build --workspace --all-targets --exclude once
           cargo build --package once --all-targets
 
+  windows-release-build:
+    name: release graph build (windows-latest)
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      MISE_VERSION: "2026.4.18"
+      MISE_GITHUB_ATTESTATIONS: 0
+      MISE_AUTO_INSTALL: "false"
+      MISE_TASK_RUN_AUTO_INSTALL: "false"
+      MISE_NOT_FOUND_AUTO_INSTALL: "false"
+      MISE_EXEC_AUTO_INSTALL: "false"
+      ONCE_BOOTSTRAP_SOURCE: source
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set HOME for mise templates
+        shell: pwsh
+        run: '"HOME=$env:USERPROFILE" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append'
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "rust jq"
+      - name: Add Rust target
+        run: rustup target add x86_64-pc-windows-msvc
+      - name: Check Rust toolchain
+        run: mise exec -- rustc -vV
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          shared-key: release-graph-build-windows
+          cache-on-failure: true
+          cache-bin: false
+      - name: Build Windows release binary with Once
+        run: |
+          set -euo pipefail
+          once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+          target="x86_64-pc-windows-msvc"
+          suffix="$(printf '%s' "${target}" | tr '.-' '__')"
+          target_id="crates/once-cli/once_cli_${suffix}"
+          trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
+          ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
+          ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version 0.0.0
+          "${once_bin}" build "${target_id}" --format json --quiet
+          test -f ".once/out/${target_id}/once.exe"
+
   windows-cas-test:
     name: windows cas test
     needs: changes

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -264,6 +264,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          probe_dir="$(mktemp -d)"
+          printf 'fn main() {}\n' > "${probe_dir}/probe.rs"
+          printf '%s\n' '--cfg=feature="default"' > "${probe_dir}/rustc-features.rsp"
+          rustc "@${probe_dir}/rustc-features.rsp" "${probe_dir}/probe.rs" \
+            --crate-name once_rustc_response_probe \
+            --emit metadata \
+            -o "${probe_dir}/probe.rmeta"
+
           dump_rustc_feature_response_files() {
             if [ ! -d .once/out ]; then
               return 0

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -263,6 +263,31 @@ jobs:
       - name: Build Windows release binary with Once
         run: |
           set -euo pipefail
+
+          probe_dir="$(mktemp -d)"
+          printf 'fn main() {}\n' > "${probe_dir}/probe.rs"
+          printf '%s\n' '--cfg=feature="default"' > "${probe_dir}/rustc-features.rsp"
+          rustc "@${probe_dir}/rustc-features.rsp" "${probe_dir}/probe.rs" \
+            --crate-name once_rustc_response_probe \
+            --emit metadata \
+            -o "${probe_dir}/probe.rmeta"
+
+          dump_rustc_feature_response_files() {
+            if [ ! -d .once/out ]; then
+              return 0
+            fi
+            local printed=0
+            while IFS= read -r file; do
+              printf '::group::%s\n' "$file"
+              sed -n '1,20p' "$file"
+              printf '::endgroup::\n'
+              printed=$((printed + 1))
+              if [ "$printed" -ge 5 ]; then
+                break
+              fi
+            done < <(find .once/out -path '*/rustc-features.rsp' -print | sort)
+          }
+
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
           target="x86_64-pc-windows-msvc"
           suffix="$(printf '%s' "${target}" | tr '.-' '__')"
@@ -270,7 +295,10 @@ jobs:
           trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
           ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
           ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version 0.0.0
-          "${once_bin}" build "${target_id}" --format json --quiet
+          if ! "${once_bin}" build "${target_id}" --format json --quiet; then
+            dump_rustc_feature_response_files
+            exit 1
+          fi
           test -f ".once/out/${target_id}/once.exe"
 
   windows-cas-test:

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -264,14 +264,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          probe_dir="$(mktemp -d)"
-          printf 'fn main() {}\n' > "${probe_dir}/probe.rs"
-          printf '%s\n' '--cfg=feature="default"' > "${probe_dir}/rustc-features.rsp"
-          rustc "@${probe_dir}/rustc-features.rsp" "${probe_dir}/probe.rs" \
-            --crate-name once_rustc_response_probe \
-            --emit metadata \
-            -o "${probe_dir}/probe.rmeta"
-
           dump_rustc_feature_response_files() {
             if [ ! -d .once/out ]; then
               return 0

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -909,11 +909,18 @@ mod tests {
             format: DeclaredArgFileFormat::RustcResponse,
             args: Vec::new(),
         };
+        let cases = [
+            "",
+            "argument with spaces",
+            r"C:\Program Files\Rust\lib",
+            "tab\tseparated",
+            "feature='alloc'",
+            "feature=\"alloc\"",
+        ];
 
-        assert_eq!(
-            rustc_response_arg(&arg_file, "feature=\"alloc\"").unwrap(),
-            "feature=\"alloc\""
-        );
+        for case in cases {
+            assert_eq!(rustc_response_arg(&arg_file, case).unwrap(), case);
+        }
     }
 
     #[test]

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -671,9 +671,9 @@ fn declared_arg_file_content(arg_file: &DeclaredArgFile) -> Result<Vec<u8>> {
             validate_arg_file_line(arg_file, arg)?;
             Ok(arg.to_string())
         }),
-        DeclaredArgFileFormat::RustcResponse => declared_arg_file_lines(arg_file, |arg| {
-            rustc_response_arg(arg_file, arg, cfg!(windows))
-        }),
+        DeclaredArgFileFormat::RustcResponse => {
+            declared_arg_file_lines(arg_file, |arg| rustc_response_arg(arg_file, arg))
+        }
     }
 }
 
@@ -690,30 +690,9 @@ fn declared_arg_file_lines(
     Ok(content)
 }
 
-fn rustc_response_arg(arg_file: &DeclaredArgFile, arg: &str, windows_host: bool) -> Result<String> {
+fn rustc_response_arg(arg_file: &DeclaredArgFile, arg: &str) -> Result<String> {
     validate_arg_file_line(arg_file, arg)?;
-    if windows_host {
-        Ok(rustc_windows_response_arg(arg))
-    } else {
-        Ok(arg.to_string())
-    }
-}
-
-fn rustc_windows_response_arg(arg: &str) -> String {
-    if arg.is_empty() {
-        return "\"\"".to_string();
-    }
-    let mut escaped = String::new();
-    for character in arg.chars() {
-        match character {
-            '\\' | '"' | '\'' | ' ' | '\t' => {
-                escaped.push('\\');
-                escaped.push(character);
-            }
-            _ => escaped.push(character),
-        }
-    }
-    escaped
+    Ok(arg.to_string())
 }
 
 fn validate_arg_file_line(arg_file: &DeclaredArgFile, arg: &str) -> Result<()> {
@@ -916,20 +895,15 @@ mod tests {
 
         materialize_declared_arg_files(workspace.path(), &arg_files).unwrap();
 
-        let expected = if cfg!(windows) {
-            "--cfg\nfeature=\\\"alloc\\\"\n"
-        } else {
-            "--cfg\nfeature=\"alloc\"\n"
-        };
         assert_eq!(
             std::fs::read_to_string(workspace.path().join(".once/out/rust/rustc-features.rsp"))
                 .unwrap(),
-            expected
+            "--cfg\nfeature=\"alloc\"\n"
         );
     }
 
     #[test]
-    fn rustc_response_args_escape_quotes_for_windows_hosts() {
+    fn rustc_response_args_keep_arguments_verbatim() {
         let arg_file = DeclaredArgFile {
             path: ".once/out/rust/rustc-features.rsp".to_string(),
             format: DeclaredArgFileFormat::RustcResponse,
@@ -937,39 +911,7 @@ mod tests {
         };
 
         assert_eq!(
-            rustc_response_arg(&arg_file, "feature=\"alloc\"", true).unwrap(),
-            "feature=\\\"alloc\\\""
-        );
-    }
-
-    #[test]
-    fn rustc_response_args_escape_windows_shell_characters() {
-        assert_eq!(rustc_windows_response_arg(""), "\"\"");
-        assert_eq!(
-            rustc_windows_response_arg("arg with spaces"),
-            "arg\\ with\\ spaces"
-        );
-        assert_eq!(
-            rustc_windows_response_arg("C:\\Program Files\\Rust\\rustc.exe"),
-            "C:\\\\Program\\ Files\\\\Rust\\\\rustc.exe"
-        );
-        assert_eq!(
-            rustc_windows_response_arg("feature=\\\"alloc\\\""),
-            "feature=\\\\\\\"alloc\\\\\\\""
-        );
-        assert_eq!(rustc_windows_response_arg("it's"), "it\\'s");
-    }
-
-    #[test]
-    fn rustc_response_args_keep_quotes_for_non_windows_hosts() {
-        let arg_file = DeclaredArgFile {
-            path: ".once/out/rust/rustc-features.rsp".to_string(),
-            format: DeclaredArgFileFormat::RustcResponse,
-            args: Vec::new(),
-        };
-
-        assert_eq!(
-            rustc_response_arg(&arg_file, "feature=\"alloc\"", false).unwrap(),
+            rustc_response_arg(&arg_file, "feature=\"alloc\"").unwrap(),
             "feature=\"alloc\""
         );
     }

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -919,7 +919,11 @@ mod tests {
         ];
 
         for case in cases {
-            assert_eq!(rustc_response_arg(&arg_file, case).unwrap(), case);
+            assert_eq!(
+                rustc_response_arg(&arg_file, case).unwrap(),
+                case,
+                "rustc response argument should stay verbatim: {case:?}"
+            );
         }
     }
 

--- a/crates/once-frontend/build.rs
+++ b/crates/once-frontend/build.rs
@@ -21,6 +21,13 @@ fn emit_rerun_if_changed(
     root: &Path,
     visited: &mut BTreeSet<PathBuf>,
 ) -> io::Result<()> {
+    let Some(canonical) = canonical_path(path)? else {
+        return Ok(());
+    };
+    if !canonical.starts_with(root) {
+        return Ok(());
+    }
+
     println!("cargo:rerun-if-changed={}", path.display());
 
     let metadata = fs::metadata(path)?;
@@ -28,8 +35,7 @@ fn emit_rerun_if_changed(
         return Ok(());
     }
 
-    let canonical = path.canonicalize()?;
-    if !canonical.starts_with(root) || !visited.insert(canonical) {
+    if !visited.insert(canonical) {
         return Ok(());
     }
 
@@ -40,4 +46,18 @@ fn emit_rerun_if_changed(
     }
 
     Ok(())
+}
+
+fn canonical_path(path: &Path) -> io::Result<Option<PathBuf>> {
+    match path.canonicalize() {
+        Ok(path) => Ok(Some(path)),
+        Err(error) if unresolved_symlink(path) || error.kind() == io::ErrorKind::NotFound => {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn unresolved_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
 }

--- a/crates/once-frontend/build.rs
+++ b/crates/once-frontend/build.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     env, fs, io,
     path::{Path, PathBuf},
 };
@@ -9,20 +10,33 @@ fn main() -> io::Result<()> {
     let manifest_dir = PathBuf::from(
         env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set for build scripts"),
     );
-    emit_rerun_if_changed(&manifest_dir.join("prelude"))
+    let prelude = manifest_dir.join("prelude");
+    let root = prelude.canonicalize()?;
+    let mut visited = BTreeSet::new();
+    emit_rerun_if_changed(&prelude, &root, &mut visited)
 }
 
-fn emit_rerun_if_changed(path: &Path) -> io::Result<()> {
+fn emit_rerun_if_changed(
+    path: &Path,
+    root: &Path,
+    visited: &mut BTreeSet<PathBuf>,
+) -> io::Result<()> {
     println!("cargo:rerun-if-changed={}", path.display());
 
-    if !fs::symlink_metadata(path)?.is_dir() {
+    let metadata = fs::metadata(path)?;
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+
+    let canonical = path.canonicalize()?;
+    if !canonical.starts_with(root) || !visited.insert(canonical) {
         return Ok(());
     }
 
     let mut entries = fs::read_dir(path)?.collect::<io::Result<Vec<_>>>()?;
     entries.sort_by_key(std::fs::DirEntry::path);
     for entry in entries {
-        emit_rerun_if_changed(&entry.path())?;
+        emit_rerun_if_changed(&entry.path(), root, visited)?;
     }
 
     Ok(())

--- a/crates/once-frontend/build.rs
+++ b/crates/once-frontend/build.rs
@@ -20,7 +20,7 @@ fn emit_rerun_if_changed(path: &Path) -> io::Result<()> {
     }
 
     let mut entries = fs::read_dir(path)?.collect::<io::Result<Vec<_>>>()?;
-    entries.sort_by_key(|entry| entry.path());
+    entries.sort_by_key(std::fs::DirEntry::path);
     for entry in entries {
         emit_rerun_if_changed(&entry.path())?;
     }

--- a/crates/once-frontend/build.rs
+++ b/crates/once-frontend/build.rs
@@ -21,7 +21,22 @@ fn emit_rerun_if_changed(
     root: &Path,
     visited: &mut BTreeSet<PathBuf>,
 ) -> io::Result<()> {
-    let canonical = path.canonicalize()?;
+    let link_metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let canonical = match path.canonicalize() {
+        Ok(canonical) => canonical,
+        Err(error)
+            if link_metadata.file_type().is_symlink()
+                || error.kind() == io::ErrorKind::NotFound =>
+        {
+            println!("cargo:rerun-if-changed={}", path.display());
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
     if !canonical.starts_with(root) {
         return Ok(());
     }

--- a/crates/once-frontend/build.rs
+++ b/crates/once-frontend/build.rs
@@ -15,10 +15,14 @@ fn main() -> io::Result<()> {
 fn emit_rerun_if_changed(path: &Path) -> io::Result<()> {
     println!("cargo:rerun-if-changed={}", path.display());
 
-    if path.is_dir() {
-        for entry in fs::read_dir(path)? {
-            emit_rerun_if_changed(&entry?.path())?;
-        }
+    if !fs::symlink_metadata(path)?.is_dir() {
+        return Ok(());
+    }
+
+    let mut entries = fs::read_dir(path)?.collect::<io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        emit_rerun_if_changed(&entry.path())?;
     }
 
     Ok(())

--- a/crates/once-frontend/build.rs
+++ b/crates/once-frontend/build.rs
@@ -21,9 +21,7 @@ fn emit_rerun_if_changed(
     root: &Path,
     visited: &mut BTreeSet<PathBuf>,
 ) -> io::Result<()> {
-    let Some(canonical) = canonical_path(path)? else {
-        return Ok(());
-    };
+    let canonical = path.canonicalize()?;
     if !canonical.starts_with(root) {
         return Ok(());
     }
@@ -46,18 +44,4 @@ fn emit_rerun_if_changed(
     }
 
     Ok(())
-}
-
-fn canonical_path(path: &Path) -> io::Result<Option<PathBuf>> {
-    match path.canonicalize() {
-        Ok(path) => Ok(Some(path)),
-        Err(error) if unresolved_symlink(path) || error.kind() == io::ErrorKind::NotFound => {
-            Ok(None)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-fn unresolved_symlink(path: &Path) -> bool {
-    fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
 }

--- a/crates/once-frontend/build.rs
+++ b/crates/once-frontend/build.rs
@@ -1,0 +1,25 @@
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+};
+
+fn main() -> io::Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let manifest_dir = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set for build scripts"),
+    );
+    emit_rerun_if_changed(&manifest_dir.join("prelude"))
+}
+
+fn emit_rerun_if_changed(path: &Path) -> io::Result<()> {
+    println!("cargo:rerun-if-changed={}", path.display());
+
+    if path.is_dir() {
+        for entry in fs::read_dir(path)? {
+            emit_rerun_if_changed(&entry?.path())?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/once-frontend/prelude/common.star
+++ b/crates/once-frontend/prelude/common.star
@@ -93,3 +93,6 @@ def _shell_quote(value):
     if not value:
         return "''"
     return "'" + value.replace("'", "'\"'\"'") + "'"
+
+def _powershell_quote(value):
+    return "'" + value.replace("'", "''") + "'"

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -699,7 +699,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     compile_env["OUT_DIR"] = _workspace_absolute(out_dir)
     return (out_dir, [script_path, stdout], compile_env, stdout)
 
-def _rustc_with_build_script_args(argv, stdout):
+def _rustc_unix_build_script_args(argv, stdout):
     script = """set -eu
 while IFS= read -r line; do
   case "$line" in
@@ -738,6 +738,93 @@ done < {stdout}
 exec "$@"
 """.format(stdout = _shell_quote(stdout))
     return [host_which("sh"), "-c", script, "once-rustc"] + argv
+
+def _rustc_windows_build_script_args(ctx, argv, stdout):
+    wrapper = declare_output(_rust_declared_output(ctx, "rustc-build-script-wrapper.ps1"))
+    script = """$ErrorActionPreference = 'Stop'
+$rustcArgs = New-Object 'System.Collections.Generic.List[string]'
+foreach ($arg in $args) {
+  [void]$rustcArgs.Add($arg)
+}
+
+function Get-DirectiveValue($line, $name) {
+  $oldPrefix = 'cargo:' + $name + '='
+  if ($line.StartsWith($oldPrefix)) {
+    return $line.Substring($oldPrefix.Length)
+  }
+  $newPrefix = 'cargo::' + $name + '='
+  if ($line.StartsWith($newPrefix)) {
+    return $line.Substring($newPrefix.Length)
+  }
+  return $null
+}
+
+foreach ($line in [System.IO.File]::ReadLines(""" + _powershell_quote(stdout) + """)) {
+  $value = Get-DirectiveValue $line 'rustc-cfg'
+  if ($null -ne $value) {
+    [void]$rustcArgs.Add('--cfg')
+    [void]$rustcArgs.Add($value)
+    continue
+  }
+  $value = Get-DirectiveValue $line 'rustc-check-cfg'
+  if ($null -ne $value) {
+    [void]$rustcArgs.Add('--check-cfg')
+    [void]$rustcArgs.Add($value)
+    continue
+  }
+  $value = Get-DirectiveValue $line 'rustc-env'
+  if ($null -ne $value) {
+    $equals = $value.IndexOf('=')
+    if ($equals -ge 0) {
+      $name = $value.Substring(0, $equals)
+      $envValue = $value.Substring($equals + 1)
+      [System.Environment]::SetEnvironmentVariable($name, $envValue, 'Process')
+    }
+    continue
+  }
+  $value = Get-DirectiveValue $line 'rustc-link-arg'
+  if ($null -ne $value) {
+    [void]$rustcArgs.Add('-C')
+    [void]$rustcArgs.Add("link-arg=$value")
+    continue
+  }
+  $value = Get-DirectiveValue $line 'rustc-link-lib'
+  if ($null -ne $value) {
+    [void]$rustcArgs.Add('-l')
+    [void]$rustcArgs.Add($value)
+    continue
+  }
+  $value = Get-DirectiveValue $line 'rustc-link-search'
+  if ($null -ne $value) {
+    [void]$rustcArgs.Add('-L')
+    [void]$rustcArgs.Add($value)
+    continue
+  }
+}
+
+if ($rustcArgs.Count -eq 0) {
+  throw 'missing rustc argv'
+}
+$program = $rustcArgs[0]
+$rest = @()
+if ($rustcArgs.Count -gt 1) {
+  $rest = $rustcArgs.GetRange(1, $rustcArgs.Count - 1).ToArray()
+}
+& $program @rest
+if ($global:LASTEXITCODE -ne $null) {
+  exit $global:LASTEXITCODE
+}
+if (-not $?) {
+  exit 1
+}
+"""
+    write_path(wrapper, script)
+    return ([host_which("powershell"), "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", wrapper] + argv, [wrapper])
+
+def _rustc_with_build_script_args(ctx, argv, stdout):
+    if host_os() == "windows":
+        return _rustc_windows_build_script_args(ctx, argv, stdout)
+    return (_rustc_unix_build_script_args(argv, stdout), [])
 
 def _rust_dep_inputs(deps):
     inputs = []
@@ -886,7 +973,9 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
     argv.extend(linker_args)
     argv.extend(_rust_linker_flags(ctx))
     if build_stdout:
-        argv = _rustc_with_build_script_args(argv, build_stdout)
+        wrapped = _rustc_with_build_script_args(ctx, argv, build_stdout)
+        argv = wrapped[0]
+        build_inputs.extend(wrapped[1])
     run_action(
         argv = argv,
         inputs = _unique(srcs + dep_inputs + build_inputs + feature_inputs + _rust_extra_inputs(ctx)),

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -195,8 +195,8 @@ def _rust_android_compile_env(ctx, target):
         env["PATH"] = path
     return env
 
-def _rust_feature_cfg(feature):
-    return "feature=\"" + feature + "\""
+def _rust_feature_cfg_arg(feature):
+    return "--cfg=feature=\"" + feature + "\""
 
 def _rust_feature_flags(ctx):
     flags = []
@@ -204,7 +204,7 @@ def _rust_feature_flags(ctx):
     features.extend(_rust_attr(ctx, "features", []))
     features.extend(_rust_attr(ctx, "crate_features", []))
     for feature in _unique(features):
-        flags.extend(["--cfg", _rust_feature_cfg(feature)])
+        flags.append(_rust_feature_cfg_arg(feature))
     return flags
 
 def _rust_feature_args(ctx):
@@ -1668,7 +1668,7 @@ _RUST_COMMON_ATTRS = [
     attr("crate_name", "string", docs = "Rust crate name passed to rustc. Defaults to the target name with `-` and `.` rewritten as `_`.", configurable = False),
     attr("crate_root", "string", docs = "Package-relative path to lib.rs or main.rs. Defaults to src/lib.rs for libraries and src/main.rs for binaries.", configurable = False),
     attr("edition", "string", default = "2021", docs = "Rust edition passed to rustc.", configurable = False),
-    attr("features", "list<string>", default = "[]", docs = "Cargo feature names lowered to rustc `--cfg feature=...` flags."),
+    attr("features", "list<string>", default = "[]", docs = "Cargo feature names lowered to rustc `--cfg=feature=...` flags."),
     attr("crate_features", "list<string>", default = "[]", docs = "Bazel-compatible alias for `features`."),
     attr("target", "string", docs = "Rust target triple passed to `rustc --target`. Defaults to the host target.", configurable = False),
     attr("env", "map<string, string>", default = "{}", docs = "Environment variables for rustc, matching Buck2's `env` attribute.", configurable = False),

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -746,6 +746,7 @@ $rustcArgs = New-Object 'System.Collections.Generic.List[string]'
 foreach ($arg in $args) {
   [void]$rustcArgs.Add($arg)
 }
+$dynamicRustcArgs = New-Object 'System.Collections.Generic.List[string]'
 
 function Get-DirectiveValue($line, $name) {
   $oldPrefix = 'cargo:' + $name + '='
@@ -762,14 +763,14 @@ function Get-DirectiveValue($line, $name) {
 foreach ($line in [System.IO.File]::ReadLines(""" + _powershell_quote(stdout) + """)) {
   $value = Get-DirectiveValue $line 'rustc-cfg'
   if ($null -ne $value) {
-    [void]$rustcArgs.Add('--cfg')
-    [void]$rustcArgs.Add($value)
+    [void]$dynamicRustcArgs.Add('--cfg')
+    [void]$dynamicRustcArgs.Add($value)
     continue
   }
   $value = Get-DirectiveValue $line 'rustc-check-cfg'
   if ($null -ne $value) {
-    [void]$rustcArgs.Add('--check-cfg')
-    [void]$rustcArgs.Add($value)
+    [void]$dynamicRustcArgs.Add('--check-cfg')
+    [void]$dynamicRustcArgs.Add($value)
     continue
   }
   $value = Get-DirectiveValue $line 'rustc-env'
@@ -784,20 +785,20 @@ foreach ($line in [System.IO.File]::ReadLines(""" + _powershell_quote(stdout) + 
   }
   $value = Get-DirectiveValue $line 'rustc-link-arg'
   if ($null -ne $value) {
-    [void]$rustcArgs.Add('-C')
-    [void]$rustcArgs.Add("link-arg=$value")
+    [void]$dynamicRustcArgs.Add('-C')
+    [void]$dynamicRustcArgs.Add("link-arg=$value")
     continue
   }
   $value = Get-DirectiveValue $line 'rustc-link-lib'
   if ($null -ne $value) {
-    [void]$rustcArgs.Add('-l')
-    [void]$rustcArgs.Add($value)
+    [void]$dynamicRustcArgs.Add('-l')
+    [void]$dynamicRustcArgs.Add($value)
     continue
   }
   $value = Get-DirectiveValue $line 'rustc-link-search'
   if ($null -ne $value) {
-    [void]$rustcArgs.Add('-L')
-    [void]$rustcArgs.Add($value)
+    [void]$dynamicRustcArgs.Add('-L')
+    [void]$dynamicRustcArgs.Add($value)
     continue
   }
 }
@@ -806,16 +807,29 @@ if ($rustcArgs.Count -eq 0) {
   throw 'missing rustc argv'
 }
 $program = $rustcArgs[0]
-$rest = @()
-if ($rustcArgs.Count -gt 1) {
-  $rest = $rustcArgs.GetRange(1, $rustcArgs.Count - 1).ToArray()
-}
-& $program @rest
-if ($global:LASTEXITCODE -ne $null) {
-  exit $global:LASTEXITCODE
-}
-if (-not $?) {
-  exit 1
+$responseFile = $null
+try {
+  if ($dynamicRustcArgs.Count -gt 0) {
+    $responseFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName() + '.rsp')
+    $encoding = New-Object System.Text.UTF8Encoding -ArgumentList $false
+    [System.IO.File]::WriteAllLines($responseFile, $dynamicRustcArgs.ToArray(), $encoding)
+    [void]$rustcArgs.Add("@$responseFile")
+  }
+  $rest = @()
+  if ($rustcArgs.Count -gt 1) {
+    $rest = $rustcArgs.GetRange(1, $rustcArgs.Count - 1).ToArray()
+  }
+  & $program @rest
+  if ($global:LASTEXITCODE -ne $null) {
+    exit $global:LASTEXITCODE
+  }
+  if (-not $?) {
+    exit 1
+  }
+} finally {
+  if ($null -ne $responseFile -and [System.IO.File]::Exists($responseFile)) {
+    [System.IO.File]::Delete($responseFile)
+  }
 }
 """
     write_path(wrapper, script)

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -269,22 +269,34 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
 }
 
 fn which_candidate_names(name: &str) -> Vec<String> {
-    if !cfg!(windows) || Path::new(name).extension().is_some() {
+    let path_ext = std::env::var_os("PATHEXT").map(|value| value.to_string_lossy().into_owned());
+    which_candidate_names_for(name, cfg!(windows), path_ext.as_deref())
+}
+
+pub(super) fn which_candidate_names_for(
+    name: &str,
+    windows: bool,
+    path_ext: Option<&str>,
+) -> Vec<String> {
+    if !windows || Path::new(name).extension().is_some() {
         return vec![name.to_string()];
     }
-    let mut candidates = vec![name.to_string()];
-    let path_ext = std::env::var_os("PATHEXT")
-        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".into())
-        .to_string_lossy()
-        .into_owned();
-    for ext in path_ext.split(';') {
+
+    let mut candidates = Vec::new();
+    let mut seen = BTreeSet::new();
+    let path_ext = path_ext.unwrap_or(".COM;.EXE;.BAT;.CMD");
+    for ext in path_ext.split(';').map(str::trim) {
         if ext.is_empty() {
             continue;
         }
-        candidates.push(format!("{name}{ext}"));
-        candidates.push(format!("{name}{}", ext.to_ascii_lowercase()));
+        for candidate in [
+            format!("{name}{ext}"),
+            format!("{name}{}", ext.to_ascii_lowercase()),
+        ] {
+            if seen.insert(candidate.clone()) {
+                candidates.push(candidate);
+            }
+        }
     }
-    candidates.sort();
-    candidates.dedup();
     candidates
 }

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -268,7 +268,7 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
     None
 }
 
-fn which_candidate_names(name: &str) -> Vec<String> {
+pub(super) fn which_candidate_names(name: &str) -> Vec<String> {
     let path_ext = std::env::var_os("PATHEXT").map(|value| value.to_string_lossy().into_owned());
     which_candidate_names_for(name, cfg!(windows), path_ext.as_deref())
 }

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -1,4 +1,6 @@
 use super::globals::expand_globs;
+#[cfg(windows)]
+use super::store::which_candidate_names;
 use super::store::{which_candidate_names_for, HostCache};
 use super::*;
 use crate::graph::GraphTarget;
@@ -127,6 +129,33 @@ fn unix_host_which_candidates_keep_name_verbatim() {
         which_candidate_names_for("rustc", false, Some(".COM;.EXE;.CMD")),
         vec!["rustc".to_string()]
     );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_host_which_candidates_use_live_pathext() {
+    static PATHEXT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    let _guard = PATHEXT_LOCK.lock().unwrap();
+    let previous = std::env::var_os("PATHEXT");
+    std::env::set_var("PATHEXT", ".COM;.EXE;.CMD");
+
+    assert_eq!(
+        which_candidate_names("rustc"),
+        vec![
+            "rustc.COM".to_string(),
+            "rustc.com".to_string(),
+            "rustc.EXE".to_string(),
+            "rustc.exe".to_string(),
+            "rustc.CMD".to_string(),
+            "rustc.cmd".to_string(),
+        ]
+    );
+
+    match previous {
+        Some(value) => std::env::set_var("PATHEXT", value),
+        None => std::env::remove_var("PATHEXT"),
+    }
 }
 
 #[test]

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -134,28 +134,16 @@ fn unix_host_which_candidates_keep_name_verbatim() {
 #[cfg(windows)]
 #[test]
 fn windows_host_which_candidates_use_live_pathext() {
-    static PATHEXT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    let _guard = PATHEXT_LOCK.lock().unwrap();
-    let previous = std::env::var_os("PATHEXT");
-    std::env::set_var("PATHEXT", ".COM;.EXE;.CMD");
-
     assert_eq!(
         which_candidate_names("rustc"),
-        vec![
-            "rustc.COM".to_string(),
-            "rustc.com".to_string(),
-            "rustc.EXE".to_string(),
-            "rustc.exe".to_string(),
-            "rustc.CMD".to_string(),
-            "rustc.cmd".to_string(),
-        ]
+        which_candidate_names_for(
+            "rustc",
+            true,
+            std::env::var_os("PATHEXT")
+                .map(|value| value.to_string_lossy().into_owned())
+                .as_deref()
+        )
     );
-
-    match previous {
-        Some(value) => std::env::set_var("PATHEXT", value),
-        None => std::env::remove_var("PATHEXT"),
-    }
 }
 
 #[test]

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -1,5 +1,5 @@
 use super::globals::expand_globs;
-use super::store::HostCache;
+use super::store::{which_candidate_names_for, HostCache};
 use super::*;
 use crate::graph::GraphTarget;
 use crate::target::AttrValue;
@@ -96,6 +96,37 @@ fn host_file_contains_matches_binary_host_files() {
     let store = store_for(tmp.path(), "pkg");
     let (_, contains) = with_active_store(store, || eval_bool(&source).unwrap());
     assert!(contains);
+}
+
+#[test]
+fn windows_host_which_candidates_skip_extensionless_names() {
+    assert_eq!(
+        which_candidate_names_for("rustc", true, Some(".COM;.EXE;.CMD")),
+        vec![
+            "rustc.COM".to_string(),
+            "rustc.com".to_string(),
+            "rustc.EXE".to_string(),
+            "rustc.exe".to_string(),
+            "rustc.CMD".to_string(),
+            "rustc.cmd".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn windows_host_which_candidates_keep_explicit_extensions() {
+    assert_eq!(
+        which_candidate_names_for("rustc.exe", true, Some(".COM;.EXE;.CMD")),
+        vec!["rustc.exe".to_string()]
+    );
+}
+
+#[test]
+fn unix_host_which_candidates_keep_name_verbatim() {
+    assert_eq!(
+        which_candidate_names_for("rustc", false, Some(".COM;.EXE;.CMD")),
+        vec!["rustc".to_string()]
+    );
 }
 
 #[test]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1895,7 +1895,13 @@ result = repr([wrapped[0], wrapped[1]])
     );
     let script = String::from_utf8(bytes.clone()).unwrap();
     assert!(script.contains("[System.IO.File]::ReadLines('.once/out/pkg/build script.stdout')"));
-    assert!(script.contains("[void]$rustcArgs.Add('--cfg')"));
+    assert!(script.contains("[void]$dynamicRustcArgs.Add('--cfg')"));
+    assert!(script.contains("[void]$dynamicRustcArgs.Add('--check-cfg')"));
+    assert!(script.contains("New-Object System.Text.UTF8Encoding -ArgumentList $false"));
+    assert!(script.contains(
+        "[System.IO.File]::WriteAllLines($responseFile, $dynamicRustcArgs.ToArray(), $encoding)"
+    ));
+    assert!(script.contains("[void]$rustcArgs.Add(\"@$responseFile\")"));
     assert!(script.contains("& $program @rest"));
 }
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1786,31 +1786,117 @@ fn prelude_rustc_wrapper_passes_initial_argv_positionally() {
     let prelude = all_prelude_source();
     let source = format!(
         r#"{prelude}
+def host_os():
+    return "macos"
+
 def host_which(name):
     if name == "sh":
         return "/usr/bin/sh"
     fail("unexpected host_which call: " + name)
 
-args = _rustc_with_build_script_args(
+wrapped = _rustc_with_build_script_args(
+    {{"attr": {{}}}},
     ["rustc", "arg with spaces", "O'Reilly"],
     ".once/out/pkg/build script.stdout",
 )
-result = repr(args)
+result = repr([wrapped[0], wrapped[1]])
 "#
     );
 
     let out = eval_prelude_source_to_repr(source).unwrap();
-    let values: Vec<String> = serde_json::from_str(&out).unwrap();
+    let values: Vec<Vec<String>> = serde_json::from_str(&out).unwrap();
+    let argv = &values[0];
 
-    assert_eq!(values[0], "/usr/bin/sh");
-    assert_eq!(values[1], "-c");
-    assert_eq!(values[3], "once-rustc");
-    assert_eq!(&values[4..], ["rustc", "arg with spaces", "O'Reilly"]);
-    let script = &values[2];
+    assert_eq!(argv[0], "/usr/bin/sh");
+    assert_eq!(argv[1], "-c");
+    assert_eq!(argv[3], "once-rustc");
+    assert_eq!(&argv[4..], ["rustc", "arg with spaces", "O'Reilly"]);
+    assert!(values[1].is_empty());
+    let script = &argv[2];
     assert_eq!(script.lines().nth(1), Some("while IFS= read -r line; do"));
     assert!(script.contains("done < '.once/out/pkg/build script.stdout'"));
     assert!(script.contains("exec \"$@\""));
     assert!(!script.contains("O'Reilly"), "{script}");
+}
+
+#[test]
+fn prelude_windows_rustc_wrapper_generates_powershell_trampoline() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_os():
+    return "windows"
+
+def host_which(name):
+    if name == "powershell":
+        return "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+    fail("unexpected host_which call: " + name)
+
+ctx = {{
+    "label": {{
+        "id": "crates/app/app",
+    }},
+    "attr": {{}},
+}}
+wrapped = _rustc_with_build_script_args(
+    ctx,
+    ["rustc", "@.once/out/pkg/rustc-features.rsp", "arg with spaces"],
+    ".once/out/pkg/build script.stdout",
+)
+result = repr([wrapped[0], wrapped[1]])
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "crates/app/app");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+    let values: Vec<Vec<String>> = serde_json::from_str(&out.unwrap()).unwrap();
+    let argv = &values[0];
+    let inputs = &values[1];
+
+    assert_eq!(
+        argv[0],
+        "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+    );
+    assert_eq!(
+        &argv[1..6],
+        [
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File"
+        ]
+    );
+    assert_eq!(
+        argv[6],
+        ".once/out/crates/app/app/rustc-build-script-wrapper.ps1"
+    );
+    assert_eq!(
+        &argv[7..],
+        [
+            "rustc",
+            "@.once/out/pkg/rustc-features.rsp",
+            "arg with spaces"
+        ]
+    );
+    assert_eq!(
+        inputs,
+        &[".once/out/crates/app/app/rustc-build-script-wrapper.ps1".to_string()]
+    );
+    assert_eq!(store.actions.len(), 1);
+    let Some(DeclaredActionOperation::WriteFile { path, bytes }) = &store.actions[0].operation
+    else {
+        panic!("wrapper should be written before rustc action");
+    };
+    assert_eq!(
+        path,
+        ".once/out/crates/app/app/rustc-build-script-wrapper.ps1"
+    );
+    let script = String::from_utf8(bytes.clone()).unwrap();
+    assert!(script.contains("[System.IO.File]::ReadLines('.once/out/pkg/build script.stdout')"));
+    assert!(script.contains("[void]$rustcArgs.Add('--cfg')"));
+    assert!(script.contains("& $program @rest"));
 }
 
 #[test]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1378,14 +1378,20 @@ result = repr("ok")
     assert_eq!(arg_file.format, DeclaredArgFileFormat::RustcResponse);
     assert!(arg_file
         .args
-        .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"default\""));
-    assert!(!arg_file.args.iter().any(|arg| arg == "feature=default"));
+        .iter()
+        .any(|arg| arg == "--cfg=feature=\"default\""));
     assert!(!arg_file
         .args
         .iter()
-        .any(|arg| arg == "feature=\\\"default\\\""));
-    assert!(!arg_file.args.iter().any(|arg| arg == "feature=r#default#"));
+        .any(|arg| arg == "--cfg=feature=default"));
+    assert!(!arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "--cfg=feature=\\\"default\\\""));
+    assert!(!arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "--cfg=feature=r#default#"));
 }
 
 #[test]
@@ -1867,19 +1873,31 @@ result = repr("ok")
     let arg_file = &rustc.arg_files[0];
     assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc-features.rsp");
     assert_eq!(arg_file.format, DeclaredArgFileFormat::RustcResponse);
-    assert!(arg_file.args.len() > 800);
-    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"default\""));
-    assert!(arg_file.args.iter().any(|arg| arg == "feature=\"std\""));
+    assert!(arg_file.args.len() > 400);
     assert!(arg_file
         .args
         .iter()
-        .any(|arg| arg == "feature=\"feature_399\""));
-    assert!(!arg_file.args.iter().any(|arg| arg == "feature=default"));
+        .any(|arg| arg == "--cfg=feature=\"default\""));
+    assert!(arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "--cfg=feature=\"std\""));
+    assert!(arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "--cfg=feature=\"feature_399\""));
     assert!(!arg_file
         .args
         .iter()
-        .any(|arg| arg == "feature=\\\"default\\\""));
-    assert!(!arg_file.args.iter().any(|arg| arg == "feature=r#default#"));
+        .any(|arg| arg == "--cfg=feature=default"));
+    assert!(!arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "--cfg=feature=\\\"default\\\""));
+    assert!(!arg_file
+        .args
+        .iter()
+        .any(|arg| arg == "--cfg=feature=r#default#"));
     assert!(
         !rustc.argv.iter().any(|arg| arg.contains("feature=\"")),
         "{:?}",
@@ -1936,12 +1954,9 @@ result = repr("ok")
     assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));
     assert!(rustc
         .argv
-        .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"default\""));
-    assert!(rustc
-        .argv
-        .windows(2)
-        .any(|pair| pair[0] == "--cfg" && pair[1] == "feature=\"std\""));
+        .iter()
+        .any(|arg| arg == "--cfg=feature=\"default\""));
+    assert!(rustc.argv.iter().any(|arg| arg == "--cfg=feature=\"std\""));
     assert!(
         !rustc.argv.iter().any(|arg| arg.starts_with('@')),
         "{:?}",
@@ -2007,8 +2022,8 @@ result = repr("ok")
     assert!(
         !rustc
             .argv
-            .windows(2)
-            .any(|pair| pair[0] == "--cfg" && pair[1].starts_with("feature=")),
+            .iter()
+            .any(|arg| arg.starts_with("--cfg=feature=")),
         "{:?}",
         rustc.argv
     );

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1294,7 +1294,7 @@ result = repr([
 }
 
 #[test]
-fn prelude_cargo_metadata_windows_features_escape_response_file_cfgs() {
+fn prelude_cargo_metadata_windows_features_keep_response_file_cfgs_literal() {
     let prelude = all_prelude_source();
     let source = format!(
         r#"{prelude}

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -198,8 +198,7 @@ The Rust executor exposes generic primitives only:
   `format` and `arg_format`. The supported `format` values are
   `line-delimited`, which writes one argument per line without shell
   escaping, and `rustc-response`, which writes one `rustc` argument per
-  line and applies the host-specific quote escaping expected by
-  `rustc @path` files. `arg_format` defaults to `@{}` and must contain
+  line verbatim. `arg_format` defaults to `@{}` and must contain
   exactly one `{}` placeholder.
 - `run_action(...)` records a command action for the executor.
 - `write_path(path, content)` materializes generated text or byte-list

--- a/docs/reference/prelude/rust_binary.md
+++ b/docs/reference/prelude/rust_binary.md
@@ -16,7 +16,7 @@ identity.
 | `crate_name` | string | no | target name | Rust crate name passed to `rustc`; `-` and `.` are rewritten as `_` when omitted |
 | `crate_root` | string | no | `src/main.rs` | Package-relative binary root |
 | `edition` | string | no | `2021` | Rust edition passed to `rustc` |
-| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg feature=...` flags |
+| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg=feature=...` flags |
 | `crate_features` | list&lt;string&gt; | no | `[]` | Bazel-compatible alias for `features` |
 | `target` | string | no | host target | Rust target triple passed to `rustc --target` |
 | `env` | map&lt;string, string&gt; | no | `{}` | Environment variables for rustc, matching Buck2's `env` attribute |

--- a/docs/reference/prelude/rust_crate.md
+++ b/docs/reference/prelude/rust_crate.md
@@ -18,7 +18,7 @@ Once graph target. `rust_crate` compiles to an rlib and emits the same
 | `crate_name` | string | no | target name | Rust crate name passed to `rustc`; `-` and `.` are rewritten as `_` when omitted |
 | `crate_root` | string | no | `src/lib.rs` | Package-relative library root |
 | `edition` | string | no | `2021` | Rust edition passed to `rustc` |
-| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg feature=...` flags |
+| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg=feature=...` flags |
 | `crate_features` | list&lt;string&gt; | no | `[]` | Bazel-compatible alias for `features` |
 | `target` | string | no | host target | Rust target triple passed to `rustc --target` |
 | `env` | map&lt;string, string&gt; | no | `{}` | Environment variables for rustc, matching Buck2's `env` attribute |

--- a/docs/reference/prelude/rust_library.md
+++ b/docs/reference/prelude/rust_library.md
@@ -18,7 +18,7 @@ Android dynamic libraries expose APK native-library provider fields.
 | `crate_name` | string | no | target name | Rust crate name passed to `rustc`; `-` and `.` are rewritten as `_` when omitted |
 | `crate_root` | string | no | `src/lib.rs` | Package-relative library root |
 | `edition` | string | no | `2021` | Rust edition passed to `rustc` |
-| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg feature=...` flags |
+| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg=feature=...` flags |
 | `crate_features` | list&lt;string&gt; | no | `[]` | Bazel-compatible alias for `features` |
 | `target` | string | no | host target | Rust target triple passed to `rustc --target` |
 | `env` | map&lt;string, string&gt; | no | `{}` | Environment variables for rustc, matching Buck2's `env` attribute |

--- a/docs/reference/prelude/rust_proc_macro.md
+++ b/docs/reference/prelude/rust_proc_macro.md
@@ -15,7 +15,7 @@ Buck2 models proc macro deps separately from normal target deps.
 | `crate_name` | string | no | target name | Rust crate name passed to `rustc`; `-` and `.` are rewritten as `_` when omitted |
 | `crate_root` | string | no | `src/lib.rs` | Package-relative macro root |
 | `edition` | string | no | `2021` | Rust edition passed to `rustc` |
-| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg feature=...` flags |
+| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg=feature=...` flags |
 | `crate_features` | list&lt;string&gt; | no | `[]` | Bazel-compatible alias for `features` |
 | `target` | string | no | host target | Rust target triple passed to `rustc --target` |
 | `env` | map&lt;string, string&gt; | no | `{}` | Environment variables for rustc, matching Buck2's `env` attribute |


### PR DESCRIPTION
## What changed

`rustc-response` argument files now write each argument exactly as the graph action declared it. The Windows-specific escaping layer was removed because normal `rustc @path` response files should be owned by the compiler-facing materializer, not by shell quoting rules.

Rust feature flags now lower from `features = ["default"]` to compiler arguments such as `--cfg=feature="default"`, with Windows placing those arguments in a generated response file.

Windows host tool lookup now skips extensionless `PATHEXT` lookups when the caller asks for a bare tool name such as `rustc` or `cargo`. This prevents the graph analyzer from returning mise shell shims that Windows cannot spawn directly through `Command`.

Build-script crates no longer invoke native Windows `rustc` through the Unix shell wrapper. On Windows, the Rust prelude now generates a small PowerShell wrapper action that reads build-script stdout, appends `cargo:rustc-*` directives to an argument array, and invokes `rustc` directly.

`once-frontend` now declares the embedded `prelude/` tree as a Cargo rebuild input. The walk is sorted, follows directory symlinks only inside the canonical prelude root, and tracks visited directories so traversal is deterministic and bounded.

The pull request workflow includes a Windows release graph build check. It vendors the Rust dependency graph, writes the release graph manifests, and builds the `x86_64-pc-windows-msvc` Once binary through Once without packaging or publishing release assets.

## Why

The `Release` workflow on `main` is failing for the Windows package jobs while compiling Rust dependencies through Once's graph actions. The failing command reaches `rustc` with incorrectly encoded feature configuration values.

The new pull request validation also exposed two adjacent Windows graph issues: `host_which("rustc")` could resolve to an extensionless mise shim, and crates with build scripts routed native Windows `rustc` through a Unix shell wrapper.

A later validation run showed that source bootstrapping could still reuse cached `once-frontend` output after Starlark prelude changes, so the Windows job could run a stale embedded prelude even when the branch contained the corrected feature lowering.

## Root cause

The original response-file materializer treated `rustc` response files like shell-escaped command lines on Windows. That wrote backslash-escaped quotes, so `rustc` received backslash tokens and rejected the configuration argument.

After removing that escaping, the Windows release graph check showed the generated response files were correct, for example `--cfg=feature="default"`. The remaining failure only appeared on crates with build scripts. Those actions wrapped `rustc` through `sh` so Once could append `cargo:rustc-*` lines from build-script stdout, and that Windows shell path changed how the native compiler consumed the response file.

The host lookup helper also included the extensionless tool name before checking `PATHEXT` candidates on Windows. That let shell-specific shims shadow executable candidates such as `rustc.exe`.

Finally, `once-frontend` embeds the Starlark prelude at compile time, but Cargo did not know that `prelude/` was an input to the package build. With restored Rust cache outputs, a source bootstrap could reuse a stale `once-frontend` artifact after only prelude files changed.

## Approach

Move response-file responsibility to the Rust materializer: `cmd_args(format = "rustc-response")` validates that arguments are one line each, then writes them verbatim.

Move feature-flag responsibility into the Rust prelude: rule authors keep passing `features = ["default"]`, and Once lowers that to compiler-ready `--cfg=feature="default"` arguments before deciding whether to place them inline or in a response file.

Keep build-script stdout handling in the Rust target kind, but avoid the Unix shell when the host is Windows. The generated PowerShell wrapper receives the original argument vector positionally, reads the build-script stdout file, appends compiler directives as array elements, and launches `rustc` without routing the response file through Git Bash.

Make host lookup return spawnable Windows tools by honoring `PATHEXT` candidates for bare tool names and skipping the extensionless path. Target kinds can keep asking for `host_which("rustc")` and get a command the graph can execute directly.

Make the embedded prelude a declared Cargo rebuild input through a small build script. This keeps future prelude-only changes from relying on incidental Rust source changes to invalidate cached bootstrap binaries.

Add a Windows release graph build to pull request validation so this failure mode is caught before merge without invoking the release packaging task.

## Impact

Windows release packaging should pass feature configuration values to `rustc` without stripping quotes or adding backslashes.

Windows graph analysis should no longer fail when mise shims appear before Rustup executables on `PATH`. Non-Windows host lookup is unchanged.

Crates with build scripts now avoid the Git Bash wrapper path when invoking native Windows `rustc`.

Prelude-only changes will now rebuild `once-frontend` reliably when Cargo restores cached outputs.

The pull request workflow gets one additional Windows job when Rust files change. The job builds like release but does not package, upload, publish, or pass a GitHub token to the build command.

## Validation

- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo test -p once-frontend windows_host_which_candidates`
- `mise exec -- cargo test -p once-cli rustc_response_args_keep_arguments_verbatim`
- `mise exec -- cargo test -p once-cli materialize_declared_arg_files_writes_rustc_response_args`
- `mise exec -- cargo test -p once-cli`
- `mise exec -- cargo test -p once-frontend`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- `mise exec -- cargo clippy -p once-cli -p once-frontend --all-targets -- -D warnings`
- `mise exec -- cargo clippy -p once-frontend --all-targets -- -D warnings`
- `mise exec -- cargo build --locked --release --package once-cli`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/once.yml"); puts "yaml ok"'`
