### PR TITLE
feat(graph): resolve declared tools with managed mise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring"] }
 tree-sitter = "0.26.9"
 tree-sitter-cypher = "0.2.6"
-reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
 sea-orm = { version = "1.1.20", default-features = false, features = ["macros", "runtime-tokio-rustls", "sqlx-sqlite"] }
 sea-orm-migration = { version = "1.1.20", default-features = false, features = ["runtime-tokio-rustls", "sqlx-sqlite"] }
 schlussel = { git = "https://github.com/tuist/schlussel.git", rev = "80a7bc1fc0b68bdc2cd2379b16240ddbfbe0267b" }

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use once_cas::{ActionResult, CacheProvider, Digest};
 use once_core::{
-    tool_env, workspace_tool, workspace_tool_env, Action, CacheState, EvidenceSubject,
+    tool_env, workspace_tool_command, workspace_tool_env, Action, CacheState, EvidenceSubject,
     InputDigestBuilder, OutputSymlinkMode, RemoteExecution, ResourceRequest, RunOpts, SandboxMode,
     WorkspacePath,
 };
@@ -320,8 +320,7 @@ async fn action_from_script_invocation(
     invocation: &ScriptInvocation,
     input_digest: Option<Digest>,
 ) -> Result<Action> {
-    let program = resolve_runtime(&invocation.workspace, &invocation.runtime).await?;
-    let mut argv = vec![program];
+    let mut argv = resolve_runtime(&invocation.workspace, &invocation.runtime).await?;
     argv.extend(invocation.runtime_args.clone());
     argv.push(host_script_path(
         invocation.script_path.as_str(),
@@ -1203,11 +1202,11 @@ async fn script_env(
     Ok(out)
 }
 
-async fn resolve_runtime(workspace: &Path, runtime: &str) -> Result<String> {
+async fn resolve_runtime(workspace: &Path, runtime: &str) -> Result<Vec<String>> {
     if runtime.contains('/') {
-        return Ok(runtime.to_string());
+        return Ok(vec![runtime.to_string()]);
     }
-    workspace_tool(workspace, runtime)
+    workspace_tool_command(workspace, runtime)
         .await
         .with_context(|| format!("resolving script runtime `{runtime}`"))
 }

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -1203,7 +1203,11 @@ async fn script_env(
 }
 
 async fn resolve_runtime(workspace: &Path, runtime: &str) -> Result<Vec<String>> {
-    if runtime.contains('/') {
+    // A runtime that looks like a path is run directly. This must match the
+    // path detection in `graph_tools_from_parts`, which excludes both
+    // separators, otherwise a backslash runtime is never installed yet
+    // still gets sent through mise here.
+    if runtime.contains('/') || runtime.contains('\\') {
         return Ok(vec![runtime.to_string()]);
     }
     workspace_tool_command(workspace, runtime)

--- a/crates/once-cli/src/commands/graph/action.rs
+++ b/crates/once-cli/src/commands/graph/action.rs
@@ -191,6 +191,7 @@ mod tests {
                 requires_outputs: Vec::new(),
             }],
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         }
     }

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -319,10 +319,28 @@ impl BuildSession {
     }
 }
 
+/// Resolve the executables declared by the graph's tools to concrete
+/// paths through the workspace's mise toolchain.
+///
+/// Resolution is scoped and best-effort so declaring a tool never makes a
+/// build worse off than the host toolchain would:
+///
+/// * Workspaces without `mise.toml` resolve every executable from the
+///   host `PATH`, so an empty map is returned and `host_which` keeps
+///   walking `PATH` (and verifying existence) as before.
+/// * A declared tool the workspace does not actually pin (for example a
+///   rust target in a node-only workspace) is not managed by mise. Its
+///   preparation and resolution failures are logged and the executable is
+///   left out of the map, so the target falls back to the host toolchain
+///   instead of aborting the whole session.
 async fn resolve_graph_tools(
     workspace: &Path,
     graph: &[GraphTarget],
 ) -> Result<BTreeMap<String, String>> {
+    if !once_core::workspace_has_mise_config(workspace) {
+        return Ok(BTreeMap::new());
+    }
+
     let tool_names = graph
         .iter()
         .flat_map(|target| target.tools.iter().map(|tool| tool.name.clone()))
@@ -338,29 +356,43 @@ async fn resolve_graph_tools(
         .collect::<BTreeSet<_>>();
     let tool_names = tool_names.into_iter().collect::<Vec<_>>();
     let tool_name_refs = tool_names.iter().map(String::as_str).collect::<Vec<_>>();
-    once_core::workspace_prepare_tools(workspace, &tool_name_refs)
-        .await
-        .context("preparing graph tools")?;
+    if let Err(error) = once_core::workspace_prepare_tools(workspace, &tool_name_refs).await {
+        tracing::debug!(
+            %error,
+            "preparing graph tools through mise failed; falling back to the host toolchain"
+        );
+    }
 
+    // Shared across every resolution task instead of cloned per executable.
+    let tool_names = Arc::<[String]>::from(tool_names);
     let mut tasks = tokio::task::JoinSet::new();
     for executable in executable_names {
         let workspace = workspace.to_path_buf();
         let executable = executable.to_string();
-        let tool_names = tool_names.clone();
+        let tool_names = Arc::clone(&tool_names);
         tasks.spawn(async move {
             let tool_name_refs = tool_names.iter().map(String::as_str).collect::<Vec<_>>();
-            let path =
-                once_core::workspace_executable(&workspace, &executable, &tool_name_refs).await?;
-            Ok::<_, once_core::ToolEnvError>((executable, path))
+            let path = once_core::workspace_executable(&workspace, &executable, &tool_name_refs)
+                .await;
+            (executable, path)
         });
     }
 
     let mut paths = BTreeMap::new();
     while let Some(result) = tasks.join_next().await {
-        let (executable, path) = result
-            .context("joining graph tool resolution")?
-            .context("resolving graph tool executable")?;
-        paths.insert(executable, path);
+        let (executable, path) = result.context("joining graph tool resolution")?;
+        match path {
+            Ok(path) => {
+                paths.insert(executable, path);
+            }
+            Err(error) => {
+                tracing::debug!(
+                    executable,
+                    %error,
+                    "resolving graph tool executable through mise failed; falling back to the host PATH"
+                );
+            }
+        }
     }
     Ok(paths)
 }

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -372,8 +372,8 @@ async fn resolve_graph_tools(
         let tool_names = Arc::clone(&tool_names);
         tasks.spawn(async move {
             let tool_name_refs = tool_names.iter().map(String::as_str).collect::<Vec<_>>();
-            let path = once_core::workspace_executable(&workspace, &executable, &tool_name_refs)
-                .await;
+            let path =
+                once_core::workspace_executable(&workspace, &executable, &tool_name_refs).await;
             (executable, path)
         });
     }

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -18,7 +18,7 @@
 mod actions;
 mod scheduler;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -72,27 +72,30 @@ pub(super) struct BuildSession {
 }
 
 impl BuildSession {
-    pub(super) fn new(
+    pub(super) async fn new(
         workspace: &Path,
         cache: &CacheProvider,
         graph: Vec<GraphTarget>,
         sandbox: SandboxMode,
     ) -> Result<Self> {
-        Self::new_with_options(workspace, cache, graph, AnalysisOptions::default(), sandbox)
+        Self::new_with_options(workspace, cache, graph, AnalysisOptions::default(), sandbox).await
     }
 
-    pub(super) fn new_with_options(
+    pub(super) async fn new_with_options(
         workspace: &Path,
         cache: &CacheProvider,
         graph: Vec<GraphTarget>,
         options: AnalysisOptions,
         sandbox: SandboxMode,
     ) -> Result<Self> {
+        let tool_paths = resolve_graph_tools(workspace, &graph).await?;
         Ok(Self::new_with_analyzer(
             workspace,
             cache,
             graph,
-            AnalysisEngine::for_workspace_with_options(workspace, options)?,
+            AnalysisEngine::for_workspace_with_options_and_tool_paths(
+                workspace, options, tool_paths,
+            )?,
             sandbox,
         ))
     }
@@ -314,6 +317,52 @@ impl BuildSession {
         .run()
         .await
     }
+}
+
+async fn resolve_graph_tools(
+    workspace: &Path,
+    graph: &[GraphTarget],
+) -> Result<BTreeMap<String, String>> {
+    let tool_names = graph
+        .iter()
+        .flat_map(|target| target.tools.iter().map(|tool| tool.name.clone()))
+        .collect::<BTreeSet<_>>();
+    let executable_names = graph
+        .iter()
+        .flat_map(|target| {
+            target
+                .tools
+                .iter()
+                .flat_map(|tool| tool.executables.iter().map(String::as_str))
+        })
+        .collect::<BTreeSet<_>>();
+    let tool_names = tool_names.into_iter().collect::<Vec<_>>();
+    let tool_name_refs = tool_names.iter().map(String::as_str).collect::<Vec<_>>();
+    once_core::workspace_prepare_tools(workspace, &tool_name_refs)
+        .await
+        .context("preparing graph tools")?;
+
+    let mut tasks = tokio::task::JoinSet::new();
+    for executable in executable_names {
+        let workspace = workspace.to_path_buf();
+        let executable = executable.to_string();
+        let tool_names = tool_names.clone();
+        tasks.spawn(async move {
+            let tool_name_refs = tool_names.iter().map(String::as_str).collect::<Vec<_>>();
+            let path =
+                once_core::workspace_executable(&workspace, &executable, &tool_name_refs).await?;
+            Ok::<_, once_core::ToolEnvError>((executable, path))
+        });
+    }
+
+    let mut paths = BTreeMap::new();
+    while let Some(result) = tasks.join_next().await {
+        let (executable, path) = result
+            .context("joining graph tool resolution")?
+            .context("resolving graph tool executable")?;
+        paths.insert(executable, path);
+    }
+    Ok(paths)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::future::Future;
 use std::path::Path;
@@ -9,8 +9,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use once_cas::{ActionResult, CacheProvider, Digest};
 use once_core::{
-    Action, CopyPathMode, EvidenceCacheState, EvidenceSubject, InputDigestBuilder,
-    OutputSymlinkMode, PreparePathMode, ResourceRequest, RunOpts, SandboxMode, WorkspacePath,
+    workspace_mise_command, workspace_mise_env, Action, CopyPathMode, EvidenceCacheState,
+    EvidenceSubject, InputDigestBuilder, OutputSymlinkMode, PreparePathMode, ResourceRequest,
+    RunOpts, SandboxMode, WorkspacePath,
 };
 use once_frontend::analysis::{
     AnalysisResult, DeclaredAction, DeclaredActionOperation, DeclaredArgFile,
@@ -86,8 +87,11 @@ pub(super) fn run_declared_actions<'a>(
 ) -> Pin<Box<dyn Future<Output = Result<BuildOutcome>> + Send + 'a>> {
     Box::pin(async move {
         let AnalysisResult {
-            actions, provider, ..
+            mut actions,
+            provider,
+            ..
         } = analysis;
+        expose_target_tools(workspace, target, &mut actions).await?;
         tracing::debug!(
             target = %target.label.id,
             declared_actions = actions.len(),
@@ -164,6 +168,47 @@ pub(super) fn run_declared_actions<'a>(
             result: aggregate_result,
         })
     })
+}
+
+async fn expose_target_tools(
+    workspace: &Path,
+    target: &GraphTarget,
+    actions: &mut [DeclaredAction],
+) -> Result<()> {
+    let tools = target
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_str())
+        .collect::<BTreeSet<_>>();
+    if tools.is_empty() {
+        return Ok(());
+    }
+    let Some(prefix) = workspace_mise_command(workspace)
+        .await
+        .context("building graph tool execution command")?
+    else {
+        return Ok(());
+    };
+    let tools = tools.into_iter().collect::<Vec<_>>();
+    let tool_env = workspace_mise_env(workspace, &tools);
+    apply_tool_execution(&prefix, &tool_env, actions);
+    Ok(())
+}
+
+fn apply_tool_execution(
+    prefix: &[String],
+    tool_env: &BTreeMap<String, String>,
+    actions: &mut [DeclaredAction],
+) {
+    for action in actions {
+        if action.operation.is_some() {
+            continue;
+        }
+        let mut argv = prefix.to_vec();
+        argv.append(&mut action.argv);
+        action.argv = argv;
+        action.env.extend(tool_env.clone());
+    }
 }
 
 fn aggregate_declared_action_cache_state(
@@ -1152,6 +1197,46 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn tool_execution_wraps_command_actions_only() {
+        let command: DeclaredAction = serde_json::from_value(serde_json::json!({
+            "argv": ["rustc", "--version"],
+            "outputs": []
+        }))
+        .unwrap();
+        let portable: DeclaredAction = serde_json::from_value(serde_json::json!({
+            "operation": {
+                "kind": "write_file",
+                "path": "out.txt",
+                "bytes": [111, 107]
+            },
+            "outputs": ["out.txt"]
+        }))
+        .unwrap();
+        let mut actions = vec![command, portable];
+
+        apply_tool_execution(
+            &[
+                "/once/mise".to_string(),
+                "exec".to_string(),
+                "--".to_string(),
+            ],
+            &BTreeMap::from([("MISE_ENABLE_TOOLS".to_string(), "rust".to_string())]),
+            &mut actions,
+        );
+
+        assert_eq!(
+            actions[0].argv,
+            ["/once/mise", "exec", "--", "rustc", "--version"]
+        );
+        assert_eq!(
+            actions[0].env.get("MISE_ENABLE_TOOLS").map(String::as_str),
+            Some("rust")
+        );
+        assert!(actions[1].argv.is_empty());
+        assert!(actions[1].env.is_empty());
+    }
+
     fn module_digest() -> Digest {
         Digest::of_bytes(b"modules")
     }
@@ -1622,6 +1707,7 @@ mod tests {
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         };
         let analysis = AnalysisResult {
@@ -1718,6 +1804,7 @@ mod tests {
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         };
         let analysis = || AnalysisResult {
@@ -1804,6 +1891,7 @@ mod tests {
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         };
         let action = |name: &str| DeclaredAction {
@@ -1887,6 +1975,7 @@ mod tests {
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         };
 

--- a/crates/once-cli/src/commands/graph/analysis/tests.rs
+++ b/crates/once-cli/src/commands/graph/analysis/tests.rs
@@ -99,7 +99,7 @@ fn target_with_capabilities(
 }
 
 #[tokio::test]
-async fn graph_tool_resolution_uses_logical_names_without_mise_config() {
+async fn graph_tool_resolution_defers_to_host_path_without_mise_config() {
     let workspace = tempfile::tempdir().unwrap();
     let mut target = target_with_capabilities("Tool", &[], &[], &["build"], []);
     target.tools.push(once_frontend::ToolRequirement {
@@ -111,8 +111,10 @@ async fn graph_tool_resolution_uses_logical_names_without_mise_config() {
         .await
         .unwrap();
 
-    assert_eq!(paths.get("rustc").map(String::as_str), Some("rustc"));
-    assert_eq!(paths.get("cargo").map(String::as_str), Some("cargo"));
+    // Without a mise config the workspace relies on the host toolchain.
+    // Returning no resolved paths keeps `host_which` walking `PATH` (and
+    // verifying existence) rather than short-circuiting to a bare name.
+    assert!(paths.is_empty());
 }
 
 #[test]

--- a/crates/once-cli/src/commands/graph/analysis/tests.rs
+++ b/crates/once-cli/src/commands/graph/analysis/tests.rs
@@ -93,8 +93,26 @@ fn target_with_capabilities(
             })
             .collect(),
         providers: Vec::new(),
+        tools: Vec::new(),
         diagnostics: Vec::new(),
     }
+}
+
+#[tokio::test]
+async fn graph_tool_resolution_uses_logical_names_without_mise_config() {
+    let workspace = tempfile::tempdir().unwrap();
+    let mut target = target_with_capabilities("Tool", &[], &[], &["build"], []);
+    target.tools.push(once_frontend::ToolRequirement {
+        name: "rust".to_string(),
+        executables: vec!["rustc".to_string(), "cargo".to_string()],
+    });
+
+    let paths = resolve_graph_tools(workspace.path(), &[target])
+        .await
+        .unwrap();
+
+    assert_eq!(paths.get("rustc").map(String::as_str), Some("rustc"));
+    assert_eq!(paths.get("cargo").map(String::as_str), Some("cargo"));
 }
 
 #[test]

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -55,7 +55,7 @@ pub async fn build(
     sandbox: SandboxMode,
 ) -> Result<ExitCode> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    let session = analysis::BuildSession::new(workspace, cache, graph, sandbox)?;
+    let session = analysis::BuildSession::new(workspace, cache, graph, sandbox).await?;
     let target = session.target(target_id)?;
     let record = build_target(workspace, cache, target, &session, sandbox).await?;
     record_capability_run(workspace, &record).await;
@@ -71,7 +71,7 @@ pub async fn test(
     sandbox: SandboxMode,
 ) -> Result<ExitCode> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    let session = analysis::BuildSession::new(workspace, cache, graph, sandbox)?;
+    let session = analysis::BuildSession::new(workspace, cache, graph, sandbox).await?;
     let target = session.target(target_id)?;
     let test_capability = ensure_capability(target, "test")?;
     if !test_capability.requires_outputs.is_empty()
@@ -132,7 +132,8 @@ pub async fn run(
             run_visible: options.visible,
         },
         sandbox,
-    )?;
+    )
+    .await?;
     let target = session.target(target_id)?;
     let run_capability = ensure_capability(target, "run")?;
     if !run_capability.requires_outputs.is_empty()
@@ -421,6 +422,7 @@ mod tests {
                 })
                 .collect(),
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         }
     }

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -22,6 +22,7 @@ struct TargetRecord {
     kind: String,
     deps: Vec<String>,
     capabilities: Vec<String>,
+    tools: Vec<once_frontend::ToolRequirement>,
 }
 
 #[derive(Debug, Serialize)]
@@ -68,6 +69,7 @@ fn target_records(graph: Vec<once_frontend::GraphTarget>, kind: Option<&str>) ->
                 .into_iter()
                 .map(|capability| capability.name)
                 .collect(),
+            tools: target.tools,
         })
         .collect::<Vec<_>>()
 }
