### PR TITLE
fix(frontend): isolate rustc response files in scratch directory

### DIFF
--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -17,6 +17,9 @@ def _rust_metadata_suffix(ctx):
 def _rust_build_dir(ctx):
     return ctx.get("build_dir") or (".once/out/" + ctx["label"]["id"])
 
+def _rust_scratch_dir(ctx):
+    return ctx.get("scratch_dir") or (".once/tmp/analysis/" + ctx["label"]["id"])
+
 def _crate_name_from_label(ctx):
     return ctx["label"]["name"].replace("-", "_").replace(".", "_")
 
@@ -224,7 +227,7 @@ def _rust_response_file_args(ctx, args, name):
     # the inline argv.
     if host_os() != "windows" or not args:
         return args
-    path = _rust_build_dir(ctx) + "/" + _rust_declared_output(ctx, name)
+    path = _rust_scratch_dir(ctx) + "/" + _rust_declared_output(ctx, name)
     return [
         cmd_args(
             args = args,

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -679,13 +679,13 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         "--crate-type", "bin",
         "--edition", edition,
         "-C", "metadata=" + _rust_metadata_suffix(ctx) + "_BUILD",
-        script_path,
         "-o", runner,
     ]
     compile_args.extend(feature_flags)
     compile_args.extend(_rust_cap_lints(ctx))
     compile_args.extend(dep_args)
     compile_args.extend(linker_args)
+    compile_args.append(script_path)
     compile_argv = [rustc] + _rust_response_file_args(ctx, compile_args, "build-script-rustc.rsp")
     build_script_compile_env = _rust_compile_action_env(ctx, host_triple, host_triple)
     run_action(
@@ -988,7 +988,6 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
         "--crate-type", crate_type,
         "--edition", edition,
         "-C", "metadata=" + _rust_metadata_suffix(ctx),
-        crate_root,
         "-o", output,
     ]
     rustc_args.extend(_rust_target_args(target))
@@ -999,6 +998,7 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
     rustc_args.extend(dep_args)
     rustc_args.extend(linker_args)
     rustc_args.extend(_rust_linker_flags(ctx))
+    rustc_args.append(crate_root)
     argv = [rustc] + _rust_response_file_args(ctx, rustc_args, "rustc.rsp")
     if build_stdout:
         wrapped = _rustc_with_build_script_args(ctx, argv, build_stdout)

--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -167,6 +167,7 @@ fn analyze_target_with_host_cache(
     capability: &str,
 ) -> Result<AnalysisResult> {
     let build_dir = format!(".once/out/{}", target.label.id);
+    let scratch_dir = format!(".once/tmp/analysis/{}", target.label.id);
     let store = AnalysisStore::with_host_cache(
         workspace_root.to_path_buf(),
         target.label.package.clone(),
@@ -181,6 +182,7 @@ fn analyze_target_with_host_cache(
             target,
             dep_providers,
             &build_dir,
+            &scratch_dir,
             capability,
         )
     });
@@ -236,6 +238,7 @@ fn analyze_in_starlark(
     target: &GraphTarget,
     dep_providers: &[JsonValue],
     build_dir: &str,
+    scratch_dir: &str,
     capability: &str,
 ) -> Result<JsonValue> {
     Module::with_temp_heap(|module| {
@@ -250,7 +253,14 @@ fn analyze_in_starlark(
         let Some(impl_value) = impl_value else {
             return Ok(JsonValue::Null);
         };
-        let ctx = build_ctx(&eval, target, dep_providers, build_dir, capability);
+        let ctx = build_ctx(
+            &eval,
+            target,
+            dep_providers,
+            build_dir,
+            scratch_dir,
+            capability,
+        );
         let provider = eval
             .eval_function(impl_value, &[ctx], &[])
             .map_err(|error| anyhow!("impl eval failed for {}: {error:?}", target.label.id))?;
@@ -285,6 +295,7 @@ fn build_ctx<'v>(
     target: &GraphTarget,
     dep_providers: &[JsonValue],
     build_dir: &str,
+    scratch_dir: &str,
     capability: &str,
 ) -> Value<'v> {
     let heap = eval.heap();
@@ -311,6 +322,7 @@ fn build_ctx<'v>(
         ("srcs", srcs_value),
         ("deps", deps),
         ("build_dir", heap.alloc(build_dir.to_string())),
+        ("scratch_dir", heap.alloc(scratch_dir.to_string())),
         ("capability", heap.alloc(capability.to_string())),
     ]))
 }

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -652,7 +652,7 @@ def _demo_impl(ctx):
         outputs = [out],
         identifier = "demo_build",
     )
-    return {"out": out}
+    return {"out": out, "scratch": ctx["scratch_dir"]}
 
 demo_kind = target_kind(
     docs = "Demo",
@@ -678,6 +678,10 @@ demo_kind = target_kind(
     assert_eq!(
         result.provider["out"],
         ".once/out/apps/ios/Sample/hello.txt"
+    );
+    assert_eq!(
+        result.provider["scratch"],
+        ".once/tmp/analysis/apps/ios/Sample"
     );
 }
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1960,17 +1960,17 @@ result = repr("ok")
     assert!(rustc
         .argv
         .iter()
-        .any(|arg| arg == "@.once/out/crates/app/app/rustc.rsp"));
+        .any(|arg| arg == "@.once/tmp/analysis/crates/app/app/rustc.rsp"));
     assert!(!rustc
         .inputs
         .iter()
-        .any(|input| input == ".once/out/crates/app/app/rustc.rsp"));
+        .any(|input| input == ".once/tmp/analysis/crates/app/app/rustc.rsp"));
     // Only the toolchain and the response-file reference remain on the command
     // line; everything else is written to the response file.
     assert_eq!(rustc.argv.len(), 2);
     assert_eq!(rustc.arg_files.len(), 1);
     let arg_file = &rustc.arg_files[0];
