### PR TITLE
feat(frontend): add rust_mobile_library target

### DIFF
--- a/crates/once-frontend/prelude/android.star
+++ b/crates/once-frontend/prelude/android.star
@@ -528,12 +528,13 @@ def _android_validate_native_library_dep(dep, consumer_label):
     label = dep.get("label_id") or "dependency"
     fail(consumer_label + ": Rust library dep `" + label + "` has crate_type `" + crate_type + "` and does not provide an Android shared library; set crate_type = \"cdylib\" or \"dylib\" for Android consumers")
 
-def _android_native_libraries(deps, consumer_label):
+def _android_native_libraries(ctx, deps):
     libraries = []
     for dep in deps:
-        _android_validate_native_library_dep(dep, consumer_label)
-        libraries.extend(dep.get("transitive_android_native_libraries") or [])
-        libraries.extend(dep.get("android_native_libraries") or [])
+        native_dep = _android_materialize_native_dep(ctx, dep)
+        _android_validate_native_library_dep(native_dep, ctx["label"]["id"])
+        libraries.extend(native_dep.get("transitive_android_native_libraries") or [])
+        libraries.extend(native_dep.get("android_native_libraries") or [])
     return _android_unique_native_libraries(libraries)
 
 def _android_native_library_paths(libraries):
@@ -1114,7 +1115,7 @@ def _android_library_impl(ctx):
     dep_resource_apks = _android_resource_apks(ctx["deps"])
     dep_asset_roots = _android_asset_roots_from_deps(ctx["deps"])
     dep_asset_files = _android_asset_files_from_deps(ctx["deps"])
-    dep_native_libraries = _android_native_libraries(ctx["deps"], ctx["label"]["id"])
+    dep_native_libraries = _android_native_libraries(ctx, ctx["deps"])
     compiled_zips = _android_compile_resources(ctx, attrs, tools, resource_files, resource_dirs)
     resource_apk, r_src_dir, r_src_hash, r_txt = _android_link_resources(ctx, attrs, tools, manifest, compiled_zips, dep_compiled_zips, True, [], [])
     classes_dir, classes_hash = _android_compile_java(ctx, attrs, tools, java_sources, r_src_dir, r_src_hash, dep_jars)
@@ -1166,7 +1167,7 @@ def _android_binary_impl(ctx):
     runtime_jars = _android_runtime_jars(ctx["deps"])
     dep_asset_roots = _android_asset_roots_from_deps(ctx["deps"])
     dep_asset_files = _android_asset_files_from_deps(ctx["deps"])
-    native_libraries = _android_native_libraries(ctx["deps"], ctx["label"]["id"])
+    native_libraries = _android_native_libraries(ctx, ctx["deps"])
     compiled_zips = _android_compile_resources(ctx, attrs, tools, resource_files, resource_dirs)
     resource_apk, r_src_dir, r_src_hash, _ = _android_link_resources(ctx, attrs, tools, manifest, compiled_zips, dep_compiled_zips, False, _unique(asset_roots + dep_asset_roots), _unique(asset_files + dep_asset_files))
     classes_dir, classes_hash = _android_compile_java(ctx, attrs, tools, java_sources, r_src_dir, r_src_hash, dep_jars)

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -442,6 +442,12 @@ def _validate_apple_native_deps(deps, consumer_label):
         label = dep.get("label_id") or "dependency"
         fail(consumer_label + ": Rust library dep `" + label + "` has crate_type `" + crate_type + "` and does not provide an Apple static library; set crate_type = \"staticlib\" for Apple consumers")
 
+def _apple_native_deps(ctx):
+    out = []
+    for dep in ctx["deps"]:
+        out.append(_apple_materialize_native_dep(ctx, dep))
+    return out
+
 # A select-shape attribute value is a dict with exactly one `select`
 # key whose value is itself a dict from configuration tokens to
 # branches:
@@ -863,7 +869,7 @@ def _apple_library_impl(ctx):
     swiftc = _resolve_swiftc(platform, sdk_variant, xcode_developer_dir)
     archive = declare_output(module_name + ".a")
 
-    deps = ctx["deps"]
+    deps = _apple_native_deps(ctx)
     _validate_apple_native_deps(deps, ctx["label"]["id"])
     # Split deps into compile-visible (exported) and link-only.
     # exported_deps entries come straight from `[target.attrs]` and may
@@ -1292,7 +1298,7 @@ def _swift_macro_impl(ctx):
     plugin_dylib = declare_output("lib" + module_name + ".dylib")
     plugin_swiftmodule = declare_output(module_name + ".swiftmodule")
 
-    deps = ctx["deps"]
+    deps = _apple_native_deps(ctx)
     _validate_apple_native_deps(deps, ctx["label"]["id"])
 
     # Aggregate dep archives, swiftmodule search paths, frameworks, and
@@ -1512,7 +1518,7 @@ def _apple_framework_impl(ctx):
     modulemap = declare_output(framework_dir + "/Modules/module.modulemap")
     info_plist = declare_output(framework_dir + "/Info.plist")
 