@@ -324,6 +326,13 @@ fn render_schema_human(schema: &once_frontend::TargetKindSchema) -> String {
                 requires
             )
             .expect("writing to string cannot fail");
+        }
+    }
+    if !schema.tools.is_empty() {
+        out.push_str("tools:\n");
+        for tool in &schema.tools {
+            writeln!(out, "  {}: {}", tool.name, tool.executables.join(", "))
+                .expect("writing to string cannot fail");
         }
     }
     out
@@ -713,6 +722,13 @@ fn render_target_human(target: &once_frontend::GraphTarget) -> String {
         out.push_str(&names.join(", "));
         out.push('\n');
     }
+    if !target.tools.is_empty() {
+        out.push_str("tools:\n");
+        for tool in &target.tools {
+            writeln!(out, "  {}: {}", tool.name, tool.executables.join(", "))
+                .expect("writing to string cannot fail");
+        }
+    }
     out
 }
 
@@ -759,6 +775,15 @@ fn render_targets_human(records: &[TargetRecord]) -> String {
         };
         writeln!(out, "  {} ({}) [{}]", target.id, target.kind, capabilities)
             .expect("writing to string cannot fail");
+        for tool in &target.tools {
+            writeln!(
+                out,
+                "    tool {}: {}",
+                tool.name,
+                tool.executables.join(", ")
+            )
+            .expect("writing to string cannot fail");
+        }
     }
     out
 }
