### PR TITLE
fix(graph): route full rustc invocation through response file on Windows

### DIFF
--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -213,6 +213,15 @@ def _rust_response_file_args(ctx, args, name):
     # its dependency graph. Route the full argument list through a rustc
     # response file so only `@path` ends up on the command line. Other hosts
     # have generous limits, so the arguments stay inline there.
+    #
+    # The routing is intentionally unconditional on Windows rather than gated on
+    # an estimated argv length. Estimating the command line length is fragile
+    # (it has to account for quoting and process startup overhead, and getting
+    # it wrong reintroduces the spawn failure this guards against), while the
+    # cost of always routing is one small file write per compile. It does not
+    # grow the action cache surface either: the arguments already participate in
+    # the action digest, just by way of the response file contents instead of
+    # the inline argv.
     if host_os() != "windows" or not args:
         return args
     path = _rust_build_dir(ctx) + "/" + _rust_declared_output(ctx, name)

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -207,23 +207,25 @@ def _rust_feature_flags(ctx):
         flags.append(_rust_feature_cfg_arg(feature))
     return flags
 
-def _rust_feature_args(ctx):
-    flags = _rust_feature_flags(ctx)
-    if not flags:
-        return ([], [])
-    if host_os() != "windows":
-        return (flags, [])
-    path = _rust_build_dir(ctx) + "/" + _rust_declared_output(ctx, "rustc-features.rsp")
-    return ([
+def _rust_response_file_args(ctx, args, name):
+    # On Windows the command line passed to rustc can exceed the operating
+    # system limit once a crate accumulates enough --extern and -L flags from
+    # its dependency graph. Route the full argument list through a rustc
+    # response file so only `@path` ends up on the command line. Other hosts
+    # have generous limits, so the arguments stay inline there.
+    if host_os() != "windows" or not args:
+        return args
+    path = _rust_build_dir(ctx) + "/" + _rust_declared_output(ctx, name)
+    return [
         cmd_args(
-            args = flags,
+            args = args,
             use_arg_file = {
                 "path": path,
                 "format": "rustc-response",
                 "arg_format": "@{}",
             },
         ),
-    ], [])
+    ]
 
 def _rust_user_flags(ctx):
     return _rust_attr(ctx, "rustc_flags", [])
@@ -651,7 +653,7 @@ def _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports):
     ])
     return "\n".join(lines)
 
-def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps, feature_args, feature_inputs):
+def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps, feature_flags):
     build_script = _rust_attr(ctx, "build_script", "")
     if not build_script:
         return (None, [], {}, None)
@@ -660,8 +662,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     out_dir = declare_output(_rust_declared_output(ctx, "build"))
     stdout = declare_output(_rust_declared_output(ctx, "build-script.stdout"))
     linker_args, linker_identity = _rust_linker(ctx, "bin", "", host_triple)
-    compile_argv = [
-        rustc,
+    compile_args = [
         "--crate-name", "build_script_build",
         "--crate-type", "bin",
         "--edition", edition,
@@ -669,14 +670,15 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         script_path,
         "-o", runner,
     ]
-    compile_argv.extend(feature_args)
-    compile_argv.extend(_rust_cap_lints(ctx))
-    compile_argv.extend(dep_args)
-    compile_argv.extend(linker_args)
+    compile_args.extend(feature_flags)
+    compile_args.extend(_rust_cap_lints(ctx))
+    compile_args.extend(dep_args)
+    compile_args.extend(linker_args)
+    compile_argv = [rustc] + _rust_response_file_args(ctx, compile_args, "build-script-rustc.rsp")
     build_script_compile_env = _rust_compile_action_env(ctx, host_triple, host_triple)
     run_action(
         argv = compile_argv,
-        inputs = _unique([script_path] + dep_inputs + feature_inputs + _rust_extra_inputs(ctx)),
+        inputs = _unique([script_path] + dep_inputs + _rust_extra_inputs(ctx)),
         outputs = [runner],
         env = build_script_compile_env,
         toolchain_identity = identity + linker_identity + "\x00build-script",
@@ -965,12 +967,11 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
         build_deps = []
     build_dep_args = _rust_dep_args(build_deps, aliases)
     build_dep_inputs = _rust_dep_inputs(build_deps)
-    feature_args, feature_inputs = _rust_feature_args(ctx)
-    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps, feature_args, feature_inputs)
+    feature_flags = _rust_feature_flags(ctx)
+    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps, feature_flags)
     compile_env = build_env if build_env else _rust_compile_action_env(ctx, target, host_triple)
     linker_args, linker_identity = _rust_linker(ctx, crate_type, target, host_triple)