-    deps = ctx["deps"]
+    deps = _apple_native_deps(ctx)
     _validate_apple_native_deps(deps, ctx["label"]["id"])
     (
         compile_swiftmodule_dirs,
@@ -1771,7 +1777,7 @@ def _apple_application_impl(ctx):
     executable = declare_output(app_dir + "/" + product_name)
     info_plist = declare_output(app_dir + "/Info.plist")
 
-    deps = ctx["deps"]
+    deps = _apple_native_deps(ctx)
     _validate_apple_native_deps(deps, ctx["label"]["id"])
     (
         compile_swiftmodule_dirs,
@@ -2025,7 +2031,7 @@ def _apple_test_bundle_impl(ctx):
         "test_info": _apple_test_info(ctx, runner_type, command_argv, action_env, labels, results, log, native_results),
     }
 
-    deps = ctx["deps"]
+    deps = _apple_native_deps(ctx)
     _validate_apple_native_deps(deps, ctx["label"]["id"])
     (
         compile_swiftmodule_dirs,

--- a/crates/once-frontend/prelude/common.star
+++ b/crates/once-frontend/prelude/common.star
@@ -71,6 +71,12 @@ def _package_relative(ctx, path):
         return package + "/" + path
     return path
 
+def _apple_materialize_native_dep(ctx, dep):
+    return dep
+
+def _android_materialize_native_dep(ctx, dep):
+    return dep
+
 def _parent_dir(path):
     idx = -1
     for i in range(len(path)):

--- a/crates/once-frontend/prelude/examples/native-mobile-shared-code-e2e/once.toml
+++ b/crates/once-frontend/prelude/examples/native-mobile-shared-code-e2e/once.toml
@@ -20,32 +20,22 @@ product_name = "SharedKotlin"
 module_name = "SharedKotlin"
 
 [[target]]
-name = "SharedRustAndroid"
-kind = "rust_library"
+name = "SharedRust"
+kind = "rust_mobile_library"
 srcs = ["shared/rust/src/**/*.rs"]
 
 [target.attrs]
 crate_name = "shared_rust"
 crate_root = "shared/rust/src/lib.rs"
-crate_type = "cdylib"
-target = "aarch64-linux-android"
-
-[[target]]
-name = "SharedRustApple"
-kind = "rust_library"
-srcs = ["shared/rust/src/**/*.rs"]
-
-[target.attrs]
-crate_name = "shared_rust"
-crate_root = "shared/rust/src/lib.rs"
-crate_type = "staticlib"
-target = "aarch64-apple-ios-sim"
+apple_target = "aarch64-apple-ios-sim"
+android_target = "aarch64-linux-android"
+android_abi = "arm64-v8a"
 
 [[target]]
 name = "AndroidApp"
 kind = "android_binary"
 srcs = ["android/src/**/*.kt"]
-deps = ["./SharedSwiftAndroid", "./SharedRustAndroid"]
+deps = ["./SharedSwiftAndroid", "./SharedRust"]
 
 [target.attrs]
 application_id = "dev.once.shared"
@@ -60,7 +50,7 @@ version_name = "1.0"
 name = "AppleApp"
 kind = "apple_application"
 srcs = ["apple/Sources/**/*.swift"]
-deps = ["./SharedKotlinApple", "./SharedRustApple"]
+deps = ["./SharedKotlinApple", "./SharedRust"]
 
 [target.attrs]
 platform = "ios"

--- a/crates/once-frontend/prelude/examples/rust-native-mobile-library/shared/rust/once.toml
+++ b/crates/once-frontend/prelude/examples/rust-native-mobile-library/shared/rust/once.toml
@@ -1,20 +1,10 @@
 [[target]]
-name = "SharedRustApple"
-kind = "rust_library"
+name = "SharedRust"
+kind = "rust_mobile_library"
 srcs = ["src/**/*.rs"]
 
 [target.attrs]
 crate_name = "shared_rust"
-crate_type = "staticlib"
-target = "aarch64-apple-ios"
-
-[[target]]
-name = "SharedRustAndroid"
-kind = "rust_library"
-srcs = ["src/**/*.rs"]
-
-[target.attrs]
-crate_name = "shared_rust"
-crate_type = "cdylib"
-target = "aarch64-linux-android"
+apple_target = "aarch64-apple-ios"
+android_target = "aarch64-linux-android"
 android_abi = "arm64-v8a"

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -99,18 +99,25 @@ def _rust_crate_root(ctx, default_root):
     return _package_relative(ctx, _rust_attr(ctx, "crate_root", default_root))
 
 def _rust_sources(ctx, crate_root):
-    srcs = _filter_by_extensions(glob(ctx["srcs"]), [".rs"])
+    resolved = ctx["attr"].get("_resolved_sources")
+    srcs = _filter_by_extensions(resolved if resolved != None else glob(ctx["srcs"]), [".rs"])
     if crate_root not in srcs:
         srcs.append(crate_root)
     return _unique(srcs)
 
 def _rust_source_inputs(ctx):
+    resolved = ctx["attr"].get("_resolved_source_inputs")
+    if resolved != None:
+        return resolved
     return glob(ctx["srcs"])
 
 def _rust_extra_inputs(ctx):
     return _rust_attr(ctx, "_extra_inputs", [])
 
 def _rust_build_script_inputs(ctx):
+    resolved = ctx["attr"].get("_resolved_build_script_inputs")
+    if resolved != None:
+        return resolved
     return glob(_rust_attr(ctx, "_build_script_inputs", []))
 
 def _rust_target(ctx):
@@ -1458,20 +1465,26 @@ def _rust_library_impl(ctx):
     crate_type = _rust_attr(ctx, "crate_type", "rlib")
     return _rust_compile(ctx, crate_type, "src/lib.rs", _rust_output_name(ctx, crate_type))
 
-def _rust_mobile_variant_ctx(ctx, target_attr, variant):
-    target = _rust_attr(ctx, target_attr, "")
+def _rust_mobile_output_prefix(provider, variant):
+    return "rust-mobile/" + (provider.get("label_id") or "dependency") + "/" + variant + "/"
+
+def _rust_mobile_variant_ctx(ctx, provider, target_attr, variant):
+    target = provider.get(target_attr) or ""
     if not target:
-        fail(ctx["label"]["id"] + ": `" + target_attr + "` is required")
+        fail((provider.get("label_id") or "rust_mobile_library") + ": `" + target_attr + "` is required")
     attrs = {}
-    for key, value in ctx["attr"].items():
+    for key, value in (provider.get("attrs") or {}).items():
         attrs[key] = value
     attrs["target"] = target
-    attrs["_output_prefix"] = variant + "/"
+    attrs["_output_prefix"] = _rust_mobile_output_prefix(provider, variant)
+    attrs["_resolved_sources"] = provider.get("resolved_sources") or []
+    attrs["_resolved_source_inputs"] = provider.get("source_inputs") or []
+    attrs["_resolved_build_script_inputs"] = provider.get("build_script_inputs") or []
     variant_ctx = {
-        "label": ctx["label"],
+        "label": provider["label"],
         "attr": attrs,
-        "srcs": ctx["srcs"],
-        "deps": ctx["deps"],
+        "srcs": provider.get("srcs") or [],
+        "deps": [],
         "build_dir": ctx.get("build_dir") or _rust_build_dir(ctx),
         "scratch_dir": ctx.get("scratch_dir") or _rust_scratch_dir(ctx),
         "_action_suffix": variant,
@@ -1483,27 +1496,67 @@ def _rust_mobile_variant_ctx(ctx, target_attr, variant):
     return variant_ctx
 
 def _rust_mobile_library_impl(ctx):
-    apple_ctx = _rust_mobile_variant_ctx(ctx, "apple_target", "apple")
-    android_ctx = _rust_mobile_variant_ctx(ctx, "android_target", "android")
-    apple = _rust_compile(apple_ctx, "staticlib", "src/lib.rs", _rust_output_name(apple_ctx, "staticlib"))
-    android = _rust_compile(android_ctx, "cdylib", "src/lib.rs", _rust_output_name(android_ctx, "cdylib"))
+    if len(ctx["deps"]) > 0:
+        fail(ctx["label"]["id"] + ": rust_mobile_library does not support Rust deps yet; use platform-specific rust_library targets when the mobile library has Rust dependencies")
+    crate_root = _rust_crate_root(ctx, "src/lib.rs")
+    resolved_sources = _rust_sources(ctx, crate_root)
     return {
+        "label": ctx["label"],
         "label_id": ctx["label"]["id"],
         "target_kind": "rust_mobile_library",
+        "attrs": ctx["attr"],
+        "srcs": ctx["srcs"],
         "crate_name": _rust_crate_name(ctx),
-        "root": _rust_crate_root(ctx, "src/lib.rs"),
-        "apple_target": _rust_target(apple_ctx),
-        "android_target": _rust_target(android_ctx),
+        "root": crate_root,
+        "apple_target": _rust_attr(ctx, "apple_target", ""),
+        "android_target": _rust_attr(ctx, "android_target", ""),
+        "resolved_sources": resolved_sources,
+        "source_inputs": _rust_source_inputs(ctx),
+        "build_script_inputs": _rust_build_script_inputs(ctx),
+        "transitive_sources": resolved_sources,
+    }
+
+def _rust_mobile_apple_provider(ctx, provider):
+    if provider.get("target_kind") != "rust_mobile_library":
+        return provider
+    apple_ctx = _rust_mobile_variant_ctx(ctx, provider, "apple_target", "apple")
+    apple = _rust_compile(apple_ctx, "staticlib", "src/lib.rs", _rust_output_name(apple_ctx, "staticlib"))
+    return {
+        "label_id": provider.get("label_id") or "",
+        "target_kind": "rust_mobile_library",
+        "crate_name": provider.get("crate_name") or "",
+        "root": provider.get("root") or "",
+        "apple_target": provider.get("apple_target") or "",
         "archive": apple.get("archive") or "",
         "staticlib": apple.get("staticlib"),
         "transitive_archives": apple.get("transitive_archives") or [],
         "transitive_linkopts": apple.get("transitive_linkopts") or [],
+        "transitive_sources": apple.get("transitive_sources") or [],
+    }
+
+def _rust_mobile_android_provider(ctx, provider):
+    if provider.get("target_kind") != "rust_mobile_library":
+        return provider
+    android_ctx = _rust_mobile_variant_ctx(ctx, provider, "android_target", "android")
+    android = _rust_compile(android_ctx, "cdylib", "src/lib.rs", _rust_output_name(android_ctx, "cdylib"))
+    return {
+        "label_id": provider.get("label_id") or "",
+        "target_kind": "rust_mobile_library",
+        "crate_name": provider.get("crate_name") or "",
+        "root": provider.get("root") or "",
+        "android_target": provider.get("android_target") or "",
         "android_abi": android.get("android_abi") or "",
         "dylib": android.get("dylib"),
         "android_native_libraries": android.get("android_native_libraries") or [],
         "transitive_android_native_libraries": android.get("transitive_android_native_libraries") or [],
-        "transitive_sources": _unique((apple.get("transitive_sources") or []) + (android.get("transitive_sources") or [])),
+        "transitive_sources": android.get("transitive_sources") or [],
     }
+
+def _apple_materialize_native_dep(ctx, dep):
+    return _rust_mobile_apple_provider(ctx, dep)
+
+def _android_materialize_native_dep(ctx, dep):
+    return _rust_mobile_android_provider(ctx, dep)
 
 def _rust_binary_impl(ctx):
     return _rust_compile(ctx, "bin", "src/main.rs", _rust_output_name(ctx, "bin"))
@@ -2307,9 +2360,7 @@ _RUST_MOBILE_ATTRS = [
     attr("android_abi", "string", docs = "Android Application Binary Interface directory (https://developer.android.com/ndk/guides/abis) for the Android shared library output, such as `arm64-v8a`; inferred from common Android target triples when omitted.", configurable = False),
     attr("android_api", "int", default = "23", docs = "Android platform level used to select the Android Native Development Kit clang wrapper for Android targets.", configurable = False),
     attr("android_ndk", "string", docs = "Android Native Development Kit root used to find clang wrapper linkers. Defaults to ANDROID_NDK_HOME.", configurable = False),
-    attr("crate_aliases", "map<string, string>", default = "{}", docs = "Map dependency label, package name, or crate name to the local extern crate name.", configurable = False),
-    attr("cargo_package", "string", docs = "Cargo package name used to select direct external deps from a cargo_dependencies dependency set. Defaults to CARGO_PKG_NAME when present.", configurable = False),
-    attr("build_script", "string", docs = "Package-relative Cargo build script path. Once compiles and runs it before rustc, consumes common cargo:rustc-* stdout directives, and passes direct dependency links metadata as DEP_* env vars.", configurable = False),
+    attr("build_script", "string", docs = "Package-relative Cargo build script path. Once compiles and runs it before each platform rustc invocation and consumes common cargo:rustc-* stdout directives.", configurable = False),
 ]
 
 cargo_dependencies = target_kind(
@@ -2356,16 +2407,15 @@ rust_library = target_kind(
 )
 
 rust_mobile_library = target_kind(
-    docs = "Rust library compiled twice for mobile consumers: an Apple static library and an Android shared library.",
+    docs = "Rust library materialized by Apple and Android consumers as native mobile libraries.",
     attrs = _RUST_MOBILE_ATTRS,
-    deps = [dep("deps", ["rust_crate", "rust_proc_macro", "rust_dependency_set"], "Rust crate dependencies consumed through --extern.")],
     providers = ["native_linkable", "apple_linkable", "android_native_library"],
-    capabilities = [capability("build", ["library"])],
+    capabilities = [capability("build", [])],
     examples = [
         example(
             "rust-native-mobile-library",
             name = "Rust native mobile library",
-            use_when = "Use this when Rust shared code should build as one target that emits native libraries for Apple and Android.",
+            use_when = "Use this when Rust shared code should be one target that Apple and Android consumers materialize as native libraries.",
         ),
         example(
             "native-mobile-shared-code-e2e",

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -20,6 +20,12 @@ def _rust_build_dir(ctx):
 def _rust_scratch_dir(ctx):
     return ctx.get("scratch_dir") or (".once/tmp/analysis/" + ctx["label"]["id"])
 
+def _rust_action_identifier(ctx, name):
+    suffix = ctx.get("_action_suffix") or ""
+    if suffix:
+        return ctx["label"]["id"] + ":" + name + ":" + suffix
+    return ctx["label"]["id"] + ":" + name
+
 def _crate_name_from_label(ctx):
     return ctx["label"]["name"].replace("-", "_").replace(".", "_")
 
@@ -173,15 +179,15 @@ def _rust_android_ndk_tool_dir(ctx):
         directory = ndk + "/toolchains/llvm/prebuilt/" + tag + "/bin"
         if host_file_exists(directory + "/" + _host_exe("clang")):
             return directory
-    fail(ctx["label"]["id"] + ": Android NDK under `" + ndk + "` has no usable LLVM prebuilt for this host")
+    fail(ctx["label"]["id"] + ": Android Native Development Kit under `" + ndk + "` has no usable LLVM prebuilt for this host")
 
 def _rust_android_linker(ctx, target):
     prefix = _rust_android_tool_prefix(target)
     if not prefix:
-        fail(ctx["label"]["id"] + ": set `linker`; Once could not infer an Android NDK linker for target `" + target + "`")
+        fail(ctx["label"]["id"] + ": set `linker`; Once could not infer an Android Native Development Kit linker for target `" + target + "`")
     tool_dir = _rust_android_ndk_tool_dir(ctx)
     if not tool_dir:
-        fail(ctx["label"]["id"] + ": set `android_ndk`, ANDROID_NDK_HOME, or `linker` so Once can find the Android NDK linker")
+        fail(ctx["label"]["id"] + ": set `android_ndk`, ANDROID_NDK_HOME, or `linker` so Once can find the Android Native Development Kit linker")
     api = str(_rust_attr(ctx, "android_api", 23))
     return tool_dir + "/" + prefix + api + "-clang"
 
@@ -698,8 +704,8 @@ def _rust_stage_rlibs_for_search(ctx, deps, tag):
     if not artifacts:
         return ([], [])
     search_dir = declare_output(_rust_declared_output(ctx, tag + "-rlib-search"))
-    prepare_path(search_dir, kind = "remove", identifier = ctx["label"]["id"] + ":" + tag + "-rlib-search-clean")
-    prepare_path(search_dir, kind = "directory", identifier = ctx["label"]["id"] + ":" + tag + "-rlib-search-prepare")
+    prepare_path(search_dir, kind = "remove", identifier = _rust_action_identifier(ctx, tag + "-rlib-search-clean"))
+    prepare_path(search_dir, kind = "directory", identifier = _rust_action_identifier(ctx, tag + "-rlib-search-prepare"))
     staged = []
     seen = {}
     for artifact in artifacts:
@@ -712,7 +718,7 @@ def _rust_stage_rlibs_for_search(ctx, deps, tag):
             artifact,
             output,
             inputs = [artifact],
-            identifier = ctx["label"]["id"] + ":" + tag + "-rlib-search:" + name,
+            identifier = _rust_action_identifier(ctx, tag + "-rlib-search:" + name),
         )
         staged.append(output)
     return (["-L", "dependency=" + search_dir], staged)
@@ -761,14 +767,14 @@ def _rust_search_path_args(ctx, deps, tag):
 
 def _rust_stage_proc_macro_for_search(ctx, output):
     search_dir = declare_output(_rust_declared_output(ctx, "proc-macro-search"))
-    prepare_path(search_dir, kind = "remove", identifier = ctx["label"]["id"] + ":proc-macro-search-clean")
-    prepare_path(search_dir, kind = "directory", identifier = ctx["label"]["id"] + ":proc-macro-search-prepare")
+    prepare_path(search_dir, kind = "remove", identifier = _rust_action_identifier(ctx, "proc-macro-search-clean"))
+    prepare_path(search_dir, kind = "directory", identifier = _rust_action_identifier(ctx, "proc-macro-search-prepare"))
     staged = search_dir + "/" + _basename(output)
     copy_path(
         output,
         staged,
         inputs = [output],
-        identifier = ctx["label"]["id"] + ":proc-macro-search:" + _basename(output),
+        identifier = _rust_action_identifier(ctx, "proc-macro-search:" + _basename(output)),
     )
     return staged
 
@@ -974,12 +980,12 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         outputs = [runner],
         env = build_script_compile_env,
         toolchain_identity = identity + linker_identity + "\x00build-script",
-        identifier = ctx["label"]["id"] + ":build-script-rustc",
+        identifier = _rust_action_identifier(ctx, "build-script-rustc"),
     )
     run_env = _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path)
     metadata_exports, metadata_inputs = _rust_dep_metadata_exports(metadata_deps)
-    prepare_path(out_dir, kind = "directory", identifier = ctx["label"]["id"] + ":build-script-out-dir")
-    prepare_path(out_dir + "/.once-build-script-status", kind = "remove", identifier = ctx["label"]["id"] + ":build-script-status-clean")
+    prepare_path(out_dir, kind = "directory", identifier = _rust_action_identifier(ctx, "build-script-out-dir"))
+    prepare_path(out_dir + "/.once-build-script-status", kind = "remove", identifier = _rust_action_identifier(ctx, "build-script-status-clean"))
     run_script = _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports)
     run_action(
         argv = [host_which("sh"), "-c", run_script],
@@ -987,7 +993,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         outputs = [out_dir, stdout],
         env = run_env,
         toolchain_identity = identity + "\x00build-script-run",
-        identifier = ctx["label"]["id"] + ":build-script",
+        identifier = _rust_action_identifier(ctx, "build-script"),
     )
     compile_env = _rust_compile_action_env(ctx, target, host_triple)
     compile_env["OUT_DIR"] = _workspace_absolute(out_dir)
@@ -1255,7 +1261,7 @@ def _rust_android_abi(ctx, target, crate_type):
         return ""
     abi = _rust_android_abi_for_target(target)
     if "android" in target and not abi:
-        fail(ctx["label"]["id"] + ": set `android_abi`; Once could not infer an Android ABI from target `" + target + "`")
+        fail(ctx["label"]["id"] + ": set `android_abi`; Once could not infer an Android Application Binary Interface from target `" + target + "`")
     return abi
 
 def _rust_native_library_key(library):
@@ -1402,7 +1408,7 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
         outputs = [output],
         env = compile_env,
         toolchain_identity = identity + linker_identity,
-        identifier = ctx["label"]["id"] + ":rustc",
+        identifier = _rust_action_identifier(ctx, "rustc"),
     )
     own_proc_macro_search = []
     own_proc_macro_extern = []
@@ -1451,6 +1457,53 @@ def _rust_compile(ctx, crate_type, default_root, output_name):
 def _rust_library_impl(ctx):
     crate_type = _rust_attr(ctx, "crate_type", "rlib")
     return _rust_compile(ctx, crate_type, "src/lib.rs", _rust_output_name(ctx, crate_type))
+
+def _rust_mobile_variant_ctx(ctx, target_attr, variant):
+    target = _rust_attr(ctx, target_attr, "")
+    if not target:
+        fail(ctx["label"]["id"] + ": `" + target_attr + "` is required")
+    attrs = {}
+    for key, value in ctx["attr"].items():
+        attrs[key] = value
+    attrs["target"] = target
+    attrs["_output_prefix"] = variant + "/"
+    variant_ctx = {
+        "label": ctx["label"],
+        "attr": attrs,
+        "srcs": ctx["srcs"],
+        "deps": ctx["deps"],
+        "build_dir": ctx.get("build_dir") or _rust_build_dir(ctx),
+        "scratch_dir": ctx.get("scratch_dir") or _rust_scratch_dir(ctx),
+        "_action_suffix": variant,
+    }
+    for key in ["build_deps", "capability", "run"]:
+        value = ctx.get(key)
+        if value != None:
+            variant_ctx[key] = value
+    return variant_ctx
+
+def _rust_mobile_library_impl(ctx):
+    apple_ctx = _rust_mobile_variant_ctx(ctx, "apple_target", "apple")
+    android_ctx = _rust_mobile_variant_ctx(ctx, "android_target", "android")
+    apple = _rust_compile(apple_ctx, "staticlib", "src/lib.rs", _rust_output_name(apple_ctx, "staticlib"))
+    android = _rust_compile(android_ctx, "cdylib", "src/lib.rs", _rust_output_name(android_ctx, "cdylib"))
+    return {
+        "label_id": ctx["label"]["id"],
+        "target_kind": "rust_mobile_library",
+        "crate_name": _rust_crate_name(ctx),
+        "root": _rust_crate_root(ctx, "src/lib.rs"),
+        "apple_target": _rust_target(apple_ctx),
+        "android_target": _rust_target(android_ctx),
+        "archive": apple.get("archive") or "",
+        "staticlib": apple.get("staticlib"),
+        "transitive_archives": apple.get("transitive_archives") or [],
+        "transitive_linkopts": apple.get("transitive_linkopts") or [],
+        "android_abi": android.get("android_abi") or "",
+        "dylib": android.get("dylib"),
+        "android_native_libraries": android.get("android_native_libraries") or [],
+        "transitive_android_native_libraries": android.get("transitive_android_native_libraries") or [],
+        "transitive_sources": _unique((apple.get("transitive_sources") or []) + (android.get("transitive_sources") or [])),
+    }
 
 def _rust_binary_impl(ctx):
     return _rust_compile(ctx, "bin", "src/main.rs", _rust_output_name(ctx, "bin"))
@@ -2226,12 +2279,34 @@ _RUST_COMMON_ATTRS = [
     attr("rustc_env", "map<string, string>", default = "{}", docs = "Bazel-compatible rustc environment variables.", configurable = False),
     attr("rustc_flags", "list<string>", default = "[]", docs = "Additional rustc flags appended after Once-managed flags.", configurable = False),
     attr("cap_lints", "string", docs = "Optional rustc lint cap passed as `--cap-lints`; generated Cargo dependencies use `allow` to match Cargo dependency builds.", configurable = False),
-    attr("linker", "string", docs = "Optional linker path passed as `-C linker=...`. Defaults to `cc` for host Unix binary-like targets and to the Android NDK clang wrapper for Android targets when ANDROID_NDK_HOME or android_ndk is set.", configurable = False),
+    attr("linker", "string", docs = "Optional linker path passed as `-C linker=...`. Defaults to `cc` for host Unix binary-like targets and to the Android Native Development Kit clang wrapper for Android targets when ANDROID_NDK_HOME or android_ndk is set.", configurable = False),
     attr("linker_flags", "list<string>", default = "[]", docs = "Additional linker flags lowered to `-C link-arg=...`.", configurable = False),
     attr("native_linkopts", "list<string>", default = "[]", docs = "Linker flags propagated to native consumers such as Apple app or framework targets.", configurable = False),
-    attr("android_abi", "string", docs = "Android ABI directory for cdylib or dylib outputs, such as `arm64-v8a`; inferred from common Android target triples when omitted.", configurable = False),
-    attr("android_api", "int", default = "23", docs = "Android API level used to select the NDK clang wrapper for Android targets.", configurable = False),
-    attr("android_ndk", "string", docs = "Android NDK root used to find clang wrapper linkers. Defaults to ANDROID_NDK_HOME.", configurable = False),
+    attr("android_abi", "string", docs = "Android Application Binary Interface directory (https://developer.android.com/ndk/guides/abis) for cdylib or dylib outputs, such as `arm64-v8a`; inferred from common Android target triples when omitted.", configurable = False),
+    attr("android_api", "int", default = "23", docs = "Android platform level used to select the Android Native Development Kit clang wrapper for Android targets.", configurable = False),
+    attr("android_ndk", "string", docs = "Android Native Development Kit root used to find clang wrapper linkers. Defaults to ANDROID_NDK_HOME.", configurable = False),
+    attr("crate_aliases", "map<string, string>", default = "{}", docs = "Map dependency label, package name, or crate name to the local extern crate name.", configurable = False),
+    attr("cargo_package", "string", docs = "Cargo package name used to select direct external deps from a cargo_dependencies dependency set. Defaults to CARGO_PKG_NAME when present.", configurable = False),
+    attr("build_script", "string", docs = "Package-relative Cargo build script path. Once compiles and runs it before rustc, consumes common cargo:rustc-* stdout directives, and passes direct dependency links metadata as DEP_* env vars.", configurable = False),
+]
+
+_RUST_MOBILE_ATTRS = [
+    attr("crate_name", "string", docs = "Rust crate name passed to rustc. Defaults to the target name with `-` and `.` rewritten as `_`.", configurable = False),
+    attr("crate_root", "string", docs = "Package-relative path to lib.rs. Defaults to src/lib.rs.", configurable = False),
+    attr("edition", "string", default = "2021", docs = "Rust edition passed to rustc.", configurable = False),
+    attr("features", "list<string>", default = "[]", docs = "Cargo feature names lowered to rustc `--cfg=feature=...` flags."),
+    attr("crate_features", "list<string>", default = "[]", docs = "Bazel-compatible alias for `features`."),
+    attr("apple_target", "string", required = True, docs = "Rust target triple passed to the Apple static library compile.", configurable = False),
+    attr("android_target", "string", required = True, docs = "Rust target triple passed to the Android shared library compile.", configurable = False),
+    attr("env", "map<string, string>", default = "{}", docs = "Environment variables for rustc, matching Buck2's `env` attribute.", configurable = False),
+    attr("rustc_env", "map<string, string>", default = "{}", docs = "Bazel-compatible rustc environment variables.", configurable = False),
+    attr("rustc_flags", "list<string>", default = "[]", docs = "Additional rustc flags appended after Once-managed flags.", configurable = False),
+    attr("cap_lints", "string", docs = "Optional rustc lint cap passed as `--cap-lints`; generated Cargo dependencies use `allow` to match Cargo dependency builds.", configurable = False),
+    attr("linker_flags", "list<string>", default = "[]", docs = "Additional linker flags lowered to `-C link-arg=...`.", configurable = False),
+    attr("native_linkopts", "list<string>", default = "[]", docs = "Linker flags propagated to native consumers such as Apple app or framework targets.", configurable = False),
+    attr("android_abi", "string", docs = "Android Application Binary Interface directory (https://developer.android.com/ndk/guides/abis) for the Android shared library output, such as `arm64-v8a`; inferred from common Android target triples when omitted.", configurable = False),
+    attr("android_api", "int", default = "23", docs = "Android platform level used to select the Android Native Development Kit clang wrapper for Android targets.", configurable = False),
+    attr("android_ndk", "string", docs = "Android Native Development Kit root used to find clang wrapper linkers. Defaults to ANDROID_NDK_HOME.", configurable = False),
     attr("crate_aliases", "map<string, string>", default = "{}", docs = "Map dependency label, package name, or crate name to the local extern crate name.", configurable = False),
     attr("cargo_package", "string", docs = "Cargo package name used to select direct external deps from a cargo_dependencies dependency set. Defaults to CARGO_PKG_NAME when present.", configurable = False),
     attr("build_script", "string", docs = "Package-relative Cargo build script path. Once compiles and runs it before rustc, consumes common cargo:rustc-* stdout directives, and passes direct dependency links metadata as DEP_* env vars.", configurable = False),
@@ -2276,10 +2351,21 @@ rust_library = target_kind(
             name = "Minimal Rust library",
             use_when = "Start here for a first-party Rust rlib target with no external dependencies.",
         ),
+    ],
+    impl = _rust_library_impl,
+)
+
+rust_mobile_library = target_kind(
+    docs = "Rust library compiled twice for mobile consumers: an Apple static library and an Android shared library.",
+    attrs = _RUST_MOBILE_ATTRS,
+    deps = [dep("deps", ["rust_crate", "rust_proc_macro", "rust_dependency_set"], "Rust crate dependencies consumed through --extern.")],
+    providers = ["native_linkable", "apple_linkable", "android_native_library"],
+    capabilities = [capability("build", ["library"])],
+    examples = [
         example(
             "rust-native-mobile-library",
             name = "Rust native mobile library",
-            use_when = "Use this when Rust shared code should build as a static library for Apple and a shared library for Android.",
+            use_when = "Use this when Rust shared code should build as one target that emits native libraries for Apple and Android.",
         ),
         example(
             "native-mobile-shared-code-e2e",
@@ -2287,7 +2373,7 @@ rust_library = target_kind(
             use_when = "Use this when one Rust codebase should be packaged into Android and linked into Apple apps alongside Swift and Kotlin shared code.",
         ),
     ],
-    impl = _rust_library_impl,
+    impl = _rust_mobile_library_impl,
 )
 
 rust_binary = target_kind(

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -145,7 +145,7 @@ fn native_mobile_shared_code_example_wires_cross_platform_apps() {
     for kind in [
         "swift_android_library",
         "kotlin_apple_framework",
-        "rust_library",
+        "rust_mobile_library",
         "android_binary",
         "apple_application",
     ] {
@@ -180,30 +180,26 @@ fn native_mobile_shared_code_example_wires_cross_platform_apps() {
     assert_eq!(android_app.kind, "android_binary");
     assert_eq!(
         android_app.deps,
-        vec![
-            "SharedSwiftAndroid".to_string(),
-            "SharedRustAndroid".to_string()
-        ]
+        vec!["SharedSwiftAndroid".to_string(), "SharedRust".to_string()]
     );
 
     let apple_app = by_id.get("AppleApp").expect("AppleApp target");
     assert_eq!(apple_app.kind, "apple_application");
     assert_eq!(
         apple_app.deps,
-        vec![
-            "SharedKotlinApple".to_string(),
-            "SharedRustApple".to_string()
-        ]
+        vec!["SharedKotlinApple".to_string(), "SharedRust".to_string()]
     );
 
+    assert_eq!(
+        by_id
+            .keys()
+            .filter(|id| id.starts_with("SharedRust"))
+            .count(),
+        1
+    );
     assert!(by_id
         .get("SharedSwiftAndroid")
         .expect("SharedSwiftAndroid target")
-        .providers
-        .contains(&"android_native_library".to_string()));
-    assert!(by_id
-        .get("SharedRustAndroid")
-        .expect("SharedRustAndroid target")
         .providers
         .contains(&"android_native_library".to_string()));
     assert!(by_id
@@ -211,9 +207,12 @@ fn native_mobile_shared_code_example_wires_cross_platform_apps() {
         .expect("SharedKotlinApple target")
         .providers
         .contains(&"apple_framework".to_string()));
-    assert!(by_id
-        .get("SharedRustApple")
-        .expect("SharedRustApple target")
+    let shared_rust = by_id.get("SharedRust").expect("SharedRust target");
+    assert_eq!(shared_rust.kind, "rust_mobile_library");
+    assert!(shared_rust
+        .providers
+        .contains(&"android_native_library".to_string()));
+    assert!(shared_rust
         .providers
         .contains(&"apple_linkable".to_string()));
 }
@@ -345,14 +344,13 @@ fn native_mobile_android_dep_providers() -> [serde_json::Value; 2] {
             ],
         }),
         json!({
-            "label_id": "SharedRustAndroid",
-            "target_kind": "rust_library",
-            "crate_type": "cdylib",
+            "label_id": "SharedRust",
+            "target_kind": "rust_mobile_library",
             "android_native_libraries": [
-                {"abi": "arm64-v8a", "path": ".once/out/SharedRustAndroid/libshared_rust.so"}
+                {"abi": "arm64-v8a", "path": ".once/out/SharedRust/android/libshared_rust.so"}
             ],
             "transitive_android_native_libraries": [
-                {"abi": "arm64-v8a", "path": ".once/out/SharedRustAndroid/libshared_rust.so"}
+                {"abi": "arm64-v8a", "path": ".once/out/SharedRust/android/libshared_rust.so"}
             ],
         }),
     ]

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -237,6 +237,14 @@ fn native_mobile_shared_code_example_declares_android_native_packaging_actions()
             .any(|source| source.ends_with("libshared_rust.so")),
         "{staged_sources:?}"
     );
+    assert!(result
+        .actions
+        .iter()
+        .any(|action| action.identifier.as_deref() == Some("SharedRust:rustc:android")));
+    assert!(!result
+        .actions
+        .iter()
+        .any(|action| action.identifier.as_deref() == Some("SharedRust:rustc:apple")));
     assert!(declares_android_native_apk_action(&result));
 }
 
@@ -326,12 +334,31 @@ fn configure_fake_android_tools(root: &Path, android_app: &mut GraphTarget) {
 fn analyze_native_mobile_android_app(root: &Path, android_app: &GraphTarget) -> AnalysisResult {
     let engine = AnalysisEngine::for_workspace(root).expect("analysis engine");
     engine
-        .analyze_target(android_app, root, &native_mobile_android_dep_providers())
+        .analyze_target(
+            android_app,
+            root,
+            &native_mobile_android_dep_providers(root),
+        )
         .expect("AndroidApp analysis")
 }
 
 #[cfg(unix)]
-fn native_mobile_android_dep_providers() -> [serde_json::Value; 2] {
+fn native_mobile_android_dep_providers(root: &Path) -> [serde_json::Value; 2] {
+    let fake_ndk = root.join("android-ndk");
+    for tag in [
+        "darwin-arm64",
+        "darwin-x86_64",
+        "linux-arm64",
+        "linux-x86_64",
+    ] {
+        let bin_dir = fake_ndk
+            .join("toolchains/llvm/prebuilt")
+            .join(tag)
+            .join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        fs::write(bin_dir.join("clang"), "").unwrap();
+    }
+    let fake_ndk = fake_ndk.to_string_lossy().into_owned();
     [
         json!({
             "label_id": "SharedSwiftAndroid",
@@ -344,14 +371,26 @@ fn native_mobile_android_dep_providers() -> [serde_json::Value; 2] {
             ],
         }),
         json!({
+            "label": {"package": "", "name": "SharedRust", "id": "SharedRust"},
             "label_id": "SharedRust",
             "target_kind": "rust_mobile_library",
-            "android_native_libraries": [
-                {"abi": "arm64-v8a", "path": ".once/out/SharedRust/android/libshared_rust.so"}
-            ],
-            "transitive_android_native_libraries": [
-                {"abi": "arm64-v8a", "path": ".once/out/SharedRust/android/libshared_rust.so"}
-            ],
+            "attrs": {
+                "crate_name": "shared_rust",
+                "crate_root": "shared/rust/src/lib.rs",
+                "apple_target": "aarch64-apple-ios-sim",
+                "android_target": "aarch64-linux-android",
+                "android_abi": "arm64-v8a",
+                "android_ndk": fake_ndk,
+            },
+            "srcs": ["shared/rust/src/**/*.rs"],
+            "crate_name": "shared_rust",
+            "root": "shared/rust/src/lib.rs",
+            "apple_target": "aarch64-apple-ios-sim",
+            "android_target": "aarch64-linux-android",
+            "resolved_sources": ["shared/rust/src/lib.rs"],
+            "source_inputs": ["shared/rust/src/lib.rs"],
+            "build_script_inputs": [],
+            "transitive_sources": ["shared/rust/src/lib.rs"],
         }),
     ]
 }

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -29,6 +29,19 @@ fn action_by_identifier<'a>(store: &'a AnalysisStore, identifier: &str) -> &'a D
         .unwrap_or_else(|| panic!("missing action `{identifier}`"))
 }
 
+#[cfg(unix)]
+fn android_ndk_prebuilt_tag() -> &'static str {
+    if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        "darwin-arm64"
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+        "darwin-x86_64"
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        "linux-arm64"
+    } else {
+        "linux-x86_64"
+    }
+}
+
 fn apple_prelude_source() -> String {
     format!(
         "{}\n{}",
@@ -165,6 +178,25 @@ fn cross_platform_target_kind_schemas_are_discoverable() {
     assert!(rust.providers.iter().any(|p| p == "android_native_library"));
     assert!(rust.attrs.iter().any(|attr| attr.name == "android_abi"));
     assert!(rust.attrs.iter().any(|attr| attr.name == "native_linkopts"));
+
+    let rust_mobile =
+        built_in_target_kind_schema("rust_mobile_library").expect("rust_mobile_library schema");
+    assert!(target_kind_has_impl("rust_mobile_library").unwrap());
+    assert!(rust_mobile.providers.iter().any(|p| p == "apple_linkable"));
+    assert!(rust_mobile
+        .providers
+        .iter()
+        .any(|p| p == "android_native_library"));
+    assert!(rust_mobile.providers.iter().any(|p| p == "native_linkable"));
+    assert!(!rust_mobile.providers.iter().any(|p| p == "rust_crate"));
+    assert!(rust_mobile
+        .attrs
+        .iter()
+        .any(|attr| attr.name == "apple_target" && attr.required));
+    assert!(rust_mobile
+        .attrs
+        .iter()
+        .any(|attr| attr.name == "android_target" && attr.required));
 }
 
 #[test]
@@ -758,8 +790,10 @@ fn prelude_rust_native_outputs_emit_mobile_provider_fields() {
         std::fs::create_dir_all(&bin_dir).unwrap();
         std::fs::write(bin_dir.join("clang"), "").unwrap();
     }
-    let fake_linker =
-        fake_ndk.join("toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android23-clang");
+    let fake_linker = fake_ndk
+        .join("toolchains/llvm/prebuilt")
+        .join(android_ndk_prebuilt_tag())
+        .join("bin/aarch64-linux-android23-clang");
     let fake_linker_arg = format!("linker={}", fake_linker.to_string_lossy());
     let fake_ndk = fake_ndk.to_string_lossy();
     let fake_linker = fake_linker.to_string_lossy();
@@ -838,6 +872,105 @@ result = repr([
         .iter()
         .any(|arg| arg == &fake_linker_arg));
     assert!(store.actions[1].argv.iter().any(|arg| arg == "--target"));
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_rust_mobile_library_emits_merged_native_provider() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let package_dir = workspace.path().join("shared/rust/src");
+    std::fs::create_dir_all(&package_dir).unwrap();
+    std::fs::write(package_dir.join("lib.rs"), "pub fn greeting() {}\n").unwrap();
+    let fake_ndk = workspace.path().join("android-ndk");
+    for tag in [
+        "darwin-arm64",
+        "darwin-x86_64",
+        "linux-arm64",
+        "linux-x86_64",
+    ] {
+        let bin_dir = fake_ndk
+            .join("toolchains/llvm/prebuilt")
+            .join(tag)
+            .join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::write(bin_dir.join("clang"), "").unwrap();
+    }
+    let fake_linker = fake_ndk
+        .join("toolchains/llvm/prebuilt")
+        .join(android_ndk_prebuilt_tag())
+        .join("bin/aarch64-linux-android24-clang");
+    let fake_linker_arg = format!("linker={}", fake_linker.to_string_lossy());
+    let fake_ndk = fake_ndk.to_string_lossy();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "rustc":
+        return "/toolchains/rust/bin/rustc"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None):
+    if len(argv) >= 3 and argv[1] == "--print" and argv[2] == "sysroot":
+        return "/toolchains/rust\n"
+    if len(argv) >= 2 and argv[1] == "--version":
+        return "rustc test\nhost: x86_64-unknown-linux-gnu\n"
+    fail("unexpected host_command: " + str(argv))
+
+ctx = {{
+    "label": {{
+        "package": "shared/rust",
+        "name": "SharedRust",
+        "id": "shared/rust/SharedRust",
+    }},
+    "attr": {{
+        "crate_name": "shared_rust",
+        "crate_root": "src/lib.rs",
+        "apple_target": "aarch64-apple-ios-sim",
+        "android_target": "aarch64-linux-android",
+        "android_abi": "arm64-v8a",
+        "android_api": 24,
+        "android_ndk": "{fake_ndk}",
+        "native_linkopts": ["-lc++"],
+    }},
+    "deps": [],
+    "srcs": ["src/**/*.rs"],
+    "build_dir": ".once/out/shared/rust/SharedRust",
+}}
+provider = _rust_mobile_library_impl(ctx)
+result = repr([
+    provider["label_id"],
+    provider["target_kind"],
+    provider["archive"],
+    provider["transitive_archives"],
+    provider["transitive_linkopts"],
+    provider["android_native_libraries"],
+    provider["transitive_android_native_libraries"],
+    provider["transitive_sources"],
+])
+"#
+    );
+    let store = store_for(workspace.path(), "shared/rust");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    let out = out.unwrap();
+    assert!(out.contains("shared/rust/SharedRust"), "{out}");
+    assert!(out.contains("rust_mobile_library"), "{out}");
+    assert!(out.contains("apple/libshared_rust.a"), "{out}");
+    assert!(out.contains("android/libshared_rust.so"), "{out}");
+    assert!(out.contains("arm64-v8a"), "{out}");
+    assert!(out.contains("-lc++"), "{out}");
+    let apple = action_by_identifier(&store, "shared/rust/SharedRust:rustc:apple");
+    let android = action_by_identifier(&store, "shared/rust/SharedRust:rustc:android");
+    assert!(apple
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("apple/libshared_rust.a")));
+    assert!(android
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("android/libshared_rust.so")));
+    assert!(android.argv.iter().any(|arg| arg == &fake_linker_arg));
 }
 
 #[cfg(unix)]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -728,14 +728,16 @@ fn prelude_android_rejects_rust_rlib_native_dep() {
     let err = eval_prelude_function_in(
         prelude,
         "_android_native_libraries",
-        r#"([
+        r#"({
+            "label": {"id": "AndroidApp"}
+        }, [
             {
                 "target_kind": "rust_library",
                 "label_id": "SharedRust",
                 "crate_type": "rlib",
                 "rlib": ".once/out/libshared.rlib",
             },
-        ], "AndroidApp")"#,
+        ])"#,
     )
     .unwrap_err();
 