@@ -807,6 +832,7 @@ mod tests {
                 })
                 .collect(),
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         }
     }
@@ -821,6 +847,7 @@ mod tests {
             kind: "apple_application".to_string(),
             deps: Vec::new(),
             capabilities: vec!["build".to_string(), "run".to_string()],
+            tools: Vec::new(),
         }]);
         assert!(rendered.contains("apps/ios/App (apple_application) [build, run]"));
     }
@@ -854,6 +881,15 @@ mod tests {
     }
 
     #[test]
+    fn render_schema_human_includes_tools() {
+        let schema = once_frontend::built_in_target_kind_schema("rust_binary").unwrap();
+
+        let rendered = render_schema_human(&schema);
+
+        assert!(rendered.contains("tools:\n  rust: rustc, cargo"));
+    }
+
+    #[test]
     fn target_records_filters_by_kind() {
         let records = target_records(
             vec![
@@ -872,6 +908,7 @@ mod tests {
                 kind: "apple_application".to_string(),
                 deps: Vec::new(),
                 capabilities: vec!["build".to_string(), "run".to_string()],
+                tools: Vec::new(),
             }]
         );
     }

--- a/crates/once-cli/src/commands/query/expression.rs
+++ b/crates/once-cli/src/commands/query/expression.rs
@@ -107,6 +107,7 @@ mod tests {
                 })
                 .collect(),
             providers: Vec::new(),
+            tools: Vec::new(),
             diagnostics: Vec::new(),
         }
     }

