### PR TITLE
feat(infrastructure): support provider capability overrides

### DIFF
--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -118,6 +118,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -139,6 +142,7 @@ jobs:
         run: |
           set -euo pipefail
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+          "${once_bin}" auth login --provider tuist --no-browser
           host_target="$(rustc -vV | sed -n 's/^host: //p')"
           suffix="$(printf '%s' "${host_target}" | tr '.-' '__')"
           target_id="crates/once-cli/once_cli_${suffix}"
@@ -231,6 +235,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         shell: bash
@@ -265,6 +272,7 @@ jobs:
           set -euo pipefail
 
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+          "${once_bin}" auth login --provider tuist --no-browser
           target="x86_64-pc-windows-msvc"
           suffix="$(printf '%s' "${target}" | tr '.-' '__')"
           target_id="crates/once-cli/once_cli_${suffix}"

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -237,8 +237,6 @@ jobs:
     needs: [changes, release-build]
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
-    env:
-      ONCE_CACHE_PROVIDER: local
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -142,7 +142,10 @@ jobs:
         run: |
           set -euo pipefail
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
-          "${once_bin}" auth login --provider tuist --no-browser
+          if ! "${once_bin}" auth login --provider tuist --no-browser; then
+            echo "Tuist authentication unavailable; using local cache for this release build."
+            export ONCE_CACHE_PROVIDER=local
+          fi
           host_target="$(rustc -vV | sed -n 's/^host: //p')"
           suffix="$(printf '%s' "${host_target}" | tr '.-' '__')"
           target_id="crates/once-cli/once_cli_${suffix}"
@@ -155,6 +158,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ONCE_BOOTSTRAP_SOURCE: source
+          TUIST_TOKEN: ${{ secrets.TUIST_TOKEN }}
       - uses: actions/upload-artifact@v7
         with:
           name: once-${{ matrix.os }}
@@ -272,7 +276,10 @@ jobs:
           set -euo pipefail
 
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
-          "${once_bin}" auth login --provider tuist --no-browser
+          if ! "${once_bin}" auth login --provider tuist --no-browser; then
+            echo "Tuist authentication unavailable; using local cache for this release build."
+            export ONCE_CACHE_PROVIDER=local
+          fi
           target="x86_64-pc-windows-msvc"
           suffix="$(printf '%s' "${target}" | tr '.-' '__')"
           target_id="crates/once-cli/once_cli_${suffix}"
@@ -281,6 +288,8 @@ jobs:
           ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version 0.0.0
           "${once_bin}" build "${target_id}" --format json --quiet
           test -f ".once/out/${target_id}/once.exe"
+        env:
+          TUIST_TOKEN: ${{ secrets.TUIST_TOKEN }}
 
   windows-cas-test:
     name: windows cas test

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -169,6 +169,8 @@ jobs:
     needs: [changes, release-build]
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
+    env:
+      ONCE_CACHE_PROVIDER: local
     strategy:
       fail-fast: false
       matrix:
@@ -193,6 +195,8 @@ jobs:
     needs: [changes, release-build]
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
+    env:
+      ONCE_CACHE_PROVIDER: local
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -118,9 +118,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      id-token: write
+    env:
+      ONCE_CACHE_PROVIDER: local
     strategy:
       fail-fast: false
       matrix:
@@ -142,30 +141,70 @@ jobs:
         run: |
           set -euo pipefail
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
-          if ! "${once_bin}" auth login --provider tuist --no-browser; then
-            echo "Tuist authentication unavailable; using local cache for this release build."
-            export ONCE_CACHE_PROVIDER=local
-          fi
           host_target="$(rustc -vV | sed -n 's/^host: //p')"
           suffix="$(printf '%s' "${host_target}" | tr '.-' '__')"
           target_id="crates/once-cli/once_cli_${suffix}"
           trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
           ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${host_target}"
           ./mise/tasks/release/write-rust-release-manifests.sh --target "${host_target}" --version 0.0.0
-          if ! "${once_bin}" build "${target_id}" --format json --quiet; then
-            echo "Release graph build failed with the configured cache provider; retrying with local cache."
-            ONCE_CACHE_PROVIDER=local "${once_bin}" build "${target_id}" --format json --quiet
-          fi
+          "${once_bin}" build "${target_id}" --format json --quiet
           mkdir -p target/release
           cp ".once/out/${target_id}/once" target/release/once
         env:
           GH_TOKEN: ${{ github.token }}
           ONCE_BOOTSTRAP_SOURCE: source
-          TUIST_TOKEN: ${{ secrets.TUIST_TOKEN }}
       - uses: actions/upload-artifact@v7
         with:
           name: once-${{ matrix.os }}
           path: target/release/once
+
+  tuist-cache-smoke:
+    name: tuist cache smoke
+    needs: changes
+    if: needs.changes.outputs.rust_ci == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
+        with:
+          experimental: true
+          cache: true
+      - run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tuist-cache-smoke
+          cache-on-failure: true
+          cache-bin: false
+      - name: Verify Tuist cache provider
+        run: |
+          set -euo pipefail
+          once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
+          smoke_root="$(mktemp -d)"
+          export XDG_STATE_HOME="${smoke_root}/state"
+          export XDG_DATA_HOME="${smoke_root}/data"
+          export XDG_CONFIG_HOME="${smoke_root}/config"
+
+          "${once_bin}" auth login --provider tuist --no-browser
+
+          XDG_CACHE_HOME="${smoke_root}/cache-first" \
+            "${once_bin}" exec --format json -- /bin/sh -c 'exit 0' \
+            2>"${smoke_root}/first.json"
+
+          XDG_CACHE_HOME="${smoke_root}/cache-second" \
+            "${once_bin}" exec --format json -- /bin/sh -c 'exit 0' \
+            2>"${smoke_root}/second.json"
+
+          if ! grep -Eq '"cache"[[:space:]]*:[[:space:]]*"hit"' "${smoke_root}/second.json"; then
+            echo "Expected the second Tuist-backed Once execution to hit the remote cache."
+            cat "${smoke_root}/first.json"
+            cat "${smoke_root}/second.json"
+            exit 1
+          fi
+        env:
+          ONCE_BOOTSTRAP_SOURCE: source
 
   dogfood:
     name: dogfood (${{ matrix.os }})
@@ -246,9 +285,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: windows-latest
-    permissions:
-      contents: read
-      id-token: write
     defaults:
       run:
         shell: bash
@@ -260,6 +296,7 @@ jobs:
       MISE_NOT_FOUND_AUTO_INSTALL: "false"
       MISE_EXEC_AUTO_INSTALL: "false"
       ONCE_BOOTSTRAP_SOURCE: source
+      ONCE_CACHE_PROVIDER: local
     steps:
       - uses: actions/checkout@v6
       - name: Set HOME for mise templates
@@ -283,23 +320,14 @@ jobs:
           set -euo pipefail
 
           once_bin="$(./mise/tasks/release/bootstrap-once.sh)"
-          if ! "${once_bin}" auth login --provider tuist --no-browser; then
-            echo "Tuist authentication unavailable; using local cache for this release build."
-            export ONCE_CACHE_PROVIDER=local
-          fi
           target="x86_64-pc-windows-msvc"
           suffix="$(printf '%s' "${target}" | tr '.-' '__')"
           target_id="crates/once-cli/once_cli_${suffix}"
           trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
           ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
           ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version 0.0.0
-          if ! "${once_bin}" build "${target_id}" --format json --quiet; then
-            echo "Release graph build failed with the configured cache provider; retrying with local cache."
-            ONCE_CACHE_PROVIDER=local "${once_bin}" build "${target_id}" --format json --quiet
-          fi
+          "${once_bin}" build "${target_id}" --format json --quiet
           test -f ".once/out/${target_id}/once.exe"
-        env:
-          TUIST_TOKEN: ${{ secrets.TUIST_TOKEN }}
 
   windows-cas-test:
     name: windows cas test

--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -152,7 +152,10 @@ jobs:
           trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
           ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${host_target}"
           ./mise/tasks/release/write-rust-release-manifests.sh --target "${host_target}" --version 0.0.0
-          "${once_bin}" build "${target_id}" --format json --quiet
+          if ! "${once_bin}" build "${target_id}" --format json --quiet; then
+            echo "Release graph build failed with the configured cache provider; retrying with local cache."
+            ONCE_CACHE_PROVIDER=local "${once_bin}" build "${target_id}" --format json --quiet
+          fi
           mkdir -p target/release
           cp ".once/out/${target_id}/once" target/release/once
         env:
@@ -290,7 +293,10 @@ jobs:
           trap './mise/tasks/release/write-rust-release-manifests.sh --clear >/dev/null 2>&1 || true' EXIT
           ./mise/tasks/release/prepare-rust-graph-deps.sh --target "${target}"
           ./mise/tasks/release/write-rust-release-manifests.sh --target "${target}" --version 0.0.0