@@ -876,7 +878,7 @@ result = repr([
 
 #[cfg(unix)]
 #[test]
-fn prelude_rust_mobile_library_emits_merged_native_provider() {
+fn prelude_rust_mobile_library_android_consumer_declares_only_android_variant() {
     let prelude = all_prelude_source();
     let workspace = TempDir::new().unwrap();
     let package_dir = workspace.path().join("shared/rust/src");
@@ -916,15 +918,15 @@ def host_command(argv, env = None):
         return "rustc test\nhost: x86_64-unknown-linux-gnu\n"
     fail("unexpected host_command: " + str(argv))
 
-ctx = {{
+mobile_ctx = {{
     "label": {{
-        "package": "shared/rust",
+        "package": "",
         "name": "SharedRust",
-        "id": "shared/rust/SharedRust",
+        "id": "SharedRust",
     }},
     "attr": {{
         "crate_name": "shared_rust",
-        "crate_root": "src/lib.rs",
+        "crate_root": "shared/rust/src/lib.rs",
         "apple_target": "aarch64-apple-ios-sim",
         "android_target": "aarch64-linux-android",
         "android_abi": "arm64-v8a",
@@ -933,44 +935,164 @@ ctx = {{
         "native_linkopts": ["-lc++"],
     }},
     "deps": [],
-    "srcs": ["src/**/*.rs"],
-    "build_dir": ".once/out/shared/rust/SharedRust",
+    "srcs": ["shared/rust/src/**/*.rs"],
+    "build_dir": ".once/out/SharedRust",
 }}
-provider = _rust_mobile_library_impl(ctx)
+provider = _rust_mobile_library_impl(mobile_ctx)
+android_ctx = {{
+    "label": {{
+        "package": "",
+        "name": "AndroidApp",
+        "id": "AndroidApp",
+    }},
+    "attr": {{}},
+    "deps": [provider],
+    "srcs": [],
+    "build_dir": ".once/out/AndroidApp",
+    "scratch_dir": ".once/tmp/analysis/AndroidApp",
+}}
+android_libraries = _android_native_libraries(android_ctx, android_ctx["deps"])
 result = repr([
     provider["label_id"],
     provider["target_kind"],
-    provider["archive"],
-    provider["transitive_archives"],
-    provider["transitive_linkopts"],
-    provider["android_native_libraries"],
-    provider["transitive_android_native_libraries"],
     provider["transitive_sources"],
+    android_libraries,
 ])
 "#
     );
-    let store = store_for(workspace.path(), "shared/rust");
+    let store = AnalysisStore::new(
+        workspace.path().to_path_buf(),
+        String::new(),
+        ".once/out/AndroidApp".to_string(),
+    );
 
     let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 
     let out = out.unwrap();
-    assert!(out.contains("shared/rust/SharedRust"), "{out}");
+    assert!(out.contains("SharedRust"), "{out}");
     assert!(out.contains("rust_mobile_library"), "{out}");
-    assert!(out.contains("apple/libshared_rust.a"), "{out}");
-    assert!(out.contains("android/libshared_rust.so"), "{out}");
+    assert!(
+        out.contains("rust-mobile/SharedRust/android/libshared_rust.so"),
+        "{out}"
+    );
     assert!(out.contains("arm64-v8a"), "{out}");
-    assert!(out.contains("-lc++"), "{out}");
-    let apple = action_by_identifier(&store, "shared/rust/SharedRust:rustc:apple");
-    let android = action_by_identifier(&store, "shared/rust/SharedRust:rustc:android");
-    assert!(apple
-        .outputs
-        .iter()
-        .any(|output| output.ends_with("apple/libshared_rust.a")));
+    let android = action_by_identifier(&store, "SharedRust:rustc:android");
+    assert_eq!(store.actions.len(), 1);
     assert!(android
         .outputs
         .iter()
-        .any(|output| output.ends_with("android/libshared_rust.so")));
+        .any(|output| output.ends_with("rust-mobile/SharedRust/android/libshared_rust.so")));
     assert!(android.argv.iter().any(|arg| arg == &fake_linker_arg));
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_rust_mobile_library_apple_consumer_declares_only_apple_variant() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let package_dir = workspace.path().join("shared/rust/src");
+    std::fs::create_dir_all(&package_dir).unwrap();
+    std::fs::write(package_dir.join("lib.rs"), "pub fn greeting() {}\n").unwrap();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "rustc":
+        return "/toolchains/rust/bin/rustc"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None):
+    if len(argv) >= 3 and argv[1] == "--print" and argv[2] == "sysroot":
+        return "/toolchains/rust\n"
+    if len(argv) >= 2 and argv[1] == "--version":
+        return "rustc test\nhost: x86_64-unknown-linux-gnu\n"
+    fail("unexpected host_command: " + str(argv))
+
+mobile_ctx = {{
+    "label": {{
+        "package": "",
+        "name": "SharedRust",
+        "id": "SharedRust",
+    }},
+    "attr": {{
+        "crate_name": "shared_rust",
+        "crate_root": "shared/rust/src/lib.rs",
+        "apple_target": "aarch64-apple-ios-sim",
+        "android_target": "aarch64-linux-android",
+    }},
+    "deps": [],
+    "srcs": ["shared/rust/src/**/*.rs"],
+    "build_dir": ".once/out/SharedRust",
+}}
+provider = _rust_mobile_library_impl(mobile_ctx)
+apple_ctx = {{
+    "label": {{
+        "package": "",
+        "name": "AppleApp",
+        "id": "AppleApp",
+    }},
+    "attr": {{}},
+    "deps": [provider],
+    "srcs": [],
+    "build_dir": ".once/out/AppleApp",
+    "scratch_dir": ".once/tmp/analysis/AppleApp",
+}}
+apple_provider = _apple_native_deps(apple_ctx)[0]
+result = repr([
+    apple_provider["archive"],
+    apple_provider["transitive_archives"],
+])
+"#
+    );
+    let store = AnalysisStore::new(
+        workspace.path().to_path_buf(),
+        String::new(),
+        ".once/out/AppleApp".to_string(),
+    );
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    let out = out.unwrap();
+    assert!(
+        out.contains("rust-mobile/SharedRust/apple/libshared_rust.a"),
+        "{out}"
+    );
+    let apple = action_by_identifier(&store, "SharedRust:rustc:apple");
+    assert_eq!(store.actions.len(), 1);
+    assert!(apple
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("rust-mobile/SharedRust/apple/libshared_rust.a")));
+}
+
+#[test]
+fn prelude_rust_mobile_library_rejects_rust_deps() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{
+    "label": {{
+        "package": "shared/rust",
+        "name": "SharedRust",
+        "id": "shared/rust/SharedRust",
+    }},
+    "attr": {{
+        "apple_target": "aarch64-apple-ios-sim",
+        "android_target": "aarch64-linux-android",
+    }},
+    "deps": [{{
+        "target_kind": "rust_crate",
+        "label_id": "third_party/dep",
+    }}],
+    "srcs": ["src/**/*.rs"],
+    "build_dir": ".once/out/shared/rust/SharedRust",
+}}
+result = repr(_rust_mobile_library_impl(ctx))
+"#
+    );
+
+    let err = eval_prelude_source_to_repr(source).unwrap_err();
+
+    assert!(err.contains("does not support Rust deps yet"), "{err}");
 }
 
 #[cfg(unix)]

