### PR TITLE
refactor(rust): reduce avoidable ownership cloning

### DIFF
--- a/crates/once-cas/src/tuist/cache.rs
+++ b/crates/once-cas/src/tuist/cache.rs
@@ -600,8 +600,7 @@ impl TuistCache {
                     let channel = connect_grpc_endpoint(&endpoint).await?;
                     let mut client = CapabilitiesClient::new(channel);
                     let request = reapi::GetCapabilitiesRequest { instance_name };
-                    let request = authorized_grpc_request_with_token(request, &token)
-                        .map_err(|error| error.clone())?;
+                    let request = authorized_grpc_request_with_token(request, &token)?;
                     timeout_result(
                         tokio::time::timeout(
                             ENDPOINT_PROBE_TIMEOUT,

--- a/crates/once-cli/src/cache_provider.rs
+++ b/crates/once-cli/src/cache_provider.rs
@@ -32,10 +32,9 @@ pub(crate) fn resolve_auth_provider(
         return resolve_config(workspace, xdg);
     }
 
-    if let Some(config) = maybe_load_user_config(xdg)? {
-        if let Some(provider) = named_user_provider(&config, provider_name) {
+    if let Some(mut config) = maybe_load_user_config(xdg)? {
+        if let Some(provider) = take_named_user_provider(&mut config, provider_name) {
             return Ok(resolve_named_provider(
-                provider_name.to_string(),
                 NamedCacheProviderConfig {
                     name: provider_name.to_string(),
                     account: None,
@@ -101,61 +100,58 @@ fn resolve_provider_config(
             direct_tuist_config(config),
         )),
         CacheProviderConfig::Named(binding) => {
-            let config = load_user_config(xdg)?;
-            let provider = named_user_provider(&config, &binding.name).with_context(|| {
-                format!(
-                    "infrastructure `{}` was not found in {}",
-                    binding.name,
-                    user_config_path(xdg).display()
-                )
-            })?;
-            Ok(resolve_named_provider(
-                binding.name.clone(),
-                binding,
-                provider,
-            ))
+            let mut config = load_user_config(xdg)?;
+            let provider =
+                take_named_user_provider(&mut config, &binding.name).with_context(|| {
+                    format!(
+                        "infrastructure `{}` was not found in {}",
+                        binding.name,
+                        user_config_path(xdg).display()
+                    )
+                })?;
+            Ok(resolve_named_provider(binding, provider))
         }
     }
 }
 
 fn resolve_default_provider(xdg: &Xdg) -> Result<ResolvedCacheProviderConfig> {
-    let Some(config) = maybe_load_user_config(xdg)? else {
+    let Some(mut config) = maybe_load_user_config(xdg)? else {
         return Ok(ResolvedCacheProviderConfig::Local);
     };
     let binding = config
         .infrastructure
-        .as_ref()
-        .and_then(|infrastructure| infrastructure.cache.clone())
-        .or_else(|| config.cache_provider.clone());
+        .take()
+        .and_then(|infrastructure| infrastructure.cache)
+        .or_else(|| config.cache_provider.take());
     let Some(binding) = binding else {
         return Ok(ResolvedCacheProviderConfig::Local);
     };
-    let provider = named_user_provider(&config, &binding.name).with_context(|| {
+    let provider = take_named_user_provider(&mut config, &binding.name).with_context(|| {
         format!(
             "infrastructure `{}` was not found in {}",
             binding.name,
             user_config_path(xdg).display()
         )
     })?;
-    Ok(resolve_named_provider(
-        binding.name.clone(),
-        binding.into_named(),
-        provider,
-    ))
+    Ok(resolve_named_provider(binding.into_named(), provider))
 }
 
-fn named_user_provider<'a>(config: &'a UserConfig, name: &str) -> Option<&'a UserCacheProvider> {
+fn take_named_user_provider(config: &mut UserConfig, name: &str) -> Option<UserCacheProvider> {
     config
         .infrastructures
-        .get(name)
-        .or_else(|| config.cache_providers.get(name))
+        .remove(name)
+        .or_else(|| config.cache_providers.remove(name))
 }
 
 fn resolve_named_provider(
-    provider_name: String,
     binding: NamedCacheProviderConfig,
-    provider: &UserCacheProvider,
+    provider: UserCacheProvider,
 ) -> ResolvedCacheProviderConfig {
+    let NamedCacheProviderConfig {
+        name,
+        account: binding_account,
+        project: binding_project,
+    } = binding;
     match provider {
         UserCacheProvider::Tuist {
             url,
@@ -163,11 +159,11 @@ fn resolve_named_provider(
             account,
             project,
         } => ResolvedCacheProviderConfig::Tuist(default_tuist_config(
-            provider_name,
-            url.clone().unwrap_or_else(|| DEFAULT_TUIST_URL.to_string()),
-            binding.account.or_else(|| account.clone()),
-            binding.project.or_else(|| project.clone()),
-            oauth_client_id.clone(),
+            name,
+            url.unwrap_or_else(|| DEFAULT_TUIST_URL.to_string()),
+            binding_account.or(account),
+            binding_project.or(project),
+            oauth_client_id,
         )),
     }
 }

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -315,7 +315,7 @@ fn script_invocation(
 
     Ok(ScriptInvocation {
         workspace,
-        runtime: runtime.clone(),
+        runtime,
         runtime_args: merged_runtime_args,
         script_path,
         script_args,

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -74,7 +74,7 @@ impl BuildSession {
     pub(super) fn new(
         workspace: &Path,
         cache: &CacheProvider,
-        graph: &[GraphTarget],
+        graph: Vec<GraphTarget>,
     ) -> Result<Self> {
         Ok(Self::new_with_analyzer(
             workspace,
@@ -87,7 +87,7 @@ impl BuildSession {
     fn new_with_analyzer(
         workspace: &Path,
         cache: &CacheProvider,
-        graph: &[GraphTarget],
+        graph: Vec<GraphTarget>,
         analyzer: AnalysisEngine,
     ) -> Self {
         let module_source_digest = Digest::of_bytes(analyzer.module_source().as_bytes());
@@ -95,12 +95,22 @@ impl BuildSession {
             workspace: workspace.to_path_buf(),
             cache: cache.clone(),
             targets: graph
-                .iter()
-                .map(|target| (target.label.id.clone(), Arc::new(target.clone())))
+                .into_iter()
+                .map(|target| {
+                    let id = target.label.id.clone();
+                    (id, Arc::new(target))
+                })
                 .collect(),
             analyzer,
             module_source_digest,
         }
+    }
+
+    pub(super) fn target(&self, target_id: &str) -> Result<&GraphTarget> {
+        self.targets
+            .get(target_id)
+            .map(Arc::as_ref)
+            .with_context(|| format!("no target matches `{target_id}`"))
     }
 
     /// Build a target and the impl-backed portion of its dependency

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -1428,7 +1428,7 @@ mod tests {
         let one = compose_input_digest(workspace.path(), &declared, module_digest(), &[]).unwrap();
         let declared2 = DeclaredAction {
             toolchain_identity: Some("id-2".to_string()),
-            ..declared.clone()
+            ..declared
         };
         let two = compose_input_digest(workspace.path(), &declared2, module_digest(), &[]).unwrap();
         assert_ne!(one, two);

--- a/crates/once-cli/src/commands/graph/analysis/scheduler.rs
+++ b/crates/once-cli/src/commands/graph/analysis/scheduler.rs
@@ -137,19 +137,19 @@ impl BuildState {
             let target = targets
                 .get(target_id)
                 .with_context(|| format!("target `{target_id}` vanished from graph"))?;
-            let deps = target
+            let mut dep_count = 0;
+            for dep_id in target
                 .deps
                 .iter()
                 .filter(|dep_id| reachable.contains(*dep_id))
-                .cloned()
-                .collect::<Vec<_>>();
-            for dep_id in &deps {
+            {
+                dep_count += 1;
                 dependents
                     .entry(dep_id.clone())
                     .or_default()
                     .push(target_id.clone());
             }
-            remaining_deps.insert(target_id.clone(), deps.len());
+            remaining_deps.insert(target_id.clone(), dep_count);
         }
 
         let mut remaining_readers = dependents

--- a/crates/once-cli/src/commands/graph/analysis/tests.rs
+++ b/crates/once-cli/src/commands/graph/analysis/tests.rs
@@ -128,7 +128,8 @@ fn reachable_analysis_deps_walks_only_analysis_backed_direct_deps() {
         target_with_capabilities("HiddenAnalysis", &[], &[], &["build"], []),
     ];
     let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
-    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+    let session =
+        BuildSession::new_with_analyzer(workspace.path(), &cache, graph.clone(), analyzer);
 
     let reachable = session.reachable_analysis_deps(&graph[0]);
 
@@ -147,7 +148,8 @@ async fn run_with_analysis_returns_none_for_target_kinds_without_implementation(
         target_with_capabilities("Dep", &[], &[], &["build"], []),
     ];
     let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
-    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+    let session =
+        BuildSession::new_with_analyzer(workspace.path(), &cache, graph.clone(), analyzer);
 
     let outcome = session.run_with_analysis(&graph[0], "test").await.unwrap();
 
@@ -182,7 +184,8 @@ async fn independent_dependencies_run_in_parallel() {
         test_target("LeafB", &[], parallel_leaf_script("LeafB", "LeafA", "b")),
     ];
     let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
-    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+    let session =
+        BuildSession::new_with_analyzer(workspace.path(), &cache, graph.clone(), analyzer);
 
     let outcome = session
         .build_with_analysis(&graph[0])
@@ -215,7 +218,8 @@ async fn uncacheable_declared_actions_bypass_action_cache() {
         ],
     )];
     let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
-    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+    let session =
+        BuildSession::new_with_analyzer(workspace.path(), &cache, graph.clone(), analyzer);
 
     let first = session
         .build_with_analysis(&graph[0])
@@ -249,7 +253,8 @@ async fn build_direct_analysis_deps_returns_only_direct_deps_in_declared_order()
         target_with_capabilities("Shared", &[], &[], &["build"], []),
     ];
     let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
-    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+    let session =
+        BuildSession::new_with_analyzer(workspace.path(), &cache, graph.clone(), analyzer);
 
     let outcomes = session.build_direct_analysis_deps(&graph[0]).await.unwrap();
     let outcome_ids = outcomes
@@ -286,7 +291,8 @@ async fn capability_runs_are_salted_by_dependency_action_digests() {
     ];
     let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
 
-    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+    let session =
+        BuildSession::new_with_analyzer(workspace.path(), &cache, graph.clone(), analyzer);
     let first = session
         .run_with_analysis(&graph[1], "test")
         .await
@@ -295,7 +301,8 @@ async fn capability_runs_are_salted_by_dependency_action_digests() {
 
     std::fs::write(workspace.path().join("dep.txt"), b"two").unwrap();
     let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE).unwrap();
-    let session = BuildSession::new_with_analyzer(workspace.path(), &cache, &graph, analyzer);
+    let session =
+        BuildSession::new_with_analyzer(workspace.path(), &cache, graph.clone(), analyzer);
     let second = session
         .run_with_analysis(&graph[1], "test")
         .await

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -48,9 +48,9 @@ pub async fn build(
     target_id: &str,
 ) -> Result<ExitCode> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    let target = require_target(&graph, target_id)?;
-    let session = analysis::BuildSession::new(workspace, cache, &graph)?;
-    let record = build_target(workspace, cache, &target, &session).await?;
+    let session = analysis::BuildSession::new(workspace, cache, graph)?;
+    let target = session.target(target_id)?;
+    let record = build_target(workspace, cache, target, &session).await?;
     record_capability_run(workspace, &record).await;
     write_record(output, &record).await?;
     Ok(ExitCode::SUCCESS)
@@ -63,19 +63,19 @@ pub async fn test(
     target_id: &str,
 ) -> Result<ExitCode> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    let target = require_target(&graph, target_id)?;
-    let test_capability = ensure_capability(&target, "test")?;
-    let session = analysis::BuildSession::new(workspace, cache, &graph)?;
+    let session = analysis::BuildSession::new(workspace, cache, graph)?;
+    let target = session.target(target_id)?;
+    let test_capability = ensure_capability(target, "test")?;
     if !test_capability.requires_outputs.is_empty()
         && target
             .capabilities
             .iter()
             .any(|capability| capability.name == "build")
     {
-        let build_record = build_target(workspace, cache, &target, &session).await?;
+        let build_record = build_target(workspace, cache, target, &session).await?;
         record_capability_run(workspace, &build_record).await;
     }
-    let record = if let Some(outcome) = session.run_with_analysis(&target, "test").await? {
+    let record = if let Some(outcome) = session.run_with_analysis(target, "test").await? {
         let analysis::BuildOutcome {
             action_digest,
             input_digest,
@@ -100,7 +100,7 @@ pub async fn test(
             result,
         }
     } else {
-        run_target_capability(workspace, cache, &target, "test").await?
+        run_target_capability(workspace, cache, target, "test").await?
     };
     record_capability_run(workspace, &record).await;
     write_record(output, &record).await?;
@@ -114,19 +114,19 @@ pub async fn run(
     target_id: &str,
 ) -> Result<ExitCode> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    let target = require_target(&graph, target_id)?;
-    let run_capability = ensure_capability(&target, "run")?;
-    let session = analysis::BuildSession::new(workspace, cache, &graph)?;
+    let session = analysis::BuildSession::new(workspace, cache, graph)?;
+    let target = session.target(target_id)?;
+    let run_capability = ensure_capability(target, "run")?;
     if !run_capability.requires_outputs.is_empty()
         && target
             .capabilities
             .iter()
             .any(|capability| capability.name == "build")
     {
-        let build_record = build_target(workspace, cache, &target, &session).await?;
+        let build_record = build_target(workspace, cache, target, &session).await?;
         record_capability_run(workspace, &build_record).await;
     }
-    let record = if let Some(outcome) = session.run_with_analysis(&target, "run").await? {
+    let record = if let Some(outcome) = session.run_with_analysis(target, "run").await? {
         let analysis::BuildOutcome {
             action_digest,
             input_digest,
@@ -151,19 +151,11 @@ pub async fn run(
             result,
         }
     } else {
-        run_target_capability(workspace, cache, &target, "run").await?
+        run_target_capability(workspace, cache, target, "run").await?
     };
     record_capability_run(workspace, &record).await;
     write_record(output, &record).await?;
     Ok(ExitCode::SUCCESS)
-}
-
-fn require_target(graph: &[GraphTarget], target_id: &str) -> Result<GraphTarget> {
-    graph
-        .iter()
-        .find(|target| target.label.id == target_id)
-        .cloned()
-        .with_context(|| format!("no target matches `{target_id}`"))
 }
 
 /// Build a target, walking deps first. If the target kind has an `impl`

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -930,7 +930,6 @@ demo_kind = target_kind(
         .unwrap();
         run_async_result({
             let store = EvidenceStore::open_workspace(tmp.path());
-            let record = record.clone();
             async move { store.append(&record).await }
         })
         .unwrap();

--- a/crates/once-core/src/outputs.rs
+++ b/crates/once-core/src/outputs.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -23,12 +23,10 @@ pub(crate) async fn restore(
     let prefetched = prefetch_output_blobs(result, cache, staging.path()).await?;
     for output in prefetched {
         let PrefetchedOutput { rel, blob_path, .. } = output;
-        let bytes = tokio::fs::read(&blob_path)
-            .await
-            .map_err(|source| Error::RestoreOutput {
-                path: rel.clone(),
-                source,
-            })?;
+        let bytes = match tokio::fs::read(&blob_path).await {
+            Ok(bytes) => bytes,
+            Err(source) => return Err(Error::RestoreOutput { path: rel, source }),
+        };
         let abs = workspace_root.join(&rel);
         if is_directory_blob(&bytes) {
             restore_directory_blob(&rel, &abs, &bytes)?;
@@ -50,22 +48,23 @@ async fn prefetch_output_blobs(
     cache: &CacheProvider,
     staging_dir: &Path,
 ) -> Result<Vec<PrefetchedOutput>> {
-    let outputs = result
+    let mut outputs = result
         .outputs
         .iter()
         .enumerate()
         .map(|(index, (rel, digest))| (index, rel.clone(), *digest))
-        .collect::<Vec<_>>();
+        .collect::<VecDeque<_>>();
+    let output_count = outputs.len();
 
     let mut tasks = JoinSet::new();
-    let mut next = 0;
-    while next < outputs.len() && next < RESTORE_PREFETCH_CONCURRENCY {
-        let (index, rel, digest) = outputs[next].clone();
+    while tasks.len() < RESTORE_PREFETCH_CONCURRENCY {
+        let Some((index, rel, digest)) = outputs.pop_front() else {
+            break;
+        };
         spawn_prefetch(&mut tasks, cache.clone(), staging_dir, index, rel, digest);
-        next += 1;
     }
 
-    let mut blobs: Vec<Option<PrefetchedOutput>> = (0..outputs.len()).map(|_| None).collect();
+    let mut blobs: Vec<Option<PrefetchedOutput>> = (0..output_count).map(|_| None).collect();
     while let Some(joined) = tasks.join_next().await {
         let output = joined.map_err(|source| Error::RestoreOutput {
             path: "cached output prefetch".to_string(),
@@ -73,10 +72,8 @@ async fn prefetch_output_blobs(
         })??;
         let index = output.index;
         blobs[index] = Some(output);
-        if next < outputs.len() {
-            let (index, rel, digest) = outputs[next].clone();
+        if let Some((index, rel, digest)) = outputs.pop_front() {
             spawn_prefetch(&mut tasks, cache.clone(), staging_dir, index, rel, digest);
-            next += 1;
         }
     }
     blobs
@@ -102,12 +99,9 @@ fn spawn_prefetch(
     let blob_path = staging_dir.join(format!("{index}.blob"));
     tasks.spawn(async move {
         let bytes = cache.get_blob(&digest).await?;
-        tokio::fs::write(&blob_path, bytes)
-            .await
-            .map_err(|source| Error::RestoreOutput {
-                path: rel.clone(),
-                source,
-            })?;
+        if let Err(source) = tokio::fs::write(&blob_path, bytes).await {
+            return Err(Error::RestoreOutput { path: rel, source });
+        }
         Ok(PrefetchedOutput {
             index,
             rel,
@@ -235,38 +229,40 @@ pub(crate) async fn capture(
                 });
             }
         };
-        let path = rel.as_str().to_string();
         let bytes = if metadata.is_dir() {
-            read_output_blocking(path.clone(), {
+            read_output_blocking(rel.as_str(), {
                 let abs = abs.clone();
                 move || capture_directory_blob(&abs, symlink_mode)
             })
             .await?
         } else {
-            read_output_blocking(path.clone(), {
+            read_output_blocking(rel.as_str(), {
                 let abs = abs.clone();
                 move || capture_file_blob(&abs)
             })
             .await?
         };
         let digest = cache.put_blob(&bytes).await?;
-        captured.insert(path, digest);
+        captured.insert(rel.as_str().to_string(), digest);
     }
     Ok(captured)
 }
 
 async fn read_output_blocking(
-    path: String,
+    path: &str,
     read: impl FnOnce() -> std::io::Result<Vec<u8>> + Send + 'static,
 ) -> Result<Vec<u8>> {
-    let path_for_join = path.clone();
-    tokio::task::spawn_blocking(read)
-        .await
-        .map_err(|source| Error::ReadOutput {
-            path: path_for_join,
+    match tokio::task::spawn_blocking(read).await {
+        Ok(Ok(bytes)) => Ok(bytes),
+        Ok(Err(source)) => Err(Error::ReadOutput {
+            path: path.to_string(),
+            source,
+        }),
+        Err(source) => Err(Error::ReadOutput {
+            path: path.to_string(),
             source: std::io::Error::other(source.to_string()),
-        })?
-        .map_err(|source| Error::ReadOutput { path, source })
+        }),
+    }
 }
 
 #[cfg(test)]

--- a/crates/once-core/src/plan.rs
+++ b/crates/once-core/src/plan.rs
@@ -176,7 +176,14 @@ impl Runner {
         // Seed: every node with no deps is immediately runnable.
         for (i, node) in plan.nodes.iter().enumerate() {
             if indeg[i] == 0 {
-                spawn(&mut tasks, self.clone(), tx.clone(), i, node.clone());
+                spawn(
+                    &mut tasks,
+                    self.clone(),
+                    tx.clone(),
+                    i,
+                    node.label.clone(),
+                    node.action.clone(),
+                );
                 in_flight += 1;
             }
         }
@@ -219,7 +226,8 @@ impl Runner {
                                         self.clone(),
                                         tx.clone(),
                                         d,
-                                        plan.nodes[d].clone(),
+                                        plan.nodes[d].label.clone(),
+                                        plan.nodes[d].action.clone(),
                                     );
                                     in_flight += 1;
                                 }
@@ -264,11 +272,11 @@ fn spawn(
     runner: Runner,
     tx: mpsc::UnboundedSender<Done>,
     index: usize,
-    node: PlanNode,
+    label: String,
+    action: Action,
 ) {
     tasks.spawn(async move {
-        let label = node.label.clone();
-        let result = runner.run(&node.action).await;
+        let result = runner.run(&action).await;
         // Send first; dropping the sender after closes the channel
         // when this is the last live task.
         let _ = tx.send(Done {

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -224,7 +224,7 @@ pub struct DepSchema {
 pub fn load_graph_workspace(root: &Path) -> Result<Vec<GraphTarget>> {
     let targets = load_workspace(root)?;
     let schemas = target_kind_schemas_for_workspace(root)?;
-    Ok(graph_from_targets_with_schemas(&targets, &schemas))
+    Ok(graph_from_owned_targets_with_schemas(targets, &schemas))
 }
 
 #[must_use]
@@ -245,6 +245,16 @@ fn graph_from_targets_with_schemas(
     targets
         .iter()
         .map(|target| graph_target_from_schema(target, schemas))
+        .collect()
+}
+
+fn graph_from_owned_targets_with_schemas(
+    targets: Vec<Target>,
+    schemas: &[TargetKindSchema],
+) -> Vec<GraphTarget> {
+    targets
+        .into_iter()
+        .map(|target| graph_target_from_owned_schema(target, schemas))
         .collect()
 }
 
@@ -345,6 +355,68 @@ fn graph_target_from_schema(target: &Target, schemas: &[TargetKindSchema]) -> Gr
     }
 }
 
+fn graph_target_from_owned_schema(target: Target, schemas: &[TargetKindSchema]) -> GraphTarget {
+    let Target {
+        package,
+        kind,
+        name,
+        deps,
+        srcs,
+        attrs,
+        typed_attrs,
+    } = target;
+    let schema = schemas.iter().find(|schema| schema.kind == kind);
+    let target_id = crate::target_ref::target_id(&package, &name);
+    let mut diagnostics = if schema.is_some() {
+        Vec::new()
+    } else {
+        vec![Diagnostic::new(
+            "unknown_target_kind",
+            format!("target kind `{kind}` has no target kind schema"),
+        )
+        .with_target(target_id.as_str())]
+    };
+    let attrs = graph_attrs_from_parts(attrs, typed_attrs);
+    if let Some(schema) = schema {
+        for attr_schema in &schema.attrs {
+            if attr_schema.configurable {
+                continue;
+            }
+            if let Some(value) = attrs.get(&attr_schema.name) {
+                if select_branches(value).is_some() {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            "select_on_non_configurable_attr",
+                            format!(
+                                "attribute `{}` is not configurable but uses `select()`",
+                                attr_schema.name
+                            ),
+                        )
+                        .with_target(target_id.as_str())
+                        .with_attribute(attr_schema.name.as_str()),
+                    );
+                }
+            }
+        }
+    }
+    GraphTarget {
+        label: TargetLabel {
+            package,
+            name,
+            id: target_id,
+        },
+        kind,
+        deps,
+        srcs,
+        attrs,
+        capabilities: schema
+            .as_ref()
+            .map_or_else(Vec::new, |schema| schema.capabilities.clone()),
+        providers: schema.map_or_else(Vec::new, |schema| schema.providers.clone()),
+        diagnostics,
+    }
+}
+
 fn graph_attrs(target: &Target) -> BTreeMap<String, AttrValue> {
     if !target.typed_attrs.is_empty() {
         return target.typed_attrs.clone();
@@ -353,6 +425,19 @@ fn graph_attrs(target: &Target) -> BTreeMap<String, AttrValue> {
         .attrs
         .iter()
         .map(|(key, value)| (key.clone(), AttrValue::String(value.clone())))
+        .collect()
+}
+
+fn graph_attrs_from_parts(
+    attrs: BTreeMap<String, String>,
+    typed_attrs: BTreeMap<String, AttrValue>,
+) -> BTreeMap<String, AttrValue> {
+    if !typed_attrs.is_empty() {
+        return typed_attrs;
+    }
+    attrs
+        .into_iter()
+        .map(|(key, value)| (key, AttrValue::String(value)))
         .collect()
 }
 

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -130,22 +130,14 @@ impl TargetToml {
             message: source.to_string(),
         })?;
         let deps = deps_from_toml(display_name, &self.name, package, self.deps.as_ref())?;
-        let typed_attrs = self
-            .attrs
-            .into_iter()
-            .map(|(key, value)| {
-                let string_value = toml_value_to_attr_string(&value);
-                (key, string_value, toml_value_to_attr_value(value))
-            })
-            .collect::<Vec<_>>();
-        let attrs = typed_attrs
-            .iter()
-            .map(|(key, value, _)| (key.clone(), value.clone()))
-            .collect();
-        let typed_attrs = typed_attrs
-            .into_iter()
-            .map(|(key, _, value)| (key, value))
-            .collect();
+        let mut attrs = BTreeMap::new();
+        let mut typed_attrs = BTreeMap::new();
+        for (key, value) in self.attrs {
+            let string_value = toml_value_to_attr_string(&value);
+            let attr_value = toml_value_to_attr_value(value);
+            attrs.insert(key.clone(), string_value);
+            typed_attrs.insert(key, attr_value);
+        }
         Ok(Target {
             package: package.to_string(),
             kind: self.kind,


### PR DESCRIPTION
## What changed

This refactors the ownership-heavy Rust paths so values move through the system when there is already a single owner.

- Move loaded graph targets into workspace graph enrichment and graph build sessions instead of cloning full target records.
- Move cached output restore records from the prefetch queue into worker tasks, and keep path allocation on the error boundary.
- Spawn action plan workers with only the label and action they need instead of cloning full plan nodes.
- Move selected user cache provider configuration out of the parsed configuration map instead of cloning provider fields.
- Split manifest string and typed attributes in one pass without an intermediate vector.
- Remove redundant clones reported by Clippy.

## Why

The affected paths build graph records, schedule actions, restore cached outputs, and resolve configuration. They already own most of the data they transform, so leaning on Rust ownership makes the data flow clearer and avoids extra heap allocations in hot orchestration code.

## Approach

I kept borrowed helper surfaces where tests and callers still pass slices, then added consuming paths for production flows that already own their inputs. Clones remain where data is intentionally shared across asynchronous tasks, schema metadata, or query projections.

## Impact

There should be no user-facing behavior change. This is an internal refactor across graph loading, action scheduling, output restoration, manifest loading, and cache provider resolution.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo clippy --workspace --all-targets -- -W clippy::redundant_clone -W clippy::clone_on_ref_ptr`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise exec -- cargo test --workspace`