-    argv = [
-        rustc,
+    rustc_args = [
         "--crate-name", crate_name,
         "--crate-type", crate_type,
         "--edition", edition,
@@ -978,21 +979,22 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
         crate_root,
         "-o", output,
     ]
-    argv.extend(_rust_target_args(target))
-    argv.extend(feature_args)
-    argv.extend(_rust_user_flags(ctx))
-    argv.extend(_rust_cap_lints(ctx))
-    argv.extend(_rust_builtin_extern_args(crate_type))
-    argv.extend(dep_args)
-    argv.extend(linker_args)
-    argv.extend(_rust_linker_flags(ctx))
+    rustc_args.extend(_rust_target_args(target))
+    rustc_args.extend(feature_flags)
+    rustc_args.extend(_rust_user_flags(ctx))
+    rustc_args.extend(_rust_cap_lints(ctx))
+    rustc_args.extend(_rust_builtin_extern_args(crate_type))
+    rustc_args.extend(dep_args)
+    rustc_args.extend(linker_args)
+    rustc_args.extend(_rust_linker_flags(ctx))
+    argv = [rustc] + _rust_response_file_args(ctx, rustc_args, "rustc.rsp")
     if build_stdout:
         wrapped = _rustc_with_build_script_args(ctx, argv, build_stdout)
         argv = wrapped[0]
         build_inputs.extend(wrapped[1])
     run_action(
         argv = argv,
-        inputs = _unique(srcs + dep_inputs + build_inputs + feature_inputs + _rust_extra_inputs(ctx)),
+        inputs = _unique(srcs + dep_inputs + build_inputs + _rust_extra_inputs(ctx)),
         outputs = [output],
         env = compile_env,
         toolchain_identity = identity + linker_identity,

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1960,16 +1960,22 @@ result = repr("ok")
     assert!(rustc
         .argv
         .iter()
-        .any(|arg| arg == "@.once/out/crates/app/app/rustc-features.rsp"));
+        .any(|arg| arg == "@.once/out/crates/app/app/rustc.rsp"));
     assert!(!rustc
         .inputs
         .iter()
-        .any(|input| input == ".once/out/crates/app/app/rustc-features.rsp"));
+        .any(|input| input == ".once/out/crates/app/app/rustc.rsp"));
+    // Only the toolchain and the response-file reference remain on the command
+    // line; everything else is written to the response file.
+    assert_eq!(rustc.argv.len(), 2);
     assert_eq!(rustc.arg_files.len(), 1);
     let arg_file = &rustc.arg_files[0];
-    assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc-features.rsp");
+    assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc.rsp");
     assert_eq!(arg_file.format, DeclaredArgFileFormat::RustcResponse);
     assert!(arg_file.args.len() > 400);
+    // The full rustc invocation, not just feature cfgs, is routed through the
+    // response file so the command line cannot exceed the Windows limit.
+    assert!(arg_file.args.iter().any(|arg| arg == "--crate-name"));
     assert!(arg_file
         .args
         .iter()
@@ -2065,7 +2071,7 @@ result = repr("ok")
 }
 
 #[test]