--- a/docs/guide/graph/android.md
+++ b/docs/guide/graph/android.md
@@ -75,8 +75,8 @@ manifest = "AndroidManifest.xml"
 Android binaries can also depend on targets that emit
 `android_native_library`, such as
 [`swift_android_library`](/reference/prelude/swift_android_library) or
-[`rust_library`](/reference/prelude/rust_library) with
-`crate_type = "cdylib"`. The APK packages each native provider under
+[`rust_mobile_library`](/reference/prelude/rust_mobile_library). The
+Android application package stages each native provider under
 `lib/<abi>/`.
 
 ## Resources

--- a/docs/guide/graph/apple.md
+++ b/docs/guide/graph/apple.md
@@ -40,9 +40,9 @@ references resolve from the package that owns the manifest.
 Apple targets can also depend on native providers from other ecosystems.
 [`kotlin_apple_framework`](/reference/prelude/kotlin_apple_framework)
 emits an Apple framework provider that application and test targets can
-link and embed. [`rust_library`](/reference/prelude/rust_library) with
-`crate_type = "staticlib"` emits archive fields that Apple link targets
-consume through the same `deps` edge.
+link and embed. [`rust_mobile_library`](/reference/prelude/rust_mobile_library)
+emits archive fields that Apple link targets consume through the same
+`deps` edge.
 
 ## Commands
 

