### PR TITLE
fix(release): grant OpenID Connect token permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
## What changed

This grants `id-token: write` to the `Release` workflow alongside its existing `contents: write` permission.

## Why

The release packaging jobs build Once graph targets that use the configured Tuist cache provider. On GitHub Actions, that provider authenticates through [OpenID Connect](https://docs.github.com/en/actions/concepts/security/openid-connect). Without the token permission, every release packaging job reaches the cache probe and fails before uploading artifacts.

## Root cause

The workflow grants repository contents write access for release creation, but it did not grant the token permission that GitHub Actions requires before exposing the OpenID Connect request variables. The failing jobs reported: `GitHub Actions OpenID Connect token request variables are not set. Set permissions: id-token: write in the workflow.`

## Approach

Keep the change at workflow scope so all release build jobs, including archive packaging, Software Development Kit library packaging, and `Once.xcframework` packaging, receive the same token permission. The release scripts stay unchanged.

## Impact

Main branch release checks can authenticate the Tuist cache provider again. The change only affects GitHub Actions permissions for the release workflow and does not change runtime code or package output.

## Validation

- `git diff --check`
- `ruby -e "require 'psych'; Psych.parse_file('.github/workflows/release.yml')"`
