### PR TITLE
feat(run): support visible mobile launches

### DIFF
--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -138,6 +138,10 @@ pub enum Cmd {
     /// to ask a compute provider to execute the command.
     #[command(arg_required_else_help = true)]
     Run {
+        /// Ask graph target kinds to open a visible runtime interface when supported.
+        #[arg(long)]
+        visible: bool,
+
         /// Serve a local JSON-RPC runtime control socket for this run.
         #[arg(long)]
         runtime_rpc: bool,

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use once_cas::{ActionResult, CacheProvider, Digest};
 use once_core::EvidenceCacheState;
-use once_frontend::analysis::AnalysisEngine;
+use once_frontend::analysis::{AnalysisEngine, AnalysisOptions};
 use once_frontend::GraphTarget;
 use serde_json::Value as JsonValue;
 
@@ -76,11 +76,20 @@ impl BuildSession {
         cache: &CacheProvider,
         graph: &[GraphTarget],
     ) -> Result<Self> {
+        Self::new_with_options(workspace, cache, graph, AnalysisOptions::default())
+    }
+
+    pub(super) fn new_with_options(
+        workspace: &Path,
+        cache: &CacheProvider,
+        graph: &[GraphTarget],
+        options: AnalysisOptions,
+    ) -> Result<Self> {
         Ok(Self::new_with_analyzer(
             workspace,
             cache,
             graph,
-            AnalysisEngine::for_workspace(workspace)?,
+            AnalysisEngine::for_workspace_with_options(workspace, options)?,
         ))
     }
 

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -14,6 +14,7 @@ use std::process::ExitCode;
 use anyhow::{anyhow, Context, Result};
 use once_cas::{ActionResult, CacheProvider, Digest};
 use once_core::{EvidenceCacheState, EvidenceSubject, RunOpts};
+use once_frontend::analysis::AnalysisOptions;
 use once_frontend::GraphTarget;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
@@ -39,6 +40,11 @@ struct CapabilityRunRecord {
     cache_state: EvidenceCacheState,
     #[serde(skip)]
     result: ActionResult,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GraphRunOptions {
+    pub visible: bool,
 }
 
 pub async fn build(
@@ -112,11 +118,19 @@ pub async fn run(
     cache: &CacheProvider,
     output: Output,
     target_id: &str,
+    options: GraphRunOptions,
 ) -> Result<ExitCode> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
     let target = require_target(&graph, target_id)?;
     let run_capability = ensure_capability(&target, "run")?;
-    let session = analysis::BuildSession::new(workspace, cache, &graph)?;
+    let session = analysis::BuildSession::new_with_options(
+        workspace,
+        cache,
+        &graph,
+        AnalysisOptions {
+            run_visible: options.visible,
+        },
+    )?;
     if !run_capability.requires_outputs.is_empty()
         && target
             .capabilities

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -290,12 +290,12 @@ impl Server {
 
     fn tool_build_target(&self, args: &Value) -> Result<Value> {
         let args: TargetExecutionArgs = serde_json::from_value(tool_args(args))?;
-        run_graph_target(&self.workspace, "build", &args.target)
+        run_graph_target(&self.workspace, "build", &args.target, false)
     }
 
     fn tool_run_target(&self, args: &Value) -> Result<Value> {
-        let args: TargetExecutionArgs = serde_json::from_value(tool_args(args))?;
-        run_graph_target(&self.workspace, "run", &args.target)
+        let args: RunTargetArgs = serde_json::from_value(tool_args(args))?;
+        run_graph_target(&self.workspace, "run", &args.target, args.visible)
     }
 
     fn tool_start_target(&self, args: &Value) -> Result<Value> {
@@ -428,9 +428,14 @@ fn run_test_target(workspace: &std::path::Path, target: &str) -> Result<Value> {
     }))
 }
 
-fn run_graph_target(workspace: &std::path::Path, capability: &str, target: &str) -> Result<Value> {
+fn run_graph_target(
+    workspace: &std::path::Path,
+    capability: &str,
+    target: &str,
+    visible: bool,
+) -> Result<Value> {
     let exe = std::env::current_exe().context("resolving current once executable")?;
-    run_graph_target_with_exe(&exe, workspace, capability, target)
+    run_graph_target_with_exe(&exe, workspace, capability, target, visible)
 }
 
 fn run_graph_target_with_exe(
@@ -438,13 +443,19 @@ fn run_graph_target_with_exe(
     workspace: &std::path::Path,
     capability: &str,
     target: &str,
+    visible: bool,
 ) -> Result<Value> {
-    let output = std::process::Command::new(exe)
+    let mut command = std::process::Command::new(exe);
+    command
         .arg("-C")
         .arg(workspace)
         .arg("--format")
         .arg("json")
-        .arg(capability)
+        .arg(capability);
+    if visible {
+        command.arg("--visible");
+    }
+    let output = command
         .arg(target)
         .output()
         .with_context(|| format!("running `{}` {capability} `{target}`", exe.display()))?;
@@ -484,6 +495,14 @@ fn tool_args(args: &Value) -> Value {
 #[serde(deny_unknown_fields)]
 struct TargetExecutionArgs {
     target: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RunTargetArgs {
+    target: String,
+    #[serde(default)]
+    visible: bool,
 }
 
 #[derive(Deserialize)]
@@ -1061,27 +1080,28 @@ srcs = ["other_spec.sh"]
         let args_path = tmp.path().join("args.txt");
         let args_file = shell_literal(args_path.to_str().unwrap());
         let script = format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {args_file}\nprintf '{{\"target\":\"%s\",\"capability\":\"%s\",\"status\":\"completed\"}}\\n' \"$6\" \"$5\"\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {args_file}\ncapability=''\ntarget=''\nfor arg do\n  case \"$arg\" in build|run|test) capability=\"$arg\" ;;\n  *) target=\"$arg\" ;;\n  esac\ndone\nprintf '{{\"target\":\"%s\",\"capability\":\"%s\",\"status\":\"completed\"}}\\n' \"$target\" \"$capability\"\n",
         );
         std::fs::write(&exe, script).unwrap();
         let mut permissions = std::fs::metadata(&exe).unwrap().permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&exe, permissions).unwrap();
 
-        let build = run_graph_target_with_exe(&exe, tmp.path(), "build", "apps/App").unwrap();
+        let build =
+            run_graph_target_with_exe(&exe, tmp.path(), "build", "apps/App", false).unwrap();
         assert_eq!(build["capability"], "build");
         assert_eq!(build["success"], true);
         assert_eq!(build["record"]["target"], "apps/App");
         assert_eq!(build["record"]["capability"], "build");
 
-        let run = run_graph_target_with_exe(&exe, tmp.path(), "run", "apps/App").unwrap();
+        let run = run_graph_target_with_exe(&exe, tmp.path(), "run", "apps/App", true).unwrap();
         assert_eq!(run["capability"], "run");
         assert_eq!(run["success"], true);
         assert_eq!(run["record"]["target"], "apps/App");
         assert_eq!(run["record"]["capability"], "run");
 
         let args = std::fs::read_to_string(args_path).unwrap();
-        assert!(args.contains("--format\njson\nrun\napps/App\n"));
+        assert!(args.contains("--format\njson\nrun\n--visible\napps/App\n"));
     }
 
     #[test]

--- a/crates/once-cli/src/commands/mcp/tools.rs
+++ b/crates/once-cli/src/commands/mcp/tools.rs
@@ -240,13 +240,17 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_run_target",
             description: "Run a target by executing its generic `run` capability.",
-            long_description: "Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`. Executes the same path as `once run <target> --format json`, including any prerequisite build outputs declared by the target's `run` capability. Execution policy declared by the target kind is preserved, so uncacheable actions are executed instead of replayed from the action cache. The tool returns stdout parsed as JSON when possible, plus exit status and stderr.",
+            long_description: "Opt-in tool exposed only when the Model Context Protocol server starts with `once mcp --allow-run`. Executes the same path as `once run <target> --format json`, including any prerequisite build outputs declared by the target's `run` capability. Set `visible` to request a visible runtime interface when the target kind supports one. Execution policy declared by the target kind is preserved, so uncacheable actions are executed instead of replayed from the action cache. The tool returns stdout parsed as JSON when possible, plus exit status and stderr.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "target": {
                         "type": "string",
                         "description": "Target id to run, such as `apps/service/Service` or `./Service`."
+                    },
+                    "visible": {
+                        "type": "boolean",
+                        "description": "Request a visible runtime interface when the target kind supports one."
                     }
                 },
                 "required": ["target"]

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -64,6 +64,7 @@ async fn run_command(
         }
         Cmd::Run {
             target,
+            visible,
             runtime_rpc,
             runtime_rpc_socket,
             remote,
@@ -74,6 +75,7 @@ async fn run_command(
                 xdg,
                 output,
                 target,
+                visible,
                 runtime_rpc,
                 runtime_rpc_socket,
                 remote.then_some(compute),
@@ -364,6 +366,7 @@ async fn dispatch_run(
     xdg: &Xdg,
     output: Output,
     target: Option<String>,
+    visible: bool,
     runtime_rpc: bool,
     runtime_rpc_socket: Option<PathBuf>,
     remote: Option<String>,
@@ -383,8 +386,12 @@ async fn dispatch_run(
             &cache,
             output,
             &resolved_target,
+            commands::graph::GraphRunOptions { visible },
         ))
         .await;
+    }
+    if visible {
+        anyhow::bail!("--visible is only supported for graph run targets");
     }
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
     run_target_command(

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -73,12 +73,14 @@ async fn run_command(
             Box::pin(dispatch_run(
                 workspace,
                 xdg,
-                output,
-                target,
-                visible,
-                runtime_rpc,
-                runtime_rpc_socket,
-                remote.then_some(compute),
+                RunDispatchArgs {
+                    output,
+                    target,
+                    visible,
+                    runtime_rpc,
+                    runtime_rpc_socket,
+                    remote: remote.then_some(compute),
+                },
             ))
             .await
         }
@@ -361,16 +363,24 @@ async fn run_cache_command(
     }
 }
 
-async fn dispatch_run(
-    workspace: &Path,
-    xdg: &Xdg,
+struct RunDispatchArgs {
     output: Output,
     target: Option<String>,
     visible: bool,
     runtime_rpc: bool,
     runtime_rpc_socket: Option<PathBuf>,
     remote: Option<String>,
-) -> Result<ExitCode> {
+}
+
+async fn dispatch_run(workspace: &Path, xdg: &Xdg, args: RunDispatchArgs) -> Result<ExitCode> {
+    let RunDispatchArgs {
+        output,
+        target,
+        visible,
+        runtime_rpc,
+        runtime_rpc_socket,
+        remote,
+    } = args;
     let resolved_target = resolve_required_target(workspace, target.clone())?;
     if commands::graph::supports(workspace, &resolved_target, "run")? {
         if runtime_rpc || runtime_rpc_socket.is_some() {

--- a/crates/once-frontend/prelude/android.star
+++ b/crates/once-frontend/prelude/android.star
@@ -324,6 +324,7 @@ def _android_adb_tools(ctx, attrs):
     return {
         "sdk_root": sdk_root,
         "adb": adb,
+        "emulator": _android_attr(attrs, "emulator", "") or sdk_root + "/emulator/emulator",
         "identity": "\x00".join(["once.android.adb.v1", "sdk", sdk_root, "adb", adb, _android_adb_version(adb)]),
     }
 
@@ -372,6 +373,97 @@ esac
 """.format(
         application_id = _shell_quote(application_id),
         error_message = _shell_quote("unable to resolve launcher activity for " + application_id),
+    )
+
+def _android_visible_emulator_script(emulator, device):
+    command = "nohup {emulator} -avd {device} >/dev/null 2>&1 &".format(
+        emulator = _shell_quote(emulator),
+        device = _shell_quote(device),
+    )
+    apple_script = "do shell script " + _android_applescript_string(command)
+    return """set -eu
+screen_bin=""
+if [ -x /usr/bin/screen ]; then
+  screen_bin=/usr/bin/screen
+elif command -v screen >/dev/null 2>&1; then
+  screen_bin="$(command -v screen)"
+fi
+if [ -n "$screen_bin" ]; then
+  session="once-android-visible-$(date +%s)-$$"
+  if "$screen_bin" -dmS "$session" {emulator} -avd {device} >/dev/null 2>&1; then
+    exit 0
+  fi
+fi
+osascript_bin=""
+if [ -x /usr/bin/osascript ]; then
+  osascript_bin=/usr/bin/osascript
+elif command -v osascript >/dev/null 2>&1; then
+  osascript_bin="$(command -v osascript)"
+fi
+if [ -n "$osascript_bin" ]; then
+  if "$osascript_bin" -e {apple_script} >/dev/null 2>&1; then
+    exit 0
+  fi
+fi
+{command}
+""".format(
+        emulator = _shell_quote(emulator),
+        device = _shell_quote(device),
+        apple_script = _shell_quote(apple_script),
+        command = command,
+    )
+
+def _android_applescript_string(value):
+    return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+def _android_device_ready_script():
+    return """set -eu
+remaining=180
+while [ "$(getprop sys.boot_completed 2>/dev/null)" != "1" ]; do
+  if [ "$remaining" -le 0 ]; then
+    echo "timed out waiting for Android boot completion" >&2
+    exit 1
+  fi
+  remaining=$((remaining - 1))
+  sleep 1
+done
+remaining=60
+while true; do
+  service_state="$(service check package 2>/dev/null || true)"
+  case "$service_state" in
+    *found*) exit 0 ;;
+  esac
+  if [ "$remaining" -le 0 ]; then
+    echo "timed out waiting for Android package service" >&2
+    exit 1
+  fi
+  remaining=$((remaining - 1))
+  sleep 1
+done
+"""
+
+def _android_touch_marker_script(argv, marker):
+    return """set -eu
+{command}
+mkdir -p {parent}
+: > {marker}
+""".format(
+        command = _android_shell_words(argv),
+        parent = _shell_quote(_parent_dir(marker)),
+        marker = _shell_quote(marker),
+    )
+
+def _android_wait_for_ready_script(adb, marker):
+    return """set -eu
+{wait_command}
+{ready_command}
+mkdir -p {parent}
+: > {marker}
+""".format(
+        wait_command = _android_shell_words(adb + ["wait-for-device"]),
+        ready_command = _android_shell_words(adb + ["shell", _android_device_ready_script()]),
+        parent = _shell_quote(_parent_dir(marker)),
+        marker = _shell_quote(marker),
     )
 
 def _android_compile_jars(deps):
@@ -507,6 +599,7 @@ def _android_link_resources(ctx, attrs, tools, manifest, compiled_zips, dep_comp
         argv.extend(["-A", dir])
     link_tool_source = declare_output("aapt2_link_tool/OnceAndroidAapt2Link.java")
     link_tool_classes = declare_output("aapt2_link_tool/classes")
+    link_tool_hash = declare_output("aapt2_link_tool/classes.sha256")
     prepare_path(r_src_dir, kind = "remove", identifier = "android_resource_link_clean:" + label_id)
     prepare_path(r_src_dir, kind = "directory", identifier = "android_resource_link_prepare:" + label_id)
     prepare_path(link_tool_classes, kind = "remove", identifier = "android_resource_link_tool_clean:" + label_id)
@@ -520,9 +613,14 @@ def _android_link_resources(ctx, attrs, tools, manifest, compiled_zips, dep_comp
         toolchain_identity = tools["identity"] + "\x00aapt2_link_tool_javac.v1",
         identifier = "android_resource_link_tool_compile:" + label_id,
     )
+    write_tree_digest(
+        link_tool_classes,
+        link_tool_hash,
+        identifier = "android_resource_link_tool_digest:" + label_id,
+    )
     run_action(
         argv = [tools["java"], "-cp", link_tool_classes, "OnceAndroidAapt2Link", r_txt] + argv,
-        inputs = _unique([manifest, link_tool_classes] + compiled_zips + dep_compiled_zips + asset_files),
+        inputs = _unique([manifest, link_tool_hash] + compiled_zips + dep_compiled_zips + asset_files),
         outputs = [resource_apk, r_src_dir, r_txt],
         env = _android_env(tools),
         toolchain_identity = tools["identity"] + "\x00aapt2_link\x00static\x00" + str(static_lib),
@@ -617,6 +715,7 @@ def _android_compile_java(ctx, attrs, tools, java_sources, r_src_dir, r_src_hash
     base_source_list = declare_output("java_sources.base.list")
     source_list_tool = declare_output("java_source_list_tool/OnceAndroidJavaSourceList.java")
     source_list_tool_classes = declare_output("java_source_list_tool/classes")
+    source_list_tool_hash = declare_output("java_source_list_tool/classes.sha256")
     classpath_entries = _unique([tools["android_jar"]] + dep_jars)
     classpath = _android_classpath_sep().join(classpath_entries)
     source_level = str(_android_attr(attrs, "java_language_level", "17"))
@@ -647,9 +746,14 @@ def _android_compile_java(ctx, attrs, tools, java_sources, r_src_dir, r_src_hash
         toolchain_identity = tools["identity"] + "\x00java_source_list_tool_javac.v1",
         identifier = "android_java_source_list_tool_compile:" + ctx["label"]["id"],
     )
+    write_tree_digest(
+        source_list_tool_classes,
+        source_list_tool_hash,
+        identifier = "android_java_source_list_tool_digest:" + ctx["label"]["id"],
+    )
     run_action(
         argv = [tools["java"], "-cp", source_list_tool_classes, "OnceAndroidJavaSourceList", base_source_list, r_src_dir, source_list],
-        inputs = [source_list_tool_classes, base_source_list, r_src_hash],
+        inputs = [source_list_tool_hash, base_source_list, r_src_hash],
         outputs = [source_list],
         env = _android_env(tools),
         toolchain_identity = tools["identity"] + "\x00java_source_list.v1",
@@ -898,24 +1002,47 @@ def _android_run_app(ctx, attrs, tools):
     label_id = ctx["label"]["id"]
     application_id = _android_attr(attrs, "application_id", "")
     launch_activity = _android_attr(attrs, "launch_activity", "")
+    emulator_device = _android_attr(attrs, "emulator_device", "")
+    run_visible = (ctx.get("run") or {}).get("visible") or False
     component = _android_launch_component(application_id, launch_activity)
     apk = _android_built_apk(ctx)
     adb = _android_adb_argv(tools, attrs)
+    host_shell = _android_host_shell(label_id)
+    device_ready_marker = declare_output("run/device-ready")
+    installed_marker = declare_output("run/installed")
+    launched_marker = declare_output("run/launched")
+    if run_visible and emulator_device:
+        run_action(
+            argv = [host_shell, "-c", _android_visible_emulator_script(tools["emulator"], emulator_device)],
+            outputs = [],
+            env = _android_env(tools),
+            cacheable = False,
+            toolchain_identity = tools["identity"] + "\x00visible_emulator\x00" + tools["emulator"] + "\x00device\x00" + emulator_device,
+            identifier = "android_visible_emulator:" + label_id,
+        )
     run_actions = [
-        (adb + ["wait-for-device"], []),
-        (adb + ["install", "-r", "-d", apk], [apk]),
+        ([host_shell, "-c", _android_wait_for_ready_script(adb, device_ready_marker)], [], [device_ready_marker]),
+        ([host_shell, "-c", _android_touch_marker_script(adb + ["install", "-r", "-d", apk], installed_marker)], [apk, device_ready_marker], [installed_marker]),
     ]
     if component:
-        run_actions.append((adb + ["shell", "am", "start", "-n", component], []))
+        run_actions.append((
+            [host_shell, "-c", _android_touch_marker_script(adb + ["shell", "am", "start", "-n", component], launched_marker)],
+            [installed_marker],
+            [launched_marker],
+        ))
     else:
-        run_actions.append((adb + ["shell", _android_launcher_script(application_id)], []))
+        run_actions.append((
+            [host_shell, "-c", _android_touch_marker_script(adb + ["shell", _android_launcher_script(application_id)], launched_marker)],
+            [installed_marker],
+            [launched_marker],
+        ))
     index = 0
     for action in run_actions:
         index = index + 1
         run_action(
             argv = action[0],
             inputs = action[1],
-            outputs = [],
+            outputs = action[2],
             env = _android_env(tools),
             cacheable = False,
             toolchain_identity = tools["identity"] + "\x00run\x00" + str(index),
@@ -1017,7 +1144,7 @@ def _android_library_impl(ctx):
     }
 
 def _android_binary_impl(ctx):
-    attrs = _android_resolve_attrs(ctx, ["manifest", "resource_dirs", "asset_dirs", "assets_dir", "android_sdk", "build_tools_version", "compile_sdk", "application_id", "custom_package", "namespace", "javac", "jar", "java", "java_home", "kotlinc", "kotlin_home", "kotlin_stdlib", "aapt2", "d8", "apksigner", "zipalign", "debug_keystore", "adb", "adb_serial", "launch_activity"])
+    attrs = _android_resolve_attrs(ctx, ["manifest", "resource_dirs", "asset_dirs", "assets_dir", "android_sdk", "build_tools_version", "compile_sdk", "application_id", "custom_package", "namespace", "javac", "jar", "java", "java_home", "kotlinc", "kotlin_home", "kotlin_stdlib", "aapt2", "d8", "apksigner", "zipalign", "debug_keystore", "adb", "adb_serial", "emulator", "emulator_device", "launch_activity"])
     _android_reject_unsupported_attrs(attrs, ctx["label"]["id"], ["enable_data_binding", "instruments", "manifest_values", "proguard_specs", "resource_configuration_filters", "densities", "nocompress_extensions", "startup_profiles", "native_target"])
     if ctx["capability"] == "run":
         tools = _android_adb_tools(ctx, attrs)
@@ -1170,6 +1297,8 @@ android_binary = target_kind(
         attr("debug_key_alias", "string", default = "\"androiddebugkey\"", docs = "Key alias for debug signing only.", configurable = False),
         attr("adb", "string", docs = "Override adb path for the run capability.", configurable = False),
         attr("adb_serial", "string", docs = "Optional adb device serial for the run capability.", configurable = False),
+        attr("emulator", "string", docs = "Override Android emulator path used by visible runs.", configurable = False),
+        attr("emulator_device", "string", docs = "Android Virtual Device name started by `once run --visible` before installing the app.", configurable = False),
         attr("launch_activity", "string", docs = "Optional Android activity component launched by once run. Defaults to the launcher intent for application_id.", configurable = False),
         attr("enable_data_binding", "bool", default = "false", docs = "Reserved for Android data binding support.", configurable = False),
         attr("instruments", "target", docs = "Reserved for instrumentation test support.", configurable = False),

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -1668,7 +1668,7 @@ def shell_quote_for_action(path):
     escaped = path.replace("'", "'\"'\"'")
     return "'" + escaped + "'"
 
-def _apple_application_run_script(label_id, platform, sdk_variant, xcrun, app_path, bundle_id, run_dir, run_record, run_log):
+def _apple_application_run_script(label_id, platform, sdk_variant, xcrun, app_path, bundle_id, run_dir, run_record, run_log, visible):
     target_json = _json_literal(label_id)
     platform_json = _json_literal(platform)
     bundle_json = _json_literal(bundle_id)
@@ -1686,15 +1686,18 @@ printf '%s\\n' {record_json} > {record}
     elif platform == "ios" and sdk_variant == "simulator":
         record_prefix = '{"schema":"once.run.v1","target":' + target_json + ',"kind":"apple_application","status":"launched","platform":' + platform_json + ',"sdk_variant":"simulator","bundle_id":' + bundle_json + ',"app_path":' + app_json + ',"simulator_id":"'
         record_suffix = '"}'
+        visible_command = """/usr/bin/open -a Simulator --args -CurrentDeviceUDID "$simulator_id" >> {log} 2>&1 || true
+""".format(log = _shell_literal(run_log)) if visible else ""
         command = _ios_simulator_selection_script(xcrun) + """
 {xcrun} simctl boot "$simulator_id" >> {log} 2>&1 || true
-{xcrun} simctl bootstatus "$simulator_id" -b >> {log} 2>&1
+{visible_command}{xcrun} simctl bootstatus "$simulator_id" -b >> {log} 2>&1
 {xcrun} simctl install "$simulator_id" {app} >> {log} 2>&1
 {xcrun} simctl launch "$simulator_id" {bundle_id} >> {log} 2>&1
 printf '%s%s%s\\n' {record_prefix} "$simulator_id" {record_suffix} > {record}
 """.format(
             xcrun = _shell_literal(xcrun),
             log = _shell_literal(run_log),
+            visible_command = visible_command,
             app = _shell_literal(app_path),
             bundle_id = _shell_literal(bundle_id),
             record_prefix = _shell_literal(record_prefix),
@@ -1750,8 +1753,9 @@ def _apple_application_impl(ctx):
         # simctl-based runners need `xcrun` on PATH at execution time;
         # resolve it here so the build path stays xcrun-free.
         runner_xcrun = host_which("xcrun") if platform == "ios" and sdk_variant == "simulator" else ""
+        run_visible = (ctx.get("run") or {}).get("visible") or False
         run_action(
-            argv = ["/bin/sh", "-c", _apple_application_run_script(ctx["label"]["id"], platform, sdk_variant, runner_xcrun, app_path, bundle_id, run_dir, run_record, run_log)],
+            argv = ["/bin/sh", "-c", _apple_application_run_script(ctx["label"]["id"], platform, sdk_variant, runner_xcrun, app_path, bundle_id, run_dir, run_record, run_log, run_visible)],
             outputs = [run_dir, run_record, run_log],
             env = swiftc["env"],
             cacheable = False,

--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -146,15 +146,18 @@ impl AnalysisEngine {
         dep_providers: &[JsonValue],
         capability: &str,
     ) -> Result<AnalysisResult> {
-        analyze_target_with_host_cache(
-            &self.source_path,
-            &self.source,
-            self.host_cache.clone(),
+        let analysis = TargetAnalysis {
             target,
             workspace_root,
             dep_providers,
             capability,
-            self.options,
+            options: self.options,
+        };
+        analyze_target_with_host_cache(
+            &self.source_path,
+            &self.source,
+            self.host_cache.clone(),
+            &analysis,
         )
     }
 }
@@ -186,36 +189,31 @@ pub fn analyze_target(
     AnalysisEngine::new()?.analyze_target(target, workspace_root, dep_providers)
 }
 
+struct TargetAnalysis<'a> {
+    target: &'a GraphTarget,
+    workspace_root: &'a Path,
+    dep_providers: &'a [JsonValue],
+    capability: &'a str,
+    options: AnalysisOptions,
+}
+
 fn analyze_target_with_host_cache(
     source_path: &str,
     source: &str,
     host_cache: HostCache,
-    target: &GraphTarget,
-    workspace_root: &Path,
-    dep_providers: &[JsonValue],
-    capability: &str,
-    options: AnalysisOptions,
+    analysis: &TargetAnalysis<'_>,
 ) -> Result<AnalysisResult> {
-    let build_dir = format!(".once/out/{}", target.label.id);
-    let scratch_dir = format!(".once/tmp/analysis/{}", target.label.id);
+    let build_dir = format!(".once/out/{}", analysis.target.label.id);
+    let scratch_dir = format!(".once/tmp/analysis/{}", analysis.target.label.id);
     let store = AnalysisStore::with_host_cache(
-        workspace_root.to_path_buf(),
-        target.label.package.clone(),
+        analysis.workspace_root.to_path_buf(),
+        analysis.target.label.package.clone(),
         build_dir.clone(),
         host_cache,
     );
 
     let (store, result) = with_active_store(store, || {
-        analyze_in_starlark(
-            source_path,
-            source,
-            target,
-            dep_providers,
-            &build_dir,
-            &scratch_dir,
-            capability,
-            options,
-        )
+        analyze_in_starlark(source_path, source, analysis, &build_dir, &scratch_dir)
     });
     let provider = result?;
     Ok(AnalysisResult {
@@ -266,12 +264,9 @@ fn parse_target_kind_impls(path: &str, source: &str) -> Result<TargetKindImpls> 
 fn analyze_in_starlark(
     path: &str,
     source: &str,
-    target: &GraphTarget,
-    dep_providers: &[JsonValue],
+    analysis: &TargetAnalysis<'_>,
     build_dir: &str,
     scratch_dir: &str,
-    capability: &str,
-    options: AnalysisOptions,
 ) -> Result<JsonValue> {
     Module::with_temp_heap(|module| {
         let ast = AstModule::parse(path, source.to_string(), &Dialect::Standard)
@@ -281,22 +276,19 @@ fn analyze_in_starlark(
         eval.eval_module(ast, &globals)
             .map_err(|error| anyhow!("prelude eval failed: {error:?}"))?;
         let target_kinds = crate::modules::exported_target_kind_values(&module);
-        let impl_value = find_impl_for_kind(&target_kinds, &target.kind)?;
+        let impl_value = find_impl_for_kind(&target_kinds, &analysis.target.kind)?;
         let Some(impl_value) = impl_value else {
             return Ok(JsonValue::Null);
         };
-        let ctx = build_ctx(
-            &eval,
-            target,
-            dep_providers,
-            build_dir,
-            scratch_dir,
-            capability,
-            options,
-        );
+        let ctx = build_ctx(&eval, analysis, build_dir, scratch_dir);
         let provider = eval
             .eval_function(impl_value, &[ctx], &[])
-            .map_err(|error| anyhow!("impl eval failed for {}: {error:?}", target.label.id))?;
+            .map_err(|error| {
+                anyhow!(
+                    "impl eval failed for {}: {error:?}",
+                    analysis.target.label.id
+                )
+            })?;
         Ok(value_to_json(provider))
     })
 }
@@ -325,34 +317,33 @@ fn find_impl_for_kind<'v>(
 
 fn build_ctx<'v>(
     eval: &Evaluator<'v, '_, '_>,
-    target: &GraphTarget,
-    dep_providers: &[JsonValue],
+    analysis: &TargetAnalysis<'_>,
     build_dir: &str,
     scratch_dir: &str,
-    capability: &str,
-    options: AnalysisOptions,
 ) -> Value<'v> {
     let heap = eval.heap();
     let label = heap.alloc(AllocDict([
-        ("package", heap.alloc(target.label.package.clone())),
-        ("name", heap.alloc(target.label.name.clone())),
-        ("id", heap.alloc(target.label.id.clone())),
+        ("package", heap.alloc(analysis.target.label.package.clone())),
+        ("name", heap.alloc(analysis.target.label.name.clone())),
+        ("id", heap.alloc(analysis.target.label.id.clone())),
     ]));
-    let attr_pairs: Vec<(String, Value<'v>)> = target
+    let attr_pairs: Vec<(String, Value<'v>)> = analysis
+        .target
         .attrs
         .iter()
         .map(|(key, value)| (key.clone(), attr_value_to_starlark(eval, value)))
         .collect();
     let attr = heap.alloc(AllocDict(attr_pairs));
-    let srcs_value = heap.alloc(target.srcs.clone());
-    let dep_values: Vec<Value<'v>> = dep_providers
+    let srcs_value = heap.alloc(analysis.target.srcs.clone());
+    let dep_values: Vec<Value<'v>> = analysis
+        .dep_providers
         .iter()
         .map(|provider| json_to_value(eval, provider))
         .collect();
     let deps = heap.alloc(dep_values);
     let run = heap.alloc(AllocDict([(
         "visible",
-        Value::new_bool(options.run_visible),
+        Value::new_bool(analysis.options.run_visible),
     )]));
     heap.alloc(AllocDict([
         ("label", label),
@@ -361,7 +352,7 @@ fn build_ctx<'v>(
         ("deps", deps),
         ("build_dir", heap.alloc(build_dir.to_string())),
         ("scratch_dir", heap.alloc(scratch_dir.to_string())),
-        ("capability", heap.alloc(capability.to_string())),
+        ("capability", heap.alloc(analysis.capability.to_string())),
         ("run", run),
     ]))
 }

--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -17,6 +17,14 @@ use super::store::{with_active_store, AnalysisStore, DeclaredAction, HostCache};
 use super::values::{attr_value_to_starlark, json_to_value, value_to_json};
 use crate::graph::GraphTarget;
 
+/// Extra execution context supplied by command surfaces.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AnalysisOptions {
+    /// Request a visible runtime surface for run capabilities when the target
+    /// kind supports one.
+    pub run_visible: bool,
+}
+
 /// Result of analyzing one target.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AnalysisResult {
@@ -40,6 +48,7 @@ pub struct AnalysisEngine {
     source: Arc<str>,
     target_kind_impls: TargetKindImpls,
     host_cache: HostCache,
+    options: AnalysisOptions,
 }
 
 impl fmt::Debug for AnalysisEngine {
@@ -49,6 +58,7 @@ impl fmt::Debug for AnalysisEngine {
             .field("source_len", &self.source.len())
             .field("target_kind_impls", &self.target_kind_impls)
             .field("host_cache", &self.host_cache)
+            .field("options", &self.options)
             .finish()
     }
 }
@@ -58,21 +68,38 @@ impl AnalysisEngine {
         Self::from_source_with_path(
             crate::modules::BUILT_IN_MODULE_PATH,
             crate::modules::built_in_module_source(),
+            AnalysisOptions::default(),
         )
     }
 
     pub fn for_workspace(root: &Path) -> Result<Self> {
+        Self::for_workspace_with_options(root, AnalysisOptions::default())
+    }
+
+    pub fn for_workspace_with_options(root: &Path, options: AnalysisOptions) -> Result<Self> {
         let source = crate::modules::combined_module_source_for_workspace(root)?;
-        Self::from_source_with_path(crate::modules::COMBINED_MODULE_PATH, source)
+        Self::from_source_with_path(crate::modules::COMBINED_MODULE_PATH, source, options)
     }
 
     pub fn from_source(source: impl Into<Arc<str>>) -> Result<Self> {
-        Self::from_source_with_path(crate::modules::BUILT_IN_MODULE_PATH, source)
+        Self::from_source_with_path(
+            crate::modules::BUILT_IN_MODULE_PATH,
+            source,
+            AnalysisOptions::default(),
+        )
+    }
+
+    pub fn from_source_with_options(
+        source: impl Into<Arc<str>>,
+        options: AnalysisOptions,
+    ) -> Result<Self> {
+        Self::from_source_with_path(crate::modules::BUILT_IN_MODULE_PATH, source, options)
     }
 
     fn from_source_with_path(
         source_path: impl Into<Arc<str>>,
         source: impl Into<Arc<str>>,
+        options: AnalysisOptions,
     ) -> Result<Self> {
         let source_path = source_path.into();
         let source = source.into();
@@ -82,6 +109,7 @@ impl AnalysisEngine {
             source,
             target_kind_impls,
             host_cache: HostCache::default(),
+            options,
         })
     }
 
@@ -126,6 +154,7 @@ impl AnalysisEngine {
             workspace_root,
             dep_providers,
             capability,
+            self.options,
         )
     }
 }
@@ -165,6 +194,7 @@ fn analyze_target_with_host_cache(
     workspace_root: &Path,
     dep_providers: &[JsonValue],
     capability: &str,
+    options: AnalysisOptions,
 ) -> Result<AnalysisResult> {
     let build_dir = format!(".once/out/{}", target.label.id);
     let scratch_dir = format!(".once/tmp/analysis/{}", target.label.id);
@@ -184,6 +214,7 @@ fn analyze_target_with_host_cache(
             &build_dir,
             &scratch_dir,
             capability,
+            options,
         )
     });
     let provider = result?;
@@ -240,6 +271,7 @@ fn analyze_in_starlark(
     build_dir: &str,
     scratch_dir: &str,
     capability: &str,
+    options: AnalysisOptions,
 ) -> Result<JsonValue> {
     Module::with_temp_heap(|module| {
         let ast = AstModule::parse(path, source.to_string(), &Dialect::Standard)
@@ -260,6 +292,7 @@ fn analyze_in_starlark(
             build_dir,
             scratch_dir,
             capability,
+            options,
         );
         let provider = eval
             .eval_function(impl_value, &[ctx], &[])
@@ -297,6 +330,7 @@ fn build_ctx<'v>(
     build_dir: &str,
     scratch_dir: &str,
     capability: &str,
+    options: AnalysisOptions,
 ) -> Value<'v> {
     let heap = eval.heap();
     let label = heap.alloc(AllocDict([
@@ -316,6 +350,10 @@ fn build_ctx<'v>(
         .map(|provider| json_to_value(eval, provider))
         .collect();
     let deps = heap.alloc(dep_values);
+    let run = heap.alloc(AllocDict([(
+        "visible",
+        Value::new_bool(options.run_visible),
+    )]));
     heap.alloc(AllocDict([
         ("label", label),
         ("attr", attr),
@@ -324,5 +362,6 @@ fn build_ctx<'v>(
         ("build_dir", heap.alloc(build_dir.to_string())),
         ("scratch_dir", heap.alloc(scratch_dir.to_string())),
         ("capability", heap.alloc(capability.to_string())),
+        ("run", run),
     ]))
 }

--- a/crates/once-frontend/src/analysis/mod.rs
+++ b/crates/once-frontend/src/analysis/mod.rs
@@ -19,7 +19,9 @@ use std::collections::BTreeMap;
 
 use crate::target::AttrValue;
 
-pub use engine::{analyze_target, target_kind_has_impl, AnalysisEngine, AnalysisResult};
+pub use engine::{
+    analyze_target, target_kind_has_impl, AnalysisEngine, AnalysisOptions, AnalysisResult,
+};
 pub use globals::globals_for_prelude;
 pub use store::{
     with_active_store, AnalysisStore, DeclaredAction, DeclaredActionOperation, DeclaredArgFile,

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -612,6 +612,27 @@ custom_library = {"_once_target_kind": True, "impl": lambda ctx: None}
 }
 
 #[test]
+fn analysis_context_exposes_visible_run_option() {
+    let engine = AnalysisEngine::from_source_with_options(
+        r#"
+def _demo_impl(ctx):
+    return {"visible": ctx["run"]["visible"]}
+
+demo_kind = {"_once_target_kind": True, "impl": _demo_impl}
+"#,
+        AnalysisOptions { run_visible: true },
+    )
+    .unwrap();
+    let tmp = TempDir::new().unwrap();
+
+    let result = engine
+        .analyze_target_capability(&target("demo_kind"), tmp.path(), &[], "run")
+        .unwrap();
+
+    assert_eq!(result.provider["visible"], true);
+}
+
+#[test]
 fn analysis_engine_debug_omits_module_source() {
     let engine = AnalysisEngine::from_source("# SECRET_MODULE_SOURCE").unwrap();
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -96,6 +96,8 @@ fn android_binary_exposes_build_and_run() {
         .collect::<Vec<_>>();
     assert!(attr_names.contains(&"adb"));
     assert!(attr_names.contains(&"adb_serial"));
+    assert!(attr_names.contains(&"emulator"));
+    assert!(attr_names.contains(&"emulator_device"));
     assert!(attr_names.contains(&"launch_activity"));
     assert!(attr_names.contains(&"kotlinc"));
     assert!(attr_names.contains(&"kotlin_home"));
@@ -184,6 +186,80 @@ fn prelude_android_kotlin_toolchain_helpers_resolve_stdlib() {
     )
     .unwrap();
     assert_eq!(configured_stdlib, "/third_party/kotlin-stdlib.jar");
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_android_visible_run_starts_configured_emulator_first() {
+    let prelude = android_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{
+    "label": {{
+        "package": "apps/hello",
+        "name": "Hello",
+        "id": "apps/hello/Hello",
+    }},
+    "attr": {{}},
+    "deps": [],
+    "srcs": [],
+    "build_dir": ".once/out/apps/hello/Hello",
+    "run": {{"visible": True}},
+}}
+tools = {{
+    "sdk_root": "/sdk",
+    "adb": "/sdk/platform-tools/adb",
+    "emulator": "/sdk/emulator/emulator",
+    "identity": "android-adb",
+}}
+_android_run_app(
+    ctx,
+    {{"application_id": "dev.once.hello", "emulator_device": "Pixel_9"}},
+    tools,
+)
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "apps/hello/Hello");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    assert_eq!(store.actions.len(), 4);
+    assert_eq!(
+        store.actions[0].identifier.as_deref(),
+        Some("android_visible_emulator:apps/hello/Hello")
+    );
+    assert!(store.actions[0].argv[2].contains("screen"));
+    assert!(store.actions[0].argv[2].contains("osascript"));
+    assert!(!store.actions[0].argv[2].contains("launchctl submit"));
+    assert!(store.actions[0].argv[2].contains("nohup '/sdk/emulator/emulator' -avd 'Pixel_9'"));
+    assert!(store.actions[1].argv[2].contains("'/sdk/platform-tools/adb' 'wait-for-device'"));
+    assert!(store.actions[1].argv[2].contains("sys.boot_completed"));
+    assert_eq!(
+        store.actions[1].outputs,
+        vec![".once/out/apps/hello/Hello/run/device-ready"]
+    );
+    assert_eq!(
+        store.actions[2].inputs,
+        vec![
+            ".once/out/apps/hello/Hello/Hello.apk",
+            ".once/out/apps/hello/Hello/run/device-ready"
+        ]
+    );
+    assert_eq!(
+        store.actions[2].outputs,
+        vec![".once/out/apps/hello/Hello/run/installed"]
+    );
+    assert_eq!(
+        store.actions[3].inputs,
+        vec![".once/out/apps/hello/Hello/run/installed"]
+    );
+    assert_eq!(
+        store.actions[3].outputs,
+        vec![".once/out/apps/hello/Hello/run/launched"]
+    );
 }
 
 #[cfg(unix)]
@@ -338,6 +414,24 @@ result = repr("ok")
                 .is_some_and(|id| id == "android_resource_link:apps/hello/Hello")
         })
         .expect("resource link action");
+    let link_tool_digest = store
+        .actions
+        .iter()
+        .find(|action| {
+            action
+                .identifier
+                .as_deref()
+                .is_some_and(|id| id == "android_resource_link_tool_digest:apps/hello/Hello")
+        })
+        .expect("link tool digest action");
+    assert_eq!(
+        link_tool_digest.operation,
+        Some(DeclaredActionOperation::WriteTreeDigest {
+            root: ".once/out/apps/hello/Hello/aapt2_link_tool/classes".to_string(),
+            output: ".once/out/apps/hello/Hello/aapt2_link_tool/classes.sha256".to_string(),
+            include_suffixes: vec![],
+        })
+    );
     assert_eq!(
         link.identifier.as_deref(),
         Some("android_resource_link:apps/hello/Hello")
@@ -351,7 +445,7 @@ result = repr("ok")
     assert!(link
         .inputs
         .iter()
-        .any(|input| input == ".once/out/apps/hello/Hello/aapt2_link_tool/classes"));
+        .any(|input| input == ".once/out/apps/hello/Hello/aapt2_link_tool/classes.sha256"));
 }
 
 #[test]
@@ -3558,6 +3652,47 @@ exit 1
     assert!(String::from_utf8(output.stderr)
         .unwrap()
         .contains("no booted or available iOS simulator found"));
+}
+
+#[test]
+fn prelude_apple_application_visible_run_opens_simulator() {
+    let call = r#"(
+        "apps/ios/App",
+        "ios",
+        "simulator",
+        "/usr/bin/xcrun",
+        ".once/out/apps/ios/App/App.app",
+        "dev.once.App",
+        ".once/out/apps/ios/App/run",
+        ".once/out/apps/ios/App/run/run.json",
+        ".once/out/apps/ios/App/run/run.log",
+        True,
+    )"#;
+    let script = eval_prelude_string_function("_apple_application_run_script", call).unwrap();
+
+    assert!(
+        script.contains("/usr/bin/open -a Simulator --args -CurrentDeviceUDID \"$simulator_id\""),
+        "{script}"
+    );
+}
+
+#[test]
+fn prelude_apple_application_default_run_does_not_open_simulator() {
+    let call = r#"(
+        "apps/ios/App",
+        "ios",
+        "simulator",
+        "/usr/bin/xcrun",
+        ".once/out/apps/ios/App/App.app",
+        "dev.once.App",
+        ".once/out/apps/ios/App/run",
+        ".once/out/apps/ios/App/run/run.json",
+        ".once/out/apps/ios/App/run/run.log",
+        False,
+    )"#;
+    let script = eval_prelude_string_function("_apple_application_run_script", call).unwrap();
+
+    assert!(!script.contains("/usr/bin/open -a Simulator"), "{script}");
 }
 
 #[test]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::Command;
 
 use once_frontend::analysis::{
-    globals_for_prelude, target_kind_has_impl, with_active_store, AnalysisStore,
+    globals_for_prelude, target_kind_has_impl, with_active_store, AnalysisStore, DeclaredAction,
     DeclaredActionOperation, DeclaredArgFileFormat, DeclaredCopyPathMode, DeclaredPreparePathMode,
 };
 use once_frontend::{built_in_target_kind_schema, graph_from_targets, Target};
@@ -19,6 +19,14 @@ fn store_for(workspace: &Path, package: &str) -> AnalysisStore {
         package.to_string(),
         format!(".once/out/{package}"),
     )
+}
+
+fn action_by_identifier<'a>(store: &'a AnalysisStore, identifier: &str) -> &'a DeclaredAction {
+    store
+        .actions
+        .iter()
+        .find(|action| action.identifier.as_deref() == Some(identifier))
+        .unwrap_or_else(|| panic!("missing action `{identifier}`"))
 }
 
 fn apple_prelude_source() -> String {
@@ -393,37 +401,14 @@ result = repr("ok")
             )
         })
     }));
-    let compile_tool = store
-        .actions
-        .iter()
-        .find(|action| {
-            action
-                .identifier
-                .as_deref()
-                .is_some_and(|id| id == "android_resource_link_tool_compile:apps/hello/Hello")
-        })
-        .expect("link tool compile action");
+    let compile_tool = action_by_identifier(
+        &store,
+        "android_resource_link_tool_compile:apps/hello/Hello",
+    );
     assert_eq!(compile_tool.argv[0], "/jdk/bin/javac");
-    let link = store
-        .actions
-        .iter()
-        .find(|action| {
-            action
-                .identifier
-                .as_deref()
-                .is_some_and(|id| id == "android_resource_link:apps/hello/Hello")
-        })
-        .expect("resource link action");
-    let link_tool_digest = store
-        .actions
-        .iter()
-        .find(|action| {
-            action
-                .identifier
-                .as_deref()
-                .is_some_and(|id| id == "android_resource_link_tool_digest:apps/hello/Hello")
-        })
-        .expect("link tool digest action");
+    let link = action_by_identifier(&store, "android_resource_link:apps/hello/Hello");
+    let link_tool_digest =
+        action_by_identifier(&store, "android_resource_link_tool_digest:apps/hello/Hello");
     assert_eq!(
         link_tool_digest.operation,
         Some(DeclaredActionOperation::WriteTreeDigest {

--- a/docs/guide/graph/android.md
+++ b/docs/guide/graph/android.md
@@ -133,9 +133,14 @@ resolves the launcher activity on the device, and starts that component with
 `am start`. Set `launch_activity` when the app needs an explicit activity
 component. Set `adb_serial` when more than one device is connected.
 
+Pass `--visible` to request a visible runtime interface. If the target sets
+`emulator_device`, Once starts that Android Virtual Device with the Android
+emulator before waiting for a device, installing the app, and launching the
+activity.
+
 ```sh
 once build apps/hello/Hello
-once run apps/hello/Hello
+once run --visible apps/hello/Hello
 ```
 
 ## Toolchain

--- a/docs/guide/graph/apple.md
+++ b/docs/guide/graph/apple.md
@@ -82,9 +82,12 @@ the host app launcher. iOS simulator apps use `simctl` to pick or boot a
 simulator, install the bundle, and launch the bundle identifier. Device
 launch support is not implemented yet.
 
+Pass `--visible` to open Simulator for the selected simulator before the
+install and launch steps:
+
 ```sh
 once build apps/ios/App
-once run apps/ios/App
+once run --visible apps/ios/App
 ```
 
 ## Configurable attributes

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -22,6 +22,7 @@ Resolves the target id against the workspace graph and executes its `run` capabi
 
 | Flag | Value | Default | Description |
 | --- | --- | --- | --- |
+| `--visible` | (flag) | `false` | Ask graph target kinds to open a visible runtime interface when supported |
 | `--runtime-rpc` | (flag) | `false` | Serve a local JSON-RPC runtime control socket for this run |
 | `--runtime-rpc-socket` | `<RUNTIME_RPC_SOCKET>` |  | Runtime RPC socket path. Defaults to `.once/runtime/<session>/control.sock` |
 | `--remote` | (flag) | `false` | Run the target's action on a compute provider |

--- a/docs/reference/mcp/tools.md
+++ b/docs/reference/mcp/tools.md
@@ -460,7 +460,7 @@ Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`.
 
 Run a target by executing its generic `run` capability.
 
-Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`. Executes the same path as `once run <target> --format json`, including any prerequisite build outputs declared by the target's `run` capability. Execution policy declared by the target kind is preserved, so uncacheable actions are executed instead of replayed from the action cache. The tool returns stdout parsed as JSON when possible, plus exit status and stderr.
+Opt-in tool exposed only when the Model Context Protocol server starts with `once mcp --allow-run`. Executes the same path as `once run <target> --format json`, including any prerequisite build outputs declared by the target's `run` capability. Set `visible` to request a visible runtime interface when the target kind supports one. Execution policy declared by the target kind is preserved, so uncacheable actions are executed instead of replayed from the action cache. The tool returns stdout parsed as JSON when possible, plus exit status and stderr.
 
 **Input schema**
 
@@ -470,6 +470,10 @@ Opt-in tool exposed only when the MCP server starts with `once mcp --allow-run`.
     "target": {
       "description": "Target id to run, such as `apps/service/Service` or `./Service`.",
       "type": "string"
+    },
+    "visible": {
+      "description": "Request a visible runtime interface when the target kind supports one.",
+      "type": "boolean"
     }
   },
   "required": [

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -169,6 +169,8 @@ An implementation receives `ctx` with generic graph data:
   action-private helper files that are materialized before an action
   runs but are not durable target outputs.
 - `ctx["capability"]`: active capability being analyzed.
+- `ctx["run"]`: run request options. `ctx["run"]["visible"]` is true when
+  the caller requested a visible runtime interface.
 
 The implementation returns a JSON-shaped provider record. Downstream
 target kinds should read provider fields from `ctx["deps"]` instead of

--- a/docs/reference/prelude/android_binary.md
+++ b/docs/reference/prelude/android_binary.md
@@ -35,6 +35,8 @@ and signs it with a debug key by default.
 | `debug_key_alias` | string | no | `androiddebugkey` | Key alias for debug signing only |
 | `adb` | string | no | SDK platform-tools | Override adb path for `run` |
 | `adb_serial` | string | no |  | Device serial passed to `adb -s` |
+| `emulator` | string | no | Android software development kit emulator | Override Android emulator path used by visible runs |
+| `emulator_device` | string | no |  | Android Virtual Device name started by `once run --visible` |
 | `launch_activity` | string | no | launcher intent | Activity component launched by `once run` |
 | `build_tools_version` | string | no | highest installed | Android SDK build-tools version |
 | `android_sdk` | string | no | env | Android SDK root, otherwise `ANDROID_HOME` or `ANDROID_SDK_ROOT` |
@@ -99,6 +101,11 @@ zipalign. Production signing is not implemented yet.
 `apk` output group. The run action then executes direct `adb` commands:
 wait for a device, install the APK with `adb install -r -d`, and launch the
 app.
+
+Pass `once run --visible` to request a visible runtime interface. When
+`emulator_device` is set, Once starts that Android Virtual Device with the
+Android emulator before waiting for a device. If `emulator_device` is empty,
+visible runs use the already-connected physical device or emulator.
 
 When `launch_activity` is empty, Once resolves the launcher activity on the
 device with `cmd package resolve-activity --brief`, then starts the resolved

--- a/docs/reference/prelude/apple_application.md
+++ b/docs/reference/prelude/apple_application.md
@@ -50,10 +50,13 @@ The target emits `apple_application` and `apple_bundle`.
 ## Running
 
 `once run` launches macOS apps with the host app launcher and iOS
-simulator apps with `simctl` boot, install, and launch. The launch
-action writes a run record under the target's output directory and is
-marked uncacheable by the target kind, so repeated runs execute the launch
-again instead of replaying an action-cache hit. Device launch support
+simulator apps with `simctl` boot, install, and launch. Pass
+`once run --visible` to also open Simulator for the selected simulator
+before installing and launching the app.
+
+The launch action writes a run record under the target's output directory
+and is marked uncacheable by the target kind, so repeated runs execute the
+launch again instead of replaying an action-cache hit. Device launch support
 is not implemented yet.
 
 ## Limitations


### PR DESCRIPTION
## What changed

This adds a `--visible` option to `once run` and threads that request through graph analysis as `ctx["run"]["visible"]` so target kinds can decide how to expose a visible runtime interface.

Apple application targets now open Simulator for visible simulator runs before installing and launching the app. Android binary targets can declare an `emulator_device` and Once will start that Android Virtual Device before waiting for the device, installing the app, and launching the activity.

The agent run tool also accepts the same visible request, and the command reference plus mobile graph guides document the new behavior.

## Why

Coding harnesses need a way to run mobile apps in a visible interface, not only through a headless install and launch path. Keeping this as an explicit run option preserves the current default while giving harnesses and developers a clear opt-in path.

## Root cause

The existing mobile run capabilities launched apps through command-line device tooling only. That was enough to install and start the app process, but it did not reliably open a visible simulator or emulator window for the user.

The Android smoke test also exposed two run-path issues that had to be fixed for visible launches to work end to end: generated helper class directories were declared directly as action inputs, and the install step could run before Android's package service was ready.

## Approach

The command-line and agent surfaces pass a visible flag into the generic analysis context instead of hardcoding mobile logic in Rust. Apple and Android target kinds consume that context in Starlark, which keeps toolchain-specific behavior inside the target kinds.

For Android, the visible emulator launcher avoids a supervised launchd job so closing the emulator does not cause macOS to reopen it. The run action now writes marker outputs for device readiness, install completion, and launch completion, which gives the executor explicit ordering between those side-effecting steps.

## Impact

Existing `once run` behavior is unchanged unless `--visible` is passed. Android targets that want Once to start an emulator need to set `emulator_device`; otherwise visible runs use an already-connected physical device or emulator.

## Validation

- `mise exec -- cargo build -p once-cli`
- `mise exec -- cargo check -p once-cli -p once-frontend`
- `mise exec -- cargo test -p once-frontend visible`
- `mise exec -- cargo test -p once-frontend prelude_android`
- `mise exec -- cargo test -p once-frontend --test examples`
- `mise exec -- cargo test -p once-cli graph_target_runner_invokes_cli_and_parses_json_record`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- Manual Apple smoke test: `once run --visible apps/Hello/Hello` opened Simulator and launched the sample app.
- Manual Android smoke test: `once run --visible apps/hello/Hello` started the configured Android Virtual Device, launched the sample app in the emulator, and left no `dev.once` launchd job behind.