--- a/docs/guide/graph/index.md
+++ b/docs/guide/graph/index.md
@@ -75,7 +75,7 @@ Today the built-in ecosystems cover these target kind sets:
 The shared-code target kinds also expose the
 `native-mobile-shared-code-e2e` schema example. It wires an Android app to
 Swift and Rust native libraries, and an Apple app to a Kotlin/Native
-framework plus a Rust static library.
+framework plus the same Rust mobile library target.
 
 See [Ecosystems](/guide/graph/ecosystems) for the adoption model and
 the tradeoffs that come with letting Once own part of an ecosystem's

--- a/docs/guide/graph/rust.md
+++ b/docs/guide/graph/rust.md
@@ -3,6 +3,8 @@
 Once builds Rust libraries and binaries from declarative `once.toml`
 manifests. [`rust_library`](/reference/prelude/rust_library) emits an
 rlib provider that downstream Rust targets consume through `--extern`.
+[`rust_mobile_library`](/reference/prelude/rust_mobile_library) emits
+native Apple and Android libraries from one Rust target.
 [`rust_binary`](/reference/prelude/rust_binary) compiles an executable
 from a main crate and its Rust deps. [`rust_crate`](/reference/prelude/rust_crate)
 is the lowered target shape for resolved third-party Cargo packages.