--- a/crates/once-cli/src/commands/run/action/script.rs
+++ b/crates/once-cli/src/commands/run/action/script.rs
@@ -177,7 +177,11 @@ async fn host_env(
 }
 
 async fn resolve_host_runtime(workspace: &std::path::Path, runtime: &str) -> Result<Vec<String>> {
-    if runtime.contains('/') {
+    // A runtime that looks like a path is run directly. This must match the
+    // path detection in `graph_tools_from_parts`, which excludes both
+    // separators, otherwise a backslash runtime is never installed yet
+    // still gets sent through mise here.
+    if runtime.contains('/') || runtime.contains('\\') {
         return Ok(vec![runtime.to_string()]);
     }
     workspace_tool_command(workspace, runtime)

--- a/crates/once-cli/src/commands/run/action/script.rs
+++ b/crates/once-cli/src/commands/run/action/script.rs
@@ -10,8 +10,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result};
 use once_cas::Digest;
 use once_core::{
-    tool_env, workspace_tool, workspace_tool_env, Action, OutputSymlinkMode, RemoteExecution,
-    ResourceRequest, SandboxMode, WorkspacePath,
+    tool_env, workspace_tool_command, workspace_tool_env, Action, OutputSymlinkMode,
+    RemoteExecution, ResourceRequest, SandboxMode, WorkspacePath,
 };
 
 use super::{input_digest, input_paths, parse_attr, ActionPlan};
@@ -94,8 +94,7 @@ async fn file_script_action(
         .cloned()
         .ok_or_else(|| anyhow::anyhow!("script {} has no script_path", target.id()))?;
 
-    let program = resolve_host_runtime(workspace, &runtime).await?;
-    let mut argv = vec![program];
+    let mut argv = resolve_host_runtime(workspace, &runtime).await?;
     argv.extend(runtime_args);
     argv.push(host_script_path(&script_path, cwd.as_ref())?);
 
@@ -177,11 +176,11 @@ async fn host_env(
     Ok(out)
 }
 
-async fn resolve_host_runtime(workspace: &std::path::Path, runtime: &str) -> Result<String> {
+async fn resolve_host_runtime(workspace: &std::path::Path, runtime: &str) -> Result<Vec<String>> {
     if runtime.contains('/') {
-        return Ok(runtime.to_string());
+        return Ok(vec![runtime.to_string()]);
     }
-    workspace_tool(workspace, runtime)
+    workspace_tool_command(workspace, runtime)
         .await
         .with_context(|| format!("resolving script runtime `{runtime}`"))
 }

--- a/crates/once-cli/src/commands/toolchain/contract.rs
+++ b/crates/once-cli/src/commands/toolchain/contract.rs
@@ -9,6 +9,7 @@ use super::platform::PlatformView;
 #[derive(Debug, Serialize)]
 pub(super) struct ToolchainContract {
     pub source: &'static str,
+    pub mise_version: &'static str,
     pub config: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lock: Option<String>,
@@ -55,6 +56,7 @@ pub(super) fn fingerprint(
     #[derive(Serialize)]
     struct Material<'a> {
         source: &'static str,
+        mise_version: &'static str,
         platform: &'a PlatformView,
         tools: &'a [ToolView],
         env: &'a BTreeMap<String, toml::Value>,
@@ -62,6 +64,7 @@ pub(super) fn fingerprint(
 
     let material = Material {
         source: "mise",
+        mise_version: once_core::MANAGED_MISE_VERSION,
         platform,
         tools,
         env,

--- a/crates/once-cli/src/commands/toolchain/human.rs
+++ b/crates/once-cli/src/commands/toolchain/human.rs
@@ -5,8 +5,9 @@ use super::contract::ToolchainContract;
 pub(super) fn render(contract: &ToolchainContract) -> String {
     let lock = contract.lock.as_deref().unwrap_or("missing");
     let mut out = format!(
-        "source: {}\nconfig: {}\nlock: {}\nplatform: {} ({}/{})\nfingerprint: {}\n",
+        "source: {}\nmise: {}\nconfig: {}\nlock: {}\nplatform: {} ({}/{})\nfingerprint: {}\n",
         contract.source,
+        contract.mise_version,
         contract.config,
         lock,
         contract.platform.mise,

--- a/crates/once-cli/src/commands/toolchain/mise.rs
+++ b/crates/once-cli/src/commands/toolchain/mise.rs
@@ -44,6 +44,7 @@ pub(super) fn inspect_workspace(
 
     Ok(ToolchainContract {
         source: "mise",
+        mise_version: once_core::MANAGED_MISE_VERSION,
         config: MISE_CONFIG.to_string(),
         lock: lock.present.then(|| lock::MISE_LOCK.to_string()),
         platform,
@@ -91,6 +92,7 @@ RUST_BACKTRACE = "1"
         let contract = inspect_workspace(tmp.path(), None).unwrap();
 
         assert_eq!(contract.source, "mise");
+        assert_eq!(contract.mise_version, once_core::MANAGED_MISE_VERSION);
         assert_eq!(contract.config, MISE_CONFIG);
         assert_eq!(contract.lock, None);
         assert!(contract.fingerprint.starts_with("blake3:"));

--- a/crates/once-core/src/env.rs
+++ b/crates/once-core/src/env.rs
@@ -15,8 +15,9 @@ mod mise_runtime;
 mod path;
 
 pub use mise::{
-    workspace_executable, workspace_mise_command, workspace_mise_env, workspace_prepare_tools,
-    workspace_tool, workspace_tool_command, workspace_tool_env, workspace_tool_var, ToolEnvError,
+    workspace_executable, workspace_has_mise_config, workspace_mise_command, workspace_mise_env,
+    workspace_prepare_tools, workspace_tool, workspace_tool_command, workspace_tool_env,
+    workspace_tool_var, ToolEnvError,
 };
 pub use mise_runtime::{managed_mise, managed_mise_path, MANAGED_MISE_VERSION};
 

--- a/crates/once-core/src/env.rs
+++ b/crates/once-core/src/env.rs
@@ -11,9 +11,14 @@ use std::collections::BTreeMap;
 use std::env;
 
 mod mise;
+mod mise_runtime;
 mod path;
 
-pub use mise::{workspace_tool, workspace_tool_env, workspace_tool_var, ToolEnvError};
+pub use mise::{
+    workspace_executable, workspace_mise_command, workspace_mise_env, workspace_prepare_tools,
+    workspace_tool, workspace_tool_command, workspace_tool_env, workspace_tool_var, ToolEnvError,
+};
+pub use mise_runtime::{managed_mise, managed_mise_path, MANAGED_MISE_VERSION};
 
 /// Variables every spawned tool action wants regardless of toolchain.
 /// `PATH` and `HOME` are universal; adding more here would silently

--- a/crates/once-core/src/env/mise.rs
+++ b/crates/once-core/src/env/mise.rs
@@ -5,7 +5,12 @@ use std::path::{Path, PathBuf};
 use futures::future::try_join_all;
 use tokio::process::Command;
 
-use super::{path::build_action_path, select_extra_env, tool_env};
+use super::{
+    managed_mise,
+    mise_runtime::{managed_mise_cache_dir, managed_mise_config_dir, managed_mise_data_dir},
+    path::build_action_path,
+    select_extra_env, tool_env, MANAGED_MISE_VERSION,
+};
 
 /// Resolve `tool` through the workspace's mise config when one exists.
 ///
@@ -13,10 +18,105 @@ use super::{path::build_action_path, select_extra_env, tool_env};
 /// return the tool name so the runner resolves it through the declared
 /// action `PATH`.
 pub async fn workspace_tool(workspace: &Path, tool: &str) -> Result<String, ToolEnvError> {
+    workspace_executable(workspace, tool, &[tool]).await
+}
+
+/// Resolve an executable while activating the declared workspace tools.
+pub async fn workspace_executable(
+    workspace: &Path,
+    executable: &str,
+    tools: &[&str],
+) -> Result<String, ToolEnvError> {
     if !has_mise_config(workspace) {
-        return Ok(tool.to_string());
+        return Ok(executable.to_string());
     }
-    let output = Command::new("mise")
+    workspace_tool_without_prepare(workspace, executable, tools).await
+}
+
+/// Install requested workspace tools before cacheable action execution.
+pub async fn workspace_prepare_tools(workspace: &Path, tools: &[&str]) -> Result<(), ToolEnvError> {
+    ensure_workspace_tools(workspace, tools).await
+}
+
+/// Build a mise execution prefix for a configured workspace.
+pub async fn workspace_mise_command(workspace: &Path) -> Result<Option<Vec<String>>, ToolEnvError> {
+    if !has_mise_config(workspace) {
+        return Ok(None);
+    }
+    let mut argv = vec![
+        managed_mise().await?.display().to_string(),
+        "exec".to_string(),
+        "-C".to_string(),
+        workspace.display().to_string(),
+    ];
+    if has_mise_lock(workspace) {
+        argv.push("--locked".to_string());
+    }
+    argv.push("--".to_string());
+    Ok(Some(argv))
+}
+
+/// Environment required by managed mise during action execution.
+pub fn workspace_mise_env(workspace: &Path, tools: &[&str]) -> BTreeMap<String, String> {
+    if !has_mise_config(workspace) {
+        return BTreeMap::new();
+    }
+    let mut selected = BTreeMap::new();
+    if let Some(home) = env::var_os("HOME") {
+        selected.insert("HOME".into(), home.to_string_lossy().into_owned());
+    }
+    selected.insert(
+        "MISE_DATA_DIR".into(),
+        managed_mise_data_dir().display().to_string(),
+    );
+    selected.insert(
+        "MISE_CONFIG_DIR".into(),
+        managed_mise_config_dir().display().to_string(),
+    );
+    selected.insert(
+        "MISE_CACHE_DIR".into(),
+        managed_mise_cache_dir().display().to_string(),
+    );
+    selected.insert(
+        "MISE_TRUSTED_CONFIG_PATHS".into(),
+        workspace.display().to_string(),
+    );
+    selected.insert("MISE_ENABLE_TOOLS".into(), tools.join(","));
+    selected.insert("MISE_AUTO_INSTALL".into(), "0".into());
+    selected.insert("MISE_EXEC_AUTO_INSTALL".into(), "0".into());
+    selected
+}
+
+/// Build an argv prefix that runs `tool` in the workspace's mise environment.
+///
+/// The managed mise runtime prepares the requested tool before the action is
+/// created. Execution then disables mise's implicit installer, keeping network
+/// access and tool mutation outside the cacheable action.
+pub async fn workspace_tool_command(
+    workspace: &Path,
+    tool: &str,
+) -> Result<Vec<String>, ToolEnvError> {
+    if !has_mise_config(workspace) {
+        return Ok(vec![tool.to_string()]);
+    }
+    ensure_workspace_tools(workspace, &[tool]).await?;
+    let mut argv = workspace_mise_command(workspace)
+        .await?
+        .expect("mise command exists when mise config exists");
+    argv.push(tool.to_string());
+    Ok(argv)
+}
+
+async fn workspace_tool_without_prepare(
+    workspace: &Path,
+    tool: &str,
+    enabled_tools: &[&str],
+) -> Result<String, ToolEnvError> {
+    let mise = managed_mise().await?;
+    let mut command = Command::new(&mise);
+    configure_mise_command(&mut command, workspace);
+    enable_mise_tools(&mut command, enabled_tools);
+    let output = command
         .args(["which", "-C"])
         .arg(workspace)
         .arg(tool)
@@ -49,10 +149,12 @@ pub async fn workspace_tool_env(
         return Ok(tool_env(extra_keys));
     }
 
+    ensure_workspace_tools(workspace, tools).await?;
     let mise_env = mise_env(workspace).await?;
     let mut selected = select_extra_env(&mise_env, extra_keys);
     let path = workspace_path(workspace, tools, &mise_env).await?;
     selected.insert("PATH".into(), path);
+    selected.extend(workspace_mise_env(workspace, tools));
     Ok(selected)
 }
 
@@ -75,8 +177,44 @@ fn has_mise_config(workspace: &Path) -> bool {
     workspace.join("mise.toml").is_file()
 }
 
+fn has_mise_lock(workspace: &Path) -> bool {
+    workspace.join("mise.lock").is_file()
+}
+
+async fn ensure_workspace_tools(workspace: &Path, tools: &[&str]) -> Result<(), ToolEnvError> {
+    if !has_mise_config(workspace) || tools.is_empty() {
+        return Ok(());
+    }
+    let mise = managed_mise().await?;
+    let mut command = Command::new(&mise);
+    configure_mise_command(&mut command, workspace);
+    command.args(["install", "-C"]).arg(workspace);
+    if has_mise_lock(workspace) {
+        command.arg("--locked");
+    }
+    command
+        .args(["--yes", "--quiet"])
+        .args(tools)
+        .env("MISE_ENABLE_TOOLS", tools.join(","));
+    let output = command
+        .output()
+        .await
+        .map_err(|source| ToolEnvError::SpawnMise { source })?;
+    if !output.status.success() {
+        return Err(ToolEnvError::MiseFailed {
+            command: format!("mise install {}", tools.join(" ")),
+            status: output.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    Ok(())
+}
+
 async fn mise_env(workspace: &Path) -> Result<BTreeMap<String, String>, ToolEnvError> {
-    let output = Command::new("mise")
+    let mise = managed_mise().await?;
+    let mut command = Command::new(&mise);
+    configure_mise_command(&mut command, workspace);
+    let output = command
         .args(["env", "--json", "-C"])
         .arg(workspace)
         .output()
@@ -92,16 +230,30 @@ async fn mise_env(workspace: &Path) -> Result<BTreeMap<String, String>, ToolEnvE
     serde_json::from_slice(&output.stdout).map_err(|source| ToolEnvError::ParseMiseEnv { source })
 }
 
+fn configure_mise_command(command: &mut Command, workspace: &Path) {
+    command
+        .env("MISE_DATA_DIR", managed_mise_data_dir())
+        .env("MISE_CONFIG_DIR", managed_mise_config_dir())
+        .env("MISE_CACHE_DIR", managed_mise_cache_dir())
+        .env("MISE_TRUSTED_CONFIG_PATHS", workspace);
+}
+
+fn enable_mise_tools(command: &mut Command, tools: &[&str]) {
+    if !tools.is_empty() {
+        command.env("MISE_ENABLE_TOOLS", tools.join(","));
+    }
+}
+
 async fn workspace_path(
     workspace: &Path,
     tools: &[&str],
     mise_env: &BTreeMap<String, String>,
 ) -> Result<String, ToolEnvError> {
-    let tool_paths = try_join_all(
-        tools
-            .iter()
-            .map(|tool| async move { workspace_tool(workspace, tool).await.map(PathBuf::from) }),
-    )
+    let tool_paths = try_join_all(tools.iter().map(|tool| async move {
+        workspace_tool_without_prepare(workspace, tool, tools)
+            .await
+            .map(PathBuf::from)
+    }))
     .await?;
     build_action_path(&tool_paths, mise_env)
 }
@@ -129,6 +281,31 @@ pub enum ToolEnvError {
         #[source]
         source: env::JoinPathsError,
     },
+    #[error("mise {MANAGED_MISE_VERSION} is unavailable for {operating_system}-{architecture}")]
+    UnsupportedMisePlatform {
+        operating_system: &'static str,
+        architecture: &'static str,
+    },
+    #[error("failed to download managed mise: {source}")]
+    DownloadMise {
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("managed mise download returned status {status}")]
+    MiseDownloadStatus { status: reqwest::StatusCode },
+    #[error("managed mise asset {asset} failed checksum verification: expected {expected}, got {actual}")]
+    MiseChecksum {
+        asset: &'static str,
+        expected: &'static str,
+        actual: String,
+    },
+    #[error("failed to {action} for managed mise at {}: {source}", path.display())]
+    InstallMiseIo {
+        action: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 #[cfg(test)]
@@ -143,5 +320,35 @@ mod tests {
             .unwrap();
         assert_eq!(env, tool_env(&["RUSTUP_TOOLCHAIN"]));
         assert_eq!(workspace_tool(tmp.path(), "rustc").await.unwrap(), "rustc");
+    }
+
+    #[test]
+    fn configured_workspace_mise_env_isolated_and_non_installing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("mise.toml"), "[tools]\nrust = '1.96.0'\n").unwrap();
+
+        let selected = workspace_mise_env(tmp.path(), &["rust"]);
+
+        assert_eq!(
+            selected.get("MISE_AUTO_INSTALL").map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            selected.get("MISE_EXEC_AUTO_INSTALL").map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            selected.get("MISE_ENABLE_TOOLS").map(String::as_str),
+            Some("rust")
+        );
+        assert_eq!(
+            selected
+                .get("MISE_TRUSTED_CONFIG_PATHS")
+                .map(String::as_str),
+            Some(tmp.path().to_string_lossy().as_ref())
+        );
+        assert!(selected.contains_key("MISE_DATA_DIR"));
+        assert!(selected.contains_key("MISE_CONFIG_DIR"));
+        assert!(selected.contains_key("MISE_CACHE_DIR"));
     }
 }

--- a/crates/once-core/src/env/mise.rs
+++ b/crates/once-core/src/env/mise.rs
@@ -21,6 +21,15 @@ pub async fn workspace_tool(workspace: &Path, tool: &str) -> Result<String, Tool
     workspace_executable(workspace, tool, &[tool]).await
 }
 
+/// Whether `workspace` pins a mise toolchain via `mise.toml`.
+///
+/// Callers that resolve declared tools use this to skip mise entirely
+/// for workspaces that rely on the host toolchain, keeping the historical
+/// host-`PATH` resolution intact.
+pub fn workspace_has_mise_config(workspace: &Path) -> bool {
+    has_mise_config(workspace)
+}
+
 /// Resolve an executable while activating the declared workspace tools.
 pub async fn workspace_executable(
     workspace: &Path,
@@ -62,25 +71,18 @@ pub fn workspace_mise_env(workspace: &Path, tools: &[&str]) -> BTreeMap<String, 
         return BTreeMap::new();
     }
     let mut selected = BTreeMap::new();
-    if let Some(home) = env::var_os("HOME") {
-        selected.insert("HOME".into(), home.to_string_lossy().into_owned());
+    // The action environment is built from scratch rather than inherited,
+    // so mise's home directory has to be forwarded explicitly. The
+    // variable that names it is platform specific: `HOME` on Unix,
+    // `USERPROFILE` on Windows.
+    for key in ["HOME", "USERPROFILE"] {
+        if let Some(value) = env::var_os(key) {
+            selected.insert(key.into(), value.to_string_lossy().into_owned());
+        }
     }
-    selected.insert(
-        "MISE_DATA_DIR".into(),
-        managed_mise_data_dir().display().to_string(),
-    );
-    selected.insert(
-        "MISE_CONFIG_DIR".into(),
-        managed_mise_config_dir().display().to_string(),
-    );
-    selected.insert(
-        "MISE_CACHE_DIR".into(),
-        managed_mise_cache_dir().display().to_string(),
-    );
-    selected.insert(
-        "MISE_TRUSTED_CONFIG_PATHS".into(),
-        workspace.display().to_string(),
-    );
+    for (key, value) in managed_mise_isolation(workspace) {
+        selected.insert(key.into(), value);
+    }
     selected.insert("MISE_ENABLE_TOOLS".into(), tools.join(","));
     selected.insert("MISE_AUTO_INSTALL".into(), "0".into());
     selected.insert("MISE_EXEC_AUTO_INSTALL".into(), "0".into());
@@ -231,11 +233,34 @@ async fn mise_env(workspace: &Path) -> Result<BTreeMap<String, String>, ToolEnvE
 }
 
 fn configure_mise_command(command: &mut Command, workspace: &Path) {
-    command
-        .env("MISE_DATA_DIR", managed_mise_data_dir())
-        .env("MISE_CONFIG_DIR", managed_mise_config_dir())
-        .env("MISE_CACHE_DIR", managed_mise_cache_dir())
-        .env("MISE_TRUSTED_CONFIG_PATHS", workspace);
+    for (key, value) in managed_mise_isolation(workspace) {
+        command.env(key, value);
+    }
+}
+
+/// Directories that isolate managed mise from the user's global mise
+/// installation.
+///
+/// The analysis-time command configuration and the execution-time action
+/// environment must agree on these, otherwise a tool installed during
+/// analysis would not be found at execution. Defining them once keeps the
+/// two paths in lockstep.
+fn managed_mise_isolation(workspace: &Path) -> [(&'static str, String); 4] {
+    [
+        (
+            "MISE_DATA_DIR",
+            managed_mise_data_dir().display().to_string(),
+        ),
+        (
+            "MISE_CONFIG_DIR",
+            managed_mise_config_dir().display().to_string(),
+        ),
+        (
+            "MISE_CACHE_DIR",
+            managed_mise_cache_dir().display().to_string(),
+        ),
+        ("MISE_TRUSTED_CONFIG_PATHS", workspace.display().to_string()),
+    ]
 }
 
 fn enable_mise_tools(command: &mut Command, tools: &[&str]) {

--- a/crates/once-core/src/env/mise_runtime.rs
+++ b/crates/once-core/src/env/mise_runtime.rs
@@ -1,0 +1,275 @@
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use futures::StreamExt as _;
+use sha2::{Digest as _, Sha256};
+use tokio::io::AsyncWriteExt as _;
+use tokio::sync::Mutex;
+
+use crate::Xdg;
+
+use super::mise::ToolEnvError;
+
+pub const MANAGED_MISE_VERSION: &str = "2026.7.5";
+
+static INSTALL_LOCK: Mutex<()> = Mutex::const_new(());
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MiseAsset {
+    filename: &'static str,
+    sha256: &'static str,
+}
+
+impl MiseAsset {
+    fn url(self) -> String {
+        format!(
+            "https://github.com/jdx/mise/releases/download/v{MANAGED_MISE_VERSION}/{}",
+            self.filename
+        )
+    }
+}
+
+pub async fn managed_mise() -> Result<PathBuf, ToolEnvError> {
+    let asset = current_asset()?;
+    let path = managed_mise_path();
+    if path.is_file() {
+        return Ok(path);
+    }
+
+    let _guard = INSTALL_LOCK.lock().await;
+    if path.is_file() {
+        return Ok(path);
+    }
+
+    install(asset, &path).await?;
+    Ok(path)
+}
+
+pub fn managed_mise_path() -> PathBuf {
+    Xdg::from_env()
+        .once_data()
+        .join("tools")
+        .join("mise")
+        .join(MANAGED_MISE_VERSION)
+        .join(binary_name())
+}
+
+pub(super) fn managed_mise_data_dir() -> PathBuf {
+    Xdg::from_env().once_data().join("tools").join("mise-data")
+}
+
+pub(super) fn managed_mise_config_dir() -> PathBuf {
+    Xdg::from_env()
+        .once_data()
+        .join("tools")
+        .join("mise-config")
+}
+
+pub(super) fn managed_mise_cache_dir() -> PathBuf {
+    Xdg::from_env().cache_home.join("once").join("mise")
+}
+
+async fn install(asset: MiseAsset, destination: &Path) -> Result<(), ToolEnvError> {
+    let parent = destination
+        .parent()
+        .expect("managed mise destination always has a parent");
+    tokio::fs::create_dir_all(parent)
+        .await
+        .map_err(|source| ToolEnvError::InstallMiseIo {
+            action: "create install directory",
+            path: parent.to_path_buf(),
+            source,
+        })?;
+
+    let temporary = temporary_path(destination);
+    if let Err(error) = download(asset, &temporary).await {
+        let _ = tokio::fs::remove_file(&temporary).await;
+        return Err(error);
+    }
+    if let Err(error) = make_executable(&temporary).await {
+        let _ = tokio::fs::remove_file(&temporary).await;
+        return Err(error);
+    }
+    match tokio::fs::rename(&temporary, destination).await {
+        Ok(()) => Ok(()),
+        Err(_) if destination.is_file() => {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            Ok(())
+        }
+        Err(source) => {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            Err(ToolEnvError::InstallMiseIo {
+                action: "activate download",
+                path: destination.to_path_buf(),
+                source,
+            })
+        }
+    }
+}
+
+async fn download(asset: MiseAsset, temporary: &Path) -> Result<(), ToolEnvError> {
+    let response = reqwest::get(asset.url())
+        .await
+        .map_err(|source| ToolEnvError::DownloadMise { source })?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(ToolEnvError::MiseDownloadStatus { status });
+    }
+    let mut file =
+        tokio::fs::File::create(temporary)
+            .await
+            .map_err(|source| ToolEnvError::InstallMiseIo {
+                action: "write download",
+                path: temporary.to_path_buf(),
+                source,
+            })?;
+    let mut hasher = Sha256::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| ToolEnvError::DownloadMise { source })?;
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|source| ToolEnvError::InstallMiseIo {
+                action: "write download",
+                path: temporary.to_path_buf(),
+                source,
+            })?;
+    }
+    file.flush()
+        .await
+        .map_err(|source| ToolEnvError::InstallMiseIo {
+            action: "flush download",
+            path: temporary.to_path_buf(),
+            source,
+        })?;
+    verify_digest(asset, &hasher.finalize())
+}
+
+#[cfg(test)]
+fn verify_checksum(asset: MiseAsset, bytes: &[u8]) -> Result<(), ToolEnvError> {
+    verify_digest(asset, &Sha256::digest(bytes))
+}
+
+fn verify_digest(asset: MiseAsset, digest: &[u8]) -> Result<(), ToolEnvError> {
+    let mut actual = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut actual, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    if actual == asset.sha256 {
+        return Ok(());
+    }
+    Err(ToolEnvError::MiseChecksum {
+        asset: asset.filename,
+        expected: asset.sha256,
+        actual,
+    })
+}
+
+fn temporary_path(destination: &Path) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    destination.with_extension(format!("download-{}-{timestamp}", std::process::id()))
+}
+
+#[cfg(unix)]
+async fn make_executable(path: &Path) -> Result<(), ToolEnvError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = tokio::fs::metadata(path)
+        .await
+        .map_err(|source| ToolEnvError::InstallMiseIo {
+            action: "read download permissions",
+            path: path.to_path_buf(),
+            source,
+        })?
+        .permissions();
+    permissions.set_mode(0o755);
+    tokio::fs::set_permissions(path, permissions)
+        .await
+        .map_err(|source| ToolEnvError::InstallMiseIo {
+            action: "set download permissions",
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(not(unix))]
+async fn make_executable(_path: &Path) -> Result<(), ToolEnvError> {
+    Ok(())
+}
+
+const fn binary_name() -> &'static str {
+    if cfg!(windows) {
+        "mise.exe"
+    } else {
+        "mise"
+    }
+}
+
+fn current_asset() -> Result<MiseAsset, ToolEnvError> {
+    asset_for(std::env::consts::OS, std::env::consts::ARCH).ok_or_else(|| {
+        ToolEnvError::UnsupportedMisePlatform {
+            operating_system: std::env::consts::OS,
+            architecture: std::env::consts::ARCH,
+        }
+    })
+}
+
+fn asset_for(operating_system: &str, architecture: &str) -> Option<MiseAsset> {
+    match (operating_system, architecture) {
+        ("linux", "x86_64") => Some(MiseAsset {
+            filename: "mise-v2026.7.5-linux-x64",
+            sha256: "5f7ab76afdf0780d12edeaa67e908094e9ccf7924cfe203e415c1cfb87bbf778",
+        }),
+        ("linux", "aarch64") => Some(MiseAsset {
+            filename: "mise-v2026.7.5-linux-arm64",
+            sha256: "41fcf744050bfa27f9871e2151ac6f44b5ce2741424b3d5282b92becc71e6bc4",
+        }),
+        ("macos", "x86_64") => Some(MiseAsset {
+            filename: "mise-v2026.7.5-macos-x64",
+            sha256: "62fe1fe9dbc32c6ce1388ee23df4a0862d3d7f40a6820b40c2f1cbab995dc1d4",
+        }),
+        ("macos", "aarch64") => Some(MiseAsset {
+            filename: "mise-v2026.7.5-macos-arm64",
+            sha256: "a456c65907e8334619d77fa152bdcf9023fddc0daa03d47fbe86d032dbf565b0",
+        }),
+        ("windows", "x86_64") => Some(MiseAsset {
+            filename: "mise-v2026.7.5-windows-x64.exe",
+            sha256: "1840f167ec8b161598e08b8ede769cf9954c0239b25bb7bdf0b326124b548c32",
+        }),
+        ("windows", "aarch64") => Some(MiseAsset {
+            filename: "mise-v2026.7.5-windows-arm64.exe",
+            sha256: "27d3279d9d6a994d910561706f5ca99abcd8a03d38ad15b73ff0b5b3e148e4ea",
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_platforms_have_pinned_assets() {
+        assert!(asset_for("linux", "x86_64").is_some());
+        assert!(asset_for("macos", "aarch64").is_some());
+        assert!(asset_for("windows", "x86_64").is_some());
+    }
+
+    #[test]
+    fn checksum_verification_rejects_changed_bytes() {
+        let asset = MiseAsset {
+            filename: "mise-test",
+            sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        };
+        assert!(verify_checksum(asset, b"").is_ok());
+        assert!(matches!(
+            verify_checksum(asset, b"changed"),
+            Err(ToolEnvError::MiseChecksum { .. })
+        ));
+    }
+}

--- a/crates/once-core/src/lib.rs
+++ b/crates/once-core/src/lib.rs
@@ -29,8 +29,8 @@ pub use action::{
 };
 pub use env::{
     managed_mise, managed_mise_path, select_tool_env, tool_env, workspace_executable,
-    workspace_mise_command, workspace_mise_env, workspace_prepare_tools, workspace_tool,
-    workspace_tool_command, workspace_tool_env, workspace_tool_var, ToolEnvError,
+    workspace_has_mise_config, workspace_mise_command, workspace_mise_env, workspace_prepare_tools,
+    workspace_tool, workspace_tool_command, workspace_tool_env, workspace_tool_var, ToolEnvError,
     MANAGED_MISE_VERSION,
 };
 pub use error::{Error, Result};

--- a/crates/once-core/src/lib.rs
+++ b/crates/once-core/src/lib.rs
@@ -28,7 +28,10 @@ pub use action::{
     Action, CopyPathMode, OutputSymlinkMode, PreparePathMode, RemoteExecution, SandboxMode,
 };
 pub use env::{
-    select_tool_env, tool_env, workspace_tool, workspace_tool_env, workspace_tool_var, ToolEnvError,
+    managed_mise, managed_mise_path, select_tool_env, tool_env, workspace_executable,
+    workspace_mise_command, workspace_mise_env, workspace_prepare_tools, workspace_tool,
+    workspace_tool_command, workspace_tool_env, workspace_tool_var, ToolEnvError,
+    MANAGED_MISE_VERSION,
 };
 pub use error::{Error, Result};
 pub use evidence::{

--- a/crates/once-frontend/prelude/common.star
+++ b/crates/once-frontend/prelude/common.star
@@ -22,6 +22,12 @@ def capability(name, output_groups, requires_outputs = []):
         "requires_outputs": requires_outputs,
     }
 
+def tool(name, executables = []):
+    return {
+        "name": name,
+        "executables": executables or [name],
+    }
+
 def example(slug, name, use_when, path = None):
     return {
         "_once_example": True,
@@ -31,7 +37,7 @@ def example(slug, name, use_when, path = None):
         "path": path or ("examples/" + slug),
     }
 
-def target_kind(kind = None, docs = "", attrs = [], deps = [], providers = [], capabilities = [], examples = [], impl = None):
+def target_kind(kind = None, docs = "", attrs = [], deps = [], providers = [], capabilities = [], examples = [], impl = None, tools = []):
     return {
         "_once_target_kind": True,
         "kind": kind,
@@ -40,12 +46,23 @@ def target_kind(kind = None, docs = "", attrs = [], deps = [], providers = [], c
         "deps": deps,
         "providers": providers,
         "capabilities": capabilities,
+        "tools": tools,
         "examples": examples,
         "impl": impl,
     }
 
-def rule(kind = None, docs = "", attrs = [], deps = [], providers = [], capabilities = [], examples = [], impl = None):
-    return target_kind(kind, docs, attrs, deps, providers, capabilities, examples, impl)
+def rule(kind = None, docs = "", attrs = [], deps = [], providers = [], capabilities = [], examples = [], impl = None, tools = []):
+    return target_kind(
+        kind = kind,
+        docs = docs,
+        attrs = attrs,
+        deps = deps,
+        providers = providers,
+        capabilities = capabilities,
+        examples = examples,
+        impl = impl,
+        tools = tools,
+    )
 
 def _ends_with(value, suffix):
     if len(value) < len(suffix):

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -11,6 +11,8 @@ def _ascii_env_key(value):
             out.append("_")
     return "".join(out)
 
+_RUST_TOOL = tool("rust", executables = ["rustc", "cargo"])
+
 def _rust_metadata_suffix(ctx):
     return _ascii_env_key(ctx["label"]["id"])
 
@@ -2786,6 +2788,7 @@ cargo_dependencies = target_kind(
     ],
     providers = ["rust_dependency_set"],
     capabilities = [capability("build", [])],
+    tools = [_RUST_TOOL],
     examples = [
         example(
             "rust-binary-with-crate",
@@ -2804,6 +2807,7 @@ rust_library = target_kind(
     deps = [dep("deps", ["rust_crate", "rust_proc_macro", "rust_dependency_set"], "Rust crate dependencies consumed through --extern.")],
     providers = ["rust_crate", "native_linkable", "apple_linkable", "android_native_library"],
     capabilities = [capability("build", ["library"])],
+    tools = [_RUST_TOOL],
     examples = [
         example(
             "rust-library-minimal",
@@ -2819,6 +2823,7 @@ rust_mobile_library = target_kind(
     attrs = _RUST_MOBILE_ATTRS,
     providers = ["native_linkable", "apple_linkable", "android_native_library"],
     capabilities = [capability("build", [])],
+    tools = [_RUST_TOOL],
     examples = [
         example(
             "rust-native-mobile-library",
@@ -2847,6 +2852,7 @@ rust_binary = target_kind(
         capability("build", ["binary"]),
         capability("run", ["default"], ["binary"]),
     ],
+    tools = [_RUST_TOOL],
     examples = [
         example(
             "rust-binary-with-crate",
@@ -2874,6 +2880,7 @@ rust_test = target_kind(
         capability("build", ["binary"]),
         capability("test", ["default", "test_results", "logs"]),
     ],
+    tools = [_RUST_TOOL],
     examples = [
         example(
             "rust-test-minimal",
@@ -2895,6 +2902,7 @@ rust_crate = target_kind(
     deps = [dep("deps", ["rust_crate", "rust_proc_macro", "rust_dependency_set"], "Resolved Cargo package dependencies.")],
     providers = ["rust_crate"],
     capabilities = [capability("build", ["rlib"])],
+    tools = [_RUST_TOOL],
     examples = [
         example(
             "rust-crate-minimal",
@@ -2916,6 +2924,7 @@ rust_proc_macro = target_kind(
     deps = [dep("deps", ["rust_crate", "rust_proc_macro", "rust_dependency_set"], "Rust crate dependencies consumed by the procedural macro.")],
     providers = ["rust_proc_macro"],
     capabilities = [capability("build", ["proc_macro"])],
+    tools = [_RUST_TOOL],
     examples = [
         example(
             "rust-proc-macro-minimal",

--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -81,6 +81,16 @@ impl AnalysisEngine {
         Self::from_source_with_path(crate::modules::COMBINED_MODULE_PATH, source, options)
     }
 
+    pub fn for_workspace_with_options_and_tool_paths(
+        root: &Path,
+        options: AnalysisOptions,
+        tool_paths: BTreeMap<String, String>,
+    ) -> Result<Self> {
+        let mut engine = Self::for_workspace_with_options(root, options)?;
+        engine.host_cache = HostCache::with_tool_paths(tool_paths);
+        Ok(engine)
+    }
+
     pub fn from_source(source: impl Into<Arc<str>>) -> Result<Self> {
         Self::from_source_with_path(
             crate::modules::BUILT_IN_MODULE_PATH,

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -169,6 +169,7 @@ pub(super) struct HostCache {
     which: Arc<Mutex<BTreeMap<String, Option<String>>>>,
     commands: Arc<Mutex<BTreeMap<CommandKey, String>>>,
     host_env: Arc<HostEnvLookup>,
+    tool_paths: Arc<BTreeMap<String, String>>,
 }
 
 impl std::fmt::Debug for HostCache {
@@ -183,6 +184,7 @@ impl Clone for HostCache {
             which: Arc::clone(&self.which),
             commands: Arc::clone(&self.commands),
             host_env: Arc::clone(&self.host_env),
+            tool_paths: Arc::clone(&self.tool_paths),
         }
     }
 }
@@ -199,6 +201,14 @@ impl HostCache {
             which: Arc::new(Mutex::new(BTreeMap::new())),
             commands: Arc::new(Mutex::new(BTreeMap::new())),
             host_env: Arc::new(host_env),
+            tool_paths: Arc::new(BTreeMap::new()),
+        }
+    }
+
+    pub(super) fn with_tool_paths(tool_paths: BTreeMap<String, String>) -> Self {
+        Self {
+            tool_paths: Arc::new(tool_paths),
+            ..Self::default()
         }
     }
 
@@ -218,6 +228,9 @@ impl HostCache {
     /// `host_which` calls for different binaries don't serialise on
     /// each other.
     pub(super) fn which(&self, name: &str) -> Result<Option<String>> {
+        if let Some(path) = self.tool_paths.get(name) {
+            return Ok(Some(path.clone()));
+        }
         if let Some(cached) = self.lock_which()?.get(name).cloned() {
             return Ok(cached);
         }

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -57,6 +57,19 @@ fn store_for(workspace: &Path, package: &str) -> AnalysisStore {
 }
 
 #[test]
+fn declared_tool_paths_take_precedence_over_host_path() {
+    let cache = HostCache::with_tool_paths(BTreeMap::from([(
+        "rustc".to_string(),
+        "/managed/rustc".to_string(),
+    )]));
+
+    assert_eq!(
+        cache.which("rustc").unwrap().as_deref(),
+        Some("/managed/rustc")
+    );
+}
+
+#[test]
 fn schema_parse_path_resolves_native_globals_without_calling_them() {
     run("def _impl():\n    return run_action\n").unwrap();
 }
@@ -721,6 +734,7 @@ fn target(kind: &str) -> GraphTarget {
             requires_outputs: Vec::new(),
         }],
         providers: Vec::new(),
+        tools: Vec::new(),
         diagnostics: Vec::new(),
     }
 }

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -51,6 +51,9 @@ pub struct GraphTarget {
     /// Providers emitted by this target.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub providers: Vec<String>,
+    /// Tools required to analyze or execute this target.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolRequirement>,
     /// Non-fatal graph loading diagnostics for this target.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<Diagnostic>,
@@ -66,6 +69,15 @@ pub struct Capability {
     /// Output groups that must already exist before this capability runs.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires_outputs: Vec<String>,
+}
+
+/// A tool made available to a target through the workspace tool environment.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ToolRequirement {
+    /// Logical tool name declared by the workspace.
+    pub name: String,
+    /// Executable names the target kind may invoke from this tool.
+    pub executables: Vec<String>,
 }
 
 /// Diagnostic emitted while constructing the typed graph.
@@ -135,6 +147,9 @@ pub struct TargetKindSchema {
     pub providers: Vec<String>,
     /// Capabilities exposed by targets of this kind.
     pub capabilities: Vec<Capability>,
+    /// Tools required by implementations of this target kind.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolRequirement>,
     /// Runnable starter workspaces. Each example is a lightweight
     /// descriptor; callers load the file bundle only when they choose
     /// a starter to materialize.
@@ -337,6 +352,7 @@ fn graph_target_from_schema(target: &Target, schemas: &[TargetKindSchema]) -> Gr
             }
         }
     }
+    let tools = graph_tools_from_parts(&target.kind, &attrs, schema);
     GraphTarget {
         label: TargetLabel {
             package: target.package.clone(),
@@ -351,6 +367,7 @@ fn graph_target_from_schema(target: &Target, schemas: &[TargetKindSchema]) -> Gr
             .as_ref()
             .map_or_else(Vec::new, |schema| schema.capabilities.clone()),
         providers: schema.map_or_else(Vec::new, |schema| schema.providers.clone()),
+        tools,
         diagnostics,
     }
 }
@@ -399,6 +416,7 @@ fn graph_target_from_owned_schema(target: Target, schemas: &[TargetKindSchema]) 
             }
         }
     }
+    let tools = graph_tools_from_parts(&kind, &attrs, schema);
     GraphTarget {
         label: TargetLabel {
             package,
@@ -413,8 +431,28 @@ fn graph_target_from_owned_schema(target: Target, schemas: &[TargetKindSchema]) 
             .as_ref()
             .map_or_else(Vec::new, |schema| schema.capabilities.clone()),
         providers: schema.map_or_else(Vec::new, |schema| schema.providers.clone()),
+        tools,
         diagnostics,
     }
+}
+
+fn graph_tools_from_parts(
+    kind: &str,
+    attrs: &BTreeMap<String, AttrValue>,
+    schema: Option<&TargetKindSchema>,
+) -> Vec<ToolRequirement> {
+    let mut tools = schema.map_or_else(Vec::new, |schema| schema.tools.clone());
+    if kind == "script" {
+        if let Some(AttrValue::String(runtime)) = attrs.get("script_runtime") {
+            if !runtime.contains('/') && !runtime.contains('\\') {
+                tools.push(ToolRequirement {
+                    name: runtime.clone(),
+                    executables: vec![runtime.clone()],
+                });
+            }
+        }
+    }
+    tools
 }
 
 fn graph_attrs(target: &Target) -> BTreeMap<String, AttrValue> {
@@ -613,6 +651,13 @@ fn target_kind_schema_from_value(
                 capability_from_value(capability, &format!("{path}.capabilities[{index}]"))
             })
             .collect::<std::result::Result<Vec<_>, _>>()?,
+        tools: field_list(value, path, "tools")?
+            .iter()
+            .enumerate()
+            .map(|(index, tool)| {
+                tool_requirement_from_value(tool, &format!("{path}.tools[{index}]"))
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()?,
         examples,
     })
 }
@@ -641,6 +686,16 @@ fn capability_from_value(value: Value<'_>, path: &str) -> std::result::Result<Ca
         name: field_string(value, path, "name")?,
         output_groups: field_string_list(value, path, "output_groups")?,
         requires_outputs: field_string_list(value, path, "requires_outputs")?,
+    })
+}
+
+fn tool_requirement_from_value(
+    value: Value<'_>,
+    path: &str,
+) -> std::result::Result<ToolRequirement, String> {
+    Ok(ToolRequirement {
+        name: non_empty_field_string(value, path, "name")?,
+        executables: field_string_list(value, path, "executables")?,
     })
 }
 
@@ -799,6 +854,7 @@ fn script_schema() -> TargetKindSchema {
         deps: Vec::new(),
         providers: vec!["script_action".to_string()],
         capabilities: vec![capability("run", &["default"], &[])],
+        tools: Vec::new(),
         examples: Vec::new(),
     }
 }
@@ -890,6 +946,25 @@ mod tests {
         let schemas = parse_target_kind_schemas("test.star", &source).unwrap();
         assert_eq!(schemas.len(), 1);
         assert_eq!(schemas[0].kind, "demo");
+    }
+
+    #[test]
+    fn parse_target_kind_schemas_exposes_tool_requirements() {
+        let source = source_with_common(
+            r#"demo = target_kind(
+    docs = "Demo kind",
+    tools = [tool("rust", executables = ["rustc", "cargo"])],
+)"#,
+        );
+        let schemas = parse_target_kind_schemas("test.star", &source).unwrap();
+
+        assert_eq!(
+            schemas[0].tools,
+            vec![ToolRequirement {
+                name: "rust".to_string(),
+                executables: vec!["rustc".to_string(), "cargo".to_string()],
+            }]
+        );
     }
 
     #[test]
@@ -1112,6 +1187,29 @@ demo_kind = target_kind(
     }
 
     #[test]
+    fn script_runtime_becomes_a_graph_tool_requirement() {
+        let target = Target {
+            package: "tools".to_string(),
+            kind: "script".to_string(),
+            name: "Generate".to_string(),
+            deps: Vec::new(),
+            srcs: Vec::new(),
+            attrs: BTreeMap::from([("script_runtime".to_string(), "python".to_string())]),
+            typed_attrs: BTreeMap::new(),
+        };
+
+        let graph = graph_from_targets(&[target]);
+
+        assert_eq!(
+            graph[0].tools,
+            vec![ToolRequirement {
+                name: "python".to_string(),
+                executables: vec!["python".to_string()],
+            }]
+        );
+    }
+
+    #[test]
     fn graph_from_targets_attaches_built_in_schema_to_each_target() {
         let targets = ["ToolA", "ToolB"].map(|name| Target {
             package: "tools".to_string(),
@@ -1190,6 +1288,7 @@ demo_kind = target_kind(
             deps: Vec::new(),
             providers: Vec::new(),
             capabilities: Vec::new(),
+            tools: Vec::new(),
             examples: Vec::new(),
         }];
 
@@ -1212,6 +1311,14 @@ demo_kind = target_kind(
         assert!(kinds.len() > 1);
         let unique = kinds.iter().collect::<std::collections::BTreeSet<_>>();
         assert_eq!(unique.len(), kinds.len());
+    }
+
+    #[test]
+    fn rust_schema_declares_its_mise_tool() {
+        let schema = built_in_target_kind_schema("rust_binary").unwrap();
+
+        assert_eq!(schema.tools[0].name, "rust");
+        assert_eq!(schema.tools[0].executables, ["rustc", "cargo"]);
     }
 
     #[test]

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -35,7 +35,7 @@ pub use graph::{
     graph_from_targets, graph_from_targets_result, load_graph_workspace,
     target_kind_schemas_for_workspace, AttrSchema, Capability, DepSchema, Diagnostic, GraphTarget,
     TargetKindExample, TargetKindExampleBundle, TargetKindExampleFile, TargetKindExampleRoot,
-    TargetKindExampleSource, TargetKindSchema, TargetLabel,
+    TargetKindExampleSource, TargetKindSchema, TargetLabel, ToolRequirement,
 };
 pub use manifest::{load_cache_provider_toml_str, load_infrastructure_toml_str, load_toml_str};
 pub use manifest_editor::{

--- a/docs/reference/cli/toolchain.md
+++ b/docs/reference/cli/toolchain.md
@@ -10,7 +10,7 @@ once toolchain [OPTIONS] <SUBCOMMAND>
 
 ## Description
 
-Reports the toolchains a project pins (Rust, Swift, mise) and the resolved versions Once will use when running actions from script adapters or graph target kinds. Pair with `once query schema` when debugging "why did the cache miss?" questions where the toolchain identity is suspect.
+Reports the toolchains a project pins (Rust, Swift, mise) and the resolved versions Once will use when running actions from script adapters or graph target kinds. Once downloads and verifies its own release-pinned mise executable when it is first needed, so the command does not depend on a developer-installed mise. Pair with `once query schema` when debugging "why did the cache miss?" questions where the toolchain identity is suspect.
 
 ## Options
 

--- a/docs/reference/cli/toolchain/inspect.md
+++ b/docs/reference/cli/toolchain/inspect.md
@@ -8,6 +8,11 @@ Print the toolchain contract derived from mise.toml
 once toolchain inspect [OPTIONS]
 ```
 
+## Description
+
+Shows the workspace tool requests, lock information, selected platform, and
+the mise version carried by this Once release.
+
 ## Options
 
 | Flag | Value | Default | Description |

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -62,6 +62,8 @@ and by MCP target kind discovery.
 - `providers`: provider names this target kind can return.
 - `capabilities`: command surfaces this target kind supports, such as
   `build`, `run`, `test`, or `metadata`.
+- `tools`: `tool(...)` declarations for workspace tools the implementation
+  needs during analysis or execution.
 - `examples`: `example(...)` declarations for starter workspaces exposed
   to agents.
 - `impl`: optional function that declares actions and returns a provider
@@ -70,6 +72,37 @@ and by MCP target kind discovery.
 Attributes can be configurable unless their schema sets
 `configurable = False`. Non-configurable attributes reject `select`
 during validation before the implementation runs.
+
+## Tool Requirements
+
+`tool(name, executables = [])` adds a tool requirement to the target kind
+schema and to every loaded graph target of that kind. `name` matches a key in
+the workspace `mise.toml`. `executables` lists the commands the target kind may
+invoke and defaults to the tool name.
+
+```python
+rust_binary = target_kind(
+    docs = "Builds a Rust executable.",
+    tools = [tool("rust", executables = ["rustc", "cargo"])],
+    capabilities = [capability("build", ["binary"])],
+    impl = _rust_binary_impl,
+)
+```
+
+The requirements are returned by `once query schema` and `once query targets`,
+so scheduling can collect the complete tool set as soon as the graph is
+loaded. Script targets derive the same requirement from their declared
+runtime.
+
+Once carries a fixed mise version with each release. On first use it downloads
+the matching mise release binary, verifies its published checksum, and stores
+it in Once's data directory. A developer-installed mise is never required.
+When a graph build session starts, Once installs the union of its declared
+tools before analysis and resolves the declared executable names from that
+environment. Command actions and scripts then run through `mise exec` with
+implicit installation disabled. Once authorizes the selected workspace
+configuration for these managed invocations while keeping user-global mise
+configuration isolated.
 
 ## Starter Examples
 

--- a/fixtures/tool_graph/http_server.py
+++ b/fixtures/tool_graph/http_server.py
@@ -1,0 +1,12 @@
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import sys
+
+
+root = sys.argv[1]
+port_file = Path(sys.argv[2])
+handler = partial(SimpleHTTPRequestHandler, directory=root)
+server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+port_file.write_text(str(server.server_address[1]))
+server.serve_forever()

--- a/fixtures/tool_graph/probe
+++ b/fixtures/tool_graph/probe
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+test "${MISE_ENABLE_TOOLS:-}" = "http:once-probe"
+test "${MISE_AUTO_INSTALL:-}" = "0"
+test "${MISE_EXEC_AUTO_INSTALL:-}" = "0"
+printf 'managed-tool:%s\n' "$MISE_ENABLE_TOOLS" > "$1"

--- a/spec/tool_graph_spec.sh
+++ b/spec/tool_graph_spec.sh
@@ -1,0 +1,78 @@
+#shellcheck shell=bash
+# End-to-end specs for graph tool requirements.
+
+Describe 'graph tools'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_graph_tool_workspace'
+
+  cleanup_graph_tool_workspace() {
+    if [ -n "${TOOL_SERVER_PID:-}" ]; then
+      kill "$TOOL_SERVER_PID" 2>/dev/null || true
+      wait "$TOOL_SERVER_PID" 2>/dev/null || true
+      unset TOOL_SERVER_PID
+    fi
+    cleanup_workspace
+  }
+
+  create_graph_tool_workspace() {
+    mkdir -p "$WORKSPACE/modules" "$WORKSPACE/tools/probe" "$WORKSPACE/tool-dist"
+    cp "$REPO_ROOT/fixtures/tool_graph/probe" "$WORKSPACE/tool-dist/probe"
+    chmod +x "$WORKSPACE/tool-dist/probe"
+
+    python3 "$REPO_ROOT/fixtures/tool_graph/http_server.py" \
+      "$WORKSPACE/tool-dist" "$WORKSPACE/tool-port" \
+      >"$WORKSPACE/tool-server.log" 2>&1 &
+    TOOL_SERVER_PID=$!
+    while [ ! -s "$WORKSPACE/tool-port" ]; do sleep 0.05; done
+    tool_port="$(cat "$WORKSPACE/tool-port")"
+
+    cat > "$WORKSPACE/once.toml" <<'EOF'
+[modules]
+paths = ["modules/*.star"]
+EOF
+    cat > "$WORKSPACE/mise.toml" <<EOF
+[tools]
+"http:once-probe" = { version = "1.0.0", url = "http://127.0.0.1:$tool_port/probe" }
+EOF
+    cat > "$WORKSPACE/modules/probe.star" <<'EOF'
+def _probe_impl(ctx):
+    out = declare_output("probe.txt")
+    run_action(
+        argv = ["probe", out],
+        outputs = [out],
+        identifier = ctx["label"]["id"] + ":probe",
+    )
+    return {"out": out}
+
+probe_action = target_kind(
+    docs = "Runs a tool supplied by the workspace tool environment.",
+    tools = [tool("http:once-probe", executables = ["probe"])],
+    capabilities = [capability("build", ["default"])],
+    impl = _probe_impl,
+)
+EOF
+    cat > "$WORKSPACE/tools/probe/once.toml" <<'EOF'
+[[target]]
+name = "Probe"
+kind = "probe_action"
+EOF
+
+    mise_version="$(once --format json toolchain inspect | sed -n 's/.*"mise_version":"\([^"]*\)".*/\1/p')"
+    managed_mise_dir="$XDG_DATA_HOME/once/tools/mise/$mise_version"
+    mkdir -p "$managed_mise_dir"
+    cp "$(command -v mise)" "$managed_mise_dir/mise"
+    chmod +x "$managed_mise_dir/mise"
+  }
+
+  It 'installs and exposes a declared mise tool to a graph action'
+    create_graph_tool_workspace
+
+    When call env PATH=/usr/bin:/bin "$ONCE_BIN" -C "$WORKSPACE" --format json build tools/probe/Probe
+    The status should be success
+    The stdout should include '"target":"tools/probe/Probe"'
+    The stdout should include '"status":"completed"'
+    The path "$XDG_DATA_HOME/once/tools/mise-data/installs/http-once-probe/1.0.0/probe" should be file
+    The path "$WORKSPACE/.once/out/tools/probe/Probe/probe.txt" should be file
+    The contents of file "$WORKSPACE/.once/out/tools/probe/Probe/probe.txt" should equal 'managed-tool:http:once-probe'
+  End
+End


### PR DESCRIPTION
## What changed

Graph target kinds can now declare workspace requirements with `tool(name, executables = [])`. Those requirements are preserved on loaded targets and exposed through schema and target queries, allowing the complete tool set to be known as soon as the graph is loaded.

Build sessions install the union of declared tools before analysis, resolve declared executables concurrently, and expose those paths to target implementations. Command actions and annotated scripts run through `mise exec`, with implicit installation disabled inside cacheable actions.

Once now carries mise version `2026.7.5` as part of its release contract. It downloads the matching platform binary on first use, verifies its checksum, and keeps its data, configuration, and cache isolated from user-global mise state. The managed mise version is included in toolchain inspection and fingerprinting.

Rust target kinds declare their Rust compiler and Cargo requirements through the generic graph contract. End-to-end coverage installs a small non-core mise tool from a local server and proves that a graph action can execute it without developer mise on `PATH`.

## Why

Tool availability is an execution prerequisite and should be represented in the graph alongside target dependencies. Loading the graph should provide enough information to prepare local execution environments and, in the future, prewarm remote compute environments before actions are scheduled.

Depending on a developer-installed mise also made execution sensitive to host setup. Binding a verified mise version to each Once release gives Once a stable tool resolver while keeping target declarations ecosystem-neutral.

## Approach

The graph carries logical tool names and executable capabilities without knowing how tools are installed. The execution layer maps those requirements to workspace `mise.toml`, prepares tools once per build session, and wraps only command actions. Portable file operations remain independent of mise.

Tool installation happens outside cacheable actions. Execution receives the selected tool list, disables automatic installation, trusts only the selected workspace configuration, and does not load user-global mise configuration.

The end-to-end test uses a real mise executable in Once's managed location and a local tool distribution, keeping the test deterministic and independent of external language toolchain downloads.

## Impact

Target kind authors can declare tools once and have them appear in discovery, analysis, and execution. Workspaces without `mise.toml` retain their existing executable lookup behavior, so there is no required migration.

The first tool-backed invocation may download the release-pinned mise binary and declared tools. Later invocations reuse the managed installation. Changing the mise version changes the toolchain fingerprint deliberately.

Remote provider provisioning is unchanged in this pull request. The graph now exposes the complete requirement set needed for that integration.

## Validation

- `MISE_ENABLE_TOOLS=rust mise exec -- cargo fmt --all -- --check`
- `MISE_ENABLE_TOOLS=rust mise exec -- cargo clippy -p once-core -p once-frontend -p once-cli --all-targets -- -D warnings`
- `MISE_ENABLE_TOOLS=rust mise exec -- cargo test -p once-core -p once-frontend --lib`, 242 tests passed
- `MISE_ENABLE_TOOLS=rust mise exec -- cargo test -p once-cli`, 184 tests passed
- `MISE_ENABLE_TOOLS=rust mise exec -- cargo build --release -p once-cli`
- `MISE_ENABLE_TOOLS=rust,shellspec mise exec -- shellspec spec/tool_graph_spec.sh spec/graph_action_spec.sh spec/rust_graph_spec.sh`, 8 examples passed