-          "${once_bin}" build "${target_id}" --format json --quiet
+          if ! "${once_bin}" build "${target_id}" --format json --quiet; then
+            echo "Release graph build failed with the configured cache provider; retrying with local cache."
+            ONCE_CACHE_PROVIDER=local "${once_bin}" build "${target_id}" --format json --quiet
+          fi
           test -f ".once/out/${target_id}/once.exe"
         env:
           TUIST_TOKEN: ${{ secrets.TUIST_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring"] }
 tree-sitter = "0.26.9"
 tree-sitter-cypher = "0.2.6"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
 sea-orm = { version = "1.1.20", default-features = false, features = ["macros", "runtime-tokio-rustls", "sqlx-sqlite"] }
 sea-orm-migration = { version = "1.1.20", default-features = false, features = ["runtime-tokio-rustls", "sqlx-sqlite"] }
 schlussel = { git = "https://github.com/tuist/schlussel.git", rev = "80a7bc1fc0b68bdc2cd2379b16240ddbfbe0267b" }

--- a/crates/once-cas/src/tuist/auth.rs
+++ b/crates/once-cas/src/tuist/auth.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
+use reqwest::{blocking::Client, StatusCode, Url};
 use schlussel::callback::{build_authorization_url, open_browser};
 use schlussel::{
     build_storage_key, CallbackServer, ClientMetadata, DynamicRegistrationClient, FileStorage,
@@ -19,6 +21,10 @@ const TUIST_TOKEN_ENV: &str = "TUIST_TOKEN";
 const REGISTRATION_PATH: &str = "oauth2/register";
 const TOKEN_PATH: &str = "oauth2/token";
 const AUTHORIZATION_PATH: &str = "oauth2/authorize";
+const OIDC_EXCHANGE_PATH: &str = "api/auth/oidc/token";
+const OIDC_AUDIENCE: &str = "tuist";
+const OIDC_REQUEST_TIMEOUT_SECONDS: u64 = 30;
+const CI_ENVIRONMENT_VARIABLES: &[&str] = &["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"];
 
 #[derive(Debug, Clone)]
 pub struct TuistAuth {
@@ -63,6 +69,10 @@ impl TuistAuth {
         open_browser_after_prompt: bool,
         handler: &mut dyn FnMut(TuistAuthPrompt),
     ) -> Result<()> {
+        if is_ci_environment() {
+            return self.login_with_ci_oidc();
+        }
+
         if let Some(client_id) = self.config.oauth_client_id.as_deref() {
             return self.login_with_client_id(client_id, open_browser_after_prompt, handler);
         }
@@ -196,6 +206,159 @@ impl TuistAuth {
         Ok(())
     }
 
+    fn login_with_ci_oidc(&self) -> Result<()> {
+        let oidc_token = Self::fetch_ci_oidc_token()?;
+        let access_token = self.exchange_oidc_token(&oidc_token)?;
+        self.store_access_token(&access_token)
+    }
+
+    fn fetch_ci_oidc_token() -> Result<String> {
+        if env_is_truthy("GITHUB_ACTIONS") {
+            let request_url = env_token("ACTIONS_ID_TOKEN_REQUEST_URL").ok_or_else(|| {
+                Error::InvalidConfig {
+                    provider: PROVIDER_NAME,
+                    message: "GitHub Actions OpenID Connect token request variables are not set. Set `permissions: id-token: write` in the workflow.".to_string(),
+                }
+            })?;
+            let request_token =
+                env_token("ACTIONS_ID_TOKEN_REQUEST_TOKEN").ok_or_else(|| Error::InvalidConfig {
+                    provider: PROVIDER_NAME,
+                    message: "GitHub Actions OpenID Connect token request variables are not set. Set `permissions: id-token: write` in the workflow.".to_string(),
+                })?;
+            return Self::fetch_github_actions_oidc_token(&request_url, &request_token);
+        }
+
+        if env_is_truthy("CIRCLECI") {
+            return env_token("CIRCLE_OIDC_TOKEN_V2")
+                .or_else(|| env_token("CIRCLE_OIDC_TOKEN"))
+                .ok_or_else(|| Error::InvalidConfig {
+                    provider: PROVIDER_NAME,
+                    message: "CircleCI OpenID Connect token was not found. Enable OpenID Connect for the CircleCI project.".to_string(),
+                });
+        }
+
+        if env_is_truthy("BITRISE_IO") {
+            return env_token("BITRISE_OIDC_ID_TOKEN")
+                .or_else(|| env_token("BITRISE_IDENTITY_TOKEN"))
+                .ok_or_else(|| Error::InvalidConfig {
+                    provider: PROVIDER_NAME,
+                    message: "Bitrise OpenID Connect token was not found. Add the Bitrise identity token step before this step.".to_string(),
+                });
+        }
+
+        Err(Error::InvalidConfig {
+            provider: PROVIDER_NAME,
+            message: "OpenID Connect authentication is not supported in this environment. Supported Continuous Integration providers: GitHub Actions, CircleCI, Bitrise.".to_string(),
+        })
+    }
+
+    fn fetch_github_actions_oidc_token(request_url: &str, request_token: &str) -> Result<String> {
+        let mut url = Url::parse(request_url).map_err(|source| Error::InvalidConfig {
+            provider: PROVIDER_NAME,
+            message: format!(
+                "invalid GitHub Actions OpenID Connect token request URL `{request_url}`: {source}"
+            ),
+        })?;
+        url.query_pairs_mut().append_pair("audience", OIDC_AUDIENCE);
+        let response = Self::oidc_http_client()?
+            .get(url)
+            .bearer_auth(request_token)
+            .send()
+            .map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "fetch GitHub Actions OpenID Connect token",
+                message: source.to_string(),
+            })?;
+        let status = response.status();
+        let body = response.text().map_err(|source| Error::Remote {
+            provider: PROVIDER_NAME,
+            operation: "fetch GitHub Actions OpenID Connect token",
+            message: source.to_string(),
+        })?;
+        if !status.is_success() {
+            return Err(Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "fetch GitHub Actions OpenID Connect token",
+                message: status_body_message(status, &body),
+            });
+        }
+
+        let token_response: OidcTokenResponse =
+            serde_json::from_str(&body).map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "decode GitHub Actions OpenID Connect token",
+                message: source.to_string(),
+            })?;
+        let token = token_response.value.trim();
+        if token.is_empty() {
+            return Err(Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "decode GitHub Actions OpenID Connect token",
+                message: "response did not include a token".to_string(),
+            });
+        }
+        Ok(token.to_string())
+    }
+
+    fn exchange_oidc_token(&self, oidc_token: &str) -> Result<Token> {
+        let response = Self::oidc_http_client()?
+            .post(self.oidc_exchange_endpoint()?)
+            .json(&OidcExchangeRequest { token: oidc_token })
+            .send()
+            .map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "exchange OpenID Connect token",
+                message: source.to_string(),
+            })?;
+        let status = response.status();
+        let body = response.text().map_err(|source| Error::Remote {
+            provider: PROVIDER_NAME,
+            operation: "exchange OpenID Connect token",
+            message: source.to_string(),
+        })?;
+        if !status.is_success() {
+            return Err(Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "exchange OpenID Connect token",
+                message: status_body_message(status, &body),
+            });
+        }
+
+        let response: OidcExchangeResponse =
+            serde_json::from_str(&body).map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "decode OpenID Connect token exchange",
+                message: source.to_string(),
+            })?;
+        let access_token = response.access_token.trim();
+        if access_token.is_empty() {
+            return Err(Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "decode OpenID Connect token exchange",
+                message: "response did not include an access token".to_string(),
+            });
+        }
+
+        Ok(Token::new(access_token, "Bearer").with_expiration(response.expires_in))
+    }
+
+    fn store_access_token(&self, token: &Token) -> Result<()> {
+        self.storage()?
+            .save(&self.storage_key(), token)
+            .map_err(|source| Self::remote_auth_error("store auth token", &source))
+    }
+
+    fn oidc_http_client() -> Result<Client> {
+        Client::builder()
+            .timeout(Duration::from_secs(OIDC_REQUEST_TIMEOUT_SECONDS))
+            .build()
+            .map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "configure OpenID Connect client",
+                message: source.to_string(),
+            })
+    }
+
     fn register_client(&self, redirect_uri: &str) -> Result<RegisteredClient> {
         let client =
             DynamicRegistrationClient::new(self.registration_endpoint()?).map_err(|source| {
@@ -295,6 +458,10 @@ impl TuistAuth {
 
     fn token_endpoint(&self) -> Result<String> {
         Ok(join_url(&self.config.url, TOKEN_PATH)?.to_string())
+    }
+
+    fn oidc_exchange_endpoint(&self) -> Result<Url> {
+        join_url(&self.config.url, OIDC_EXCHANGE_PATH)
     }
 
     fn load_registered_client(&self) -> Result<Option<RegisteredClient>> {
@@ -405,8 +572,47 @@ struct RegisteredClient {
     client_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct OidcTokenResponse {
+    value: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OidcExchangeRequest<'a> {
+    token: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct OidcExchangeResponse {
+    access_token: String,
+    #[serde(default)]
+    expires_in: Option<u64>,
+}
+
 fn random_state() -> String {
     PkcePair::generate().verifier()[..22].to_string()
+}
+
+fn is_ci_environment() -> bool {
+    CI_ENVIRONMENT_VARIABLES
+        .iter()
+        .any(|name| std::env::var_os(name).is_some())
+}
+
+fn env_is_truthy(name: &str) -> bool {
+    matches!(
+        std::env::var(name).ok().as_deref(),
+        Some("1" | "true" | "TRUE" | "yes" | "YES")
+    )
+}
+
+fn status_body_message(status: StatusCode, body: &str) -> String {
+    let body = body.trim();
+    if body.is_empty() {
+        format!("HTTP {}", status.as_u16())
+    } else {
+        format!("HTTP {}: {body}", status.as_u16())
+    }
 }
 
 fn print_prompt(prompt: &TuistAuthPrompt) {
@@ -426,9 +632,27 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::sync::Mutex;
     use std::thread;
 
     use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    const TEST_ENV_KEYS: &[&str] = &[
+        "GITHUB_RUN_ID",
+        "CI",
+        "BUILD_NUMBER",
+        "GITHUB_ACTIONS",
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        "CIRCLECI",
+        "CIRCLE_OIDC_TOKEN_V2",
+        "CIRCLE_OIDC_TOKEN",
+        "BITRISE_IO",
+        "BITRISE_OIDC_ID_TOKEN",
+        "BITRISE_IDENTITY_TOKEN",
+        "TUIST_TOKEN",
+    ];
 
     fn static_config(url: String) -> TuistCacheConfig {
         TuistCacheConfig {
@@ -559,6 +783,161 @@ mod tests {
         assert_eq!(token, "env-token");
     }
 
+    #[test]
+    fn token_reads_account_token_from_environment() {
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config("https://tuist.dev".to_string()));
+
+        let token = with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("TUIST_TOKEN", "account-token".to_string()),
+            ],
+            || auth.token().unwrap(),
+        );
+
+        assert_eq!(token, "account-token");
+    }
+
+    #[test]
+    fn github_actions_openid_connect_login_fetches_and_exchanges_token() {
+        let github_server = OneShotHttpServer::new(200, r#"{"value":"github-identity-token"}"#);
+        let exchange_server = OneShotHttpServer::new(
+            200,
+            r#"{"access_token":"tuist-access-token","expires_in":3600}"#,
+        );
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config(exchange_server.base_url()));
+
+        with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("GITHUB_ACTIONS", "true".to_string()),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_URL",
+                    github_server.endpoint("/identity-token?existing=1"),
+                ),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                    "github-request-token".to_string(),
+                ),
+            ],
+            || {
+                let mut handler = |_| panic!("browser prompt should not be used in runner auth");
+                auth.login_with_handler(false, &mut handler).unwrap();
+            },
+        );
+
+        let github_request = github_server.request();
+        let exchange_request = exchange_server.request();
+        let stored = auth
+            .storage()
+            .unwrap()
+            .load(&auth.storage_key())
+            .unwrap()
+            .unwrap();
+
+        assert!(github_request.starts_with("GET /identity-token?existing=1&audience=tuist "));
+        assert!(github_request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer github-request-token"));
+        assert!(exchange_request.starts_with("POST /api/auth/oidc/token "));
+        assert!(exchange_request.contains(r#""token":"github-identity-token""#));
+        assert_eq!(stored.access_token, "tuist-access-token");
+        assert_eq!(stored.expires_in, Some(3600));
+        assert!(stored.expires_at.is_some());
+    }
+
+    #[test]
+    fn circle_ci_openid_connect_login_exchanges_environment_token() {
+        let exchange_server = OneShotHttpServer::new(
+            200,
+            r#"{"access_token":"tuist-access-token","expires_in":3600}"#,
+        );
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config(exchange_server.base_url()));
+
+        with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("CIRCLECI", "true".to_string()),
+                ("CIRCLE_OIDC_TOKEN_V2", "circle-identity-token".to_string()),
+            ],
+            || {
+                let mut handler = |_| panic!("browser prompt should not be used in runner auth");
+                auth.login_with_handler(false, &mut handler).unwrap();
+            },
+        );
+
+        let exchange_request = exchange_server.request();
+        let stored = auth
+            .storage()
+            .unwrap()
+            .load(&auth.storage_key())
+            .unwrap()
+            .unwrap();
+
+        assert!(exchange_request.starts_with("POST /api/auth/oidc/token "));
+        assert!(exchange_request.contains(r#""token":"circle-identity-token""#));
+        assert_eq!(stored.access_token, "tuist-access-token");
+    }
+
+    #[test]
+    fn github_actions_openid_connect_login_reports_missing_permissions() {
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config("https://tuist.dev".to_string()));
+
+        let error = with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("GITHUB_ACTIONS", "true".to_string()),
+            ],
+            || {
+                let mut handler = |_| panic!("browser prompt should not be used in runner auth");
+                auth.login_with_handler(false, &mut handler).unwrap_err()
+            },
+        );
+
+        assert!(error.to_string().contains("permissions: id-token: write"));
+    }
+
+    fn with_ci_env<T>(vars: &[(&'static str, String)], test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::new(TEST_ENV_KEYS);
+        for (name, value) in vars {
+            std::env::set_var(name, value);
+        }
+        test()
+    }
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new(names: &'static [&'static str]) -> Self {
+            let saved = names
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect();
+            for name in names {
+                std::env::remove_var(name);
+            }
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.saved {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
     struct OneShotHttpServer {
         _temp: TempDir,
         base_url: String,
@@ -594,6 +973,10 @@ mod tests {
 
         fn base_url(&self) -> String {
             self.base_url.clone()
+        }
+
+        fn endpoint(&self, path: &str) -> String {
+            format!("{}{}", self.base_url, path)
         }
 
         fn request(mut self) -> String {

--- a/crates/once-cas/src/tuist/auth.rs
+++ b/crates/once-cas/src/tuist/auth.rs
@@ -56,7 +56,13 @@ impl TuistAuth {
             return Ok(token);
         }
 
-        Ok(self.load_valid_token()?.access_token)
+        match self.load_valid_token() {
+            Ok(token) => Ok(token.access_token),
+            Err(_) if is_ci_environment() => {
+                Ok(self.exchange_and_store_ci_oidc_token()?.access_token)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     pub fn login(&self, open_browser_after_prompt: bool) -> Result<()> {
@@ -211,9 +217,14 @@ impl TuistAuth {
     }
 
     fn login_with_ci_oidc(&self) -> Result<()> {
+        self.exchange_and_store_ci_oidc_token().map(|_| ())
+    }
+
+    fn exchange_and_store_ci_oidc_token(&self) -> Result<Token> {
         let oidc_token = Self::fetch_ci_oidc_token()?;
         let access_token = self.exchange_oidc_token(&oidc_token)?;
-        self.store_access_token(&access_token)
+        self.store_access_token(&access_token)?;
+        Ok(access_token)
     }
 
     fn fetch_ci_oidc_token() -> Result<String> {
@@ -698,7 +709,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let auth = TuistAuth::new(temp.path(), &static_config("https://tuist.dev".to_string()));
 
-        let error = auth.token().unwrap_err();
+        let error = with_ci_env(&[], || auth.token().unwrap_err());
 
         assert!(error
             .to_string()
@@ -868,6 +879,47 @@ mod tests {
         assert_eq!(stored.access_token, "tuist-access-token");
         assert_eq!(stored.expires_in, Some(3600));
         assert!(stored.expires_at.is_some());
+    }
+
+    #[test]
+    fn token_fetches_and_exchanges_github_actions_openid_connect_when_storage_is_missing() {
+        let github_server = OneShotHttpServer::new(200, r#"{"value":"github-identity-token"}"#);
+        let exchange_server = OneShotHttpServer::new(
+            200,
+            r#"{"access_token":"tuist-access-token","expires_in":3600}"#,
+        );
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config(exchange_server.base_url()));
+
+        let token = with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("GITHUB_ACTIONS", "true".to_string()),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_URL",
+                    github_server.endpoint("/identity-token?existing=1"),
+                ),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                    "github-request-token".to_string(),
+                ),
+            ],
+            || auth.token().unwrap(),
+        );
+
+        let github_request = github_server.request();
+        let exchange_request = exchange_server.request();
+        let stored = auth
+            .storage()
+            .unwrap()
+            .load(&auth.storage_key())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(token, "tuist-access-token");
+        assert!(github_request.starts_with("GET /identity-token?existing=1&audience=tuist "));
+        assert!(exchange_request.starts_with("POST /api/auth/oidc/token "));
+        assert_eq!(stored.access_token, "tuist-access-token");
     }
 
     #[test]

--- a/crates/once-cas/src/tuist/auth.rs
+++ b/crates/once-cas/src/tuist/auth.rs
@@ -69,6 +69,10 @@ impl TuistAuth {
         open_browser_after_prompt: bool,
         handler: &mut dyn FnMut(TuistAuthPrompt),
     ) -> Result<()> {
+        if env_token(TUIST_TOKEN_ENV).is_some() {
+            return Ok(());
+        }
+
         if is_ci_environment() {
             return self.login_with_ci_oidc();
         }
@@ -797,6 +801,24 @@ mod tests {
         );
 
         assert_eq!(token, "account-token");
+    }
+
+    #[test]
+    fn login_succeeds_with_account_token_in_environment() {
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config("https://tuist.dev".to_string()));
+
+        with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("TUIST_TOKEN", "account-token".to_string()),
+            ],
+            || {
+                let mut handler =
+                    |_| panic!("browser prompt should not be used with account token");
+                auth.login_with_handler(false, &mut handler).unwrap();
+            },
+        );
     }
 
     #[test]

--- a/crates/once-cas/src/tuist/auth.rs
+++ b/crates/once-cas/src/tuist/auth.rs
@@ -1,5 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::thread;
 use std::time::Duration;
 
 use reqwest::{blocking::Client, StatusCode, Url};
@@ -24,12 +26,17 @@ const AUTHORIZATION_PATH: &str = "oauth2/authorize";
 const OIDC_EXCHANGE_PATH: &str = "api/auth/oidc/token";
 const OIDC_AUDIENCE: &str = "tuist";
 const OIDC_REQUEST_TIMEOUT_SECONDS: u64 = 30;
+const OIDC_EXCHANGE_MAX_RETRIES: usize = 3;
+const OIDC_EXCHANGE_RETRY_BASE_DELAY_MS: u64 = 100;
+const OIDC_TOKEN_REFRESH_WINDOW_SECONDS: u64 = 60;
 const CI_ENVIRONMENT_VARIABLES: &[&str] = &["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"];
 
 #[derive(Debug, Clone)]
 pub struct TuistAuth {
     credentials_root: PathBuf,
     config: TuistCacheConfig,
+    cached_ci_token: Arc<StdMutex<Option<Token>>>,
+    ci_exchange_lock: Arc<StdMutex<()>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +51,8 @@ impl TuistAuth {
         Self {
             credentials_root: credentials_root.as_ref().to_path_buf(),
             config: config.clone(),
+            cached_ci_token: Arc::new(StdMutex::new(None)),
+            ci_exchange_lock: Arc::new(StdMutex::new(())),
         }
     }
 
@@ -53,6 +62,10 @@ impl TuistAuth {
 
     fn token_with_env(&self, env_token: Option<String>) -> Result<String> {
         if let Some(token) = env_token {
+            return Ok(token);
+        }
+
+        if let Some(token) = self.cached_ci_access_token()? {
             return Ok(token);
         }
 
@@ -221,9 +234,25 @@ impl TuistAuth {
     }
 
     fn exchange_and_store_ci_oidc_token(&self) -> Result<Token> {
+        let _guard = self
+            .ci_exchange_lock
+            .lock()
+            .map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "lock Continuous Integration auth token exchange",
+                message: source.to_string(),
+            })?;
+        if let Some(token) = self.cached_ci_token()? {
+            return Ok(token);
+        }
+        if let Ok(token) = self.load_valid_token() {
+            self.remember_ci_token(&token)?;
+            return Ok(token);
+        }
         let oidc_token = Self::fetch_ci_oidc_token()?;
         let access_token = self.exchange_oidc_token(&oidc_token)?;
         self.store_access_token(&access_token)?;
+        self.remember_ci_token(&access_token)?;
         Ok(access_token)
     }
 
@@ -316,45 +345,97 @@ impl TuistAuth {
     }
 
     fn exchange_oidc_token(&self, oidc_token: &str) -> Result<Token> {
-        let response = Self::oidc_http_client()?
-            .post(self.oidc_exchange_endpoint()?)
+        let client = Self::oidc_http_client()?;
+        let endpoint = self.oidc_exchange_endpoint()?;
+
+        for retry in 0..=OIDC_EXCHANGE_MAX_RETRIES {
+            match Self::exchange_oidc_token_once(&client, endpoint.clone(), oidc_token) {
+                Ok(token) => return Ok(token),
+                Err(error) if retry < OIDC_EXCHANGE_MAX_RETRIES && error.retryable => {
+                    thread::sleep(oidc_exchange_retry_delay(retry));
+                }
+                Err(error) => return Err(error.into_remote_error()),
+            }
+        }
+
+        unreachable!("OpenID Connect exchange retry loop must return")
+    }
+
+    fn exchange_oidc_token_once(
+        client: &Client,
+        endpoint: Url,
+        oidc_token: &str,
+    ) -> std::result::Result<Token, OidcExchangeAttemptError> {
+        let response = client
+            .post(endpoint)
             .json(&OidcExchangeRequest { token: oidc_token })
             .send()
-            .map_err(|source| Error::Remote {
-                provider: PROVIDER_NAME,
-                operation: "exchange OpenID Connect token",
+            .map_err(|source| OidcExchangeAttemptError {
                 message: source.to_string(),
+                retryable: true,
             })?;
         let status = response.status();
-        let body = response.text().map_err(|source| Error::Remote {
-            provider: PROVIDER_NAME,
-            operation: "exchange OpenID Connect token",
+        let body = response.text().map_err(|source| OidcExchangeAttemptError {
             message: source.to_string(),
+            retryable: oidc_status_is_retryable(status),
         })?;
         if !status.is_success() {
-            return Err(Error::Remote {
-                provider: PROVIDER_NAME,
-                operation: "exchange OpenID Connect token",
+            return Err(OidcExchangeAttemptError {
                 message: status_body_message(status, &body),
+                retryable: oidc_status_is_retryable(status),
             });
         }
 
         let response: OidcExchangeResponse =
-            serde_json::from_str(&body).map_err(|source| Error::Remote {
-                provider: PROVIDER_NAME,
-                operation: "decode OpenID Connect token exchange",
+            serde_json::from_str(&body).map_err(|source| OidcExchangeAttemptError {
                 message: source.to_string(),
+                retryable: false,
             })?;
         let access_token = response.access_token.trim();
         if access_token.is_empty() {
-            return Err(Error::Remote {
-                provider: PROVIDER_NAME,
-                operation: "decode OpenID Connect token exchange",
+            return Err(OidcExchangeAttemptError {
                 message: "response did not include an access token".to_string(),
+                retryable: false,
             });
         }
 
         Ok(Token::new(access_token, "Bearer").with_expiration(response.expires_in))
+    }
+
+    fn cached_ci_access_token(&self) -> Result<Option<String>> {
+        Ok(self.cached_ci_token()?.map(|token| token.access_token))
+    }
+
+    fn cached_ci_token(&self) -> Result<Option<Token>> {
+        let mut cached = self
+            .cached_ci_token
+            .lock()
+            .map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "load cached Continuous Integration auth token",
+                message: source.to_string(),
+            })?;
+        let Some(token) = cached.as_ref() else {
+            return Ok(None);
+        };
+        if !token.expires_within(OIDC_TOKEN_REFRESH_WINDOW_SECONDS) {
+            return Ok(Some(token.clone()));
+        }
+        *cached = None;
+        Ok(None)
+    }
+
+    fn remember_ci_token(&self, token: &Token) -> Result<()> {
+        let mut cached = self
+            .cached_ci_token
+            .lock()
+            .map_err(|source| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation: "store cached Continuous Integration auth token",
+                message: source.to_string(),
+            })?;
+        *cached = Some(token.clone());
+        Ok(())
     }
 
     fn store_access_token(&self, token: &Token) -> Result<()> {
@@ -604,6 +685,22 @@ struct OidcExchangeResponse {
     expires_in: Option<u64>,
 }
 
+#[derive(Debug)]
+struct OidcExchangeAttemptError {
+    message: String,
+    retryable: bool,
+}
+
+impl OidcExchangeAttemptError {
+    fn into_remote_error(self) -> Error {
+        Error::Remote {
+            provider: PROVIDER_NAME,
+            operation: "exchange OpenID Connect token",
+            message: self.message,
+        }
+    }
+}
+
 fn random_state() -> String {
     PkcePair::generate().verifier()[..22].to_string()
 }
@@ -628,6 +725,17 @@ fn status_body_message(status: StatusCode, body: &str) -> String {
     } else {
         format!("HTTP {}: {body}", status.as_u16())
     }
+}
+
+fn oidc_status_is_retryable(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
+fn oidc_exchange_retry_delay(retry: usize) -> Duration {
+    let multiplier = (0..retry).fold(1_u64, |multiplier, _| multiplier.saturating_mul(2));
+    Duration::from_millis(OIDC_EXCHANGE_RETRY_BASE_DELAY_MS.saturating_mul(multiplier))
 }
 
 fn print_prompt(prompt: &TuistAuthPrompt) {
@@ -923,6 +1031,85 @@ mod tests {
     }
 
     #[test]
+    fn openid_connect_exchange_retries_retryable_tuist_failures() {
+        let github_server = OneShotHttpServer::new(200, r#"{"value":"github-identity-token"}"#);
+        let exchange_server = MultiShotHttpServer::new(vec![
+            (502, "error code: 502"),
+            (
+                200,
+                r#"{"access_token":"tuist-access-token","expires_in":3600}"#,
+            ),
+        ]);
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config(exchange_server.base_url()));
+
+        let token = with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("GITHUB_ACTIONS", "true".to_string()),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_URL",
+                    github_server.endpoint("/identity-token"),
+                ),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                    "github-request-token".to_string(),
+                ),
+            ],
+            || auth.token().unwrap(),
+        );
+
+        let github_request = github_server.request();
+        let exchange_requests = exchange_server.requests();
+        assert_eq!(token, "tuist-access-token");
+        assert!(github_request.starts_with("GET /identity-token?audience=tuist "));
+        assert_eq!(exchange_requests.len(), 2);
+        assert!(exchange_requests[0].starts_with("POST /api/auth/oidc/token "));
+        assert!(exchange_requests[1].starts_with("POST /api/auth/oidc/token "));
+    }
+
+    #[test]
+    fn token_reuses_cached_openid_connect_token_when_storage_is_missing() {
+        let github_server = OneShotHttpServer::new(200, r#"{"value":"github-identity-token"}"#);
+        let exchange_server = OneShotHttpServer::new(
+            200,
+            r#"{"access_token":"tuist-access-token","expires_in":3600}"#,
+        );
+        let temp = TempDir::new().unwrap();
+        let auth = TuistAuth::new(temp.path(), &static_config(exchange_server.base_url()));
+
+        let (first, second) = with_ci_env(
+            &[
+                ("CI", "true".to_string()),
+                ("GITHUB_ACTIONS", "true".to_string()),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_URL",
+                    github_server.endpoint("/identity-token"),
+                ),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                    "github-request-token".to_string(),
+                ),
+            ],
+            || {
+                let first = auth.token().unwrap();
+                auth.storage().unwrap().delete(&auth.storage_key()).unwrap();
+                let second = auth.token().unwrap();
+                (first, second)
+            },
+        );
+
+        assert_eq!(first, "tuist-access-token");
+        assert_eq!(second, "tuist-access-token");
+        assert!(github_server
+            .request()
+            .starts_with("GET /identity-token?audience=tuist "));
+        assert!(exchange_server
+            .request()
+            .starts_with("POST /api/auth/oidc/token "));
+    }
+
+    #[test]
     fn circle_ci_openid_connect_login_exchanges_environment_token() {
         let exchange_server = OneShotHttpServer::new(
             200,
@@ -1058,6 +1245,66 @@ mod tests {
                 join_handle.join().unwrap();
             }
             std::fs::read_to_string(&self.request_file).unwrap()
+        }
+    }
+
+    struct MultiShotHttpServer {
+        _temp: TempDir,
+        base_url: String,
+        request_dir: PathBuf,
+        request_count: usize,
+        join_handle: Option<thread::JoinHandle<()>>,
+    }
+
+    impl MultiShotHttpServer {
+        fn new(responses: Vec<(u16, &'static str)>) -> Self {
+            let temp = TempDir::new().unwrap();
+            let request_dir = temp.path().join("requests");
+            std::fs::create_dir_all(&request_dir).unwrap();
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let request_dir_for_thread = request_dir.clone();
+            let request_count = responses.len();
+            let join_handle = thread::spawn(move || {
+                for (index, (status, body)) in responses.into_iter().enumerate() {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    let request = read_http_request(&mut stream);
+                    std::fs::write(
+                        request_dir_for_thread.join(format!("request-{index}.txt")),
+                        request,
+                    )
+                    .unwrap();
+                    let response = format!(
+                        "HTTP/1.1 {status} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    stream.write_all(response.as_bytes()).unwrap();
+                }
+            });
+
+            Self {
+                _temp: temp,
+                base_url: format!("http://{addr}"),
+                request_dir,
+                request_count,
+                join_handle: Some(join_handle),
+            }
+        }
+
+        fn base_url(&self) -> String {
+            self.base_url.clone()
+        }
+
+        fn requests(mut self) -> Vec<String> {
+            if let Some(join_handle) = self.join_handle.take() {
+                join_handle.join().unwrap();
+            }
+            (0..self.request_count)
+                .map(|index| {
+                    std::fs::read_to_string(self.request_dir.join(format!("request-{index}.txt")))
+                        .unwrap()
+                })
+                .collect()
         }
     }
 

--- a/crates/once-cas/src/tuist/cache.rs
+++ b/crates/once-cas/src/tuist/cache.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use bazel_remote_apis::{
     build::bazel::remote::execution::v2::{
         self as reapi, action_cache_client::ActionCacheClient,
-        capabilities_client::CapabilitiesClient,
         content_addressable_storage_client::ContentAddressableStorageClient,
     },
     google::rpc::Status as RpcStatus,
@@ -587,29 +586,16 @@ impl TuistCache {
     }
 
     async fn pick_fastest_endpoint(&self, endpoints: &[String]) -> Result<String> {
-        let token = self.auth_token().await?;
-        let instance_name = String::new();
         let mut set = tokio::task::JoinSet::new();
         for endpoint in endpoints {
             let endpoint = endpoint.clone();
-            let token = token.clone();
-            let instance_name = instance_name.clone();
             set.spawn(async move {
                 let start = Instant::now();
-                let outcome = async {
-                    let channel = connect_grpc_endpoint(&endpoint).await?;
-                    let mut client = CapabilitiesClient::new(channel);
-                    let request = reapi::GetCapabilitiesRequest { instance_name };
-                    let request = authorized_grpc_request_with_token(request, &token)?;
-                    timeout_result(
-                        tokio::time::timeout(
-                            ENDPOINT_PROBE_TIMEOUT,
-                            client.get_capabilities(request),
-                        )
-                        .await,
-                    )
-                }
-                .await;
+                let outcome =
+                    tokio::time::timeout(ENDPOINT_PROBE_TIMEOUT, connect_grpc_endpoint(&endpoint))
+                        .await
+                        .map_err(|_| "endpoint probe timed out".to_string())
+                        .and_then(|result| result.map(|_| ()));
                 match outcome {
                     Ok(()) => Ok((start.elapsed(), endpoint)),
                     Err(error) => Err(format!("{endpoint}: {error}")),
@@ -696,11 +682,13 @@ impl TuistCache {
         operation: &'static str,
     ) -> Result<Request<T>> {
         let token = self.auth_token().await?;
-        authorized_grpc_request_with_token(message, &token).map_err(|message| Error::Remote {
-            provider: PROVIDER_NAME,
-            operation,
-            message,
-        })
+        authorized_grpc_request_with_token(message, &token, Some(self.account())).map_err(
+            |message| Error::Remote {
+                provider: PROVIDER_NAME,
+                operation,
+                message,
+            },
+        )
     }
 
     fn account(&self) -> &str {
@@ -712,9 +700,9 @@ impl TuistCache {
 
     fn instance_name(&self) -> String {
         let Some(project) = self.config.project.as_deref() else {
-            return self.account().to_string();
+            return "default".to_string();
         };
-        format!("{}/{}", self.account(), project)
+        project.to_string()
     }
 
     fn endpoints_url(&self) -> Result<Url> {
@@ -798,22 +786,19 @@ async fn connect_grpc_endpoint(endpoint: &str) -> std::result::Result<Channel, S
 fn authorized_grpc_request_with_token<T>(
     message: T,
     token: &str,
+    account: Option<&str>,
 ) -> std::result::Result<Request<T>, String> {
     let header = format!("Bearer {token}");
     let metadata = MetadataValue::try_from(header.as_str()).map_err(|source| source.to_string())?;
     let mut request = Request::new(message);
     request.metadata_mut().insert("authorization", metadata);
-    Ok(request)
-}
-
-fn timeout_result<T>(
-    result: std::result::Result<std::result::Result<T, Status>, tokio::time::error::Elapsed>,
-) -> std::result::Result<(), String> {
-    match result {
-        Ok(Ok(_)) => Ok(()),
-        Ok(Err(status)) => Err(status.to_string()),
-        Err(source) => Err(source.to_string()),
+    if let Some(account) = account.and_then(non_empty_str) {
+        let metadata = MetadataValue::try_from(account).map_err(|source| source.to_string())?;
+        request
+            .metadata_mut()
+            .insert("x-tuist-account-handle", metadata);
     }
+    Ok(request)
 }
 
 fn grpc_error(operation: &'static str, status: &Status) -> Error {
@@ -906,9 +891,34 @@ fn grpc_endpoint_url(endpoint: &str) -> String {
     }
 }
 
+fn non_empty_str(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    fn tuist_cache(temp: &TempDir, project: Option<&str>) -> TuistCache {
+        TuistCache::new(
+            Cas::open(temp.path().join("cas")),
+            temp.path().join("auth"),
+            TuistCacheConfig {
+                url: "https://tuist.dev".to_string(),
+                account: Some("tuist".to_string()),
+                project: project.map(str::to_string),
+                oauth_client_id: None,
+                provider_name: "tuist".to_string(),
+            },
+        )
+        .unwrap()
+    }
 
     #[test]
     fn grpc_endpoint_url_normalizes_grpc_schemes() {
@@ -923,6 +933,43 @@ mod tests {
         assert_eq!(
             grpc_endpoint_url("https://cache.example.com"),
             "https://cache.example.com"
+        );
+    }
+
+    #[test]
+    fn instance_name_uses_project_namespace_without_account_prefix() {
+        let temp = TempDir::new().unwrap();
+        let cache = tuist_cache(&temp, Some("gradle-plugin"));
+
+        assert_eq!(cache.instance_name(), "gradle-plugin");
+    }
+
+    #[test]
+    fn instance_name_defaults_to_default_namespace() {
+        let temp = TempDir::new().unwrap();
+        let cache = tuist_cache(&temp, None);
+
+        assert_eq!(cache.instance_name(), "default");
+    }
+
+    #[test]
+    fn authorized_grpc_request_includes_tuist_account_header() {
+        let request =
+            authorized_grpc_request_with_token((), "token", Some("acme")).expect("valid metadata");
+
+        assert_eq!(
+            request
+                .metadata()
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer token")
+        );
+        assert_eq!(
+            request
+                .metadata()
+                .get("x-tuist-account-handle")
+                .and_then(|value| value.to_str().ok()),
+            Some("acme")
         );
     }
 

--- a/crates/once-cli/src/cache_provider.rs
+++ b/crates/once-cli/src/cache_provider.rs
@@ -3,9 +3,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use once_cas::{CacheProvider, TuistCacheConfig, TUIST_OAUTH_CLIENT_ID_ENV};
+use once_core::RemoteExecution;
 use once_core::Xdg;
 use once_frontend::{
-    CacheProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
+    CacheProviderConfig, InfrastructureConfig, InfrastructureProviderConfig,
+    NamedCacheProviderConfig, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
 };
 use serde::Deserialize;
 
@@ -15,8 +17,38 @@ pub(crate) enum ResolvedCacheProviderConfig {
     Tuist(TuistCacheConfig),
 }
 
+const DEFAULT_EXECUTION_PROVIDER: &str = "microsandbox";
+
 pub fn resolve(workspace: &Path, xdg: &Xdg) -> Result<CacheProvider> {
     build_provider(xdg, resolve_config(workspace, xdg)?)
+}
+
+pub(crate) fn resolve_execution(
+    workspace: &Path,
+    xdg: &Xdg,
+    explicit_provider: Option<&str>,
+) -> Result<RemoteExecution> {
+    if let Some(provider) = explicit_provider.and_then(non_empty_str) {
+        return Ok(RemoteExecution::provider(provider));
+    }
+
+    let workspace_config =
+        once_frontend::load_infrastructure_config(workspace).context("loading infrastructure")?;
+    if let Some(binding) = workspace_config.execution.clone() {
+        return resolve_execution_binding(xdg, &workspace_config, binding);
+    }
+
+    if let Some(mut config) = maybe_load_user_config(xdg)? {
+        if let Some(binding) = config
+            .infrastructure
+            .take()
+            .and_then(|infrastructure| infrastructure.execution)
+        {
+            return resolve_execution_user_binding(xdg, binding.into_named(), config);
+        }
+    }
+
+    Ok(RemoteExecution::provider(DEFAULT_EXECUTION_PROVIDER))
 }
 
 pub(crate) fn resolve_auth_provider(
@@ -30,6 +62,19 @@ pub(crate) fn resolve_auth_provider(
     }
     if provider_name == "workspace" {
         return resolve_config(workspace, xdg);
+    }
+
+    let workspace_config =
+        once_frontend::load_infrastructure_config(workspace).context("loading infrastructure")?;
+    if let Some(provider) = workspace_config.providers.get(provider_name) {
+        return Ok(resolve_named_workspace_provider(
+            NamedCacheProviderConfig {
+                name: provider_name.to_string(),
+                account: None,
+                project: None,
+            },
+            provider.clone(),
+        ));
     }
 
     if let Some(mut config) = maybe_load_user_config(xdg)? {
@@ -66,17 +111,16 @@ pub(crate) fn credentials_root(xdg: &Xdg) -> PathBuf {
 }
 
 fn resolve_config(workspace: &Path, xdg: &Xdg) -> Result<ResolvedCacheProviderConfig> {
-    match once_frontend::load_cache_provider_override(workspace)
-        .context("loading cache provider")?
-    {
-        Some(config) => resolve_provider_config(xdg, config),
-        None => {
-            if let Some(config) = resolve_tuist_workspace_config(workspace) {
-                Ok(ResolvedCacheProviderConfig::Tuist(config?))
-            } else {
-                resolve_default_provider(xdg)
-            }
-        }
+    let workspace_config =
+        once_frontend::load_infrastructure_config(workspace).context("loading infrastructure")?;
+    if let Some(config) = workspace_config.cache {
+        return resolve_provider_config(xdg, &workspace_config.providers, config);
+    }
+
+    if let Some(config) = resolve_tuist_workspace_config(workspace) {
+        Ok(ResolvedCacheProviderConfig::Tuist(config?))
+    } else {
+        resolve_default_provider(xdg)
     }
 }
 
@@ -92,6 +136,7 @@ fn build_provider(xdg: &Xdg, config: ResolvedCacheProviderConfig) -> Result<Cach
 
 fn resolve_provider_config(
     xdg: &Xdg,
+    workspace_providers: &BTreeMap<String, InfrastructureProviderConfig>,
     config: CacheProviderConfig,
 ) -> Result<ResolvedCacheProviderConfig> {
     match config {
@@ -100,6 +145,9 @@ fn resolve_provider_config(
             direct_tuist_config(config),
         )),
         CacheProviderConfig::Named(binding) => {
+            if let Some(provider) = workspace_providers.get(&binding.name) {
+                return Ok(resolve_named_workspace_provider(binding, provider.clone()));
+            }
             let mut config = load_user_config(xdg)?;
             let provider =
                 take_named_user_provider(&mut config, &binding.name).with_context(|| {
@@ -166,6 +214,126 @@ fn resolve_named_provider(
             oauth_client_id,
         )),
     }
+}
+
+fn resolve_named_workspace_provider(
+    binding: NamedCacheProviderConfig,
+    provider: InfrastructureProviderConfig,
+) -> ResolvedCacheProviderConfig {
+    let NamedCacheProviderConfig {
+        name,
+        account: binding_account,
+        project: binding_project,
+    } = binding;
+    match provider {
+        InfrastructureProviderConfig::Local => ResolvedCacheProviderConfig::Local,
+        InfrastructureProviderConfig::Tuist(config) => {
+            ResolvedCacheProviderConfig::Tuist(default_tuist_config(
+                name,
+                config.url,
+                binding_account.or(config.account),
+                binding_project.or(config.project),
+                config.oauth_client_id,
+            ))
+        }
+    }
+}
+
+fn resolve_execution_binding(
+    xdg: &Xdg,
+    workspace_config: &InfrastructureConfig,
+    binding: NamedCacheProviderConfig,
+) -> Result<RemoteExecution> {
+    if let Some(provider) = workspace_config.providers.get(&binding.name) {
+        return Ok(remote_from_workspace_provider(binding, provider.clone()));
+    }
+
+    if let Some(config) = maybe_load_user_config(xdg)? {
+        return resolve_execution_user_binding(xdg, binding, config);
+    }
+
+    if is_builtin_execution_provider(&binding.name) {
+        return Ok(remote_from_binding(binding));
+    }
+
+    bail!(
+        "infrastructure `{}` was not found in {}",
+        binding.name,
+        user_config_path(xdg).display()
+    )
+}
+
+fn resolve_execution_user_binding(
+    xdg: &Xdg,
+    binding: NamedCacheProviderConfig,
+    mut config: UserConfig,
+) -> Result<RemoteExecution> {
+    if let Some(provider) = take_named_user_provider(&mut config, &binding.name) {
+        return Ok(remote_from_user_provider(binding, provider));
+    }
+    if is_builtin_execution_provider(&binding.name) {
+        return Ok(remote_from_binding(binding));
+    }
+    bail!(
+        "infrastructure `{}` was not found in {}",
+        binding.name,
+        user_config_path(xdg).display()
+    )
+}
+
+fn remote_from_workspace_provider(
+    binding: NamedCacheProviderConfig,
+    provider: InfrastructureProviderConfig,
+) -> RemoteExecution {
+    let NamedCacheProviderConfig {
+        name,
+        account: binding_account,
+        project: binding_project,
+    } = binding;
+    match provider {
+        InfrastructureProviderConfig::Local => RemoteExecution {
+            provider: name,
+            account: binding_account,
+            project: binding_project,
+        },
+        InfrastructureProviderConfig::Tuist(config) => RemoteExecution {
+            provider: name,
+            account: binding_account.or(config.account),
+            project: binding_project.or(config.project),
+        },
+    }
+}
+
+fn remote_from_user_provider(
+    binding: NamedCacheProviderConfig,
+    provider: UserCacheProvider,
+) -> RemoteExecution {
+    let NamedCacheProviderConfig {
+        name,
+        account: binding_account,
+        project: binding_project,
+    } = binding;
+    match provider {
+        UserCacheProvider::Tuist {
+            account, project, ..
+        } => RemoteExecution {
+            provider: name,
+            account: binding_account.or(account),
+            project: binding_project.or(project),
+        },
+    }
+}
+
+fn remote_from_binding(binding: NamedCacheProviderConfig) -> RemoteExecution {
+    RemoteExecution {
+        provider: binding.name,
+        account: binding.account,
+        project: binding.project,
+    }
+}
+
+fn is_builtin_execution_provider(name: &str) -> bool {
+    matches!(name, "microsandbox" | "daytona")
 }
 
 fn direct_tuist_config(config: TuistCacheProviderConfig) -> TuistCacheConfig {
@@ -456,11 +624,13 @@ struct UserConfig {
 #[serde(default, deny_unknown_fields)]
 struct UserInfrastructureConfig {
     cache: Option<UserCacheProviderBinding>,
+    execution: Option<UserCacheProviderBinding>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct UserCacheProviderBinding {
+    #[serde(alias = "provider")]
     name: String,
     account: Option<String>,
     project: Option<String>,
@@ -520,6 +690,13 @@ fn maybe_load_user_config(xdg: &Xdg) -> Result<Option<UserConfig>> {
     {
         normalize_binding(binding, &path)?;
     }
+    if let Some(binding) = config
+        .infrastructure
+        .as_mut()
+        .and_then(|infrastructure| infrastructure.execution.as_mut())
+    {
+        normalize_binding(binding, &path)?;
+    }
     Ok(Some(config))
 }
 
@@ -549,6 +726,15 @@ fn non_empty(value: Option<String>) -> Option<String> {
             Some(trimmed.to_string())
         }
     })
+}
+
+fn non_empty_str(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
 
 #[cfg(test)]
@@ -856,6 +1042,95 @@ account = "acme"
         let config = expect_tuist(resolve_config(tmp.path(), &xdg).unwrap());
         assert_eq!(config.account.as_deref(), Some("acme"));
         assert_eq!(config.project.as_deref(), Some("repo-app"));
+    }
+
+    #[test]
+    fn workspace_cache_binding_uses_root_provider_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructure.cache]
+provider = "tuist"
+project = "cache-app"
+
+[infrastructures.tuist]
+kind = "tuist"
+url = "https://cache.tuist.dev"
+account = "acme"
+project = "default-app"
+"#,
+        );
+
+        let config = expect_tuist(resolve_config(tmp.path(), &xdg).unwrap());
+
+        assert_eq!(config.url, "https://cache.tuist.dev");
+        assert_eq!(config.account.as_deref(), Some("acme"));
+        assert_eq!(config.project.as_deref(), Some("cache-app"));
+        assert_eq!(config.provider_name, "tuist");
+    }
+
+    #[test]
+    fn resolve_execution_uses_root_provider_with_capability_overrides() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructure.execution]
+provider = "tuist"
+project = "remote-builds"
+
+[infrastructures.tuist]
+kind = "tuist"
+url = "https://cache.tuist.dev"
+account = "acme"
+project = "default-app"
+"#,
+        );
+
+        let remote = resolve_execution(tmp.path(), &xdg, None).unwrap();
+
+        assert_eq!(
+            remote,
+            RemoteExecution {
+                provider: "tuist".to_string(),
+                account: Some("acme".to_string()),
+                project: Some("remote-builds".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_execution_defaults_to_microsandbox_without_config() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+
+        let remote = resolve_execution(tmp.path(), &xdg, None).unwrap();
+
+        assert_eq!(remote, RemoteExecution::provider("microsandbox"));
+    }
+
+    #[test]
+    fn resolve_execution_explicit_provider_beats_workspace_config() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructure.execution]
+provider = "tuist"
+
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+"#,
+        );
+
+        let remote = resolve_execution(tmp.path(), &xdg, Some("daytona")).unwrap();
+
+        assert_eq!(remote, RemoteExecution::provider("daytona"));
     }
 
     #[test]

--- a/crates/once-cli/src/cache_provider.rs
+++ b/crates/once-cli/src/cache_provider.rs
@@ -18,6 +18,7 @@ pub(crate) enum ResolvedCacheProviderConfig {
 }
 
 const DEFAULT_EXECUTION_PROVIDER: &str = "microsandbox";
+const ONCE_CACHE_PROVIDER_ENV: &str = "ONCE_CACHE_PROVIDER";
 
 pub fn resolve(workspace: &Path, xdg: &Xdg) -> Result<CacheProvider> {
     build_provider(xdg, resolve_config(workspace, xdg)?)
@@ -111,8 +112,19 @@ pub(crate) fn credentials_root(xdg: &Xdg) -> PathBuf {
 }
 
 fn resolve_config(workspace: &Path, xdg: &Xdg) -> Result<ResolvedCacheProviderConfig> {
+    resolve_config_with_env(workspace, xdg, std::env::var(ONCE_CACHE_PROVIDER_ENV).ok())
+}
+
+fn resolve_config_with_env(
+    workspace: &Path,
+    xdg: &Xdg,
+    cache_provider_override: Option<String>,
+) -> Result<ResolvedCacheProviderConfig> {
     let workspace_config =
         once_frontend::load_infrastructure_config(workspace).context("loading infrastructure")?;
+    if let Some(config) = cache_provider_config_from_env(cache_provider_override) {
+        return resolve_provider_config(xdg, &workspace_config.providers, config);
+    }
     if let Some(config) = workspace_config.cache {
         return resolve_provider_config(xdg, &workspace_config.providers, config);
     }
@@ -121,6 +133,19 @@ fn resolve_config(workspace: &Path, xdg: &Xdg) -> Result<ResolvedCacheProviderCo
         Ok(ResolvedCacheProviderConfig::Tuist(config?))
     } else {
         resolve_default_provider(xdg)
+    }
+}
+
+fn cache_provider_config_from_env(value: Option<String>) -> Option<CacheProviderConfig> {
+    let name = non_empty(value)?;
+    if name == "local" {
+        Some(CacheProviderConfig::Local)
+    } else {
+        Some(CacheProviderConfig::Named(NamedCacheProviderConfig {
+            name,
+            account: None,
+            project: None,
+        }))
     }
 }
 
@@ -838,6 +863,57 @@ account = "acme"
 
         let provider = resolve_config(tmp.path(), &xdg).unwrap();
         assert_eq!(provider, ResolvedCacheProviderConfig::Local);
+    }
+
+    #[test]
+    fn env_cache_provider_override_beats_workspace_config() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructure.cache]
+provider = "tuist"
+
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+project = "repo-app"
+"#,
+        );
+
+        let provider =
+            resolve_config_with_env(tmp.path(), &xdg, Some("local".to_string())).unwrap();
+
+        assert_eq!(provider, ResolvedCacheProviderConfig::Local);
+    }
+
+    #[test]
+    fn env_cache_provider_override_resolves_named_workspace_provider() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructure.cache]
+provider = "local"
+
+[infrastructures.tuist]
+kind = "tuist"
+url = "https://cache.tuist.dev"
+account = "acme"
+project = "repo-app"
+"#,
+        );
+
+        let config = expect_tuist(
+            resolve_config_with_env(tmp.path(), &xdg, Some("tuist".to_string())).unwrap(),
+        );
+
+        assert_eq!(config.url, "https://cache.tuist.dev");
+        assert_eq!(config.account.as_deref(), Some("acme"));
+        assert_eq!(config.project.as_deref(), Some("repo-app"));
+        assert_eq!(config.provider_name, "tuist");
     }
 
     #[test]

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -155,9 +155,9 @@ pub enum Cmd {
         #[arg(long)]
         remote: bool,
 
-        /// Compute provider used with --remote.
-        #[arg(long, value_name = "PROVIDER", default_value = "microsandbox")]
-        compute: String,
+        /// Compute provider used with --remote. Defaults to the configured execution provider.
+        #[arg(long, value_name = "PROVIDER")]
+        compute: Option<String>,
 
         /// Target id, e.g. `examples/hello/hello` or `./hello`.
         #[arg(required_unless_present = "list")]
@@ -219,9 +219,9 @@ pub enum Cmd {
         #[arg(long)]
         remote: bool,
 
-        /// Compute provider used with --remote.
-        #[arg(long, value_name = "PROVIDER", default_value = "microsandbox")]
-        compute: String,
+        /// Compute provider used with --remote. Defaults to the configured execution provider.
+        #[arg(long, value_name = "PROVIDER")]
+        compute: Option<String>,
 
         /// Command and arguments. Use `--` to separate from once flags.
         #[arg(trailing_var_arg = true, required_unless_present = "list")]

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -49,7 +49,7 @@ pub struct ExecArgs {
     pub cwd: Option<WorkspacePath>,
     pub timeout_ms: Option<u64>,
     pub cache_failures: bool,
-    pub remote: Option<String>,
+    pub remote: Option<RemoteExecution>,
     pub argv: Vec<String>,
 }
 
@@ -85,13 +85,13 @@ pub async fn exec(
     } = args;
 
     let (workspace, action) = if script {
-        script_action(workspace, env, cwd, timeout_ms, remote.as_deref(), &argv)?
+        script_action(workspace, env, cwd, timeout_ms, remote.clone(), &argv)?
     } else if let Some(plan) = autodetected_script_action(
         workspace,
         env.clone(),
         cwd.clone(),
         timeout_ms,
-        remote.as_deref(),
+        remote.clone(),
         &argv,
     )? {
         plan
@@ -107,7 +107,7 @@ pub async fn exec(
                 output_symlink_mode: OutputSymlinkMode::default(),
                 resources: ResourceRequest::default(),
                 timeout_ms,
-                remote: remote_execution(remote.as_deref()),
+                remote,
             },
         )
     };
@@ -188,7 +188,7 @@ fn script_action(
     explicit_env: Vec<(String, String)>,
     cwd_override: Option<WorkspacePath>,
     timeout_ms_override: Option<u64>,
-    remote_override: Option<&str>,
+    remote_override: Option<RemoteExecution>,
     argv: &[String],
 ) -> Result<(PathBuf, Action)> {
     let invocation = script_invocation(
@@ -225,9 +225,7 @@ fn script_action(
 }
 
 fn remote_execution(provider: Option<&str>) -> Option<RemoteExecution> {
-    provider.map(|provider| RemoteExecution {
-        provider: provider.to_string(),
-    })
+    provider.map(RemoteExecution::provider)
 }
 
 fn action_remote(action: &Action) -> Option<&RemoteExecution> {
@@ -242,7 +240,7 @@ fn autodetected_script_action(
     explicit_env: Vec<(String, String)>,
     cwd_override: Option<WorkspacePath>,
     timeout_ms_override: Option<u64>,
-    remote_override: Option<&str>,
+    remote_override: Option<RemoteExecution>,
     argv: &[String],
 ) -> Result<Option<(PathBuf, Action)>> {
     let Ok((_, _, script_arg, _)) = parse_script_exec_argv(workspace, argv) else {
@@ -273,7 +271,7 @@ fn script_invocation(
     explicit_env: BTreeMap<String, String>,
     cwd_override: Option<WorkspacePath>,
     timeout_ms_override: Option<u64>,
-    remote_override: Option<&str>,
+    remote_override: Option<RemoteExecution>,
     argv: &[String],
 ) -> Result<ScriptInvocation> {
     let (runtime, runtime_args, script_arg, script_args) = parse_script_exec_argv(workspace, argv)?;
@@ -310,7 +308,7 @@ fn script_invocation(
     let input_digest = Some(script_input_digest(&workspace, &inputs)?);
     let timeout_ms = timeout_ms_override;
     let env = script_env(&workspace, &runtime, &annotations.env_vars, explicit_env)?;
-    let remote = remote_execution(remote_override.or(annotations.remote.as_deref()));
+    let remote = remote_override.or_else(|| remote_execution(annotations.remote.as_deref()));
     let output_symlink_mode = output_symlink_mode(annotations.output_symlinks.as_deref())?;
 
     Ok(ScriptInvocation {

--- a/crates/once-cli/src/commands/run.rs
+++ b/crates/once-cli/src/commands/run.rs
@@ -21,7 +21,7 @@ pub struct RunArgs {
     pub output: Output,
     pub runtime_rpc: bool,
     pub runtime_rpc_socket: Option<PathBuf>,
-    pub remote: Option<String>,
+    pub remote: Option<RemoteExecution>,
 }
 
 pub async fn run(
@@ -34,8 +34,8 @@ pub async fn run(
     let target = &targets[idx];
 
     let mut plan = action_for(workspace, target)?;
-    if let Some(provider) = args.remote.as_deref() {
-        set_remote(&mut plan.action, provider);
+    if let Some(remote) = args.remote.clone() {
+        set_remote(&mut plan.action, remote);
     }
     if let Some(out_dir) = &plan.output_dir {
         tokio::fs::create_dir_all(out_dir)
@@ -135,11 +135,9 @@ async fn finish_run(
     Ok(())
 }
 
-fn set_remote(action: &mut Action, provider: &str) {
+fn set_remote(action: &mut Action, remote_execution: RemoteExecution) {
     if let Action::RunCommand { remote, .. } = action {
-        *remote = Some(RemoteExecution {
-            provider: provider.to_string(),
-        });
+        *remote = Some(remote_execution);
     }
 }
 

--- a/crates/once-cli/src/commands/run/action/script.rs
+++ b/crates/once-cli/src/commands/run/action/script.rs
@@ -116,9 +116,7 @@ fn remote(target: &once_frontend::Target) -> Option<RemoteExecution> {
     target
         .attrs
         .get("remote_provider")
-        .map(|provider| RemoteExecution {
-            provider: provider.clone(),
-        })
+        .map(RemoteExecution::provider)
 }
 
 fn runtime_args(target: &once_frontend::Target) -> Result<Vec<String>> {

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use once_cas::CacheProvider;
-use once_core::Xdg;
+use once_core::{RemoteExecution, Xdg};
 
 use crate::cli::{self, Cli, Cmd, Output};
 use crate::commands;
@@ -79,7 +79,7 @@ async fn run_command(
                     visible,
                     runtime_rpc,
                     runtime_rpc_socket,
-                    remote: remote.then_some(compute),
+                    remote: resolve_remote_execution(workspace, xdg, remote, compute.as_deref())?,
                 },
             ))
             .await
@@ -104,7 +104,7 @@ async fn run_command(
                     cwd,
                     timeout_ms,
                     cache_failures,
-                    remote: remote.then_some(compute),
+                    remote: resolve_remote_execution(workspace, xdg, remote, compute.as_deref())?,
                     argv,
                 },
             )
@@ -369,7 +369,7 @@ struct RunDispatchArgs {
     visible: bool,
     runtime_rpc: bool,
     runtime_rpc_socket: Option<PathBuf>,
-    remote: Option<String>,
+    remote: Option<RemoteExecution>,
 }
 
 async fn dispatch_run(workspace: &Path, xdg: &Xdg, args: RunDispatchArgs) -> Result<ExitCode> {
@@ -433,7 +433,7 @@ async fn run_target_command(
     target: Option<String>,
     runtime_rpc: bool,
     runtime_rpc_socket: Option<PathBuf>,
-    remote: Option<String>,
+    remote: Option<RemoteExecution>,
 ) -> Result<ExitCode> {
     let target = resolve_required_target(workspace, target)?;
     commands::run::run(
@@ -448,6 +448,19 @@ async fn run_target_command(
         },
     )
     .await
+}
+
+fn resolve_remote_execution(
+    workspace: &Path,
+    xdg: &Xdg,
+    remote: bool,
+    compute: Option<&str>,
+) -> Result<Option<RemoteExecution>> {
+    if remote {
+        crate::cache_provider::resolve_execution(workspace, xdg, compute).map(Some)
+    } else {
+        Ok(None)
+    }
 }
 
 fn resolve_required_target(workspace: &Path, target: Option<String>) -> Result<String> {

--- a/crates/once-core/src/action.rs
+++ b/crates/once-core/src/action.rs
@@ -163,6 +163,20 @@ impl Action {
 #[serde(rename_all = "snake_case")]
 pub struct RemoteExecution {
     pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+}
+
+impl RemoteExecution {
+    pub fn provider(provider: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            account: None,
+            project: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/once-core/src/runner.rs
+++ b/crates/once-core/src/runner.rs
@@ -736,9 +736,7 @@ mod tests {
             output_symlink_mode: OutputSymlinkMode::default(),
             resources: ResourceRequest::default(),
             timeout_ms: None,
-            remote: Some(RemoteExecution {
-                provider: "unknown-remote".to_string(),
-            }),
+            remote: Some(RemoteExecution::provider("unknown-remote")),
         };
 
         let error = run(&action, tmp.path(), &cas, RunOpts::default())

--- a/crates/once-frontend/src/cache_provider.rs
+++ b/crates/once-frontend/src/cache_provider.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 
 use crate::error::{Error, Result};
@@ -11,6 +13,15 @@ pub enum CacheProviderConfig {
     Named(NamedCacheProviderConfig),
     Tuist(TuistCacheProviderConfig),
 }
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InfrastructureConfig {
+    pub cache: Option<CacheProviderConfig>,
+    pub execution: Option<ExecutionProviderConfig>,
+    pub providers: BTreeMap<String, InfrastructureProviderConfig>,
+}
+
+pub type ExecutionProviderConfig = NamedCacheProviderConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NamedCacheProviderConfig {
@@ -27,10 +38,17 @@ pub struct TuistCacheProviderConfig {
     pub oauth_client_id: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InfrastructureProviderConfig {
+    Local,
+    Tuist(TuistCacheProviderConfig),
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub(crate) struct InfrastructureToml {
     pub cache: Option<CacheProviderToml>,
+    pub execution: Option<NamedCacheProviderToml>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -43,6 +61,7 @@ pub(crate) enum CacheProviderToml {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct NamedCacheProviderToml {
+    #[serde(alias = "provider")]
     name: String,
     account: Option<String>,
     project: Option<String>,
@@ -60,23 +79,24 @@ pub(crate) enum DirectCacheProviderToml {
     },
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum InfrastructureProviderToml {
+    Local,
+    Tuist {
+        url: Option<String>,
+        account: Option<String>,
+        project: Option<String>,
+        oauth_client_id: Option<String>,
+    },
+}
+
 impl CacheProviderToml {
     pub(crate) fn into_config(self, display_name: &str) -> Result<CacheProviderConfig> {
         match self {
-            Self::Named(named) => {
-                let name = named.name.trim().to_string();
-                if name.is_empty() {
-                    return Err(Error::Eval {
-                        path: display_name.to_string(),
-                        message: "cache_provider name must not be empty".to_string(),
-                    });
-                }
-                Ok(CacheProviderConfig::Named(NamedCacheProviderConfig {
-                    name,
-                    account: non_empty(named.account),
-                    project: non_empty(named.project),
-                }))
-            }
+            Self::Named(named) => Ok(CacheProviderConfig::Named(
+                named.into_config(display_name, "cache_provider")?,
+            )),
             Self::Direct(DirectCacheProviderToml::Local) => Ok(CacheProviderConfig::Local),
             Self::Direct(DirectCacheProviderToml::Tuist {
                 url,
@@ -92,6 +112,46 @@ impl CacheProviderToml {
                     oauth_client_id: non_empty(oauth_client_id),
                 }))
             }
+        }
+    }
+}
+
+impl NamedCacheProviderToml {
+    pub(crate) fn into_config(
+        self,
+        display_name: &str,
+        section_name: &str,
+    ) -> Result<NamedCacheProviderConfig> {
+        let name = self.name.trim().to_string();
+        if name.is_empty() {
+            return Err(Error::Eval {
+                path: display_name.to_string(),
+                message: format!("{section_name} provider must not be empty"),
+            });
+        }
+        Ok(NamedCacheProviderConfig {
+            name,
+            account: non_empty(self.account),
+            project: non_empty(self.project),
+        })
+    }
+}
+
+impl InfrastructureProviderToml {
+    pub(crate) fn into_config(self) -> InfrastructureProviderConfig {
+        match self {
+            Self::Local => InfrastructureProviderConfig::Local,
+            Self::Tuist {
+                url,
+                account,
+                project,
+                oauth_client_id,
+            } => InfrastructureProviderConfig::Tuist(TuistCacheProviderConfig {
+                url: non_empty(url).unwrap_or_else(|| DEFAULT_TUIST_URL.to_string()),
+                account: non_empty(account),
+                project: non_empty(project),
+                oauth_client_id: non_empty(oauth_client_id),
+            }),
         }
     }
 }

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -24,7 +24,9 @@ pub const TOML_BUILD_FILE_NAME: &str = "once.toml";
 pub const BUILD_FILE_NAME: &str = TOML_BUILD_FILE_NAME;
 
 pub use cache_provider::{
-    CacheProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
+    CacheProviderConfig, ExecutionProviderConfig, InfrastructureConfig,
+    InfrastructureProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig,
+    DEFAULT_TUIST_URL,
 };
 pub use error::{Error, Result};
 pub use examples::{load_example_bundle, load_target_kind_example};
@@ -35,7 +37,7 @@ pub use graph::{
     TargetKindExample, TargetKindExampleBundle, TargetKindExampleFile, TargetKindExampleRoot,
     TargetKindExampleSource, TargetKindSchema, TargetLabel,
 };
-pub use manifest::{load_cache_provider_toml_str, load_toml_str};
+pub use manifest::{load_cache_provider_toml_str, load_infrastructure_toml_str, load_toml_str};
 pub use manifest_editor::{
     apply_operations, apply_operations_with_schemas, EditOperation, TargetSpec, TargetUpdate,
 };
@@ -46,4 +48,7 @@ pub use target_ref::{
     target_id, validate_target_name, TargetIdError,
 };
 pub use target_validator::validate_target;
-pub use workspace::{load_cache_provider, load_cache_provider_override, load_file, load_workspace};
+pub use workspace::{
+    load_cache_provider, load_cache_provider_override, load_file, load_infrastructure_config,
+    load_workspace,
+};

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::cache_provider::{CacheProviderToml, InfrastructureToml};
+use crate::cache_provider::{CacheProviderToml, InfrastructureProviderToml, InfrastructureToml};
 use crate::error::{Error, Result};
 use crate::target::{AttrValue, Target};
 use crate::target_ref::{normalize_manifest_target, validate_target_name};
@@ -15,6 +15,7 @@ use crate::target_ref::{normalize_manifest_target, validate_target_name};
 struct Manifest {
     workspace: WorkspaceToml,
     infrastructure: InfrastructureToml,
+    infrastructures: BTreeMap<String, InfrastructureProviderToml>,
     cache_provider: Option<CacheProviderToml>,
     modules: Option<ModulesToml>,
     rules: Option<ModulesToml>,
@@ -75,17 +76,40 @@ pub fn load_cache_provider_toml_str(
     path: &str,
     src: &str,
 ) -> Result<Option<crate::cache_provider::CacheProviderConfig>> {
+    Ok(load_infrastructure_toml_str(path, src)?.cache)
+}
+
+pub fn load_infrastructure_toml_str(
+    path: &str,
+    src: &str,
+) -> Result<crate::cache_provider::InfrastructureConfig> {
     let manifest: Manifest = toml::from_str(src).map_err(|source| Error::Parse {
         path: path.to_string(),
         message: source.to_string(),
     })?;
-    if let Some(raw) = manifest.infrastructure.cache {
-        return raw.into_config(path).map(Some);
-    }
-    manifest
-        .cache_provider
-        .map(|raw| raw.into_config(path))
-        .transpose()
+    let cache = if let Some(raw) = manifest.infrastructure.cache {
+        Some(raw.into_config(path)?)
+    } else {
+        manifest
+            .cache_provider
+            .map(|raw| raw.into_config(path))
+            .transpose()?
+    };
+    let execution = manifest
+        .infrastructure
+        .execution
+        .map(|raw| raw.into_config(path, "infrastructure.execution"))
+        .transpose()?;
+    let providers = manifest
+        .infrastructures
+        .into_iter()
+        .map(|(name, provider)| (name, provider.into_config()))
+        .collect();
+    Ok(crate::cache_provider::InfrastructureConfig {
+        cache,
+        execution,
+        providers,
+    })
 }
 
 pub(crate) fn load_module_paths_toml_str(path: &str, src: &str) -> Result<Vec<String>> {

--- a/crates/once-frontend/src/workspace.rs
+++ b/crates/once-frontend/src/workspace.rs
@@ -5,9 +5,12 @@ use std::path::{Path, PathBuf};
 use glob::Pattern;
 use walkdir::WalkDir;
 
-use crate::cache_provider::CacheProviderConfig;
+use crate::cache_provider::{CacheProviderConfig, InfrastructureConfig};
 use crate::error::{Error, Result};
-use crate::manifest::{load_cache_provider_toml_str, load_toml_with, load_workspace_toml_str};
+use crate::manifest::{
+    load_cache_provider_toml_str, load_infrastructure_toml_str, load_toml_with,
+    load_workspace_toml_str,
+};
 use crate::target::Target;
 use crate::TOML_BUILD_FILE_NAME;
 
@@ -150,6 +153,25 @@ pub fn load_cache_provider_override(root: &Path) -> Result<Option<CacheProviderC
         }
     };
     load_cache_provider_toml_str(TOML_BUILD_FILE_NAME, &src)
+}
+
+/// Load the workspace-level infrastructure config from the root
+/// `once.toml`.
+pub fn load_infrastructure_config(root: &Path) -> Result<InfrastructureConfig> {
+    let path = root.join(TOML_BUILD_FILE_NAME);
+    let src = match std::fs::read_to_string(&path) {
+        Ok(src) => src,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(InfrastructureConfig::default());
+        }
+        Err(source) => {
+            return Err(Error::Read {
+                path: path.display().to_string(),
+                source,
+            });
+        }
+    };
+    load_infrastructure_toml_str(TOML_BUILD_FILE_NAME, &src)
 }
 
 /// Load the workspace-level cache provider config from the root

--- a/docs/guide/infrastructure/index.md
+++ b/docs/guide/infrastructure/index.md
@@ -1,0 +1,56 @@
+# Infrastructure
+
+Infrastructure providers connect Once to shared services for cache storage and
+remote execution. The repository root `once.toml` owns this configuration so
+every script, graph target, and command-line invocation resolves the same
+defaults.
+
+## Providers
+
+Name each provider once under `infrastructures`, then bind capabilities to that
+name:
+
+```text
+[infrastructure.cache]
+provider = "tuist"
+
+[infrastructure.execution]
+provider = "tuist"
+project = "preview-execution"
+
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+project = "app"
+```
+
+In this example, cache and execution both use the `tuist` provider and the same
+account. Cache uses the provider default project, while execution overrides the
+project with `preview-execution`.
+
+Use this shape when a provider supports more than one capability. It keeps the
+shared server, account, and authentication setup in one place, while each
+capability can still override the fields that should differ.
+
+## Capability Overrides
+
+Capability tables accept the provider name plus provider-specific fields:
+
+```text
+[infrastructure.cache]
+provider = "tuist"
+project = "app-cache"
+
+[infrastructure.execution]
+provider = "tuist"
+project = "linux-execution"
+```
+
+Pass `--compute <provider>` with `--remote` when a single command should bypass
+the configured execution provider. Set `ONCE_CACHE_PROVIDER=local` for a process
+that should keep the repository configuration but use only the local cache.
+
+## Available Providers
+
+- [Tuist](/guide/infrastructure/tuist): shared cache storage and execution
+  sessions backed by Tuist.

--- a/docs/guide/infrastructure/index.md
+++ b/docs/guide/infrastructure/index.md
@@ -1,7 +1,7 @@
 # Infrastructure
 
-Infrastructure providers connect Once to shared services for cache storage and
-remote execution. The repository root `once.toml` owns this configuration so
+Infrastructure providers connect Once to shared services for remote cache and
+execution. The repository root `once.toml` owns this configuration so
 every script, graph target, and command-line invocation resolves the same
 defaults.
 
@@ -10,18 +10,18 @@ defaults.
 Name each provider once under `infrastructures`, then bind capabilities to that
 name:
 
-```text
+```toml
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+project = "app"
+
 [infrastructure.cache]
 provider = "tuist"
 
 [infrastructure.execution]
 provider = "tuist"
 project = "preview-execution"
-
-[infrastructures.tuist]
-kind = "tuist"
-account = "acme"
-project = "app"
 ```
 
 In this example, cache and execution both use the `tuist` provider and the same
@@ -36,7 +36,7 @@ capability can still override the fields that should differ.
 
 Capability tables accept the provider name plus provider-specific fields:
 
-```text
+```toml
 [infrastructure.cache]
 provider = "tuist"
 project = "app-cache"
@@ -52,5 +52,5 @@ that should keep the repository configuration but use only the local cache.
 
 ## Available Providers
 
-- [Tuist](/guide/infrastructure/tuist): shared cache storage and execution
+- [Tuist](/guide/infrastructure/tuist): remote cache and execution
   sessions backed by Tuist.

--- a/docs/guide/infrastructure/tuist.md
+++ b/docs/guide/infrastructure/tuist.md
@@ -80,10 +80,3 @@ steps:
 ```
 
 Once saves the resulting Tuist session for the rest of the job.
-
-Set `ONCE_CACHE_PROVIDER=local` on any step that should keep the repository
-configuration but avoid remote cache traffic for that process:
-
-```sh
-ONCE_CACHE_PROVIDER=local once exec -- ./scripts/build.sh
-```

--- a/docs/guide/infrastructure/tuist.md
+++ b/docs/guide/infrastructure/tuist.md
@@ -1,0 +1,78 @@
+# Tuist
+
+[Tuist](https://tuist.dev) can provide Once cache storage and remote execution
+configuration from the same named infrastructure provider. Once uses the Tuist
+session to discover the closest cache endpoint and to talk to Tuist through the
+[Bazel Remote Execution protocol](https://bazel.build/remote/remote-execution).
+
+## Configure Tuist
+
+Add a Tuist provider at the repository root:
+
+```text
+[infrastructure.cache]
+provider = "tuist"
+
+[infrastructure.execution]
+provider = "tuist"
+project = "preview-execution"
+
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+project = "app"
+```
+
+The `account` identifies the Tuist account. The `project` identifies the Tuist
+project used by default. Per-capability `project` fields override the provider
+default, so cache and execution can share the same provider while using
+different Tuist projects.
+
+## Authenticate Locally
+
+Sign in once before running cacheable commands:
+
+```sh
+once auth login --provider tuist
+```
+
+Once stores the Tuist session and reuses it for cache reads, cache writes, and
+endpoint discovery. To remove the stored session:
+
+```sh
+once auth logout --provider tuist
+```
+
+## Continuous Integration
+
+For Continuous Integration
+([CI](https://en.wikipedia.org/wiki/Continuous_integration)), Tuist accepts two
+authentication shapes:
+
+- Set `TUIST_TOKEN` to a Tuist account token with cache access.
+- Run `once auth login --provider tuist --no-browser` on a runner that exposes
+  an [OpenID Connect](https://openid.net/developers/how-connect-works/) identity
+  token.
+
+On GitHub Actions, grant identity-token permissions before the login step:
+
+```text
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: actions/checkout@v6
+  - run: once auth login --provider tuist --no-browser
+  - run: once exec -- ./scripts/build.sh
+```
+
+Once exchanges the runner identity token with Tuist and saves the resulting
+Tuist session for the rest of the job.
+
+Set `ONCE_CACHE_PROVIDER=local` on any step that should keep the repository
+configuration but avoid remote cache traffic for that process:
+
+```sh
+ONCE_CACHE_PROVIDER=local once exec -- ./scripts/build.sh
+```

--- a/docs/guide/infrastructure/tuist.md
+++ b/docs/guide/infrastructure/tuist.md
@@ -1,6 +1,6 @@
 # Tuist
 
-[Tuist](https://tuist.dev) can provide Once cache storage and remote execution
+[Tuist](https://tuist.dev) can provide Once remote cache and execution
 configuration from the same named infrastructure provider. Once uses the Tuist
 session to discover the closest cache endpoint and to talk to Tuist through the
 [Bazel Remote Execution protocol](https://bazel.build/remote/remote-execution).
@@ -9,18 +9,18 @@ session to discover the closest cache endpoint and to talk to Tuist through the
 
 Add a Tuist provider at the repository root:
 
-```text
+```toml
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+project = "app"
+
 [infrastructure.cache]
 provider = "tuist"
 
 [infrastructure.execution]
 provider = "tuist"
 project = "preview-execution"
-
-[infrastructures.tuist]
-kind = "tuist"
-account = "acme"
-project = "app"
 ```
 
 The `account` identifies the Tuist account. The `project` identifies the Tuist
@@ -28,9 +28,14 @@ project used by default. Per-capability `project` fields override the provider
 default, so cache and execution can share the same provider while using
 different Tuist projects.
 
-## Authenticate Locally
+## Authentication
 
-Sign in once before running cacheable commands:
+Tuist supports three authentication shapes.
+
+### User Authentication
+
+Use user authentication on developer machines. Sign in once before running
+cacheable commands:
 
 ```sh
 once auth login --provider tuist
@@ -43,20 +48,27 @@ endpoint discovery. To remove the stored session:
 once auth logout --provider tuist
 ```
 
-## Continuous Integration
+### Token
 
-For Continuous Integration
-([CI](https://en.wikipedia.org/wiki/Continuous_integration)), Tuist accepts two
-authentication shapes:
+Set `TUIST_TOKEN` to a Tuist account token with cache access. Use this when the
+environment can store a long-lived secret, for example a private Continuous
+Integration ([CI](https://en.wikipedia.org/wiki/Continuous_integration)) runner
+or a local automation machine.
 
-- Set `TUIST_TOKEN` to a Tuist account token with cache access.
-- Run `once auth login --provider tuist --no-browser` on a runner that exposes
-  an [OpenID Connect](https://openid.net/developers/how-connect-works/) identity
-  token.
+```sh
+TUIST_TOKEN=tuist_... once exec -- ./scripts/build.sh
+```
+
+### OpenID Connect
+
+Use [OpenID Connect](https://openid.net/developers/how-connect-works/) on
+supported Continuous Integration runners. Run
+`once auth login --provider tuist --no-browser` before cacheable commands, and
+Once exchanges the runner identity token with Tuist.
 
 On GitHub Actions, grant identity-token permissions before the login step:
 
-```text
+```yaml
 permissions:
   id-token: write
   contents: read
@@ -67,8 +79,7 @@ steps:
   - run: once exec -- ./scripts/build.sh
 ```
 
-Once exchanges the runner identity token with Tuist and saves the resulting
-Tuist session for the rest of the job.
+Once saves the resulting Tuist session for the rest of the job.
 
 Set `ONCE_CACHE_PROVIDER=local` on any step that should keep the repository
 configuration but avoid remote cache traffic for that process:

--- a/docs/guide/scripts/index.md
+++ b/docs/guide/scripts/index.md
@@ -57,6 +57,28 @@ and declared outputs. Root `once.toml` files configure shared settings such as
 cache providers, while package `once.toml` files may grow build graph
 declarations as Once expands beyond scripts.
 
+The root configuration can name a provider once and use it for more than one
+capability. Per-capability fields override the provider defaults:
+
+```text
+[infrastructure.cache]
+provider = "tuist"
+
+[infrastructure.execution]
+provider = "tuist"
+project = "preview-execution"
+
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+project = "app"
+```
+
+In this example, cache and execution both use the `tuist` provider and the
+same account. Cache uses the provider's default project, while execution sends
+`preview-execution`. Pass `--compute <provider>` with `--remote` when a single
+run should bypass the configured execution provider.
+
 ## Next
 
 Read [Caching](/guide/scripts/caching) for annotation examples across

--- a/docs/guide/scripts/index.md
+++ b/docs/guide/scripts/index.md
@@ -57,49 +57,8 @@ and declared outputs. Root `once.toml` files configure shared settings such as
 cache providers, while package `once.toml` files may grow build graph
 declarations as Once expands beyond scripts.
 
-The root configuration can name a provider once and use it for more than one
-capability. Per-capability fields override the provider defaults:
-
-```text
-[infrastructure.cache]
-provider = "tuist"
-
-[infrastructure.execution]
-provider = "tuist"
-project = "preview-execution"
-
-[infrastructures.tuist]
-kind = "tuist"
-account = "acme"
-project = "app"
-```
-
-In this example, cache and execution both use the `tuist` provider and the
-same account. Cache uses the provider's default project, while execution sends
-`preview-execution`. Pass `--compute <provider>` with `--remote` when a single
-run should bypass the configured execution provider.
-
-For Continuous Integration
-([CI](https://en.wikipedia.org/wiki/Continuous_integration)), Tuist accepts two
-authentication shapes. Set `TUIST_TOKEN` to an account token with cache scopes,
-or run `once auth login --provider tuist` before cacheable commands on GitHub
-Actions, CircleCI, or Bitrise. In those runners, Once requests the provider's
-OpenID Connect identity token, exchanges it with Tuist, and saves the resulting
-Tuist session for the rest of the job.
-
-Set `ONCE_CACHE_PROVIDER=local` on a command when a runner should keep the
-repository configuration but use only the local cache for that process.
-
-```yaml
-permissions:
-  id-token: write
-  contents: read
-
-steps:
-  - uses: actions/checkout@v5
-  - run: once auth login --provider tuist
-  - run: once exec -- ./scripts/build.sh
-```
+See [Infrastructure](/guide/infrastructure/) for remote cache and execution
+provider configuration.
 
 ## Next
 

--- a/docs/guide/scripts/index.md
+++ b/docs/guide/scripts/index.md
@@ -87,6 +87,9 @@ Actions, CircleCI, or Bitrise. In those runners, Once requests the provider's
 OpenID Connect identity token, exchanges it with Tuist, and saves the resulting
 Tuist session for the rest of the job.
 
+Set `ONCE_CACHE_PROVIDER=local` on a command when a runner should keep the
+repository configuration but use only the local cache for that process.
+
 ```yaml
 permissions:
   id-token: write

--- a/docs/guide/scripts/index.md
+++ b/docs/guide/scripts/index.md
@@ -79,6 +79,25 @@ same account. Cache uses the provider's default project, while execution sends
 `preview-execution`. Pass `--compute <provider>` with `--remote` when a single
 run should bypass the configured execution provider.
 
+For Continuous Integration
+([CI](https://en.wikipedia.org/wiki/Continuous_integration)), Tuist accepts two
+authentication shapes. Set `TUIST_TOKEN` to an account token with cache scopes,
+or run `once auth login --provider tuist` before cacheable commands on GitHub
+Actions, CircleCI, or Bitrise. In those runners, Once requests the provider's
+OpenID Connect identity token, exchanges it with Tuist, and saves the resulting
+Tuist session for the rest of the job.
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: actions/checkout@v5
+  - run: once auth login --provider tuist
+  - run: once exec -- ./scripts/build.sh
+```
+
 ## Next
 
 Read [Caching](/guide/scripts/caching) for annotation examples across

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,10 @@ hero:
       text: Graph
       link: /guide/graph/
 features:
-  - title: Graph-aware automation
-    details: Model work as targets with build, run, and test capabilities that agents and humans can query before executing anything.
-  - title: Flexible action adapters
-    details: Keep existing scripts and tools in place while they lower into the same content-addressed action model as typed target kinds.
-  - title: Deterministic cache keys
-    details: Inputs, outputs, environment variables, working directories, and timeouts become part of the action contract.
-  - title: Providers
-    details: Provider implementation is decoupled from actions, so teams can choose local cache storage, Tuist, and future remote compute providers.
+  - title: Cache remotely
+    details: Reuse content-addressed action results through a shared cache without changing the scripts that produce them.
+  - title: Run remotely
+    details: Execute declared actions on remote compute while keeping inputs, outputs, environment, and runtime metadata explicit.
+  - title: Do it anywhere
+    details: Configure infrastructure providers at the repository root so teams can swap vendors without changing action definitions.
 ---

--- a/docs/reference/cli/exec.md
+++ b/docs/reference/cli/exec.md
@@ -28,7 +28,7 @@ Low-level action surface for direct commands and script adapters. The cache key 
 | `--timeout-ms` | `<MS>` |  | Per-action timeout in milliseconds. The child is killed if it exceeds the deadline |
 | `--cache-failures` | (flag) | `false` | Cache non-zero exits the same way zero exits are cached. Off by default; transient failures shouldn't poison the cache |
 | `--remote` | (flag) | `false` | Run the command on a compute provider |
-| `--compute` | `<PROVIDER>` | `microsandbox` | Compute provider used with --remote |
+| `--compute` | `<PROVIDER>` |  | Compute provider used with --remote. Defaults to the configured execution provider |
 | `-C, --directory` | `<DIR>` |  | Project root. Defaults to the current directory; the cache lives under `<project>/.once/`. Mirrors `make -C` |
 | `--format` | `<FORMAT>` | `human` | Output format for Once's structured data (`cache stats`, `run`/`exec` trailers). Defaults to a human-readable rendering; pass `json` or `toon` to get machine-parseable output for scripting and for agent consumers |
 | `-v, --verbose` | (flag) | `0` | Increase log verbosity. Repeat for more (-v: info, -vv: debug, -vvv: trace). Overridden by `RUST_LOG` |

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -26,7 +26,7 @@ Resolves the target id against the workspace graph and executes its `run` capabi
 | `--runtime-rpc` | (flag) | `false` | Serve a local JSON-RPC runtime control socket for this run |
 | `--runtime-rpc-socket` | `<RUNTIME_RPC_SOCKET>` |  | Runtime RPC socket path. Defaults to `.once/runtime/<session>/control.sock` |
 | `--remote` | (flag) | `false` | Run the target's action on a compute provider |
-| `--compute` | `<PROVIDER>` | `microsandbox` | Compute provider used with --remote |
+| `--compute` | `<PROVIDER>` |  | Compute provider used with --remote. Defaults to the configured execution provider |
 | `-C, --directory` | `<DIR>` |  | Project root. Defaults to the current directory; the cache lives under `<project>/.once/`. Mirrors `make -C` |
 | `--format` | `<FORMAT>` | `human` | Output format for Once's structured data (`cache stats`, `run`/`exec` trailers). Defaults to a human-readable rendering; pass `json` or `toon` to get machine-parseable output for scripting and for agent consumers |
 | `-v, --verbose` | (flag) | `0` | Increase log verbosity. Repeat for more (-v: info, -vv: debug, -vvv: trace). Overridden by `RUST_LOG` |

--- a/docs/site.js
+++ b/docs/site.js
@@ -114,6 +114,14 @@ export const site = {
         ],
       },
       {
+        text: "Infrastructure",
+        collapsed: false,
+        items: [
+          { text: "Overview", link: "/guide/infrastructure/" },
+          { text: "Tuist", link: "/guide/infrastructure/tuist" },
+        ],
+      },
+      {
         text: "Memory",
         collapsed: false,
         items: [

--- a/once.toml
+++ b/once.toml
@@ -8,6 +8,14 @@ exclude = [
   "fixtures/**",
 ]
 
+[infrastructure.cache]
+provider = "tuist"
+
+[infrastructures.tuist]
+kind = "tuist"
+account = "tuist"
+project = "once"
+
 [[target]]
 name = "cargo_dependencies"
 kind = "cargo_dependencies"

--- a/spec/exec_spec.sh
+++ b/spec/exec_spec.sh
@@ -56,7 +56,7 @@ EOF
     cat > "$WORKSPACE/input.txt" <<'EOF'
 hello direct script
 EOF
-    When call env PATH=/usr/bin:/bin "$WORKSPACE/scripts/build.sh"
+    When call env ONCE_CACHE_PROVIDER=local PATH=/usr/bin:/bin "$WORKSPACE/scripts/build.sh"
     The status should be success
     The stdout should equal 'hello direct script'
     The stderr should include 'cache miss'
@@ -74,8 +74,8 @@ EOF
     cat > "$WORKSPACE/input.txt" <<'EOF'
 cached direct script
 EOF
-    env PATH=/usr/bin:/bin "$WORKSPACE/scripts/build.sh" >/dev/null 2>&1
-    When call env PATH=/usr/bin:/bin "$WORKSPACE/scripts/build.sh"
+    env ONCE_CACHE_PROVIDER=local PATH=/usr/bin:/bin "$WORKSPACE/scripts/build.sh" >/dev/null 2>&1
+    When call env ONCE_CACHE_PROVIDER=local PATH=/usr/bin:/bin "$WORKSPACE/scripts/build.sh"
     The status should be success
     The stdout should equal 'cached direct script'
     The stderr should include 'cache hit'


### PR DESCRIPTION
## What changed

This adds a root-level provider model for Once infrastructure configuration.
The root `once.toml` can now name a provider once, bind cache and execution to it, and override account or project per capability when needed.

It also wires Tuist through the cache path end to end:

- Tuist remote cache requests now include the account handle metadata expected by Kura.
- Tuist remote cache instance names use the project namespace, with `default` as the fallback namespace.
- Endpoint selection probes connection latency instead of issuing capability requests that can be authorized against the wrong namespace.
- `once auth login --provider tuist` can authenticate in Continuous Integration ([CI](https://en.wikipedia.org/wiki/Continuous_integration)) through GitHub Actions, CircleCI, or Bitrise OpenID Connect.
- The repository root now uses the `tuist/once` project as its configured Tuist cache provider.

## Why

Once needs a single infrastructure concept that can cover cache and execution without hardcoding a provider into the command surface. A provider can offer one capability or both, and callers should still be able to override the project used for a single capability.

The Tuist provider is the first real remote provider for this shape. It needs to manage the Tuist session, discover the nearest endpoint, and talk to Bazel's [remote execution protocol](https://github.com/bazelbuild/remote-apis) using the namespace and metadata Kura expects.

## Root cause

The earlier Tuist cache integration treated the remote instance name as `account/project` and did not send the Tuist account handle on remote cache protocol calls. Kura expects the project namespace as the instance name and the account handle as request metadata. Endpoint probing through capability calls also failed when authorization was checked against a default namespace instead of the project being used for cache requests.

## Approach

The frontend parser now produces an infrastructure configuration with cache, execution, and named providers. The command-line resolution layer applies that configuration to cache providers and to remote execution selection, while preserving `--compute` as an explicit per-run override.

The core action model now carries remote execution provider, account, and project fields. Tuist cache resolution maps those fields into the Tuist cache configuration, and the Tuist cache client maps the account and project into Kura-compatible metadata and instance names.

For Continuous Integration authentication, `TUIST_TOKEN` remains the direct account-token path. When `once auth login --provider tuist` runs inside a supported runner, Once fetches the runner's OpenID Connect identity token, exchanges it with Tuist, and stores the resulting Tuist access token for the job.

## Impact

Users can configure providers at the repository root and share defaults between cache and execution. Providers that support both capabilities can be referenced once, while projects or accounts can still be overridden per capability.

Tuist-backed cache is usable from Once with the `tuist/once` project, including blob cache and action cache operations. Continuous Integration jobs can either provide `TUIST_TOKEN` or use OpenID Connect login before running cacheable commands.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-cas tuist::auth`
- `mise exec -- cargo test -p once-cas`
- `mise exec -- cargo check -p once-cli -p once-core -p once-cas -p once-frontend`
- `mise exec -- cargo clippy -p once-cas --all-targets -- -D warnings`
- `git diff --check`
- Live smoke against the `tuist/once` project: blob put and fetch through Tuist after clearing local cache.
- Live smoke against the `tuist/once` project: action result restored from Tuist after clearing local cache.
