### PR TITLE
refactor(apple): resolve toolchain paths without xcrun

### DIFF
--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -82,22 +82,85 @@ def _apple_triple(platform, minimum_os, sdk_variant, arch, mac_catalyst):
     suffix = _apple_triple_suffix(platform, sdk_variant)
     return arch + "-apple-" + triple_os + minimum_os + suffix
 
-def _xcrun_env(xcode_developer_dir):
+def _developer_env(xcode_developer_dir):
     env = {}
     if xcode_developer_dir:
         env["DEVELOPER_DIR"] = xcode_developer_dir
     return env
 
-def _xcrun_swiftc(platform, sdk_variant, xcode_developer_dir):
-    xcrun = host_which("xcrun")
+# When a target sets `xcode_developer_dir`, the build resolves tools and
+# SDK paths directly from the layout under that directory rather than
+# shelling out to `xcrun`. The xcrun fallback still applies when no
+# developer dir is configured.
+_XCTOOLCHAIN_BIN_REL = "Toolchains/XcodeDefault.xctoolchain/usr/bin"
+
+_SDK_PATH_REL = {
+    "macosx": "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+    "iphoneos": "Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk",
+    "iphonesimulator": "Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+    "appletvos": "Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk",
+    "appletvsimulator": "Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk",
+    "watchos": "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk",
+    "watchsimulator": "Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk",
+    "xros": "Platforms/XROS.platform/Developer/SDKs/XROS.sdk",
+    "xrsimulator": "Platforms/XRSimulator.platform/Developer/SDKs/XRSimulator.sdk",
+}
+
+_PLATFORM_PATH_REL = {
+    "macosx": "Platforms/MacOSX.platform",
+    "iphoneos": "Platforms/iPhoneOS.platform",
+    "iphonesimulator": "Platforms/iPhoneSimulator.platform",
+    "appletvos": "Platforms/AppleTVOS.platform",
+    "appletvsimulator": "Platforms/AppleTVSimulator.platform",
+    "watchos": "Platforms/WatchOS.platform",
+    "watchsimulator": "Platforms/WatchSimulator.platform",
+    "xros": "Platforms/XROS.platform",
+    "xrsimulator": "Platforms/XRSimulator.platform",
+}
+
+def _developer_sdk_path(xcode_developer_dir, sdk_name):
+    rel = _SDK_PATH_REL.get(sdk_name)
+    if not rel:
+        fail("no SDK layout entry for `" + sdk_name + "`; add it to _SDK_PATH_REL")
+    return xcode_developer_dir + "/" + rel
+
+def _developer_platform_path(xcode_developer_dir, sdk_name):
+    rel = _PLATFORM_PATH_REL.get(sdk_name)
+    if not rel:
+        fail("no platform layout entry for `" + sdk_name + "`; add it to _PLATFORM_PATH_REL")
+    return xcode_developer_dir + "/" + rel
+
+def _xctoolchain_bin(xcode_developer_dir, name):
+    return xcode_developer_dir + "/" + _XCTOOLCHAIN_BIN_REL + "/" + name
+
+# Resolves a build tool and the active SDK path to absolute file paths.
+# Returns a dict so the action helper can invoke the tool directly
+# (`[tool_path, ...flags]`) instead of going through `xcrun --sdk X
+# <tool>`. Direct mode skips `xcrun` entirely; the fallback still uses
+# `xcrun --find` / `--show-sdk-path` for discovery but the cached
+# action argv contains only the resolved tool path.
+def _resolve_swiftc(platform, sdk_variant, xcode_developer_dir):
     sdk = _apple_sdk_name(platform, sdk_variant)
-    env = _xcrun_env(xcode_developer_dir)
-    swiftc_path = host_command([xcrun, "--sdk", sdk, "--find", "swiftc"], env = env).strip()
-    version = host_command([xcrun, "--sdk", sdk, "swiftc", "--version"], env = env).strip()
-    # Identity also folds in the developer dir override so different
-    # Xcode installations partition the action cache cleanly.
+    env = _developer_env(xcode_developer_dir)
+    if xcode_developer_dir:
+        swiftc_path = _xctoolchain_bin(xcode_developer_dir, "swiftc")
+        sdk_path = _developer_sdk_path(xcode_developer_dir, sdk)
+    else:
+        xcrun = host_which("xcrun")
+        swiftc_path = host_command([xcrun, "--sdk", sdk, "--find", "swiftc"], env = env).strip()
+        sdk_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-path"], env = env).strip()
+    version = host_command([swiftc_path, "--version"], env = env).strip()
+    # Identity folds in the developer dir override so different Xcode
+    # installations partition the action cache cleanly.
     identity = "once.apple.swiftc.v1\x00" + swiftc_path + "\x00" + version + "\x00" + (xcode_developer_dir or "")
-    return (xcrun, sdk, identity, env)
+    return {
+        "argv": [swiftc_path, "-sdk", sdk_path],
+        "swiftc_path": swiftc_path,
+        "sdk_name": sdk,
+        "sdk_path": sdk_path,
+        "identity": identity,
+        "env": env,
+    }
 
 def _filter_swift_sources(paths):
     return _filter_by_extensions(paths, [".swift"])
@@ -111,53 +174,82 @@ def _filter_c_sources(paths):
 def _filter_cxx_sources(paths):
     return _filter_by_extensions(paths, [".cc", ".cpp", ".cxx"])
 
-def _xcrun_clang(platform, sdk_variant, xcode_developer_dir):
-    xcrun = host_which("xcrun")
+def _resolve_clang(platform, sdk_variant, xcode_developer_dir):
     sdk = _apple_sdk_name(platform, sdk_variant)
-    env = _xcrun_env(xcode_developer_dir)
-    clang_path = host_command([xcrun, "--sdk", sdk, "--find", "clang"], env = env).strip()
-    sdk_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-path"], env = env).strip()
-    version = host_command([xcrun, "--sdk", sdk, "clang", "--version"], env = env).strip()
+    env = _developer_env(xcode_developer_dir)
+    if xcode_developer_dir:
+        clang_path = _xctoolchain_bin(xcode_developer_dir, "clang")
+        clangxx_path = _xctoolchain_bin(xcode_developer_dir, "clang++")
+        sdk_path = _developer_sdk_path(xcode_developer_dir, sdk)
+    else:
+        xcrun = host_which("xcrun")
+        clang_path = host_command([xcrun, "--sdk", sdk, "--find", "clang"], env = env).strip()
+        clangxx_path = host_command([xcrun, "--sdk", sdk, "--find", "clang++"], env = env).strip()
+        sdk_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-path"], env = env).strip()
+    version = host_command([clang_path, "--version"], env = env).strip()
     identity = "once.apple.clang.v1\x00" + clang_path + "\x00" + version + "\x00" + (xcode_developer_dir or "")
-    return (xcrun, sdk, sdk_path, identity, env)
+    return {
+        "clang_path": clang_path,
+        "clangxx_path": clangxx_path,
+        "sdk_name": sdk,
+        "sdk_path": sdk_path,
+        "identity": identity,
+        "env": env,
+    }
 
-def _xcrun_libtool(platform, sdk_variant, xcode_developer_dir):
-    xcrun = host_which("xcrun")
+def _resolve_libtool(platform, sdk_variant, xcode_developer_dir):
     sdk = _apple_sdk_name(platform, sdk_variant)
-    env = _xcrun_env(xcode_developer_dir)
-    libtool_path = host_command([xcrun, "--sdk", sdk, "--find", "libtool"], env = env).strip()
+    env = _developer_env(xcode_developer_dir)
+    if xcode_developer_dir:
+        libtool_path = _xctoolchain_bin(xcode_developer_dir, "libtool")
+    else:
+        xcrun = host_which("xcrun")
+        libtool_path = host_command([xcrun, "--sdk", sdk, "--find", "libtool"], env = env).strip()
     identity = "once.apple.libtool.v1\x00" + libtool_path + "\x00" + (xcode_developer_dir or "")
-    return (xcrun, sdk, identity, env)
+    return {
+        "argv": [libtool_path],
+        "libtool_path": libtool_path,
+        "identity": identity,
+        "env": env,
+    }
 
-def _xcrun_lipo(platform, sdk_variant, xcode_developer_dir):
-    xcrun = host_which("xcrun")
+def _resolve_lipo(platform, sdk_variant, xcode_developer_dir):
     sdk = _apple_sdk_name(platform, sdk_variant)
-    env = _xcrun_env(xcode_developer_dir)
-    lipo_path = host_command([xcrun, "--sdk", sdk, "--find", "lipo"], env = env).strip()
+    env = _developer_env(xcode_developer_dir)
+    if xcode_developer_dir:
+        lipo_path = _xctoolchain_bin(xcode_developer_dir, "lipo")
+    else:
+        xcrun = host_which("xcrun")
+        lipo_path = host_command([xcrun, "--sdk", sdk, "--find", "lipo"], env = env).strip()
     identity = "once.apple.lipo.v1\x00" + lipo_path + "\x00" + (xcode_developer_dir or "")
