### PR TITLE
ci(infra): downsize production cluster and workload

### DIFF
--- a/infra/helm/once/values.yaml
+++ b/infra/helm/once/values.yaml
@@ -15,7 +15,9 @@ image:
   pullPolicy: IfNotPresent
   pullSecretName: ghcr-pull
 
-replicaCount: 2
+# Single replica: the site is static and runs on a single-node cluster, so
+# horizontal scaling and HA are not achievable or needed right now.
+replicaCount: 1
 
 resources:
   requests:
@@ -24,14 +26,18 @@ resources:
   limits:
     memory: 512Mi
 
+# Disabled: an HPA can't scale past a single-node cluster, and there is no
+# load to autoscale for a static site.
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 2
   maxReplicas: 4
   targetCPUUtilizationPercentage: 75
 
+# Disabled: with one replica, a minAvailable of 1 would block node drains
+# during CAPI rollouts instead of protecting availability.
 pdb:
-  enabled: true
+  enabled: false
   minAvailable: 1
 
 service:
@@ -76,8 +82,12 @@ externalSecrets:
     field: "notesPlain"
 
 postgres:
+  # Kept running but unused by the app today; a single instance frees a
+  # replica pod and its 20Gi volume. Dropping Postgres entirely needs app
+  # changes (Repo is started unconditionally and runtime.exs requires
+  # DATABASE_URL), so that is left for the larger restructure.
   enabled: true
-  instances: 2
+  instances: 1
   storageSize: 20Gi
   storageClass: hcloud-volumes
   imageName: ghcr.io/cloudnative-pg/postgresql:18.0

--- a/infra/k8s/cluster-production.yaml
+++ b/infra/k8s/cluster-production.yaml
@@ -1,8 +1,11 @@
 # Once production workload Cluster, topology mode against `tuist-hcloud`.
 #
 # Reconciled by the self-hosted CAPI + caph management cluster maintained
-# in tuist/tuist. The cluster shape mirrors Atlas with a smaller general
-# worker pool because Once currently runs only the Phoenix web workload.
+# in tuist/tuist. Once currently serves only the static Phoenix marketing
+# site, so the cluster is collapsed to the minimum that stays operational:
+# a single control-plane node and a single worker. HA is intentionally
+# given up here to keep the Hetzner bill down until the registry backend
+# lands and warrants a larger shape again.
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
@@ -22,7 +25,7 @@ spec:
       name: tuist-hcloud
     version: v1.34.6
     controlPlane:
-      replicas: 3
+      replicas: 1
     variables:
       - name: region
         value: fsn1
@@ -37,7 +40,7 @@ spec:
       machineDeployments:
         - class: hcloud-worker
           name: md-0
-          replicas: 2
+          replicas: 1
           failureDomain: fsn1
           metadata:
             labels:


### PR DESCRIPTION
## Why

`buildonce.dev` serves only the **static** Phoenix marketing site today — two server-rendered pages, registry data hardcoded in Elixir, **zero DB reads/writes** — yet it runs on a full HA cluster (**3 control-plane + 2 workers**) with a **2-instance Postgres the app never queries**. This collapses it to the minimum that stays operational **within the existing CAPI + Helm model** to cut the Hetzner bill. No re-architecture: the Helm deploy pipeline, 1Password secrets, cert-manager, external-dns, and CNPG stay intact. The larger "move off k8s / build the real registry backend" work is left for a follow-up.

## Changes

| Change | File | Effect |
|---|---|---|
| Control plane 3 → 1 | `infra/k8s/cluster-production.yaml` | −2 × cpx22 |
| Workers 2 → 1 | `infra/k8s/cluster-production.yaml` | −1 × cpx22 |
| `replicaCount` 2 → 1 | `infra/helm/once/values.yaml` | single app pod (HA not achievable on one node) |
| Autoscaling off | `infra/helm/once/values.yaml` | an HPA can't scale past a single node, and there's no load to scale for |
| PDB off | `infra/helm/once/values.yaml` | with one replica, `minAvailable: 1` would **block** node drains instead of protecting availability |
| Postgres 2 → 1 instance | `infra/helm/once/values.yaml` | frees a Postgres pod + its 20Gi volume |

**Net: 5 × cpx22 → 2 × cpx22 nodes.**

## Why Postgres is kept (not removed)

The DB is currently unused, but it isn't cleanly removable without app changes: `OnceSite.Repo` is started unconditionally in the supervision tree and `config/runtime.exs` **raises** if `DATABASE_URL` is missing in prod. Flipping `postgres.enabled=false` alone would crash-loop the app. Fully dropping it (and the Ecto coupling) belongs in the larger restructure, so this keeps a single instance running. A comment in `values.yaml` flags exactly this.

## Rollout order (two separate apply paths — same as tuist/hive#101)

1. **Merge first.** The `deploy web` workflow auto-runs `helm upgrade --install`, settling the workload to 1 app replica + 1 Postgres instance **while still on the current nodes**.
2. **Then resize the cluster.** `cluster-production.yaml` is reconciled by the CAPI management cluster in `tuist/tuist` (`org-tuist` namespace), **not** this repo's workflow — `kubectl apply` it against the management cluster once the Helm side has settled. CAPI drains the extra worker (PDB is off, so the app pod reschedules cleanly) and rolls etcd 3 → 1. Best done in a quiet window watching CNPG re-elect its primary.

## Verification

- `helm lint` passes (only the pre-existing "icon recommended" info)
- `infra/helm/once/tests/render-conditionals.sh` passes
- Render confirms `replicas: 1`, Postgres `instances: 1`, **0** HorizontalPodAutoscaler, **0** PodDisruptionBudget

🤖 Generated with [Claude Code](https://claude.com/claude-code)