@@ -47,7 +49,8 @@ Rust targets accept Bazel and Buck2 style controls such as
 `rustc_flags`, `linker`, `linker_flags`, `crate_aliases`, `cargo_package`,
 and `target` for `rustc --target`. Final artifact libraries can set
 `crate_type` on `rust_library` to produce `staticlib`, `cdylib`, or
-`dylib` outputs.
+`dylib` outputs. Use `rust_mobile_library` when one target should emit
+both the Apple static library and Android shared library variants.
 `features` and `crate_features` may also use `select` with the same
 host or target tokens.
 Targets may also set `build_script` to compile and run a Cargo-style
@@ -67,36 +70,32 @@ crates follow Cargo's lint-capping behavior.
 ## Native Mobile Outputs
 
 Rust shared code can feed Apple and Android targets through native provider
-fields. Use `crate_type = "staticlib"` for Apple consumers such as
-`apple_application`, and use `crate_type = "cdylib"` for Android consumers
-such as `android_binary`. Android dynamic libraries also need an ABI, which
-Once can infer from common Android target triples or read from
-`android_abi`. When `ANDROID_NDK_HOME` or `android_ndk` is available,
-Once uses the NDK clang wrapper as the default linker for Android targets.
-Set `android_api` to choose the wrapper API level.
+fields. Use `rust_mobile_library` when the same Rust sources should feed
+both Apple consumers such as `apple_application` and Android consumers such
+as `android_binary`. The rule builds an Apple `staticlib` and an Android
+`cdylib` with separate target triples, outputs, scratch files, and action
+identifiers.
+
+Android dynamic libraries also need an Android
+[Application Binary Interface](https://developer.android.com/ndk/guides/abis)
+directory, which Once can infer from common Android target triples or read
+from `android_abi`. When `ANDROID_NDK_HOME` or `android_ndk` is available,
+Once uses the Android Native Development Kit clang wrapper as the default
+linker for Android targets. Set `android_api` to choose the Android platform
+level.
 
 ```toml
 [[target]]
-name = "SharedRustApple"
-kind = "rust_library"
+name = "SharedRust"
+kind = "rust_mobile_library"
 srcs = ["src/**/*.rs"]
 
 [target.attrs]
 crate_name = "shared_rust"
-crate_type = "staticlib"
-target = "aarch64-apple-ios"
-
-[[target]]
-name = "SharedRustAndroid"
-kind = "rust_library"
-srcs = ["src/**/*.rs"]
-
-[target.attrs]
-crate_name = "shared_rust"
-crate_type = "cdylib"
-target = "aarch64-linux-android"
+apple_target = "aarch64-apple-ios"
+android_target = "aarch64-linux-android"
 android_abi = "arm64-v8a"
-android_api = 23
+android_api = 24
 ```
 
 ## Dependency Resolution

--- a/docs/guide/graph/rust.md
+++ b/docs/guide/graph/rust.md
@@ -3,8 +3,8 @@
 Once builds Rust libraries and binaries from declarative `once.toml`
 manifests. [`rust_library`](/reference/prelude/rust_library) emits an
 rlib provider that downstream Rust targets consume through `--extern`.
-[`rust_mobile_library`](/reference/prelude/rust_mobile_library) emits
-native Apple and Android libraries from one Rust target.
+[`rust_mobile_library`](/reference/prelude/rust_mobile_library) lets Apple
+and Android consumers materialize native libraries from one Rust target.
 [`rust_binary`](/reference/prelude/rust_binary) compiles an executable
 from a main crate and its Rust deps. [`rust_crate`](/reference/prelude/rust_crate)
 is the lowered target shape for resolved third-party Cargo packages.
@@ -49,8 +49,8 @@ Rust targets accept Bazel and Buck2 style controls such as
 `rustc_flags`, `linker`, `linker_flags`, `crate_aliases`, `cargo_package`,
 and `target` for `rustc --target`. Final artifact libraries can set
 `crate_type` on `rust_library` to produce `staticlib`, `cdylib`, or
-`dylib` outputs. Use `rust_mobile_library` when one target should emit
-both the Apple static library and Android shared library variants.
+`dylib` outputs. Use `rust_mobile_library` when one target should expose
+consumer-owned Apple static library and Android shared library variants.
 `features` and `crate_features` may also use `select` with the same
 host or target tokens.
 Targets may also set `build_script` to compile and run a Cargo-style
@@ -72,9 +72,10 @@ crates follow Cargo's lint-capping behavior.
 Rust shared code can feed Apple and Android targets through native provider
 fields. Use `rust_mobile_library` when the same Rust sources should feed
 both Apple consumers such as `apple_application` and Android consumers such
-as `android_binary`. The rule builds an Apple `staticlib` and an Android
-`cdylib` with separate target triples, outputs, scratch files, and action
-identifiers.
+as `android_binary`. Each consumer declares only the variant it needs: Apple
+consumers materialize a `staticlib`, and Android consumers materialize a
+`cdylib`. The platform compiles use separate target triples, outputs, scratch
+files, and action identifiers.
 
 Android dynamic libraries also need an Android
 [Application Binary Interface](https://developer.android.com/ndk/guides/abis)
@@ -83,6 +84,10 @@ from `android_abi`. When `ANDROID_NDK_HOME` or `android_ndk` is available,
 Once uses the Android Native Development Kit clang wrapper as the default
 linker for Android targets. Set `android_api` to choose the Android platform
 level.
+
+`rust_mobile_library` does not support Rust dependencies yet. Use explicit
+platform-specific `rust_library` targets when the shared Rust code depends on
+other Rust crates.
 
 ```toml
 [[target]]

--- a/docs/reference/prelude/android_binary.md
+++ b/docs/reference/prelude/android_binary.md
@@ -79,8 +79,8 @@ The target emits `android_application` and `android_apk`.
 Native library deps are copied into the unsigned APK under
 `lib/<abi>/<library>`. Providers such as
 [`swift_android_library`](/reference/prelude/swift_android_library) and
-`rust_library` with `crate_type = "cdylib"` emit the required
-`android_native_libraries` records.
+[`rust_mobile_library`](/reference/prelude/rust_mobile_library) emit the
+required `android_native_libraries` records.
 
 ## Signing
 

--- a/docs/reference/prelude/index.md
+++ b/docs/reference/prelude/index.md
@@ -49,8 +49,8 @@ metadata at the keyboard.
   by downstream Rust targets, or native static/shared libraries consumed
   by Apple and Android targets
 - [`rust_mobile_library`](/reference/prelude/rust_mobile_library): Rust
-  native library compiled once for Apple linking and once for Android
-  packaging under one target label
+  native library materialized by Apple and Android consumers under one
+  target label
 - [`rust_binary`](/reference/prelude/rust_binary): Rust executable built
   from a main crate and Rust deps
 - [`rust_crate`](/reference/prelude/rust_crate): resolved third-party

--- a/docs/reference/prelude/index.md
+++ b/docs/reference/prelude/index.md
@@ -48,6 +48,9 @@ metadata at the keyboard.
 - [`rust_library`](/reference/prelude/rust_library): Rust rlib consumed
   by downstream Rust targets, or native static/shared libraries consumed
   by Apple and Android targets
+- [`rust_mobile_library`](/reference/prelude/rust_mobile_library): Rust
+  native library compiled once for Apple linking and once for Android
+  packaging under one target label
 - [`rust_binary`](/reference/prelude/rust_binary): Rust executable built
   from a main crate and Rust deps
 - [`rust_crate`](/reference/prelude/rust_crate): resolved third-party

--- a/docs/reference/prelude/rust_library.md
+++ b/docs/reference/prelude/rust_library.md
@@ -9,7 +9,10 @@ through `--extern`; transitive rlibs are exposed as dependency search
 paths for downstream Rust targets. The default output is an rlib. Final
 artifact targets may set `crate_type` to `staticlib`, `cdylib`, or
 `dylib`. Static libraries expose Apple linkable provider fields, and
-Android dynamic libraries expose APK native-library provider fields.
+Android dynamic libraries expose Android application package
+native-library provider fields. Use
+[`rust_mobile_library`](/reference/prelude/rust_mobile_library) when one
+Rust target should emit both the Apple and Android native outputs.
 
 ## Attributes
 
@@ -25,12 +28,12 @@ Android dynamic libraries expose APK native-library provider fields.
 | `rustc_env` | map&lt;string, string&gt; | no | `{}` | Bazel-compatible rustc environment variables |
 | `rustc_flags` | list&lt;string&gt; | no | `[]` | Additional `rustc` flags appended after Once-managed flags |
 | `cap_lints` | string | no | empty | Optional rustc lint cap passed as `--cap-lints`; generated Cargo dependencies use `allow` |
-| `linker` | string | no | empty | Optional linker path passed as `-C linker=...`; defaults to `cc` for host Unix binary-like targets and to the Android NDK clang wrapper for Android targets when available |
+| `linker` | string | no | empty | Optional linker path passed as `-C linker=...`; defaults to `cc` for host Unix binary-like targets and to the Android Native Development Kit clang wrapper for Android targets when available |
 | `linker_flags` | list&lt;string&gt; | no | `[]` | Additional linker flags lowered to `-C link-arg=...` |
 | `native_linkopts` | list&lt;string&gt; | no | `[]` | Linker flags propagated to native consumers such as Apple app or framework targets |
-| `android_abi` | string | no | inferred | Android ABI directory for `cdylib` or `dylib` outputs, such as `arm64-v8a` |
-| `android_api` | int | no | `23` | Android API level used to select the NDK clang wrapper for Android targets |
-| `android_ndk` | string | no | `ANDROID_NDK_HOME` | Android NDK root used to find clang wrapper linkers |
+| `android_abi` | string | no | inferred | Android [Application Binary Interface](https://developer.android.com/ndk/guides/abis) directory for `cdylib` or `dylib` outputs, such as `arm64-v8a` |
+| `android_api` | int | no | `23` | Android platform level used to select the Android Native Development Kit clang wrapper for Android targets |
+| `android_ndk` | string | no | `ANDROID_NDK_HOME` | Android Native Development Kit root used to find clang wrapper linkers |
 | `crate_aliases` | map&lt;string, string&gt; | no | `{}` | Map dependency label, package name, or crate name to the local extern crate name |
 | `cargo_package` | string | no | empty | Cargo package name used to select direct external deps from a `cargo_dependencies` dependency set. Defaults to `CARGO_PKG_NAME` when present |
 | `build_script` | string | no | empty | Package-relative Cargo build script path run before `rustc`; common `cargo:rustc-*` stdout directives are consumed, dependency `cargo:rustc-link-search` outputs are replayed downstream, and direct dependency `links` metadata is consumed |
@@ -59,9 +62,9 @@ use.
 | `archive` | string | Apple-linkable archive path for `staticlib` outputs |
 | `transitive_archives` | list&lt;string&gt; | Archives consumed by Apple link targets |
 | `transitive_linkopts` | list&lt;string&gt; | Native linker flags propagated to Apple link targets |
-| `android_abi` | string | Android ABI for dynamic library outputs |
+| `android_abi` | string | Android [Application Binary Interface](https://developer.android.com/ndk/guides/abis) for dynamic library outputs |
 | `android_native_libraries` | list&lt;record&gt; | Direct Android native libraries with `abi` and `path` fields |
-| `transitive_android_native_libraries` | list&lt;record&gt; | Direct and dependency Android native libraries for APK packaging |
+| `transitive_android_native_libraries` | list&lt;record&gt; | Direct and dependency Android native libraries packaged into Android applications |
 
 ## Capabilities
 
@@ -90,25 +93,5 @@ crate_name = "hello"
 edition = "2021"
 ```
 
-```toml
-[[target]]
-name = "SharedRustApple"
-kind = "rust_library"
-srcs = ["src/**/*.rs"]
-
-[target.attrs]
-crate_name = "shared_rust"
-crate_type = "staticlib"
-target = "aarch64-apple-ios"
-
-[[target]]
-name = "SharedRustAndroid"
-kind = "rust_library"
-srcs = ["src/**/*.rs"]
-
-[target.attrs]
-crate_name = "shared_rust"
-crate_type = "cdylib"
-target = "aarch64-linux-android"
-android_abi = "arm64-v8a"
-```
+For mobile shared code that needs both Apple and Android artifacts from
+one label, use [`rust_mobile_library`](/reference/prelude/rust_mobile_library).

--- a/docs/reference/prelude/rust_mobile_library.md
+++ b/docs/reference/prelude/rust_mobile_library.md
@@ -1,0 +1,96 @@
+# `rust_mobile_library`
+
+Rust library compiled for Apple and Android native consumers.
+
+## Description
+
+Compiles one first-party Rust library target twice. The Apple compile emits a
+`staticlib`; the Android compile emits a `cdylib`. Both compiles share the same
+sources, crate metadata, features, Rust flags, and Rust dependencies, but they
+use separate target triples, output directories, scratch files, and action
+identifiers.
+
+The target emits native provider fields for Apple and Android app targets. It
+does not emit `rust_crate`, because there is no single rlib output for
+downstream Rust compilation.
+
+## Attributes
+
+| Attribute | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `crate_name` | string | no | target name | Rust crate name passed to `rustc`; `-` and `.` are rewritten as `_` when omitted |
+| `crate_root` | string | no | `src/lib.rs` | Package-relative library root |
+| `edition` | string | no | `2021` | Rust edition passed to `rustc` |
+| `features` | list&lt;string&gt; | no | `[]` | Cargo feature names lowered to `--cfg=feature=...` flags |
+| `crate_features` | list&lt;string&gt; | no | `[]` | Bazel-compatible alias for `features` |
+| `apple_target` | string | yes |  | Rust target triple for the Apple static library compile |
+| `android_target` | string | yes |  | Rust target triple for the Android shared library compile |
+| `env` | map&lt;string, string&gt; | no | `{}` | Environment variables for `rustc`, matching Buck2's `env` attribute |
+| `rustc_env` | map&lt;string, string&gt; | no | `{}` | Bazel-compatible `rustc` environment variables |
+| `rustc_flags` | list&lt;string&gt; | no | `[]` | Additional `rustc` flags appended after Once-managed flags |
+| `cap_lints` | string | no | empty | Optional `rustc` lint cap passed as `--cap-lints`; generated Cargo dependencies use `allow` |
+| `linker_flags` | list&lt;string&gt; | no | `[]` | Additional linker flags lowered to `-C link-arg=...` |
+| `native_linkopts` | list&lt;string&gt; | no | `[]` | Linker flags propagated to Apple app or framework targets |
+| `android_abi` | string | no | inferred | Android [Application Binary Interface](https://developer.android.com/ndk/guides/abis) directory for the Android shared library output, such as `arm64-v8a` |
+| `android_api` | int | no | `23` | Android platform level used to select the Android Native Development Kit clang wrapper |
+| `android_ndk` | string | no | `ANDROID_NDK_HOME` | Android Native Development Kit root used to find clang wrapper linkers |
+| `crate_aliases` | map&lt;string, string&gt; | no | `{}` | Map dependency label, package name, or crate name to the local extern crate name |
+| `cargo_package` | string | no | empty | Cargo package name used to select direct external deps from a `cargo_dependencies` dependency set. Defaults to `CARGO_PKG_NAME` when present |
+| `build_script` | string | no | empty | Package-relative Cargo build script path run before each compile; common `cargo:rustc-*` stdout directives are consumed, dependency `cargo:rustc-link-search` outputs are replayed downstream, and direct dependency `links` metadata is consumed |
+
+## Dep Edges
+
+| Edge | Accepts | Description |
+| --- | --- | --- |
+| `deps` | `rust_crate`, `rust_proc_macro`, `rust_dependency_set` | Rust crate dependencies consumed through `--extern` |
+
+## Providers
+
+The target emits `native_linkable`, `apple_linkable`, and
+`android_native_library`.
+
+## Provider Record
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `label_id` | string | Original target label id |
+| `archive` | string | Apple-linkable static library path |
+| `staticlib` | string | Apple static library output |
+| `transitive_archives` | list&lt;string&gt; | Archives consumed by Apple link targets |
+| `transitive_linkopts` | list&lt;string&gt; | Native linker flags propagated to Apple link targets |
+| `android_abi` | string | Android [Application Binary Interface](https://developer.android.com/ndk/guides/abis) for the shared library output |
+| `dylib` | string | Android shared library output |
+| `android_native_libraries` | list&lt;record&gt; | Direct Android native libraries with `abi` and `path` fields |
+| `transitive_android_native_libraries` | list&lt;record&gt; | Direct and dependency Android native libraries packaged into Android applications |
+| `transitive_sources` | list&lt;string&gt; | Rust sources from this target and Rust deps |
+
+## Capabilities
+
+| Capability | Output groups |
+| --- | --- |
+| `build` | `library` |
+
+## Outputs
+
+| Output | Location |
+| --- | --- |
+| Apple static library | `.once/out/<target>/apple/lib<crate_name>.a` or `.lib` |
+| Android shared library | `.once/out/<target>/android/lib<crate_name>.so` |
+
+## Example
+
+```toml
+[[target]]
+name = "SharedRust"
+kind = "rust_mobile_library"
+srcs = ["shared/src/**/*.rs"]
+
+[target.attrs]
+crate_name = "shared"
+crate_root = "shared/src/lib.rs"
+edition = "2021"
+apple_target = "aarch64-apple-ios-sim"
+android_target = "aarch64-linux-android"
+android_abi = "arm64-v8a"
+android_api = 24
+```

--- a/docs/reference/prelude/rust_mobile_library.md
+++ b/docs/reference/prelude/rust_mobile_library.md
@@ -1,18 +1,22 @@
 # `rust_mobile_library`
 
-Rust library compiled for Apple and Android native consumers.
+Rust library materialized by Apple and Android native consumers.
 
 ## Description
 
-Compiles one first-party Rust library target twice. The Apple compile emits a
-`staticlib`; the Android compile emits a `cdylib`. Both compiles share the same
-sources, crate metadata, features, Rust flags, and Rust dependencies, but they
-use separate target triples, output directories, scratch files, and action
-identifiers.
+Describes one first-party Rust library target that Apple and Android consumers
+can materialize for their platform. Apple consumers declare a `staticlib`
+compile, and Android consumers declare a `cdylib` compile. Each consumer only
+declares the variant it needs, so Android-only builds do not require the Apple
+Rust target and Apple-only builds do not require the Android linker.
 
 The target emits native provider fields for Apple and Android app targets. It
 does not emit `rust_crate`, because there is no single rlib output for
 downstream Rust compilation.
+
+Rust dependencies are not supported on this target kind yet. Use explicit
+platform-specific [`rust_library`](/reference/prelude/rust_library) targets
+when the shared Rust code depends on other Rust crates.
 
 ## Attributes
 
@@ -34,15 +38,11 @@ downstream Rust compilation.
 | `android_abi` | string | no | inferred | Android [Application Binary Interface](https://developer.android.com/ndk/guides/abis) directory for the Android shared library output, such as `arm64-v8a` |
 | `android_api` | int | no | `23` | Android platform level used to select the Android Native Development Kit clang wrapper |
 | `android_ndk` | string | no | `ANDROID_NDK_HOME` | Android Native Development Kit root used to find clang wrapper linkers |
-| `crate_aliases` | map&lt;string, string&gt; | no | `{}` | Map dependency label, package name, or crate name to the local extern crate name |
-| `cargo_package` | string | no | empty | Cargo package name used to select direct external deps from a `cargo_dependencies` dependency set. Defaults to `CARGO_PKG_NAME` when present |
-| `build_script` | string | no | empty | Package-relative Cargo build script path run before each compile; common `cargo:rustc-*` stdout directives are consumed, dependency `cargo:rustc-link-search` outputs are replayed downstream, and direct dependency `links` metadata is consumed |
+| `build_script` | string | no | empty | Package-relative Cargo build script path run before each platform compile |
 
 ## Dep Edges
 
-| Edge | Accepts | Description |
-| --- | --- | --- |
-| `deps` | `rust_crate`, `rust_proc_macro`, `rust_dependency_set` | Rust crate dependencies consumed through `--extern` |
+This target kind currently declares no dependency edges.
 
 ## Providers
 
@@ -54,28 +54,25 @@ The target emits `native_linkable`, `apple_linkable`, and
 | Field | Type | Meaning |
 | --- | --- | --- |
 | `label_id` | string | Original target label id |
-| `archive` | string | Apple-linkable static library path |
-| `staticlib` | string | Apple static library output |
-| `transitive_archives` | list&lt;string&gt; | Archives consumed by Apple link targets |
-| `transitive_linkopts` | list&lt;string&gt; | Native linker flags propagated to Apple link targets |
-| `android_abi` | string | Android [Application Binary Interface](https://developer.android.com/ndk/guides/abis) for the shared library output |
-| `dylib` | string | Android shared library output |
-| `android_native_libraries` | list&lt;record&gt; | Direct Android native libraries with `abi` and `path` fields |
-| `transitive_android_native_libraries` | list&lt;record&gt; | Direct and dependency Android native libraries packaged into Android applications |
-| `transitive_sources` | list&lt;string&gt; | Rust sources from this target and Rust deps |
+| `transitive_sources` | list&lt;string&gt; | Rust sources from this target |
+
+Apple consumers materialize `archive`, `staticlib`, `transitive_archives`,
+and `transitive_linkopts` while collecting their link inputs. Android consumers
+materialize `android_abi`, `dylib`, `android_native_libraries`, and
+`transitive_android_native_libraries` while collecting native libraries.
 
 ## Capabilities
 
 | Capability | Output groups |
 | --- | --- |
-| `build` | `library` |
+| `build` | none |
 
 ## Outputs
 
 | Output | Location |
 | --- | --- |
-| Apple static library | `.once/out/<target>/apple/lib<crate_name>.a` or `.lib` |
-| Android shared library | `.once/out/<target>/android/lib<crate_name>.so` |
+| Apple static library | `.once/out/<consumer>/rust-mobile/<target>/apple/lib<crate_name>.a` or `.lib` |
+| Android shared library | `.once/out/<consumer>/rust-mobile/<target>/android/lib<crate_name>.so` |
 
 ## Example
 


### PR DESCRIPTION
## What changed

This adds a higher-level `rust_mobile_library` target kind to the Rust Starlark prelude. The target itself now records source and crate metadata, while Apple and Android consumers materialize only the native library variant they need.

The bundled mobile examples declare one `SharedRust` target instead of separate Apple and Android Rust targets. The generated graph tests assert that both apps depend on the same Rust target, that an Android app declares only the Android Rust compile action, and that Apple and Android consumers receive the expected native provider fields.

The guide and reference pages document the new target kind, including the current limitation that `rust_mobile_library` does not support Rust dependencies yet. The `android_abi` field is documented as the Android [Application Binary Interface](https://developer.android.com/ndk/guides/abis).

## Why

A single Rust dependency can be consumed by both Apple and Android app targets in the same graph. A target-local configurable `crate_type` or `target` selection cannot know which consumer is asking for the dependency, so the mobile shape needs to be represented as one higher-level rule with consumer-owned platform outputs.

## Root cause

The first implementation declared both platform Rust compile actions while analyzing the shared dependency. That meant an Android-only consumer still required the Apple Rust target, and an Apple-only consumer still required the Android linker.

It also reused one resolved Rust dependency provider set for both platform compiles. Those provider records contain compiled Rust artifacts for one target triple, so sharing them across Apple and Android would mix incompatible compiled dependency outputs.

## Approach

The Starlark prelude now exposes generic native-dependency materialization hooks. The Rust prelude overrides those hooks for `rust_mobile_library`, so Apple consumers compile the `staticlib` variant and Android consumers compile the `cdylib` variant only when they collect native dependencies.

Each materialized variant keeps the original `SharedRust` label in the provider, but uses consumer-owned output and scratch directories under `rust-mobile/<target>/<platform>/`. The action identifiers remain platform-specific, such as `SharedRust:rustc:apple` and `SharedRust:rustc:android`.

Until target-specific Rust dependency resolution exists for this rule, `rust_mobile_library` rejects Rust dependencies. Projects that need Rust dependencies can keep using explicit platform-specific `rust_library` targets.

## Impact

Android-only graphs no longer require Apple Rust targets, and Apple-only graphs no longer require the Android linker. The behavior remains implemented in Starlark target kinds and helper hooks, without adding toolchain-specific branches to the Rust engine.

The new target kind still does not advertise `rust_crate`, because it does not produce one reusable rlib for downstream Rust compilation.

## Validation

- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo test -p once-frontend --test examples`
- `mise exec -- cargo test -p once-frontend`
- `mise exec -- cargo fmt --all -- --check`