-    return (xcrun, sdk, identity, env)
+    return {
+        "argv": [lipo_path],
+        "lipo_path": lipo_path,
+        "identity": identity,
+        "env": env,
+    }
 
-def _xcrun_codesign(xcode_developer_dir):
-    xcrun = host_which("xcrun")
-    env = _xcrun_env(xcode_developer_dir)
-    codesign_path = host_command([xcrun, "--find", "codesign"], env = env).strip()
+def _resolve_codesign(xcode_developer_dir):
+    env = _developer_env(xcode_developer_dir)
+    if xcode_developer_dir:
+        # codesign isn't under DEVELOPER_DIR; it's a system tool.
+        codesign_path = "/usr/bin/codesign"
+    else:
+        xcrun = host_which("xcrun")
+        codesign_path = host_command([xcrun, "--find", "codesign"], env = env).strip()
     identity = "once.apple.codesign.v1\x00" + codesign_path + "\x00" + (xcode_developer_dir or "")
-    return (xcrun, codesign_path, identity, env)
+    return {
+        "codesign_path": codesign_path,
+        "identity": identity,
+        "env": env,
+    }
 
-def _swift_testing_macros_plugin(xcrun, xcrun_env):
-    swiftc_path = host_command([xcrun, "--find", "swiftc"], env = xcrun_env).strip()
+def _swift_testing_macros_plugin(swiftc_path):
     suffix = "/usr/bin/swiftc"
     if not _ends_with(swiftc_path, suffix):
         fail("unable to derive Swift toolchain path from swiftc at " + swiftc_path)
     toolchain_dir = swiftc_path[:len(swiftc_path) - len(suffix)]
     return toolchain_dir + "/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib"
-
-def _xcrun_actool(xcode_developer_dir):
-    xcrun = host_which("xcrun")
-    env = _xcrun_env(xcode_developer_dir)
-    actool_path = host_command([xcrun, "--find", "actool"], env = env).strip()
-    identity = "once.apple.actool.v1\x00" + actool_path + "\x00" + (xcode_developer_dir or "")
-    return (xcrun, actool_path, identity, env)
 
 def _unique_dirs(paths):
     seen = {}
@@ -769,7 +861,7 @@ def _apple_library_impl(ctx):
         fail("apple_library " + ctx["label"]["id"] + " sets mac_catalyst = true but platform = `" + platform + "`; mac_catalyst requires platform = macos")
     is_universal = len(archs) > 1
 
-    xcrun, sdk, swiftc_identity, xcrun_env = _xcrun_swiftc(platform, sdk_variant, xcode_developer_dir)
+    swiftc = _resolve_swiftc(platform, sdk_variant, xcode_developer_dir)
     archive = declare_output(module_name + ".a")
 
     deps = ctx["deps"]
@@ -931,11 +1023,7 @@ def _apple_library_impl(ctx):
         swift_archive = per_arch_archive if swift_only else (declare_output(module_name + "-swift" + arch_suffix + ".a") if len(swift_srcs) > 0 else "")
 
         if len(swift_srcs) > 0:
-            swift_base_argv = [
-                xcrun,
-                "--sdk",
-                sdk,
-                "swiftc",
+            swift_base_argv = list(swiftc["argv"]) + [
                 "-module-name",
                 module_name,
                 "-target",
@@ -1013,8 +1101,8 @@ def _apple_library_impl(ctx):
                 argv = swift_module_argv,
                 inputs = swift_inputs,
                 outputs = [swiftmodule, swiftdoc, swift_objc_header],
-                env = xcrun_env,
-                toolchain_identity = swiftc_identity,
+                env = swiftc["env"],
+                toolchain_identity = swiftc["identity"],
                 identifier = "swift_module_compile_" + module_name + arch_suffix,
             )
 
@@ -1027,14 +1115,14 @@ def _apple_library_impl(ctx):
                 argv = swift_archive_argv,
                 inputs = swift_inputs,
                 outputs = [swift_archive],
-                env = xcrun_env,
-                toolchain_identity = swiftc_identity,
+                env = swiftc["env"],
+                toolchain_identity = swiftc["identity"],
                 identifier = "swift_archive_compile_" + module_name + arch_suffix,
             )
 
         arch_clang_objects = []
         if len(objc_srcs) > 0 or len(c_srcs) > 0 or len(cxx_srcs) > 0:
-            clang_xcrun, clang_sdk, sdk_path, clang_identity, clang_env = _xcrun_clang(platform, sdk_variant, xcode_developer_dir)
+            clang = _resolve_clang(platform, sdk_variant, xcode_developer_dir)
 
             def compile_with_clang(src, language):
                 # Sanitise the source path into a stable .o filename
@@ -1044,17 +1132,14 @@ def _apple_library_impl(ctx):
                 sanitised = src.replace("/", "_")
                 obj = declare_output(sanitised + arch_suffix + ".o")
                 argv = [
-                    clang_xcrun,
-                    "--sdk",
-                    clang_sdk,
-                    "clang" if language != "c++" else "clang++",
+                    clang["clang_path"] if language != "c++" else clang["clangxx_path"],
                     "-c",
                     "-x",
                     language,
                     "-arch",
                     arch,
                     "-isysroot",
-                    sdk_path,
+                    clang["sdk_path"],
                     "-target",
                     triple,
                     "-o",
@@ -1091,8 +1176,8 @@ def _apple_library_impl(ctx):
                     argv = argv,
                     inputs = inputs,
                     outputs = [obj],
-                    env = clang_env,
-                    toolchain_identity = clang_identity,
+                    env = clang["env"],
+                    toolchain_identity = clang["identity"],
                     identifier = "clang_compile_" + module_name + arch_suffix + "_" + sanitised,
                 )
                 arch_clang_objects.append(obj)
@@ -1108,12 +1193,8 @@ def _apple_library_impl(ctx):
         # is at least one non-Swift input alongside Swift; Swift-only
         # and C-only libraries already wrote into per_arch_archive.
         if not swift_only and len(swift_srcs) > 0:
-            libtool_xcrun, libtool_sdk, libtool_identity, libtool_env = _xcrun_libtool(platform, sdk_variant, xcode_developer_dir)
-            libtool_argv = [
-                libtool_xcrun,
-                "--sdk",
-                libtool_sdk,
-                "libtool",
+            libtool = _resolve_libtool(platform, sdk_variant, xcode_developer_dir)
+            libtool_argv = list(libtool["argv"]) + [
                 "-static",
                 "-o",
                 per_arch_archive,
@@ -1126,20 +1207,20 @@ def _apple_library_impl(ctx):
                 argv = libtool_argv,
                 inputs = libtool_inputs,
                 outputs = [per_arch_archive],
-                env = libtool_env,
-                toolchain_identity = libtool_identity,
+                env = libtool["env"],
+                toolchain_identity = libtool["identity"],
                 identifier = "libtool_merge_" + module_name + arch_suffix,
             )
         elif len(swift_srcs) == 0 and len(arch_clang_objects) > 0:
-            libtool_xcrun, libtool_sdk, libtool_identity, libtool_env = _xcrun_libtool(platform, sdk_variant, xcode_developer_dir)
-            libtool_argv = [libtool_xcrun, "--sdk", libtool_sdk, "libtool", "-static", "-o", per_arch_archive]
+            libtool = _resolve_libtool(platform, sdk_variant, xcode_developer_dir)
+            libtool_argv = list(libtool["argv"]) + ["-static", "-o", per_arch_archive]
             libtool_argv.extend(arch_clang_objects)
             run_action(
                 argv = libtool_argv,
                 inputs = list(arch_clang_objects),
                 outputs = [per_arch_archive],
-                env = libtool_env,
-                toolchain_identity = libtool_identity,
+                env = libtool["env"],
+                toolchain_identity = libtool["identity"],
                 identifier = "libtool_archive_" + module_name + arch_suffix,
             )
 
@@ -1153,15 +1234,15 @@ def _apple_library_impl(ctx):
     # final fat archive. Single-arch builds skip this entirely; the
     # one per-arch archive already wrote into `archive` directly.
     if is_universal:
-        lipo_xcrun, lipo_sdk, lipo_identity, lipo_env = _xcrun_lipo(platform, sdk_variant, xcode_developer_dir)
-        lipo_argv = [lipo_xcrun, "--sdk", lipo_sdk, "lipo", "-create", "-output", archive]
+        lipo = _resolve_lipo(platform, sdk_variant, xcode_developer_dir)
+        lipo_argv = list(lipo["argv"]) + ["-create", "-output", archive]
         lipo_argv.extend(per_arch_archives)
         run_action(
             argv = lipo_argv,
             inputs = list(per_arch_archives),
             outputs = [archive],
-            env = lipo_env,
-            toolchain_identity = lipo_identity,
+            env = lipo["env"],
+            toolchain_identity = lipo["identity"],
             identifier = "lipo_" + module_name,
         )
 
@@ -1206,7 +1287,7 @@ def _swift_macro_impl(ctx):
     # Swift macros are host-loaded compiler plugins. They always build
     # for macOS in the simulator-equivalent SDK; macOS ignores the
     # variant anyway.
-    xcrun, sdk, swiftc_identity, xcrun_env = _xcrun_swiftc("macos", "simulator", xcode_developer_dir)
+    swiftc = _resolve_swiftc("macos", "simulator", xcode_developer_dir)
     triple = _apple_triple("macos", minimum_os, "simulator", host_arch(), False)
 
     plugin_dylib = declare_output("lib" + module_name + ".dylib")
@@ -1239,11 +1320,7 @@ def _swift_macro_impl(ctx):
             if opt and opt not in dep_linkopts:
                 dep_linkopts.append(opt)
 
-    swift_argv = [
-        xcrun,
-        "--sdk",
-        sdk,
-        "swiftc",
+    swift_argv = list(swiftc["argv"]) + [
         "-emit-library",
         "-emit-module",
         "-module-name",
@@ -1280,8 +1357,8 @@ def _swift_macro_impl(ctx):
         argv = swift_argv,
         inputs = swift_inputs,
         outputs = [plugin_dylib, plugin_swiftmodule],
-        env = xcrun_env,
-        toolchain_identity = swiftc_identity,
+        env = swiftc["env"],
+        toolchain_identity = swiftc["identity"],
         identifier = "swift_macro_compile_" + module_name,
     )
 
@@ -1426,7 +1503,7 @@ def _apple_framework_impl(ctx):
     # lands in a follow-up; today the same machinery as `apple_library`
     # can be wired in but the demo path doesn't need it.
     arch = host_arch()
-    xcrun, sdk, swiftc_identity, xcrun_env = _xcrun_swiftc(platform, sdk_variant, xcode_developer_dir)
+    swiftc = _resolve_swiftc(platform, sdk_variant, xcode_developer_dir)
     triple = _apple_triple(platform, target_sdk_version, sdk_variant, arch, False)
 
     framework_dir = product_name + ".framework"
@@ -1453,11 +1530,7 @@ def _apple_framework_impl(ctx):
         plugin_dylibs,
     ) = _collect_dep_compile_inputs(deps, ctx["build_dir"])
 
-    swift_argv = [
-        xcrun,
-        "--sdk",
-        sdk,
-        "swiftc",
+    swift_argv = list(swiftc["argv"]) + [
         "-emit-library",
         "-emit-module",
         "-module-name",
@@ -1527,8 +1600,8 @@ def _apple_framework_impl(ctx):
         argv = swift_argv,
         inputs = swift_inputs,
         outputs = [dylib, swiftmodule, swiftdoc],
-        env = xcrun_env,
-        toolchain_identity = swiftc_identity,
+        env = swiftc["env"],
+        toolchain_identity = swiftc["identity"],
         identifier = "apple_framework_compile_" + module_name,
     )
 
@@ -1553,14 +1626,14 @@ def _apple_framework_impl(ctx):
 
     # Ad-hoc codesign so iOS simulator's dyld accepts the dylib when
     # the embedding app loads it.
-    cs_xcrun, codesign_path, cs_identity, cs_env = _xcrun_codesign(xcode_developer_dir)
+    codesign = _resolve_codesign(xcode_developer_dir)
     cs_stamp = declare_output(framework_dir + "/_CodeSignature/CodeResources")
     run_action(
-        argv = [codesign_path, "--force", "--sign", "-", "--timestamp=none", ctx["build_dir"] + "/" + framework_dir],
+        argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", ctx["build_dir"] + "/" + framework_dir],
         inputs = [dylib, info_plist, modulemap, swiftmodule],
         outputs = [cs_stamp],
-        env = cs_env,
-        toolchain_identity = cs_identity,
+        env = codesign["env"],
+        toolchain_identity = codesign["identity"],
         identifier = "apple_framework_codesign_" + module_name,
     )
 
@@ -1666,7 +1739,7 @@ def _apple_application_impl(ctx):
         fail("apple_application " + ctx["label"]["id"] + " has no Swift sources (.swift)")
 
     arch = host_arch()
-    xcrun, sdk, swiftc_identity, xcrun_env = _xcrun_swiftc(platform, sdk_variant, xcode_developer_dir)
+    swiftc = _resolve_swiftc(platform, sdk_variant, xcode_developer_dir)
     triple = _apple_triple(platform, target_sdk_version, sdk_variant, arch, False)
 
     app_dir = product_name + ".app"
@@ -1675,12 +1748,15 @@ def _apple_application_impl(ctx):
         run_dir = ctx["build_dir"] + "/run"
         run_record = run_dir + "/run.json"
         run_log = run_dir + "/run.log"
+        # simctl-based runners need `xcrun` on PATH at execution time;
+        # resolve it here so the build path stays xcrun-free.
+        runner_xcrun = host_which("xcrun") if platform == "ios" and sdk_variant == "simulator" else ""
         run_action(
-            argv = ["/bin/sh", "-c", _apple_application_run_script(ctx["label"]["id"], platform, sdk_variant, xcrun, app_path, bundle_id, run_dir, run_record, run_log)],
+            argv = ["/bin/sh", "-c", _apple_application_run_script(ctx["label"]["id"], platform, sdk_variant, runner_xcrun, app_path, bundle_id, run_dir, run_record, run_log)],
             outputs = [run_dir, run_record, run_log],
-            env = xcrun_env,
+            env = swiftc["env"],
             cacheable = False,
-            toolchain_identity = "once.apple.application.run.v1\x00" + swiftc_identity,
+            toolchain_identity = "once.apple.application.run.v1\x00" + swiftc["identity"],
             identifier = "apple_application_run_" + product_name,
         )
         return {
@@ -1709,11 +1785,7 @@ def _apple_application_impl(ctx):
         plugin_dylibs,
     ) = _collect_dep_compile_inputs(deps, ctx["build_dir"])
 
-    swift_argv = [
-        xcrun,
-        "--sdk",
-        sdk,
-        "swiftc",
+    swift_argv = list(swiftc["argv"]) + [
         "-module-name",
         product_name,
         "-target",
@@ -1779,8 +1851,8 @@ def _apple_application_impl(ctx):
         argv = swift_argv,
         inputs = swift_inputs,
         outputs = [executable],
-        env = xcrun_env,
-        toolchain_identity = swiftc_identity,
+        env = swiftc["env"],
+        toolchain_identity = swiftc["identity"],
         identifier = "apple_application_compile_" + product_name,
     )
 
@@ -1794,7 +1866,7 @@ def _apple_application_impl(ctx):
         "CFBundleShortVersionString": "1.0",
         "CFBundleVersion": "1",
         "MinimumOSVersion": minimum_os,
-        "DTPlatformName": sdk,
+        "DTPlatformName": swiftc["sdk_name"],
     }
     bool_entries = {"LSRequiresIPhoneOS": True}
     device_family_codes = []
@@ -1810,7 +1882,7 @@ def _apple_application_impl(ctx):
     # Each framework is copied as a whole bundle directory and
     # individually ad-hoc codesigned so the app's dyld loads them
     # without rejecting the signature.
-    cs_xcrun, codesign_path, cs_identity, cs_env = _xcrun_codesign(xcode_developer_dir)
+    codesign = _resolve_codesign(xcode_developer_dir)
     embedded_stamps = []
     dep_framework_paths = []
     dep_framework_files = {}
@@ -1850,11 +1922,11 @@ def _apple_application_impl(ctx):
             identifier = "apple_application_embed_copy_" + framework_basename,
         )
         run_action(
-            argv = [codesign_path, "--force", "--sign", "-", "--timestamp=none", embedded_framework_path],
+            argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", embedded_framework_path],
             inputs = embed_inputs,
             outputs = embed_outputs,
-            env = cs_env,
-            toolchain_identity = cs_identity,
+            env = codesign["env"],
+            toolchain_identity = codesign["identity"],
             identifier = "apple_application_embed_" + framework_basename,
         )
         embedded_stamps.append(embedded_stamp)
@@ -1867,11 +1939,11 @@ def _apple_application_impl(ctx):
     for stamp in embedded_stamps:
         cs_inputs.append(stamp)
     run_action(
-        argv = [codesign_path, "--force", "--sign", "-", "--timestamp=none", ctx["build_dir"] + "/" + app_dir],
+        argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", ctx["build_dir"] + "/" + app_dir],
         inputs = cs_inputs,
         outputs = [app_cs_stamp],
-        env = cs_env,
-        toolchain_identity = cs_identity,
+        env = codesign["env"],
+        toolchain_identity = codesign["identity"],
         identifier = "apple_application_codesign_" + product_name,
     )
 
@@ -1909,19 +1981,22 @@ def _apple_test_bundle_impl(ctx):
     for key in test_env:
         action_env[key] = test_env[key]
     arch = host_arch()
-    xcrun, sdk, swiftc_identity, xcrun_env = _xcrun_swiftc(platform, sdk_variant, xcode_developer_dir)
+    swiftc = _resolve_swiftc(platform, sdk_variant, xcode_developer_dir)
     triple = _apple_triple(platform, target_sdk_version, sdk_variant, arch, False)
-    for key in xcrun_env:
-        action_env[key] = xcrun_env[key]
+    for key in swiftc["env"]:
+        action_env[key] = swiftc["env"][key]
 
-    # XCTest lives in the platform's developer-frameworks tree, not
-    # the SDK's default search path. Resolve `<platform>/Developer/
-    # Library/Frameworks` via xcrun and add it as `-F`/`-rpath` so the
-    # linker finds the framework and dyld locates it at runtime.
-    platform_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-platform-path"], env = xcrun_env).strip()
+    # XCTest lives in the platform's developer-frameworks tree, not the
+    # SDK's default search path. With a developer dir we resolve it
+    # directly; otherwise we ask xcrun for `--show-sdk-platform-path`.
+    if xcode_developer_dir:
+        platform_path = _developer_platform_path(xcode_developer_dir, swiftc["sdk_name"])
+    else:
+        xcrun = host_which("xcrun")
+        platform_path = host_command([xcrun, "--sdk", swiftc["sdk_name"], "--show-sdk-platform-path"], env = swiftc["env"]).strip()
     xctest_framework_dir = platform_path + "/Developer/Library/Frameworks"
     xctest_usr_lib_dir = platform_path + "/Developer/usr/lib"
-    testing_macros_plugin = _swift_testing_macros_plugin(xcrun, xcrun_env)
+    testing_macros_plugin = _swift_testing_macros_plugin(swiftc["swiftc_path"])
 
     bundle_dir = product_name + ".xctest"
     if platform == "macos" or platform == "macosx":
@@ -1932,7 +2007,11 @@ def _apple_test_bundle_impl(ctx):
         info_plist = declare_output(bundle_dir + "/Info.plist")
     test_bundle_path = ctx["build_dir"] + "/" + bundle_dir
     runner_type = "swift_testing" if swift_testing else "xctest"
-    command_argv = [xcrun, "xctest", test_bundle_path]
+    # `xctest` and `simctl` are macOS-only runtime tools. We only
+    # resolve `xcrun` when the test capability fires; outside it the
+    # `command_argv` advertised by the provider is informational.
+    runner_xcrun = host_which("xcrun") if ctx["capability"] == "test" else "xcrun"
+    command_argv = [runner_xcrun, "xctest", test_bundle_path]
     provider = {
         "label_id": ctx["label"]["id"],
         "test_bundle_path": test_bundle_path,
@@ -1963,11 +2042,7 @@ def _apple_test_bundle_impl(ctx):
     # `Developer/Library/Frameworks`; add it to both the framework
     # search path (`-F`) and the dyld rpath so the test runner can
     # load it at simulator launch time.
-    swift_argv = [
-        xcrun,
-        "--sdk",
-        sdk,
-        "swiftc",
+    swift_argv = list(swiftc["argv"]) + [
         "-emit-library",
         "-module-name",
         module_name,
@@ -2043,8 +2118,8 @@ def _apple_test_bundle_impl(ctx):
         argv = swift_argv,
         inputs = swift_inputs,
         outputs = [test_binary],
-        env = xcrun_env,
-        toolchain_identity = swiftc_identity,
+        env = swiftc["env"],
+        toolchain_identity = swiftc["identity"],
         identifier = "apple_test_bundle_compile_" + module_name,
     )
 
@@ -2061,17 +2136,17 @@ def _apple_test_bundle_impl(ctx):
     }
     write_path(info_plist, _render_plist(plist_entries))
 
-    cs_xcrun, codesign_path, cs_identity, cs_env = _xcrun_codesign(xcode_developer_dir)
+    codesign = _resolve_codesign(xcode_developer_dir)
     if platform == "macos" or platform == "macosx":
         test_cs_stamp = declare_output(bundle_dir + "/Contents/_CodeSignature/CodeResources")
     else:
         test_cs_stamp = declare_output(bundle_dir + "/_CodeSignature/CodeResources")
     run_action(
-        argv = [codesign_path, "--force", "--sign", "-", "--timestamp=none", test_bundle_path],
+        argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", test_bundle_path],
         inputs = [test_binary, info_plist],
         outputs = [test_cs_stamp],
-        env = cs_env,
-        toolchain_identity = cs_identity,
+        env = codesign["env"],
+        toolchain_identity = codesign["identity"],
         identifier = "apple_test_bundle_codesign_" + module_name,
     )
 
@@ -2081,10 +2156,10 @@ def _apple_test_bundle_impl(ctx):
             runner_command = """DYLD_LIBRARY_PATH={usr_lib}${{DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}} DYLD_FALLBACK_FRAMEWORK_PATH={frameworks}${{DYLD_FALLBACK_FRAMEWORK_PATH:+:$DYLD_FALLBACK_FRAMEWORK_PATH}} {command}""".format(
                 usr_lib = _shell_literal(xctest_usr_lib_dir),
                 frameworks = _shell_literal(xctest_framework_dir),
-                command = _shell_words([xcrun, "xctest", test_bundle_path]),
+                command = _shell_words([runner_xcrun, "xctest", test_bundle_path]),
             )
         elif sdk_variant == "simulator":
-            runner_command = _ios_simulator_selection_script(xcrun) + """
+            runner_command = _ios_simulator_selection_script(runner_xcrun) + """
 {xcrun} simctl boot "$simulator_id" >/dev/null 2>&1 || true
 {xcrun} simctl bootstatus "$simulator_id" -b
 tmpdir=$(mktemp -d "${{TMPDIR:-/tmp}}/once-xctest.XXXXXX")
@@ -2095,7 +2170,7 @@ find "$tmpdir/{bundle_name}" -type f -exec chmod 644 {{}} +
 chmod 755 "$tmpdir/{bundle_name}/{binary_name}"
 SIMCTL_CHILD_DYLD_LIBRARY_PATH={usr_lib} SIMCTL_CHILD_DYLD_FALLBACK_FRAMEWORK_PATH={frameworks} {xcrun} simctl spawn "$simulator_id" {xctest_agent} -XCTest All "$tmpdir/{bundle_name}"
 """.format(
-                xcrun = _shell_literal(xcrun),
+                xcrun = _shell_literal(runner_xcrun),
                 bundle = _shell_literal(test_bundle_path),
                 bundle_name = bundle_dir,
                 binary_name = product_name,
@@ -2147,7 +2222,7 @@ exit "$status"
             outputs = [test_dir, results, log, native_results],
             env = action_env,
             cacheable = False,
-            toolchain_identity = "once.apple." + runner_type + ".runner.v1\x00" + swiftc_identity,
+            toolchain_identity = "once.apple." + runner_type + ".runner.v1\x00" + swiftc["identity"],
             identifier = "apple_" + runner_type + ":" + ctx["label"]["id"],
         )
 

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -231,9 +231,13 @@ def _resolve_lipo(platform, sdk_variant, xcode_developer_dir):
 
 def _resolve_codesign(xcode_developer_dir):
     env = _developer_env(xcode_developer_dir)
+    # codesign isn't under DEVELOPER_DIR; it's a system tool. Resolve it
+    # via PATH so a custom install (different macOS version, custom
+    # image, PATH-managed environment) is honored instead of hardcoding
+    # /usr/bin/codesign. The xcrun fallback uses `--find` for the same
+    # reason: it doesn't require codesign to live at the standard path.
     if xcode_developer_dir:
-        # codesign isn't under DEVELOPER_DIR; it's a system tool.
-        codesign_path = "/usr/bin/codesign"
+        codesign_path = host_which("codesign")
     else:
         xcrun = host_which("xcrun")
         codesign_path = host_command([xcrun, "--find", "codesign"], env = env).strip()
@@ -2007,10 +2011,13 @@ def _apple_test_bundle_impl(ctx):
         info_plist = declare_output(bundle_dir + "/Info.plist")
     test_bundle_path = ctx["build_dir"] + "/" + bundle_dir
     runner_type = "swift_testing" if swift_testing else "xctest"
-    # `xctest` and `simctl` are macOS-only runtime tools. We only
-    # resolve `xcrun` when the test capability fires; outside it the
-    # `command_argv` advertised by the provider is informational.
-    runner_xcrun = host_which("xcrun") if ctx["capability"] == "test" else "xcrun"
+    # `xctest` and `simctl` are macOS-only runtime tools. Resolve
+    # `xcrun` here so the provider's `command_argv` always carries an
+    # absolute path. Outside the test capability the value is
+    # informational, but we still emit a resolved path rather than the
+    # literal string `xcrun` so consumers don't have to special-case
+    # the placeholder.
+    runner_xcrun = host_which("xcrun")
     command_argv = [runner_xcrun, "xctest", test_bundle_path]
     provider = {
         "label_id": ctx["label"]["id"],

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -231,16 +231,11 @@ def _resolve_lipo(platform, sdk_variant, xcode_developer_dir):
 
 def _resolve_codesign(xcode_developer_dir):
     env = _developer_env(xcode_developer_dir)
-    # codesign isn't under DEVELOPER_DIR; it's a system tool. Resolve it
-    # via PATH so a custom install (different macOS version, custom
-    # image, PATH-managed environment) is honored instead of hardcoding
-    # /usr/bin/codesign. The xcrun fallback uses `--find` for the same
-    # reason: it doesn't require codesign to live at the standard path.
-    if xcode_developer_dir:
-        codesign_path = host_which("codesign")
-    else:
-        xcrun = host_which("xcrun")
-        codesign_path = host_command([xcrun, "--find", "codesign"], env = env).strip()
+    # codesign is a system tool, not a toolchain binary under
+    # DEVELOPER_DIR. Resolve it through xcrun so signing does not
+    # depend on a shell search path replacement.
+    xcrun = host_which("xcrun")
+    codesign_path = host_command([xcrun, "--find", "codesign"], env = env).strip()
     identity = "once.apple.codesign.v1\x00" + codesign_path + "\x00" + (xcode_developer_dir or "")
     return {
         "codesign_path": codesign_path,

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -779,7 +779,9 @@ def host_which(name):
 def host_command(argv, env = None):
     if "--find" in argv:
         return "/toolchain/" + argv[len(argv) - 1] + "\n"
-    if "swiftc" in argv and "--version" in argv:
+    if "--show-sdk-path" in argv:
+        return "/sdks/iPhoneSimulator.sdk\n"
+    if "--version" in argv:
         return "Swift version test\n"
     fail("unexpected host_command: " + str(argv))
 
@@ -2547,71 +2549,24 @@ exit 1
         .contains("no booted or available iOS simulator found"));
 }
 
-#[cfg(unix)]
 #[test]
 fn prelude_swift_testing_macros_plugin_uses_swift_toolchain_path() {
-    let tmp = TempDir::new().unwrap();
-    let xcrun = tmp.path().join("xcrun");
-    let swiftc = tmp
-        .path()
-        .join("Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc");
-    std::fs::create_dir_all(swiftc.parent().unwrap()).unwrap();
-    write_executable(
-        &xcrun,
-        &format!(
-            r#"#!/bin/sh
-if [ "${{1:-}}" = "--find" ] && [ "${{2:-}}" = "swiftc" ]; then
-  printf '%s\n' {}
-  exit 0
-fi
-exit 1
-"#,
-            starlark_string_literal(&swiftc.display().to_string())
-        ),
-    );
-    let store = store_for(tmp.path(), "");
-    let call = format!(
-        "({}, {{}})",
-        starlark_string_literal(&xcrun.display().to_string())
-    );
+    let swiftc = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc";
+    let call = format!("({})", starlark_string_literal(swiftc));
 
-    let (_, out) = with_active_store(store, || {
-        eval_prelude_string_function("_swift_testing_macros_plugin", &call)
-    });
+    let out = eval_prelude_string_function("_swift_testing_macros_plugin", &call).unwrap();
 
     assert_eq!(
-            out.unwrap(),
-            tmp.path()
-                .join("Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib")
-                .display()
-                .to_string()
-        );
+        out,
+        "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib"
+    );
 }
 
-#[cfg(unix)]
 #[test]
 fn prelude_swift_testing_macros_plugin_rejects_unexpected_swiftc_path() {
-    let tmp = TempDir::new().unwrap();
-    let xcrun = tmp.path().join("xcrun");
-    write_executable(
-        &xcrun,
-        r#"#!/bin/sh
-if [ "${1:-}" = "--find" ] && [ "${2:-}" = "swiftc" ]; then
-  printf '%s\n' '/tmp/swiftc'
-  exit 0
-fi
-exit 1
-"#,
-    );
-    let store = store_for(tmp.path(), "");
-    let call = format!(
-        "({}, {{}})",
-        starlark_string_literal(&xcrun.display().to_string())
-    );
+    let call = format!("({})", starlark_string_literal("/tmp/swiftc"));
 
-    let (_, err) = with_active_store(store, || {
-        eval_prelude_string_function("_swift_testing_macros_plugin", &call).unwrap_err()
-    });
+    let err = eval_prelude_string_function("_swift_testing_macros_plugin", &call).unwrap_err();
 
     assert!(
         err.contains("unable to derive Swift toolchain path"),
@@ -2623,11 +2578,13 @@ exit 1
 fn prelude_ios_simulator_selection_helper_feeds_run_and_test_scripts() {
     let source = include_str!("../prelude/apple.star");
 
+    // Both the application run script and the test runner concatenate
+    // the selection helper output. The xcrun argument name differs
+    // between callsites, so match on the closing paren + `+`.
     assert_eq!(
-        source
-            .matches("_ios_simulator_selection_script(xcrun) +")
-            .count(),
-        2
+        source.matches("_ios_simulator_selection_script(").count() - 1,
+        2,
+        "expected two callers of _ios_simulator_selection_script"
     );
 }
 
@@ -2690,6 +2647,213 @@ fn prelude_apple_config_tokens_rejects_select_on_platform() {
         err.contains("attribute `platform` cannot use select()"),
         "{err}"
     );
+}
+
+/// Direct-mode swiftc resolution must derive both the compiler and
+/// the active SDK from the configured developer dir without
+/// shelling out to xcrun. The returned argv is what every Swift
+/// action prepends to its flags, so it has to invoke swiftc by
+/// absolute path and pass `-sdk <path>` explicitly.
+#[test]
+fn prelude_resolve_swiftc_direct_mode_skips_xcrun() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    fail("host_which must not be called in direct mode (asked for " + name + ")")
+
+def host_command(argv, env = None):
+    if "--version" in argv:
+        return "Swift version 6.0\n"
+    fail("unexpected host_command: " + str(argv))
+
+swiftc = _resolve_swiftc("ios", "simulator", "/opt/Xcode/Developer")
+result = repr([
+    swiftc["argv"],
+    swiftc["sdk_name"],
+    swiftc["sdk_path"],
+    swiftc["swiftc_path"],
+    swiftc["env"],
+    "identity:" in ("identity:" if swiftc["identity"].startswith("once.apple.swiftc.v1") else ""),
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"), "{out}");
+    assert!(out.contains("/opt/Xcode/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"), "{out}");
+    assert!(out.contains("\"iphonesimulator\""), "{out}");
+    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+    assert!(out.contains("True"), "identity prefix should match: {out}");
+}
+
+/// Direct-mode clang resolution must produce both clang and
+/// clang++ under `Toolchains/XcodeDefault.xctoolchain/usr/bin/`
+/// without xcrun, and the SDK path must follow the standard
+/// Platforms layout so the per-source action passes a correct
+/// `-isysroot`.
+#[test]
+fn prelude_resolve_clang_direct_mode_finds_both_drivers() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    fail("host_which must not be called in direct mode (asked for " + name + ")")
+
+def host_command(argv, env = None):
+    if "--version" in argv:
+        return "Apple clang version test\n"
+    fail("unexpected host_command: " + str(argv))
+
+clang = _resolve_clang("ios", "device", "/opt/Xcode/Developer")
+result = repr([
+    clang["clang_path"],
+    clang["clangxx_path"],
+    clang["sdk_path"],
+    clang["sdk_name"],
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang\""), "{out}");
+    assert!(out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"), "{out}");
+    assert!(out.contains("/opt/Xcode/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"), "{out}");
+    assert!(out.contains("\"iphoneos\""), "{out}");
+}
+
+/// codesign is a system tool, not part of the developer dir. In
+/// direct mode we hand back `/usr/bin/codesign` and skip xcrun
+/// discovery entirely — keeping the action argv stable regardless
+/// of which Xcode the user pinned.
+#[test]
+fn prelude_resolve_codesign_direct_mode_uses_system_path() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    fail("host_which must not be called in direct mode")
+
+def host_command(argv, env = None):
+    fail("host_command must not be called for codesign in direct mode")
+
+codesign = _resolve_codesign("/opt/Xcode/Developer")
+result = repr([codesign["codesign_path"], codesign["env"]])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(out.contains("/usr/bin/codesign"), "{out}");
+    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+}
+
+/// The xcrun fallback path is what every macOS user hits today
+/// (no `xcode_developer_dir` configured). The resolver should
+/// still produce a direct tool invocation — the action argv must
+/// not contain xcrun even when discovery went through it. This
+/// keeps cache keys identical whether or not the user pins a
+/// developer dir.
+#[test]
+fn prelude_resolve_swiftc_fallback_returns_direct_invocation() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None):
+    if "--find" in argv and argv[len(argv) - 1] == "swiftc":
+        return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc\n"
+    if "--show-sdk-path" in argv:
+        return "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk\n"
+    if "--version" in argv:
+        return "Swift version 6.0\n"
+    fail("unexpected host_command: " + str(argv))
+
+swiftc = _resolve_swiftc("ios", "simulator", "")
+result = repr([
+    swiftc["argv"],
+    swiftc["swiftc_path"],
+    swiftc["sdk_path"],
+    swiftc["env"],
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(!out.contains("/usr/bin/xcrun"), "fallback argv must not include xcrun: {out}");
+    assert!(out.contains("XcodeDefault.xctoolchain/usr/bin/swiftc"), "{out}");
+    assert!(out.contains("iPhoneSimulator.sdk"), "{out}");
+    // No developer dir was configured, so the action env stays empty.
+    assert!(out.contains("{}"), "{out}");
+}
+
+/// End-to-end direct-mode sanity check: building an `apple_library`
+/// against a configured developer dir must produce actions whose
+/// argv is rooted at the toolchain path. No action should contain
+/// `xcrun` as an argv element, and no `host_which` lookup should
+/// fire while the impl runs.
+#[test]
+fn prelude_apple_library_direct_mode_emits_xcrun_free_actions() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let package_dir = workspace.path().join("ios/Lib/Sources");
+    std::fs::create_dir_all(&package_dir).unwrap();
+    std::fs::write(package_dir.join("Lib.swift"), "public func hello() {}\n").unwrap();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    fail("host_which must not be called in direct mode (asked for " + name + ")")
+
+def host_command(argv, env = None):
+    if "--version" in argv:
+        return "Swift version 6.0\n"
+    fail("unexpected host_command: " + str(argv))
+
+ctx = {{
+    "label": {{
+        "package": "ios/Lib",
+        "name": "Lib",
+        "id": "ios/Lib/Lib",
+    }},
+    "attr": {{
+        "platform": "ios",
+        "sdk_variant": "simulator",
+        "xcode_developer_dir": "/opt/Xcode/Developer",
+    }},
+    "deps": [],
+    "srcs": ["Sources/**/*.swift"],
+    "build_dir": ".once/out/ios/Lib/Lib",
+    "capability": "build",
+}}
+provider = _apple_library_impl(ctx)
+result = repr(provider["archive"])
+"#
+    );
+    let store = store_for(workspace.path(), "ios/Lib");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    out.unwrap();
+    assert!(!store.actions.is_empty(), "expected swiftc actions");
+    for action in &store.actions {
+        for arg in &action.argv {
+            assert!(
+                !arg.contains("xcrun"),
+                "direct-mode argv should not mention xcrun: {:?}",
+                action.argv
+            );
+        }
+        assert_eq!(
+            action.argv[0],
+            "/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
+            "first argv element should be the resolved swiftc"
+        );
+        // The action env carries DEVELOPER_DIR through to the tool so
+        // it can find ancillary resources next to swiftc.
+        assert_eq!(
+            action.env.get("DEVELOPER_DIR").map(String::as_str),
+            Some("/opt/Xcode/Developer"),
+        );
+    }
 }
 
 /// `_resolve_attrs` must reject `select()` on attributes the target kind

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -774,6 +774,8 @@ fn prelude_apple_application_embeds_framework_self_path_output() {
 def host_which(name):
     if name == "xcrun":
         return "/usr/bin/xcrun"
+    if name == "codesign":
+        return "/usr/bin/codesign"
     fail("unexpected host_which: " + name)
 
 def host_command(argv, env = None):
@@ -2578,13 +2580,34 @@ fn prelude_swift_testing_macros_plugin_rejects_unexpected_swiftc_path() {
 fn prelude_ios_simulator_selection_helper_feeds_run_and_test_scripts() {
     let source = include_str!("../prelude/apple.star");
 
-    // Both the application run script and the test runner concatenate
-    // the selection helper output. The xcrun argument name differs
-    // between callsites, so match on the closing paren + `+`.
+    // The helper is defined once and called from exactly two sites:
+    // the application run script (with `xcrun`) and the test runner
+    // (with `runner_xcrun`). Match each call site by its bound
+    // argument so the assertion doesn't break if the helper is
+    // mentioned in a comment or docstring and so the definition
+    // doesn't need to be subtracted out.
     assert_eq!(
-        source.matches("_ios_simulator_selection_script(").count() - 1,
-        2,
-        "expected two callers of _ios_simulator_selection_script"
+        source.matches("def _ios_simulator_selection_script(").count(),
+        1,
+        "expected exactly one definition of _ios_simulator_selection_script"
+    );
+    // Match the helper concatenated with the surrounding `+ """` to
+    // exclude the `def` line and to anchor each call site to its
+    // actual usage (script-building expression). The two call sites
+    // pass `xcrun` and `runner_xcrun` respectively.
+    assert_eq!(
+        source
+            .matches("_ios_simulator_selection_script(xcrun) + \"\"\"")
+            .count(),
+        1,
+        "expected the application run script to call _ios_simulator_selection_script(xcrun)"
+    );
+    assert_eq!(
+        source
+            .matches("_ios_simulator_selection_script(runner_xcrun) + \"\"\"")
+            .count(),
+        1,
+        "expected the test runner to call _ios_simulator_selection_script(runner_xcrun)"
     );
 }
 
@@ -2720,27 +2743,30 @@ result = repr([
     assert!(out.contains("\"iphoneos\""), "{out}");
 }
 
-/// codesign is a system tool, not part of the developer dir. In
-/// direct mode we hand back `/usr/bin/codesign` and skip xcrun
-/// discovery entirely — keeping the action argv stable regardless
-/// of which Xcode the user pinned.
+/// codesign is a system tool, not part of the developer dir. We
+/// resolve it via PATH so a custom install is honored instead of a
+/// hardcoded `/usr/bin/codesign`; xcrun is never involved, so the
+/// action argv stays stable regardless of which Xcode the user
+/// pinned.
 #[test]
-fn prelude_resolve_codesign_direct_mode_uses_system_path() {
+fn prelude_resolve_codesign_uses_path() {
     let prelude = apple_prelude_source();
     let source = format!(
         r#"{prelude}
 def host_which(name):
-    fail("host_which must not be called in direct mode")
+    if name == "codesign":
+        return "/opt/local/bin/codesign"
+    fail("unexpected host_which: " + name)
 
 def host_command(argv, env = None):
-    fail("host_command must not be called for codesign in direct mode")
+    fail("host_command must not be called when resolving codesign")
 
 codesign = _resolve_codesign("/opt/Xcode/Developer")
 result = repr([codesign["codesign_path"], codesign["env"]])
 "#
     );
     let out = eval_prelude_source_to_repr(source).unwrap();
-    assert!(out.contains("/usr/bin/codesign"), "{out}");
+    assert!(out.contains("/opt/local/bin/codesign"), "{out}");
     assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
 }
 
@@ -2784,6 +2810,199 @@ result = repr([
     assert!(out.contains("iPhoneSimulator.sdk"), "{out}");
     // No developer dir was configured, so the action env stays empty.
     assert!(out.contains("{}"), "{out}");
+}
+
+/// The SDK and platform path maps that direct mode relies on must
+/// have an entry for every SDK name `_apple_sdk_name` can return.
+/// If a new Apple platform is added to the SDK selector but its
+/// layout entries are forgotten, direct-mode builds against that
+/// SDK would fail at runtime with a `fail(...)` instead of being
+/// caught by this test.
+#[test]
+fn prelude_developer_sdk_and_platform_maps_cover_supported_sdks() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def _collect_sdks():
+    platforms = [
+        ("macos", "device"),
+        ("macosx", "device"),
+        ("ios", "device"),
+        ("ios", "simulator"),
+        ("tvos", "device"),
+        ("tvos", "simulator"),
+        ("watchos", "device"),
+        ("watchos", "simulator"),
+        ("visionos", "device"),
+        ("visionos", "simulator"),
+        ("xros", "device"),
+        ("xros", "simulator"),
+    ]
+    sdks = []
+    for entry in platforms:
+        platform = entry[0]
+        sdk_variant = entry[1]
+        sdk = _apple_sdk_name(platform, sdk_variant)
+        # Both maps must cover the SDK. _developer_sdk_path /
+        # _developer_platform_path fail explicitly when an entry is
+        # missing, so a successful resolution proves coverage.
+        _developer_sdk_path("/dev", sdk)
+        _developer_platform_path("/dev", sdk)
+        sdks.append(sdk)
+    return sdks
+
+result = repr(_collect_sdks())
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    // Spot-check that the iteration actually produced an entry per
+    // platform, so a future refactor that empties the list fails
+    // loudly instead of passing vacuously.
+    for sdk in [
+        "macosx",
+        "iphoneos",
+        "iphonesimulator",
+        "appletvos",
+        "appletvsimulator",
+        "watchos",
+        "watchsimulator",
+        "xros",
+        "xrsimulator",
+    ] {
+        assert!(out.contains(sdk), "expected SDK {sdk} in {out}");
+    }
+}
+
+/// Direct-mode libtool resolution must come from the standard
+/// `Toolchains/XcodeDefault.xctoolchain/usr/bin/` layout and the
+/// returned argv must invoke libtool directly so the per-arch
+/// archive action keeps cache keys aligned with the rest of the
+/// build.
+#[test]
+fn prelude_resolve_libtool_direct_mode_uses_toolchain_layout() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    fail("host_which must not be called in direct mode (asked for " + name + ")")
+
+def host_command(argv, env = None):
+    fail("host_command must not be called in direct mode")
+
+libtool = _resolve_libtool("ios", "simulator", "/opt/Xcode/Developer")
+result = repr([
+    libtool["argv"],
+    libtool["libtool_path"],
+    libtool["env"],
+    libtool["identity"].startswith("once.apple.libtool.v1"),
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(
+        out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool"),
+        "{out}"
+    );
+    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+    assert!(out.contains("True"), "identity prefix should match: {out}");
+}
+
+/// Libtool's xcrun fallback path (no `xcode_developer_dir`
+/// configured) must still produce a direct invocation: the argv
+/// stored in the action must contain libtool's absolute path, not
+/// `xcrun`, so cache keys match what the direct-mode path emits.
+#[test]
+fn prelude_resolve_libtool_fallback_returns_direct_invocation() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None):
+    if "--find" in argv and argv[len(argv) - 1] == "libtool":
+        return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool\n"
+    fail("unexpected host_command: " + str(argv))
+
+libtool = _resolve_libtool("ios", "simulator", "")
+result = repr([
+    libtool["argv"],
+    libtool["libtool_path"],
+    libtool["env"],
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(!out.contains("/usr/bin/xcrun"), "fallback argv must not include xcrun: {out}");
+    assert!(out.contains("XcodeDefault.xctoolchain/usr/bin/libtool"), "{out}");
+    assert!(out.contains("{}"), "no developer dir means an empty action env: {out}");
+}
+
+/// Direct-mode lipo resolution mirrors libtool: it resolves the
+/// universal-binary tool from the standard toolchain layout and the
+/// returned argv invokes lipo by absolute path, never via xcrun.
+#[test]
+fn prelude_resolve_lipo_direct_mode_uses_toolchain_layout() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    fail("host_which must not be called in direct mode (asked for " + name + ")")
+
+def host_command(argv, env = None):
+    fail("host_command must not be called in direct mode")
+
+lipo = _resolve_lipo("ios", "simulator", "/opt/Xcode/Developer")
+result = repr([
+    lipo["argv"],
+    lipo["lipo_path"],
+    lipo["env"],
+    lipo["identity"].startswith("once.apple.lipo.v1"),
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(
+        out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo"),
+        "{out}"
+    );
+    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+    assert!(out.contains("True"), "identity prefix should match: {out}");
+}
+
+/// Lipo's xcrun fallback must produce a direct invocation: the
+/// action argv carries the resolved tool path so multi-arch fat
+/// binary builds cache the same way regardless of whether the
+/// caller pinned a developer dir.
+#[test]
+fn prelude_resolve_lipo_fallback_returns_direct_invocation() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None):
+    if "--find" in argv and argv[len(argv) - 1] == "lipo":
+        return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo\n"
+    fail("unexpected host_command: " + str(argv))
+
+lipo = _resolve_lipo("ios", "simulator", "")
+result = repr([
+    lipo["argv"],
+    lipo["lipo_path"],
+    lipo["env"],
+])
+"#
+    );
+    let out = eval_prelude_source_to_repr(source).unwrap();
+    assert!(!out.contains("/usr/bin/xcrun"), "fallback argv must not include xcrun: {out}");
+    assert!(out.contains("XcodeDefault.xctoolchain/usr/bin/lipo"), "{out}");
+    assert!(out.contains("{}"), "no developer dir means an empty action env: {out}");
 }
 
 /// End-to-end direct-mode sanity check: building an `apple_library`

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -2587,7 +2587,9 @@ fn prelude_ios_simulator_selection_helper_feeds_run_and_test_scripts() {
     // mentioned in a comment or docstring and so the definition
     // doesn't need to be subtracted out.
     assert_eq!(
-        source.matches("def _ios_simulator_selection_script(").count(),
+        source
+            .matches("def _ios_simulator_selection_script(")
+            .count(),
         1,
         "expected exactly one definition of _ios_simulator_selection_script"
     );
@@ -2702,10 +2704,16 @@ result = repr([
 "#
     );
     let out = eval_prelude_source_to_repr(source).unwrap();
-    assert!(out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"), "{out}");
+    assert!(
+        out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"),
+        "{out}"
+    );
     assert!(out.contains("/opt/Xcode/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"), "{out}");
     assert!(out.contains("\"iphonesimulator\""), "{out}");
-    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+    assert!(
+        out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""),
+        "{out}"
+    );
     assert!(out.contains("True"), "identity prefix should match: {out}");
 }
 
@@ -2737,37 +2745,51 @@ result = repr([
 "#
     );
     let out = eval_prelude_source_to_repr(source).unwrap();
-    assert!(out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang\""), "{out}");
-    assert!(out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"), "{out}");
-    assert!(out.contains("/opt/Xcode/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"), "{out}");
+    assert!(
+        out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang\""),
+        "{out}"
+    );
+    assert!(
+        out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"),
+        "{out}"
+    );
+    assert!(
+        out.contains(
+            "/opt/Xcode/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
+        ),
+        "{out}"
+    );
     assert!(out.contains("\"iphoneos\""), "{out}");
 }
 
-/// codesign is a system tool, not part of the developer dir. We
-/// resolve it via PATH so a custom install is honored instead of a
-/// hardcoded `/usr/bin/codesign`; xcrun is never involved, so the
-/// action argv stays stable regardless of which Xcode the user
-/// pinned.
+/// codesign is a system tool, not part of the developer dir. Direct
+/// mode resolves it through xcrun instead of the shell search path,
+/// so signing actions do not pick up a replacement.
 #[test]
-fn prelude_resolve_codesign_uses_path() {
+fn prelude_resolve_codesign_direct_mode_uses_xcrun_find() {
     let prelude = apple_prelude_source();
     let source = format!(
         r#"{prelude}
 def host_which(name):
-    if name == "codesign":
-        return "/opt/local/bin/codesign"
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
     fail("unexpected host_which: " + name)
 
 def host_command(argv, env = None):
-    fail("host_command must not be called when resolving codesign")
+    if argv == ["/usr/bin/xcrun", "--find", "codesign"] and env == {{"DEVELOPER_DIR": "/opt/Xcode/Developer"}}:
+        return "/usr/bin/codesign\n"
+    fail("unexpected host_command: " + str(argv) + " env=" + str(env))
 
 codesign = _resolve_codesign("/opt/Xcode/Developer")
 result = repr([codesign["codesign_path"], codesign["env"]])
 "#
     );
     let out = eval_prelude_source_to_repr(source).unwrap();
-    assert!(out.contains("/opt/local/bin/codesign"), "{out}");
-    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+    assert!(out.contains("/usr/bin/codesign"), "{out}");
+    assert!(
+        out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""),
+        "{out}"
+    );
 }
 
 /// The xcrun fallback path is what every macOS user hits today
@@ -2805,8 +2827,14 @@ result = repr([
 "#
     );
     let out = eval_prelude_source_to_repr(source).unwrap();
-    assert!(!out.contains("/usr/bin/xcrun"), "fallback argv must not include xcrun: {out}");
-    assert!(out.contains("XcodeDefault.xctoolchain/usr/bin/swiftc"), "{out}");
+    assert!(
+        !out.contains("/usr/bin/xcrun"),
+        "fallback argv must not include xcrun: {out}"
+    );
+    assert!(
+        out.contains("XcodeDefault.xctoolchain/usr/bin/swiftc"),
+        "{out}"
+    );
     assert!(out.contains("iPhoneSimulator.sdk"), "{out}");
     // No developer dir was configured, so the action env stays empty.
     assert!(out.contains("{}"), "{out}");
@@ -2903,7 +2931,10 @@ result = repr([
         out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool"),
         "{out}"
     );
-    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+    assert!(
+        out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""),
+        "{out}"
+    );
     assert!(out.contains("True"), "identity prefix should match: {out}");
 }
 
@@ -2935,9 +2966,18 @@ result = repr([
 "#
     );
     let out = eval_prelude_source_to_repr(source).unwrap();
-    assert!(!out.contains("/usr/bin/xcrun"), "fallback argv must not include xcrun: {out}");
-    assert!(out.contains("XcodeDefault.xctoolchain/usr/bin/libtool"), "{out}");
-    assert!(out.contains("{}"), "no developer dir means an empty action env: {out}");
+    assert!(
+        !out.contains("/usr/bin/xcrun"),
+        "fallback argv must not include xcrun: {out}"
+    );
+    assert!(
+        out.contains("XcodeDefault.xctoolchain/usr/bin/libtool"),
+        "{out}"
+    );
+    assert!(
+        out.contains("{}"),
+        "no developer dir means an empty action env: {out}"
+    );
 }
 
 /// Direct-mode lipo resolution mirrors libtool: it resolves the
@@ -2968,7 +3008,10 @@ result = repr([
         out.contains("/opt/Xcode/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo"),
         "{out}"
     );
-    assert!(out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""), "{out}");
+    assert!(
+        out.contains("\"DEVELOPER_DIR\": \"/opt/Xcode/Developer\""),
+        "{out}"
+    );
     assert!(out.contains("True"), "identity prefix should match: {out}");
 }
 
@@ -3000,9 +3043,18 @@ result = repr([
 "#
     );
     let out = eval_prelude_source_to_repr(source).unwrap();
-    assert!(!out.contains("/usr/bin/xcrun"), "fallback argv must not include xcrun: {out}");
-    assert!(out.contains("XcodeDefault.xctoolchain/usr/bin/lipo"), "{out}");
-    assert!(out.contains("{}"), "no developer dir means an empty action env: {out}");
+    assert!(
+        !out.contains("/usr/bin/xcrun"),
+        "fallback argv must not include xcrun: {out}"
+    );
+    assert!(
+        out.contains("XcodeDefault.xctoolchain/usr/bin/lipo"),
+        "{out}"
+    );
+    assert!(
+        out.contains("{}"),
+        "no developer dir means an empty action env: {out}"
+    );
 }
 
 /// End-to-end direct-mode sanity check: building an `apple_library`

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -80,6 +80,29 @@ mkdir -p "$app/_CodeSignature"
 : > "$app/_CodeSignature/CodeResources"
 SH
     chmod +x "$WORKSPACE/bin/codesign"
+    cat > "$WORKSPACE/bin/swiftc" <<'SH'
+#!/bin/sh
+case "${1:-}" in
+  --version)
+    printf '%s\n' 'Apple Swift version mock'
+    exit 0
+    ;;
+esac
+out=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="${1:-}"
+    break
+  fi
+  shift
+done
+[ -n "$out" ] || exit 2
+mkdir -p "$(dirname "$out")"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "$out"
+chmod 755 "$out"
+SH
+    chmod +x "$WORKSPACE/bin/swiftc"
     cat > "$WORKSPACE/bin/xcrun" <<SH
 #!/bin/sh
 log='$WORKSPACE/xcrun.log'
@@ -89,29 +112,13 @@ fi
 case "\${1:-}" in
   --find)
     case "\${2:-}" in
-      swiftc) printf '%s\\n' "\$0" ;;
+      swiftc) printf '%s\\n' '$WORKSPACE/bin/swiftc' ;;
       codesign) printf '%s\\n' '$WORKSPACE/bin/codesign' ;;
       *) printf '%s\\n' "\$0" ;;
     esac
     ;;
-  swiftc)
-    if [ "\${2:-}" = "--version" ]; then
-      printf '%s\\n' 'Apple Swift version mock'
-      exit 0
-    fi
-    out=''
-    while [ "\$#" -gt 0 ]; do
-      if [ "\$1" = "-o" ]; then
-        shift
-        out="\${1:-}"
-        break
-      fi
-      shift
-    done
-    [ -n "\$out" ] || exit 2
-    mkdir -p "\$(dirname "\$out")"
-    printf '%s\\n' '#!/bin/sh' 'exit 0' > "\$out"
-    chmod 755 "\$out"
+  --show-sdk-path)
+    printf '%s\\n' '$WORKSPACE/sdk'
     ;;
   simctl)
     printf '%s\\n' "\$*" >> "\$log"
@@ -157,6 +164,29 @@ mkdir -p "$app/_CodeSignature"
 : > "$app/_CodeSignature/CodeResources"
 SH
     chmod +x "$WORKSPACE/bin/codesign"
+    cat > "$WORKSPACE/toolchain/usr/bin/swiftc" <<'SH'
+#!/bin/sh
+case "${1:-}" in
+  --version)
+    printf '%s\n' 'Apple Swift version mock'
+    exit 0
+    ;;
+esac
+out=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="${1:-}"
+    break
+  fi
+  shift
+done
+[ -n "$out" ] || exit 2
+mkdir -p "$(dirname "$out")"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "$out"
+chmod 755 "$out"
+SH
+    chmod +x "$WORKSPACE/toolchain/usr/bin/swiftc"
     cat > "$WORKSPACE/toolchain/usr/bin/xcrun" <<SH
 #!/bin/sh
 log='$WORKSPACE/xcrun.log'
@@ -176,24 +206,8 @@ case "\${1:-}" in
   --show-sdk-platform-path)
     printf '%s\\n' "\$platform_path"
     ;;
-  swiftc)
-    if [ "\${2:-}" = "--version" ]; then
-      printf '%s\\n' 'Apple Swift version mock'
-      exit 0
-    fi
-    out=''
-    while [ "\$#" -gt 0 ]; do
-      if [ "\$1" = "-o" ]; then
-        shift
-        out="\${1:-}"
-        break
-      fi
-      shift
-    done
-    [ -n "\$out" ] || exit 2
-    mkdir -p "\$(dirname "\$out")"
-    printf '%s\\n' '#!/bin/sh' 'exit 0' > "\$out"
-    chmod 755 "\$out"
+  --show-sdk-path)
+    printf '%s\\n' "\$platform_path/Developer/SDKs/iPhoneSimulator.sdk"
     ;;
   simctl)
     printf '%s\\n' "\$*" >> "\$log"


### PR DESCRIPTION
## What changed

This change introduces resolver records for the Apple toolchain. The records carry the absolute paths for `swiftc`, `clang`, `clang++`, `libtool`, `lipo`, and `codesign`, along with the action cache identity and environment values each action needs.

When `xcode_developer_dir` is set, the compile and archive resolvers derive tool and platform paths from the standard Xcode developer directory layout. When it is unset, discovery still goes through `xcrun`, but build actions invoke the resolved tool path directly and pass an explicit software development kit path.

`codesign` is handled as a system tool rather than a toolchain binary. It is now discovered through `xcrun --find codesign` in both modes so signing does not pick up a shell search path replacement, while the action still invokes the resolved signer path directly.

The Apple library, framework, application, macro, and test bundle implementations now consume those resolver records. Simulator launch and test runner scripts still resolve `xcrun` where they need `simctl` or `xctest`.

The Apple shellspec fixtures now mock direct `swiftc` invocation and the platform path queries used by the new resolver shape.

## Why

Apple builds were coupled to `xcrun` even when a manifest pinned `xcode_developer_dir`. The configured developer directory influenced discovery, but the action command still depended on a host `xcrun` binary and an `xcrun --sdk ... <tool>` command line.

That made the Apple rules harder to reuse with an already provisioned Xcode developer directory. The new indirection makes the toolchain path explicit before the build action is declared.

## Root cause

The previous helper functions mixed discovery with execution. They returned `xcrun` and a software development kit name, then call sites reused that tuple to construct build action arguments. That made the wrapper part of the cached action shape.

## Approach

Direct mode computes compile and archive paths under `Toolchains/XcodeDefault.xctoolchain/usr/bin` and `Platforms/.../Developer/...`. Fallback mode keeps using `xcrun --find` and `xcrun --show-sdk-path` only to discover paths.

Toolchain identities still include the resolved tool path, the tool version where available, and the configured developer directory, so separate Xcode installations continue to partition the action cache.

Runtime paths are intentionally narrower in this change. The simulator and test runner flows still ask `xcrun` for `simctl` and `xctest`, because those are execution-time tools rather than compile or archive tools. Signing also asks `xcrun` to discover `codesign`, because that tool is supplied by the operating system rather than the selected developer directory.

## Impact

Existing macOS users who do not set `xcode_developer_dir` keep the same discovery behavior. Their build actions become more explicit because they invoke absolute tool paths instead of wrapping every tool through `xcrun`.

Pinned developer directory builds no longer need `xcrun` in compile, archive, merge, and signing action arguments. Signing discovery still uses `xcrun --find codesign` so the selected signer is not controlled by the shell search path.

Simulator launch and test bundle execution still require `xcrun` until their runner paths get the same treatment.

## Validation

- `mise exec -- cargo fmt --all -- --check` completed successfully.
- `mise exec -- cargo test -p once-frontend prelude_resolve_codesign_direct_mode_uses_xcrun_find` completed successfully.
- `mise exec -- cargo test --workspace` completed successfully.
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings` completed successfully.
- `mise exec -- cargo build --release` completed successfully.
- `mise exec -- shellspec spec/apple_spec.sh` completed successfully with 33 examples and 0 failures.