-    assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc.rsp");
+    assert_eq!(arg_file.path, ".once/tmp/analysis/crates/app/app/rustc.rsp");
     assert_eq!(arg_file.format, DeclaredArgFileFormat::RustcResponse);
     assert!(arg_file.args.len() > 400);
     // The full rustc invocation, not just feature cfgs, is routed through the
@@ -2123,13 +2123,13 @@ result = repr("ok")
         rustc
             .argv
             .iter()
-            .any(|arg| arg == "@.once/out/crates/app/app/rustc.rsp"),
+            .any(|arg| arg == "@.once/tmp/analysis/crates/app/app/rustc.rsp"),
         "{:?}",
         rustc.argv
     );
     assert_eq!(rustc.arg_files.len(), 1);
     let arg_file = &rustc.arg_files[0];
-    assert_eq!(arg_file.path, ".once/out/crates/app/app/rustc.rsp");
+    assert_eq!(arg_file.path, ".once/tmp/analysis/crates/app/app/rustc.rsp");
     assert!(arg_file.args.iter().any(|arg| arg == "--crate-name"));
     assert!(
         !arg_file

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -2100,7 +2100,11 @@ ctx = {{
         "target": "x86_64-pc-windows-msvc",
         "crate_root": "src/lib.rs",
     }},
-    "deps": [],
+    "deps": [{{
+        "label_id": "crates/dep/dep",
+        "crate_name": "dep",
+        "rlib": ".once/out/crates/dep/dep/libdep.rlib",
+    }}],
     "srcs": ["src/**/*.rs"],
 }}
 _rust_compile(ctx, "rlib", "src/lib.rs", "libapp.rlib")
@@ -2131,6 +2135,26 @@ result = repr("ok")
     let arg_file = &rustc.arg_files[0];
     assert_eq!(arg_file.path, ".once/tmp/analysis/crates/app/app/rustc.rsp");
     assert!(arg_file.args.iter().any(|arg| arg == "--crate-name"));
+    let extern_arg = "--extern=dep=.once/out/crates/dep/dep/libdep.rlib";
+    let extern_position = arg_file
+        .args
+        .iter()
+        .position(|arg| arg == extern_arg)
+        .expect("dependency extern flag");
+    let root_position = arg_file
+        .args
+        .iter()
+        .position(|arg| arg == "crates/app/src/lib.rs")
+        .expect("crate root");
+    assert!(
+        extern_position < root_position,
+        "dependency flags should precede the crate root: {:?}",
+        arg_file.args
+    );
+    assert_eq!(
+        arg_file.args.last().map(String::as_str),
+        Some("crates/app/src/lib.rs")
+    );
     assert!(
         !arg_file
             .args

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -165,6 +165,9 @@ An implementation receives `ctx` with generic graph data:
 - `ctx["deps"]`: provider records returned by analyzed dependencies.
 - `ctx["build_dir"]`: workspace-relative output directory for the
   target.
+- `ctx["scratch_dir"]`: workspace-relative scratch directory for
+  action-private helper files that are materialized before an action
+  runs but are not durable target outputs.
 - `ctx["capability"]`: active capability being analyzed.
 
 The implementation returns a JSON-shaped provider record. Downstream
@@ -198,7 +201,9 @@ The Rust executor exposes generic primitives only:
   `format` and `arg_format`. The supported `format` values are
   `line-delimited`, which writes one argument per line without shell
   escaping, and `rustc-response`, which writes one `rustc` argument per
-  line verbatim. `arg_format` defaults to `@{}` and must contain
+  line verbatim. The caller chooses `path`; use `ctx["scratch_dir"]`
+  for action-private helper files and `declare_output` for durable
+  target outputs. `arg_format` defaults to `@{}` and must contain
   exactly one `{}` placeholder.
 - `run_action(...)` records a command action for the executor.
 - `write_path(path, content)` materializes generated text or byte-list


### PR DESCRIPTION
## What changed

This introduces an explicit `ctx["scratch_dir"]` for Starlark target kind implementations and documents it in the public module reference.

The Rust target kind now writes Windows `rustc` response files under that scratch directory instead of the target build output directory. The related tests now assert the scratch path is exposed through analysis and that response files use it.

## Why

The `main` branch release graph build on Windows was still failing after the full `rustc` invocation moved into response files. The failing compiler invocation reported missing dependency crates while compiling `once-core`, which points at the response-file helper path being too tightly coupled to durable build outputs.

Action-private helper files need a path chosen by analysis, not inferred by the executor and not mixed with target outputs. This keeps the action model explicit while giving target kinds a stable place for files that are materialized before an action runs.

## Root cause

The Rust prelude used `ctx["build_dir"]` for response files. That directory is the durable output namespace for the target. Response files are not target outputs; they are action-private command-line materialization details.

## Approach

The frontend analysis context now carries both paths:

- `ctx["build_dir"]` for declared target outputs.
- `ctx["scratch_dir"]` for action-private helper files.

The Rust prelude routes Windows response files through `ctx["scratch_dir"]`, while keeping actual outputs and generated wrapper scripts in their existing declared locations.

## Impact

Target kind authors get an explicit scratch path for helper files. Existing target output paths stay unchanged, and durable provider paths continue to use `ctx["build_dir"]`.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-frontend`
- `mise exec -- cargo test --workspace`