-fn prelude_rust_empty_feature_list_emits_no_response_file() {
+fn prelude_rust_windows_routes_invocation_through_response_file_without_features() {
     let prelude = all_prelude_source();
     let source = format!(
         r#"{prelude}
@@ -2110,18 +2116,28 @@ result = repr("ok")
     assert_eq!(store.actions.len(), 1);
     let rustc = &store.actions[0];
     assert_eq!(rustc.identifier.as_deref(), Some("crates/app/app:rustc"));
+    // On Windows the invocation is always routed through a response file, even
+    // when the crate has no features, because the command line still carries
+    // the crate metadata, source, and dependency flags.
     assert!(
-        !rustc.argv.iter().any(|arg| arg.starts_with('@')),
+        rustc
+            .argv
+            .iter()
+            .any(|arg| arg == "@.once/out/crates/app/app/rustc.rsp"),
         "{:?}",
         rustc.argv
     );
+    assert_eq!(rustc.arg_files.len(), 1);
+    let arg_file = &rustc.arg_files[0];
+    assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc.rsp");
+    assert!(arg_file.args.iter().any(|arg| arg == "--crate-name"));
     assert!(
-        !rustc
-            .argv
+        !arg_file
+            .args
             .iter()
             .any(|arg| arg.starts_with("--cfg=feature=")),
         "{:?}",
-        rustc.argv
+        arg_file.args
     );
 }
 


### PR DESCRIPTION
## Motivation

CI on `main` has been failing on the Windows release jobs (`Build x86_64-pc-windows-msvc`, `Build SDK libraries x86_64-pc-windows-msvc`, and `release graph build (windows-latest)`). The failure surfaces while compiling `once-core`:

```
once: executing action 0 for crates/once-core/once_core_x86_64_pc_windows_msvc (...:rustc):
failed to spawn rustc.exe: The filename or extension is too long. (os error 206)
```

`os error 206` is Windows telling us the command line handed to `CreateProcess` is over its limit (roughly 32 KB). The rustc invocation for a crate carries one `--extern=name=path` flag per dependency plus a `-L dependency=path` search path per dependency directory, and on Windows those paths are long and absolute. For a crate with a dependency graph as large as `once-core`, the combined length blows past the limit before rustc even starts.

## Context

We had already started moving arguments off the command line in earlier changes, but only the feature cfgs were being routed through a rustc response file. That left the actual bulk of the invocation, the `--extern` and `-L` flags, still inline, so the limit was still being hit. The previous attempts treated the symptom (feature cfgs) rather than where the size actually comes from (the dependency flags).

> [!NOTE]
> **What is a response file?**
> Most compilers, rustc included, accept an argument of the form `@path/to/file`. Instead of reading that one token literally, the compiler opens the file and reads its contents as if those arguments had been typed on the command line. rustc's response files are simple: one argument per line, taken literally, no shell-style quoting or escaping. This lets us keep the command line tiny (just the toolchain path and `@response-file`) while passing an effectively unbounded number of arguments through the file, which is the standard way to sidestep the operating system command line length limit on Windows.

## Approach and tradeoffs

I considered keeping the surgical approach and only moving the dependency flags into the response file, but that would leave the same class of bug latent for any other argument category that grows over time (linker flags, user flags, and so on). Instead I route the entire post-`rustc` argument list through a single response file on Windows for both compile actions (the build script compile and the main crate compile). The only things left on the command line are the toolchain path and the `@response-file` reference.

On non-Windows hosts the arguments stay inline, because their command line limits are generous and there is no reason to pay for an extra file write and read on every compile.

This is safe because outputs and inputs are declared explicitly to the action (`run_action(outputs=..., inputs=...)`) rather than parsed out of the argv, the argv is handed to the executor verbatim with no path rewriting, the response file contents are folded into the action digest so caching stays correct, and rustc resolves the relative paths inside the file against the same working directory it uses for the command line.

## Verification

- `cargo test -p once-frontend --test prelude rust_` (18 passing, including the Windows response file coverage)
- `cargo test -p once-frontend --test prelude cargo_metadata_windows`
- `cargo test -p once-cli arg_file`

The existing Windows tests were updated to assert that the whole invocation (not just feature cfgs) lands in a single `rustc.rsp`, and that with no features the invocation is still routed through the response file because the crate metadata, source, and dependency flags are always present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)