### PR TITLE
feat(cache): expand language library integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3367,6 +3367,7 @@ version = "0.0.0"
 dependencies = [
  "once-cas",
  "once-core",
+ "once-frontend",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/once-cli/src/cache_provider.rs
+++ b/crates/once-cli/src/cache_provider.rs
@@ -6,12 +6,9 @@ use once_cas::{CacheProvider, TuistCacheConfig, TUIST_OAUTH_CLIENT_ID_ENV};
 use once_core::RemoteExecution;
 use once_core::Xdg;
 use once_frontend::{
-    CacheProviderConfig, InfrastructureConfig, InfrastructureProviderConfig,
-    NamedCacheProviderConfig, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
+    InfrastructureConfig, InfrastructureProviderConfig, NamedCacheProviderConfig, DEFAULT_TUIST_URL,
 };
 use serde::Deserialize;
-
-mod tuist_swift_config;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ResolvedCacheProviderConfig {
@@ -122,33 +119,24 @@ fn resolve_config_with_env(
     xdg: &Xdg,
     cache_provider_override: Option<String>,
 ) -> Result<ResolvedCacheProviderConfig> {
-    let workspace_config =
-        once_frontend::load_infrastructure_config(workspace).context("loading infrastructure")?;
-    if let Some(config) = cache_provider_config_from_env(cache_provider_override) {
-        return resolve_provider_config(xdg, &workspace_config.providers, config);
-    }
-    if let Some(config) = workspace_config.cache {
-        return resolve_provider_config(xdg, &workspace_config.providers, config);
-    }
-
-    if let Some(config) = resolve_tuist_workspace_config(workspace) {
-        Ok(ResolvedCacheProviderConfig::Tuist(config?))
-    } else {
-        resolve_default_provider(xdg)
-    }
-}
-
-fn cache_provider_config_from_env(value: Option<String>) -> Option<CacheProviderConfig> {
-    let name = non_empty(value)?;
-    if name == "local" {
-        Some(CacheProviderConfig::Local)
-    } else {
-        Some(CacheProviderConfig::Named(NamedCacheProviderConfig {
-            name,
-            account: None,
-            project: None,
-        }))
-    }
+    let config = once_frontend::resolve_cache_provider(
+        workspace,
+        &user_config_path(xdg),
+        cache_provider_override,
+    )
+    .context("resolving cache provider")?;
+    Ok(match config {
+        once_frontend::ResolvedCacheProviderConfig::Local => ResolvedCacheProviderConfig::Local,
+        once_frontend::ResolvedCacheProviderConfig::Tuist(config) => {
+            ResolvedCacheProviderConfig::Tuist(default_tuist_config(
+                config.provider_name,
+                config.url,
+                config.account,
+                config.project,
+                config.oauth_client_id,
+            ))
+        }
+    })
 }
 
 fn build_provider(xdg: &Xdg, config: ResolvedCacheProviderConfig) -> Result<CacheProvider> {
@@ -159,56 +147,6 @@ fn build_provider(xdg: &Xdg, config: ResolvedCacheProviderConfig) -> Result<Cach
                 .context("configuring Tuist cache provider")
         }
     }
-}
-
-fn resolve_provider_config(
-    xdg: &Xdg,
-    workspace_providers: &BTreeMap<String, InfrastructureProviderConfig>,
-    config: CacheProviderConfig,
-) -> Result<ResolvedCacheProviderConfig> {
-    match config {
-        CacheProviderConfig::Local => Ok(ResolvedCacheProviderConfig::Local),
-        CacheProviderConfig::Tuist(config) => Ok(ResolvedCacheProviderConfig::Tuist(
-            direct_tuist_config(config),
-        )),
-        CacheProviderConfig::Named(binding) => {
-            if let Some(provider) = workspace_providers.get(&binding.name) {
-                return Ok(resolve_named_workspace_provider(binding, provider.clone()));
-            }
-            let mut config = load_user_config(xdg)?;
-            let provider =
-                take_named_user_provider(&mut config, &binding.name).with_context(|| {
-                    format!(
-                        "infrastructure `{}` was not found in {}",
-                        binding.name,
-                        user_config_path(xdg).display()
-                    )
-                })?;
-            Ok(resolve_named_provider(binding, provider))
-        }
-    }
-}
-
-fn resolve_default_provider(xdg: &Xdg) -> Result<ResolvedCacheProviderConfig> {
-    let Some(mut config) = maybe_load_user_config(xdg)? else {
-        return Ok(ResolvedCacheProviderConfig::Local);
-    };
-    let binding = config
-        .infrastructure
-        .take()
-        .and_then(|infrastructure| infrastructure.cache)
-        .or_else(|| config.cache_provider.take());
-    let Some(binding) = binding else {
-        return Ok(ResolvedCacheProviderConfig::Local);
-    };
-    let provider = take_named_user_provider(&mut config, &binding.name).with_context(|| {
-        format!(
-            "infrastructure `{}` was not found in {}",
-            binding.name,
-            user_config_path(xdg).display()
-        )
-    })?;
-    Ok(resolve_named_provider(binding.into_named(), provider))
 }
 
 fn take_named_user_provider(config: &mut UserConfig, name: &str) -> Option<UserCacheProvider> {
@@ -363,16 +301,6 @@ fn is_builtin_execution_provider(name: &str) -> bool {
     matches!(name, "microsandbox" | "daytona")
 }
 
-fn direct_tuist_config(config: TuistCacheProviderConfig) -> TuistCacheConfig {
-    default_tuist_config(
-        "tuist".to_string(),
-        config.url,
-        config.account,
-        config.project,
-        config.oauth_client_id,
-    )
-}
-
 fn default_tuist_config(
     provider_name: String,
     url: String,
@@ -387,66 +315,6 @@ fn default_tuist_config(
         oauth_client_id: resolve_tuist_oauth_client_id(oauth_client_id),
         provider_name,
     }
-}
-
-fn resolve_tuist_workspace_config(workspace: &Path) -> Option<Result<TuistCacheConfig>> {
-    load_tuist_toml_config(workspace)
-        .or_else(|| load_tuist_swift_config(workspace))
-        .map(|config| {
-            let (account, project) = split_full_handle(&config.full_handle).with_context(|| {
-                format!(
-                    "Tuist project handle `{}` must have the form `account/project`",
-                    config.full_handle
-                )
-            })?;
-            Ok(default_tuist_config(
-                "tuist".to_string(),
-                config.url.unwrap_or_else(|| DEFAULT_TUIST_URL.to_string()),
-                Some(account),
-                Some(project),
-                None,
-            ))
-        })
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TuistWorkspaceConfig {
-    full_handle: String,
-    url: Option<String>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(default)]
-struct TuistTomlConfig {
-    project: Option<String>,
-    url: Option<String>,
-}
-
-fn load_tuist_toml_config(workspace: &Path) -> Option<TuistWorkspaceConfig> {
-    let path = workspace.join("tuist.toml");
-    let src = std::fs::read_to_string(path).ok()?;
-    let config: TuistTomlConfig = toml::from_str(&src).ok()?;
-    Some(TuistWorkspaceConfig {
-        full_handle: non_empty(config.project)?,
-        url: non_empty(config.url),
-    })
-}
-
-fn load_tuist_swift_config(workspace: &Path) -> Option<TuistWorkspaceConfig> {
-    let path = workspace.join("Tuist.swift");
-    let src = std::fs::read_to_string(path).ok()?;
-    let (full_handle, url) = tuist_swift_config::parse_tuist_config(&src)?;
-    Some(TuistWorkspaceConfig { full_handle, url })
-}
-
-fn split_full_handle(full_handle: &str) -> Option<(String, String)> {
-    let mut parts = full_handle.split('/');
-    let account = non_empty(parts.next().map(str::to_string))?;
-    let project = non_empty(parts.next().map(str::to_string))?;
-    if parts.next().is_some() {
-        return None;
-    }
-    Some((account, project))
 }
 
 fn resolve_tuist_oauth_client_id(config_value: Option<String>) -> Option<String> {
@@ -498,15 +366,6 @@ enum UserCacheProvider {
         account: Option<String>,
         project: Option<String>,
     },
-}
-
-fn load_user_config(xdg: &Xdg) -> Result<UserConfig> {
-    maybe_load_user_config(xdg)?.with_context(|| {
-        format!(
-            "user cache config {} does not exist",
-            user_config_path(xdg).display()
-        )
-    })
 }
 
 fn maybe_load_user_config(xdg: &Xdg) -> Result<Option<UserConfig>> {

--- a/crates/once-frontend/src/cache_resolution.rs
+++ b/crates/once-frontend/src/cache_resolution.rs
@@ -1,0 +1,247 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::{
+    load_infrastructure_config, CacheProviderConfig, Error, InfrastructureProviderConfig,
+    NamedCacheProviderConfig, Result, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
+};
+
+mod tuist_swift;
+mod user;
+
+use user::{load_user_config, maybe_load_user_config, take_named_user_provider, UserCacheProvider};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedCacheProviderConfig {
+    Local,
+    Tuist(ResolvedTuistCacheProviderConfig),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTuistCacheProviderConfig {
+    pub provider_name: String,
+    pub url: String,
+    pub account: Option<String>,
+    pub project: Option<String>,
+    pub oauth_client_id: Option<String>,
+}
+
+pub fn resolve_cache_provider(
+    workspace: &Path,
+    user_config_path: &Path,
+    provider_override: Option<String>,
+) -> Result<ResolvedCacheProviderConfig> {
+    let workspace_config = load_infrastructure_config(workspace)?;
+    if let Some(config) = cache_provider_config_from_override(provider_override) {
+        return resolve_provider_config(user_config_path, &workspace_config.providers, config);
+    }
+    if let Some(config) = workspace_config.cache {
+        return resolve_provider_config(user_config_path, &workspace_config.providers, config);
+    }
+
+    if let Some(config) = resolve_tuist_workspace_config(workspace)? {
+        Ok(ResolvedCacheProviderConfig::Tuist(config))
+    } else {
+        resolve_default_provider(user_config_path)
+    }
+}
+
+fn cache_provider_config_from_override(value: Option<String>) -> Option<CacheProviderConfig> {
+    let name = non_empty(value)?;
+    if name == "local" {
+        Some(CacheProviderConfig::Local)
+    } else {
+        Some(CacheProviderConfig::Named(NamedCacheProviderConfig {
+            name,
+            account: None,
+            project: None,
+        }))
+    }
+}
+
+fn resolve_provider_config(
+    user_config_path: &Path,
+    workspace_providers: &BTreeMap<String, InfrastructureProviderConfig>,
+    config: CacheProviderConfig,
+) -> Result<ResolvedCacheProviderConfig> {
+    match config {
+        CacheProviderConfig::Local => Ok(ResolvedCacheProviderConfig::Local),
+        CacheProviderConfig::Tuist(config) => Ok(ResolvedCacheProviderConfig::Tuist(
+            direct_tuist_config(config),
+        )),
+        CacheProviderConfig::Named(binding) => {
+            if let Some(provider) = workspace_providers.get(&binding.name) {
+                return Ok(resolve_named_workspace_provider(binding, provider.clone()));
+            }
+            let mut config = load_user_config(user_config_path)?;
+            let provider =
+                take_named_user_provider(&mut config, &binding.name).ok_or_else(|| {
+                    Error::Eval {
+                        path: user_config_path.display().to_string(),
+                        message: format!(
+                            "infrastructure `{}` was not found in {}",
+                            binding.name,
+                            user_config_path.display()
+                        ),
+                    }
+                })?;
+            Ok(resolve_named_provider(binding, provider))
+        }
+    }
+}
+
+fn resolve_default_provider(user_config_path: &Path) -> Result<ResolvedCacheProviderConfig> {
+    let Some(mut config) = maybe_load_user_config(user_config_path)? else {
+        return Ok(ResolvedCacheProviderConfig::Local);
+    };
+    let binding = config
+        .infrastructure
+        .take()
+        .and_then(|infrastructure| infrastructure.cache)
+        .or_else(|| config.cache_provider.take());
+    let Some(binding) = binding else {
+        return Ok(ResolvedCacheProviderConfig::Local);
+    };
+    let provider =
+        take_named_user_provider(&mut config, &binding.name).ok_or_else(|| Error::Eval {
+            path: user_config_path.display().to_string(),
+            message: format!(
+                "infrastructure `{}` was not found in {}",
+                binding.name,
+                user_config_path.display()
+            ),
+        })?;
+    Ok(resolve_named_provider(binding.into_named(), provider))
+}
+
+fn resolve_named_provider(
+    binding: NamedCacheProviderConfig,
+    provider: UserCacheProvider,
+) -> ResolvedCacheProviderConfig {
+    let NamedCacheProviderConfig {
+        name,
+        account: binding_account,
+        project: binding_project,
+    } = binding;
+    match provider {
+        UserCacheProvider::Tuist {
+            url,
+            oauth_client_id,
+            account,
+            project,
+        } => ResolvedCacheProviderConfig::Tuist(ResolvedTuistCacheProviderConfig {
+            provider_name: name,
+            url: url.unwrap_or_else(|| DEFAULT_TUIST_URL.to_string()),
+            account: binding_account.or(account),
+            project: binding_project.or(project),
+            oauth_client_id,
+        }),
+    }
+}
+
+fn resolve_named_workspace_provider(
+    binding: NamedCacheProviderConfig,
+    provider: InfrastructureProviderConfig,
+) -> ResolvedCacheProviderConfig {
+    let NamedCacheProviderConfig {
+        name,
+        account: binding_account,
+        project: binding_project,
+    } = binding;
+    match provider {
+        InfrastructureProviderConfig::Local => ResolvedCacheProviderConfig::Local,
+        InfrastructureProviderConfig::Tuist(config) => {
+            ResolvedCacheProviderConfig::Tuist(ResolvedTuistCacheProviderConfig {
+                provider_name: name,
+                url: config.url,
+                account: binding_account.or(config.account),
+                project: binding_project.or(config.project),
+                oauth_client_id: config.oauth_client_id,
+            })
+        }
+    }
+}
+
+fn direct_tuist_config(config: TuistCacheProviderConfig) -> ResolvedTuistCacheProviderConfig {
+    ResolvedTuistCacheProviderConfig {
+        provider_name: "tuist".to_string(),
+        url: config.url,
+        account: config.account,
+        project: config.project,
+        oauth_client_id: config.oauth_client_id,
+    }
+}
+
+fn resolve_tuist_workspace_config(
+    workspace: &Path,
+) -> Result<Option<ResolvedTuistCacheProviderConfig>> {
+    let Some(config) =
+        load_tuist_toml_config(workspace).or_else(|| load_tuist_swift_config(workspace))
+    else {
+        return Ok(None);
+    };
+    let (account, project) = split_full_handle(&config.full_handle).ok_or_else(|| Error::Eval {
+        path: workspace.display().to_string(),
+        message: format!(
+            "Tuist project handle `{}` must have the form `account/project`",
+            config.full_handle
+        ),
+    })?;
+    Ok(Some(ResolvedTuistCacheProviderConfig {
+        provider_name: "tuist".to_string(),
+        url: config.url.unwrap_or_else(|| DEFAULT_TUIST_URL.to_string()),
+        account: Some(account),
+        project: Some(project),
+        oauth_client_id: None,
+    }))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TuistWorkspaceConfig {
+    full_handle: String,
+    url: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct TuistTomlConfig {
+    project: Option<String>,
+    url: Option<String>,
+}
+
+fn load_tuist_toml_config(workspace: &Path) -> Option<TuistWorkspaceConfig> {
+    let src = std::fs::read_to_string(workspace.join("tuist.toml")).ok()?;
+    let config: TuistTomlConfig = toml::from_str(&src).ok()?;
+    Some(TuistWorkspaceConfig {
+        full_handle: non_empty(config.project)?,
+        url: non_empty(config.url),
+    })
+}
+
+fn load_tuist_swift_config(workspace: &Path) -> Option<TuistWorkspaceConfig> {
+    let src = std::fs::read_to_string(workspace.join("Tuist.swift")).ok()?;
+    let (full_handle, url) = tuist_swift::parse_tuist_config(&src)?;
+    Some(TuistWorkspaceConfig { full_handle, url })
+}
+
+fn split_full_handle(full_handle: &str) -> Option<(String, String)> {
+    let mut parts = full_handle.split('/');
+    let account = non_empty(parts.next().map(str::to_string))?;
+    let project = non_empty(parts.next().map(str::to_string))?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((account, project))
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/once-frontend/src/cache_resolution/tests.rs
+++ b/crates/once-frontend/src/cache_resolution/tests.rs
@@ -1,0 +1,171 @@
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use super::{resolve_cache_provider, ResolvedCacheProviderConfig};
+
+fn user_config_path(root: &Path) -> PathBuf {
+    root.join("config").join("once").join("config.toml")
+}
+
+fn write_user_config(root: &Path, body: &str) -> PathBuf {
+    let path = user_config_path(root);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+#[test]
+fn defaults_to_local_without_configuration() {
+    let tmp = TempDir::new().unwrap();
+
+    let config = resolve_cache_provider(tmp.path(), &user_config_path(tmp.path()), None).unwrap();
+
+    assert_eq!(config, ResolvedCacheProviderConfig::Local);
+}
+
+#[test]
+fn workspace_provider_beats_user_default() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("once.toml"),
+        r#"
+[infrastructure.cache]
+provider = "local"
+
+[infrastructures.local]
+kind = "local"
+"#,
+    )
+    .unwrap();
+    let user_config = write_user_config(
+        tmp.path(),
+        r#"
+[infrastructure.cache]
+name = "tuist"
+
+[infrastructures.tuist]
+kind = "tuist"
+account = "acme"
+"#,
+    );
+
+    let config = resolve_cache_provider(tmp.path(), &user_config, None).unwrap();
+
+    assert_eq!(config, ResolvedCacheProviderConfig::Local);
+}
+
+#[test]
+fn override_beats_workspace_provider() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("once.toml"),
+        r#"
+[cache_provider]
+kind = "tuist"
+account = "acme"
+"#,
+    )
+    .unwrap();
+
+    let config = resolve_cache_provider(
+        tmp.path(),
+        &user_config_path(tmp.path()),
+        Some("local".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(config, ResolvedCacheProviderConfig::Local);
+}
+
+#[test]
+fn resolves_named_workspace_provider_scope() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("once.toml"),
+        r#"
+[infrastructure.cache]
+provider = "shared"
+project = "app"
+
+[infrastructures.shared]
+kind = "tuist"
+url = "https://cache.example.com"
+account = "acme"
+project = "default"
+"#,
+    )
+    .unwrap();
+
+    let config = resolve_cache_provider(tmp.path(), &user_config_path(tmp.path()), None).unwrap();
+    let ResolvedCacheProviderConfig::Tuist(config) = config else {
+        panic!("expected remote cache provider");
+    };
+
+    assert_eq!(config.provider_name, "shared");
+    assert_eq!(config.url, "https://cache.example.com");
+    assert_eq!(config.account.as_deref(), Some("acme"));
+    assert_eq!(config.project.as_deref(), Some("app"));
+}
+
+#[test]
+fn resolves_user_default_provider() {
+    let tmp = TempDir::new().unwrap();
+    let user_config = write_user_config(
+        tmp.path(),
+        r#"
+[infrastructure.cache]
+name = "shared"
+project = "app"
+
+[infrastructures.shared]
+kind = "tuist"
+url = "https://cache.example.com"
+account = "acme"
+"#,
+    );
+
+    let config = resolve_cache_provider(tmp.path(), &user_config, None).unwrap();
+    let ResolvedCacheProviderConfig::Tuist(config) = config else {
+        panic!("expected remote cache provider");
+    };
+
+    assert_eq!(config.provider_name, "shared");
+    assert_eq!(config.project.as_deref(), Some("app"));
+}
+
+#[test]
+fn resolves_legacy_tuist_manifest() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("Tuist.swift"),
+        r#"
+let ignored = "fullHandle: \"wrong/value\""
+let tuist = Tuist(
+    url: "https://cache.example.com",
+    fullHandle: "acme/app"
+)
+"#,
+    )
+    .unwrap();
+
+    let config = resolve_cache_provider(tmp.path(), &user_config_path(tmp.path()), None).unwrap();
+    let ResolvedCacheProviderConfig::Tuist(config) = config else {
+        panic!("expected remote cache provider");
+    };
+
+    assert_eq!(config.account.as_deref(), Some("acme"));
+    assert_eq!(config.project.as_deref(), Some("app"));
+    assert_eq!(config.url, "https://cache.example.com");
+}
+
+#[test]
+fn rejects_malformed_legacy_handle() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("tuist.toml"), "project = \"invalid\"\n").unwrap();
+
+    let error =
+        resolve_cache_provider(tmp.path(), &user_config_path(tmp.path()), None).unwrap_err();
+
+    assert!(error.to_string().contains("account/project"));
+}

--- a/crates/once-frontend/src/cache_resolution/tuist_swift.rs
+++ b/crates/once-frontend/src/cache_resolution/tuist_swift.rs
@@ -1,12 +1,3 @@
-//! Extracts the Tuist project handle and cache URL from a `Tuist.swift`
-//! manifest. Swift has no cheap off-the-shelf parser here, so this is a
-//! narrow scanner: it walks the source while skipping comments and string
-//! literals, finds the top-level `Tuist(...)` constructor, and reads the
-//! `fullHandle` and `url` string arguments out of its argument list.
-
-/// Reads `(fullHandle, url)` from the top-level `Tuist(...)` constructor.
-/// Returns `None` when the manifest has no such constructor or no
-/// non-empty `fullHandle`.
 pub(super) fn parse_tuist_config(src: &str) -> Option<(String, Option<String>)> {
     let body = tuist_constructor_body(src)?;
     let full_handle = string_argument(body, "fullHandle")?;
@@ -197,9 +188,5 @@ fn leading_string(src: &str) -> Option<String> {
 
 fn non_empty(value: &str) -> Option<String> {
     let trimmed = value.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }

--- a/crates/once-frontend/src/cache_resolution/user.rs
+++ b/crates/once-frontend/src/cache_resolution/user.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::{Error, NamedCacheProviderConfig, Result};
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct UserConfig {
+    pub(super) infrastructure: Option<UserInfrastructureConfig>,
+    pub(super) infrastructures: BTreeMap<String, UserCacheProvider>,
+    pub(super) cache_provider: Option<UserCacheProviderBinding>,
+    pub(super) cache_providers: BTreeMap<String, UserCacheProvider>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct UserInfrastructureConfig {
+    pub(super) cache: Option<UserCacheProviderBinding>,
+    execution: Option<UserCacheProviderBinding>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct UserCacheProviderBinding {
+    #[serde(alias = "provider")]
+    pub(super) name: String,
+    account: Option<String>,
+    project: Option<String>,
+}
+
+impl UserCacheProviderBinding {
+    pub(super) fn into_named(self) -> NamedCacheProviderConfig {
+        NamedCacheProviderConfig {
+            name: self.name,
+            account: self.account,
+            project: self.project,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum UserCacheProvider {
+    Tuist {
+        url: Option<String>,
+        oauth_client_id: Option<String>,
+        account: Option<String>,
+        project: Option<String>,
+    },
+}
+
+pub(super) fn take_named_user_provider(
+    config: &mut UserConfig,
+    name: &str,
+) -> Option<UserCacheProvider> {
+    config
+        .infrastructures
+        .remove(name)
+        .or_else(|| config.cache_providers.remove(name))
+}
+
+pub(super) fn load_user_config(path: &Path) -> Result<UserConfig> {
+    maybe_load_user_config(path)?.ok_or_else(|| Error::Read {
+        path: path.display().to_string(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "user cache configuration does not exist",
+        ),
+    })
+}
+
+pub(super) fn maybe_load_user_config(path: &Path) -> Result<Option<UserConfig>> {
+    let src = match std::fs::read_to_string(path) {
+        Ok(src) => src,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(Error::Read {
+                path: path.display().to_string(),
+                source,
+            });
+        }
+    };
+    let mut config: UserConfig = toml::from_str(&src).map_err(|source| Error::Parse {
+        path: path.display().to_string(),
+        message: source.to_string(),
+    })?;
+    if let Some(binding) = config.cache_provider.as_mut() {
+        normalize_binding(binding, path)?;
+    }
+    if let Some(infrastructure) = config.infrastructure.as_mut() {
+        if let Some(binding) = infrastructure.cache.as_mut() {
+            normalize_binding(binding, path)?;
+        }
+        if let Some(binding) = infrastructure.execution.as_mut() {
+            normalize_binding(binding, path)?;
+        }
+    }
+    Ok(Some(config))
+}
+
+fn normalize_binding(binding: &mut UserCacheProviderBinding, path: &Path) -> Result<()> {
+    binding.name = binding.name.trim().to_string();
+    if binding.name.is_empty() {
+        return Err(Error::Eval {
+            path: path.display().to_string(),
+            message: "user cache configuration has an empty infrastructure name".to_string(),
+        });
+    }
+    binding.account = non_empty(binding.account.take());
+    binding.project = non_empty(binding.project.take());
+    Ok(())
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod analysis;
 mod cache_provider;
+mod cache_resolution;
 mod error;
 mod examples;
 mod graph;
@@ -29,6 +30,9 @@ pub use cache_provider::{
     CacheProviderConfig, ExecutionProviderConfig, InfrastructureConfig,
     InfrastructureProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig,
     DEFAULT_TUIST_URL,
+};
+pub use cache_resolution::{
+    resolve_cache_provider, ResolvedCacheProviderConfig, ResolvedTuistCacheProviderConfig,
 };
 pub use error::{Error, Result};
 pub use examples::{load_example_bundle, load_target_kind_example};

--- a/crates/once/Cargo.toml
+++ b/crates/once/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Rust SDK and C ABI for Once cache access"
+description = "Rust and C bindings for Once cache access"
 
 [lib]
 name = "once"
@@ -15,6 +15,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 once-cas.workspace = true
 once-core.workspace = true
+once-frontend.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/once/README.md
+++ b/crates/once/README.md
@@ -29,9 +29,16 @@ The high-level programming interface is:
 
 - `Cache`: reusable client bound to the default local cache described by the
   [freedesktop.org base directory specification](https://specifications.freedesktop.org/basedir-spec/latest/).
-- Blob operations: `put_blob`, `get_blob`, and `has_blob`.
+- Cache selection: `local` for an isolated root and `from_workspace` for the
+  same effective provider as the command line.
+- Blob operations: in-memory access with `put_blob` and `get_blob`, bounded
+  input with `put_stream` and `put_file`, file output with
+  `get_blob_to_file`, and existence checks with `has_blob`.
 - Action-cache operations: `put_action_result`, `get_action_result`, and `forget_action`.
-- Cache primitives: `Digest`, `ActionResult`, `Stats`, `CacheProvider`, and `digest_from_hex`.
+- Action identity: `ActionKeyBuilder` builds a versioned digest from ordered,
+  labeled inputs.
+- Cache primitives: `Digest`, `ActionResult`, `Stats`, `CacheProvider`,
+  `TuistCacheConfig`, and `digest_from_hex`.
 
 ## Apple
 
@@ -50,8 +57,10 @@ print(String(decoding: bytes, as: UTF8.self))
 If you call the C application programming interface directly, all owned
 strings returned by `once_*` functions must be released with
 `once_string_free`. The C module name is `Once`.
-[JavaScript Object Notation (JSON)](https://www.json.org/json-en.html) requests
-use the default local cache.
+[JavaScript Object Notation](https://www.json.org/json-en.html) requests omit
+cache-selection fields for the default local cache, or provide
+`local_cache_root` or `workspace_root`. File operations keep large payloads
+out of the host language's memory.
 
 ## Ruby
 
@@ -99,7 +108,7 @@ async function main() {
 
 Foreign functions return
 [Unicode Transformation Format, 8-bit (UTF-8)](https://www.unicode.org/faq/utf_bom.html#UTF8)
-JSON:
+[JavaScript Object Notation](https://www.json.org/json-en.html):
 
 ```json
 { "status": "ok", "value": "..." }

--- a/crates/once/include/Once/once.h
+++ b/crates/once/include/Once/once.h
@@ -24,9 +24,15 @@ void once_string_free(char *value);
 
 char *once_digest_bytes(const uint8_t *data, size_t len);
 
+char *once_action_key_json(const char *request_json);
+
 char *once_cache_put_blob_json(const char *request_json);
 
+char *once_cache_put_file_json(const char *request_json);
+
 char *once_cache_get_blob_json(const char *request_json);
+
+char *once_cache_get_blob_to_file_json(const char *request_json);
 
 char *once_cache_has_blob_json(const char *request_json);
 

--- a/crates/once/once.toml
+++ b/crates/once/once.toml
@@ -4,6 +4,7 @@ kind = "rust_library"
 deps = [
   "crates/once-cas/once_cas",
   "crates/once-core/once_core",
+  "crates/once-frontend/once_frontend",
   "cargo_dependencies",
 ]
 srcs = ["src/**/*.rs"]

--- a/crates/once/src/action_key.rs
+++ b/crates/once/src/action_key.rs
@@ -1,0 +1,91 @@
+use once_cas::Digest;
+
+const DOMAIN: &[u8] = b"once.sdk.action-key.v1\0";
+
+/// Build a stable digest for one cached automation action.
+///
+/// The namespace partitions unrelated integrations. Inputs are ordered, so
+/// callers should add them in a deterministic order. Labels and values use a
+/// length-prefixed encoding, and the versioned domain lets Once evolve the
+/// format without making old cache entries unsafe.
+#[derive(Debug, Clone)]
+pub struct ActionKeyBuilder {
+    encoded: Vec<u8>,
+}
+
+impl ActionKeyBuilder {
+    pub fn new(namespace: impl AsRef<[u8]>) -> Self {
+        let namespace = namespace.as_ref();
+        let mut encoded = Vec::with_capacity(DOMAIN.len() + namespace.len() + 64);
+        encoded.extend_from_slice(DOMAIN);
+        push_field(&mut encoded, namespace);
+        Self { encoded }
+    }
+
+    pub fn push_digest(&mut self, label: impl AsRef<[u8]>, digest: Digest) -> &mut Self {
+        self.encoded.push(1);
+        push_field(&mut self.encoded, label.as_ref());
+        self.encoded.extend_from_slice(digest.as_bytes());
+        self
+    }
+
+    pub fn push_bytes(&mut self, label: impl AsRef<[u8]>, bytes: impl AsRef<[u8]>) -> &mut Self {
+        self.encoded.push(2);
+        push_field(&mut self.encoded, label.as_ref());
+        push_field(&mut self.encoded, bytes.as_ref());
+        self
+    }
+
+    pub fn finish(self) -> Digest {
+        Digest::of_bytes(&self.encoded)
+    }
+}
+
+fn push_field(encoded: &mut Vec<u8>, value: &[u8]) {
+    let length = u64::try_from(value.len()).unwrap_or(u64::MAX);
+    encoded.extend_from_slice(&length.to_le_bytes());
+    encoded.extend_from_slice(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_actions_have_identical_keys() {
+        let build = || {
+            let mut key = ActionKeyBuilder::new("compile");
+            key.push_bytes("tool", "swiftc")
+                .push_digest("source", Digest::of_bytes(b"source"));
+            key.finish()
+        };
+
+        assert_eq!(build(), build());
+    }
+
+    #[test]
+    fn namespaces_labels_order_and_values_partition_keys() {
+        let key = |namespace: &str, inputs: &[(&str, &str)]| {
+            let mut key = ActionKeyBuilder::new(namespace);
+            for (label, value) in inputs {
+                key.push_bytes(label, value);
+            }
+            key.finish()
+        };
+
+        let base = key("compile", &[("tool", "swiftc"), ("mode", "debug")]);
+        assert_ne!(base, key("link", &[("tool", "swiftc"), ("mode", "debug")]));
+        assert_ne!(
+            base,
+            key("compile", &[("mode", "debug"), ("tool", "swiftc")])
+        );
+        assert_ne!(
+            base,
+            key("compile", &[("tool", "clang"), ("mode", "debug")])
+        );
+        assert_ne!(
+            base,
+            key("compile", &[("compiler", "swiftc"), ("mode", "debug")])
+        );
+    }
+}

--- a/crates/once/src/cache.rs
+++ b/crates/once/src/cache.rs
@@ -1,0 +1,193 @@
+use std::path::{Path, PathBuf};
+
+use once_cas::{ActionResult, CacheProvider, Digest, Stats, TuistCacheConfig};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid digest: {0}")]
+    InvalidDigest(String),
+    #[error(transparent)]
+    Cache(#[from] once_cas::Error),
+}
+
+/// Embeddable Once cache client.
+///
+/// `Cache` is cheap to clone and can be reused across many cache
+/// operations. The default constructor opens the local filesystem cache
+/// at `$XDG_CACHE_HOME/once/cas`, or `$HOME/.cache/once/cas` when
+/// `XDG_CACHE_HOME` is not set.
+#[derive(Clone)]
+pub struct Cache {
+    cache: CacheProvider,
+}
+
+impl Cache {
+    /// Create a client backed by Once's default base-directory local cache.
+    pub fn new() -> Self {
+        Self::with_provider(CacheProvider::open_local(default_cache_root()))
+    }
+
+    /// Create a client backed by a caller-owned local cache root.
+    pub fn local(root: impl Into<PathBuf>) -> Self {
+        Self::with_provider(CacheProvider::open_local(root))
+    }
+
+    /// Create a client using the effective provider for a workspace.
+    ///
+    /// Provider selection matches the command line: the process override,
+    /// workspace infrastructure, legacy Tuist project configuration, and the
+    /// user default are considered in that order.
+    pub fn from_workspace(workspace: impl AsRef<Path>) -> Result<Self> {
+        let xdg = once_core::Xdg::from_env();
+        let config = once_frontend::resolve_cache_provider(
+            workspace.as_ref(),
+            &xdg.config_home.join("once").join("config.toml"),
+            std::env::var("ONCE_CACHE_PROVIDER").ok(),
+        )
+        .map_err(|error| once_cas::Error::InvalidConfig {
+            provider: "workspace",
+            message: error.to_string(),
+        })?;
+        let provider = match config {
+            once_frontend::ResolvedCacheProviderConfig::Local => {
+                CacheProvider::open_local(xdg.once_cas())
+            }
+            once_frontend::ResolvedCacheProviderConfig::Tuist(config) => {
+                let oauth_client_id =
+                    non_empty_env(once_cas::TUIST_OAUTH_CLIENT_ID_ENV).or(config.oauth_client_id);
+                CacheProvider::tuist(
+                    xdg.once_cas(),
+                    xdg.config_home.join("once").join("credentials"),
+                    TuistCacheConfig {
+                        url: config.url,
+                        account: config.account,
+                        project: config.project,
+                        oauth_client_id,
+                        provider_name: config.provider_name,
+                    },
+                )?
+            }
+        };
+        Ok(Self::with_provider(provider))
+    }
+
+    /// Create a client with an explicit cache provider.
+    pub fn with_provider(cache: CacheProvider) -> Self {
+        Self { cache }
+    }
+
+    /// Cache provider used by this client.
+    pub fn provider(&self) -> &CacheProvider {
+        &self.cache
+    }
+
+    /// Root directory used by the underlying provider.
+    pub fn root(&self) -> &Path {
+        self.cache.root()
+    }
+
+    /// Store a blob and return its content digest.
+    pub async fn put_blob(&self, bytes: &[u8]) -> Result<Digest> {
+        Ok(self.cache.put_blob(bytes).await?)
+    }
+
+    /// Store bytes from an asynchronous reader with bounded memory use.
+    pub async fn put_stream<R>(&self, reader: R) -> Result<Digest>
+    where
+        R: tokio::io::AsyncRead + Unpin,
+    {
+        Ok(self.cache.put_stream(reader).await?)
+    }
+
+    /// Store a file without loading the complete file into memory.
+    pub async fn put_file(&self, path: impl AsRef<Path>) -> Result<Digest> {
+        let path = path.as_ref();
+        let file = tokio::fs::File::open(path)
+            .await
+            .map_err(|source| once_cas::Error::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        self.put_stream(file).await
+    }
+
+    /// Read a blob by digest.
+    pub async fn get_blob(&self, digest: Digest) -> Result<Vec<u8>> {
+        Ok(self.cache.get_blob(&digest).await?)
+    }
+
+    /// Materialize a blob at a file path and return the number of bytes written.
+    pub async fn get_blob_to_file(&self, digest: Digest, path: impl AsRef<Path>) -> Result<u64> {
+        let path = path.as_ref();
+        let bytes = self.get_blob(digest).await?;
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|source| once_cas::Error::Io {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+        }
+        tokio::fs::write(path, &bytes)
+            .await
+            .map_err(|source| once_cas::Error::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        Ok(bytes.len() as u64)
+    }
+
+    /// Return whether a blob exists.
+    pub async fn has_blob(&self, digest: Digest) -> Result<bool> {
+        Ok(self.cache.has_blob(&digest).await?)
+    }
+
+    /// Store the cached result for an action digest.
+    pub async fn put_action_result(&self, action: Digest, result: &ActionResult) -> Result<()> {
+        Ok(self.cache.put_action_result(&action, result).await?)
+    }
+
+    /// Read the cached result for an action digest.
+    pub async fn get_action_result(&self, action: Digest) -> Result<Option<ActionResult>> {
+        Ok(self.cache.get_action_result(&action).await?)
+    }
+
+    /// Remove one cached action result, leaving referenced blobs intact.
+    pub async fn forget_action(&self, action: Digest) -> Result<bool> {
+        Ok(self.cache.forget_action(&action).await?)
+    }
+
+    /// Return local cache statistics.
+    pub async fn stats(&self) -> Result<Stats> {
+        Ok(self.cache.stats().await?)
+    }
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn digest_from_hex(hex: &str) -> Result<Digest> {
+    Digest::from_hex(hex).ok_or_else(|| Error::InvalidDigest(hex.to_string()))
+}
+
+fn default_cache_root() -> PathBuf {
+    once_core::Xdg::from_env().once_cas()
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/once/src/cache/tests.rs
+++ b/crates/once/src/cache/tests.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeMap;
+
+use super::*;
+
+#[test]
+fn default_cache_uses_xdg_cas_root() {
+    let _env_lock = crate::TEST_ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("XDG_CACHE_HOME", tmp.path());
+    let cache = Cache::new();
+
+    assert_eq!(cache.root(), tmp.path().join("once").join("cas"));
+    std::env::remove_var("XDG_CACHE_HOME");
+}
+
+#[tokio::test]
+async fn stores_and_reads_blobs() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let cache = Cache::with_provider(CacheProvider::open_local(tmp.path()));
+
+    let digest = cache.put_blob(b"hello").await.unwrap();
+
+    assert!(cache.has_blob(digest).await.unwrap());
+    assert_eq!(cache.get_blob(digest).await.unwrap(), b"hello");
+}
+
+#[tokio::test]
+async fn stores_files_and_materializes_blobs() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let cache = Cache::local(tmp.path().join("cache"));
+    let input = tmp.path().join("inputs/payload.bin");
+    let output = tmp.path().join("outputs/nested/payload.bin");
+    std::fs::create_dir_all(input.parent().unwrap()).unwrap();
+    std::fs::write(&input, b"file payload").unwrap();
+
+    let digest = cache.put_file(&input).await.unwrap();
+    let bytes = cache.get_blob_to_file(digest, &output).await.unwrap();
+
+    assert_eq!(bytes, 12);
+    assert_eq!(std::fs::read(output).unwrap(), b"file payload");
+}
+
+#[test]
+fn workspace_constructor_uses_explicit_local_provider() {
+    let _env_lock = crate::TEST_ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("XDG_CACHE_HOME", tmp.path().join("cache-home"));
+    std::fs::write(
+        tmp.path().join("once.toml"),
+        "[cache_provider]\nkind = \"local\"\n",
+    )
+    .unwrap();
+
+    let cache = Cache::from_workspace(tmp.path()).unwrap();
+
+    assert_eq!(
+        cache.root(),
+        tmp.path().join("cache-home").join("once").join("cas")
+    );
+    std::env::remove_var("XDG_CACHE_HOME");
+}
+
+#[tokio::test]
+async fn stores_and_reads_action_results() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let cache = Cache::with_provider(CacheProvider::open_local(tmp.path()));
+    let stdout = cache.put_blob(b"out").await.unwrap();
+    let action = Digest::of_bytes(b"action");
+    let result = ActionResult {
+        exit_code: 0,
+        stdout: Some(stdout),
+        stderr: None,
+        outputs: BTreeMap::new(),
+    };
+
+    cache.put_action_result(action, &result).await.unwrap();
+
+    assert_eq!(cache.get_action_result(action).await.unwrap(), Some(result));
+    assert!(cache.forget_action(action).await.unwrap());
+    assert_eq!(cache.get_action_result(action).await.unwrap(), None);
+}

--- a/crates/once/src/ffi.rs
+++ b/crates/once/src/ffi.rs
@@ -1,8 +1,8 @@
-//! C ABI boundary for the embeddable Once cache API.
+//! C foreign-function boundary for the embeddable Once cache interface.
 //!
 //! The exported functions are safe to call from any host thread. Strings
 //! returned from this module are owned by Rust and must be released with
-//! `once_string_free`. JSON cache functions share a lazily initialized
+//! `once_string_free`. Cache request functions share a lazily initialized
 //! Tokio runtime. Raw pointer inputs are checked before dereferencing:
 //! a null byte pointer is valid only with length zero, which is treated
 //! as an empty byte buffer.
@@ -11,52 +11,19 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uchar};
 use std::sync::{Mutex, OnceLock};
 
-use once_cas::{ActionResult, Digest};
+use once_cas::Digest;
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Runtime;
 
-use crate::{digest_from_hex, Cache};
+use crate::{digest_from_hex, ActionKeyBuilder, Cache};
 
-#[derive(Debug, Deserialize)]
-struct BlobPutRequest {
-    bytes: Vec<u8>,
-}
+mod protocol;
 
-#[derive(Debug, Deserialize)]
-struct DigestRequest {
-    digest: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct ActionResultPutRequest {
-    action_digest: String,
-    result: ActionResult,
-}
-
-#[derive(Debug, Deserialize)]
-struct ActionDigestRequest {
-    action_digest: String,
-}
-
-#[derive(Debug, Serialize)]
-struct BlobResponse {
-    bytes: Vec<u8>,
-}
-
-#[derive(Debug, Serialize)]
-struct StatsResponse {
-    blob_count: u64,
-    blob_bytes: u64,
-    action_count: u64,
-    action_bytes: u64,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "status", rename_all = "snake_case")]
-enum FfiResponse<T> {
-    Ok { value: T },
-    Error { message: String },
-}
+use protocol::{
+    ActionDigestRequest, ActionKeyInputRequest, ActionKeyRequest, ActionResultPutRequest,
+    BlobFileRequest, BlobPutRequest, BlobResponse, CacheRequest, CacheSelection, DigestRequest,
+    FfiResponse, FilePutRequest, StatsResponse,
+};
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 static RUNTIME_INIT: Mutex<()> = Mutex::new(());
@@ -94,11 +61,30 @@ pub extern "C" fn once_digest_bytes(data: *const c_uchar, len: usize) -> *mut c_
     response_ok(Digest::of_bytes(bytes).to_hex())
 }
 
-/// Store a blob in the local cache.
+/// Build a versioned action key from labeled bytes and digests.
+#[no_mangle]
+pub extern "C" fn once_action_key_json(request_json: *const c_char) -> *mut c_char {
+    run_json::<ActionKeyRequest, _>(request_json, |request| {
+        let mut builder = ActionKeyBuilder::new(request.namespace);
+        for input in request.inputs {
+            match input {
+                ActionKeyInputRequest::Bytes { label, bytes } => {
+                    builder.push_bytes(label, bytes);
+                }
+                ActionKeyInputRequest::Digest { label, digest } => {
+                    builder.push_digest(label, digest_from_hex(&digest)?);
+                }
+            }
+        }
+        Ok(builder.finish().to_hex())
+    })
+}
+
+/// Store a blob in the selected cache.
 #[no_mangle]
 pub extern "C" fn once_cache_put_blob_json(request_json: *const c_char) -> *mut c_char {
     run_json::<BlobPutRequest, _>(request_json, |request| {
-        let cache = Cache::new();
+        let cache = cache_from_selection(request.cache)?;
         block_on(async {
             cache
                 .put_blob(&request.bytes)
@@ -108,12 +94,26 @@ pub extern "C" fn once_cache_put_blob_json(request_json: *const c_char) -> *mut 
     })
 }
 
-/// Read a blob from the local cache.
+/// Store a file in the selected cache without encoding its bytes in the request.
+#[no_mangle]
+pub extern "C" fn once_cache_put_file_json(request_json: *const c_char) -> *mut c_char {
+    run_json::<FilePutRequest, _>(request_json, |request| {
+        let cache = cache_from_selection(request.cache)?;
+        block_on(async {
+            cache
+                .put_file(request.path)
+                .await
+                .map(|digest| digest.to_hex())
+        })
+    })
+}
+
+/// Read a blob from the selected cache.
 #[no_mangle]
 pub extern "C" fn once_cache_get_blob_json(request_json: *const c_char) -> *mut c_char {
     run_json::<DigestRequest, _>(request_json, |request| {
         let digest = digest_from_hex(&request.digest)?;
-        let cache = Cache::new();
+        let cache = cache_from_selection(request.cache)?;
         block_on(async {
             cache
                 .get_blob(digest)
@@ -123,22 +123,32 @@ pub extern "C" fn once_cache_get_blob_json(request_json: *const c_char) -> *mut 
     })
 }
 
-/// Return whether a blob exists in the local cache.
+/// Materialize a blob at a file path without encoding its bytes in the response.
+#[no_mangle]
+pub extern "C" fn once_cache_get_blob_to_file_json(request_json: *const c_char) -> *mut c_char {
+    run_json::<BlobFileRequest, _>(request_json, |request| {
+        let digest = digest_from_hex(&request.digest)?;
+        let cache = cache_from_selection(request.cache)?;
+        block_on(async { cache.get_blob_to_file(digest, request.path).await })
+    })
+}
+
+/// Return whether a blob exists in the selected cache.
 #[no_mangle]
 pub extern "C" fn once_cache_has_blob_json(request_json: *const c_char) -> *mut c_char {
     run_json::<DigestRequest, _>(request_json, |request| {
         let digest = digest_from_hex(&request.digest)?;
-        let cache = Cache::new();
+        let cache = cache_from_selection(request.cache)?;
         block_on(async { cache.has_blob(digest).await })
     })
 }
 
-/// Store an action result in the local cache.
+/// Store an action result in the selected cache.
 #[no_mangle]
 pub extern "C" fn once_cache_put_action_result_json(request_json: *const c_char) -> *mut c_char {
     run_json::<ActionResultPutRequest, _>(request_json, |request| {
         let action = digest_from_hex(&request.action_digest)?;
-        let cache = Cache::new();
+        let cache = cache_from_selection(request.cache)?;
         block_on(async {
             cache
                 .put_action_result(action, &request.result)
@@ -148,40 +158,52 @@ pub extern "C" fn once_cache_put_action_result_json(request_json: *const c_char)
     })
 }
 
-/// Read an action result from the local cache.
+/// Read an action result from the selected cache.
 #[no_mangle]
 pub extern "C" fn once_cache_get_action_result_json(request_json: *const c_char) -> *mut c_char {
     run_json::<ActionDigestRequest, _>(request_json, |request| {
         let action = digest_from_hex(&request.action_digest)?;
-        let cache = Cache::new();
+        let cache = cache_from_selection(request.cache)?;
         block_on(async { cache.get_action_result(action).await })
     })
 }
 
-/// Remove an action result from the local cache.
+/// Remove an action result from the selected cache.
 #[no_mangle]
 pub extern "C" fn once_cache_forget_action_json(request_json: *const c_char) -> *mut c_char {
     run_json::<ActionDigestRequest, _>(request_json, |request| {
         let action = digest_from_hex(&request.action_digest)?;
-        let cache = Cache::new();
+        let cache = cache_from_selection(request.cache)?;
         block_on(async { cache.forget_action(action).await })
     })
 }
 
 /// Return local cache statistics.
 #[no_mangle]
-pub extern "C" fn once_cache_stats_json(_request_json: *const c_char) -> *mut c_char {
-    let cache = Cache::new();
-    match block_on(async {
-        cache.stats().await.map(|stats| StatsResponse {
-            blob_count: stats.blob_count,
-            blob_bytes: stats.blob_bytes,
-            action_count: stats.action_count,
-            action_bytes: stats.action_bytes,
+pub extern "C" fn once_cache_stats_json(request_json: *const c_char) -> *mut c_char {
+    run_json::<CacheRequest, _>(request_json, |request| {
+        let cache = cache_from_selection(request.cache)?;
+        block_on(async {
+            cache.stats().await.map(|stats| StatsResponse {
+                blob_count: stats.blob_count,
+                blob_bytes: stats.blob_bytes,
+                action_count: stats.action_count,
+                action_bytes: stats.action_bytes,
+            })
         })
-    }) {
-        Ok(value) => response_ok(value),
-        Err(error) => response_error(error.to_string()),
+    })
+}
+
+fn cache_from_selection(selection: CacheSelection) -> crate::Result<Cache> {
+    match (selection.local_cache_root, selection.workspace_root) {
+        (None, None) => Ok(Cache::new()),
+        (Some(root), None) => Ok(Cache::local(root)),
+        (None, Some(workspace)) => Cache::from_workspace(workspace),
+        (Some(_), Some(_)) => Err(once_cas::Error::InvalidConfig {
+            provider: "sdk",
+            message: "local_cache_root and workspace_root cannot be used together".to_string(),
+        }
+        .into()),
     }
 }
 
@@ -276,146 +298,10 @@ fn str_from_raw(value: *const c_char, name: &str) -> std::result::Result<String,
     unsafe {
         CStr::from_ptr(value)
             .to_str()
-            .map_err(|_| format!("{name} must be valid UTF-8"))
+            .map_err(|_| format!("{name} must use Unicode Transformation Format, 8-bit"))
             .map(std::borrow::ToOwned::to_owned)
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    fn response_json(response: *mut c_char) -> serde_json::Value {
-        let json = unsafe { CStr::from_ptr(response).to_string_lossy().into_owned() };
-        once_string_free(response);
-        serde_json::from_str(&json).unwrap()
-    }
-
-    #[test]
-    fn version_returns_owned_string() {
-        let response = once_version();
-        let version = unsafe { CStr::from_ptr(response).to_string_lossy().into_owned() };
-        once_string_free(response);
-
-        assert_eq!(version, env!("CARGO_PKG_VERSION"));
-    }
-
-    #[test]
-    fn digest_bytes_returns_json_response() {
-        let response = once_digest_bytes(b"hello".as_ptr(), 5);
-        let json = response_json(response);
-
-        assert_eq!(json["status"], "ok");
-        assert_eq!(json["value"], Digest::of_bytes(b"hello").to_hex());
-    }
-
-    #[test]
-    fn digest_bytes_rejects_null_pointer_with_non_zero_length() {
-        let response = once_digest_bytes(std::ptr::null(), 1);
-        let json = response_json(response);
-
-        assert_eq!(json["status"], "error");
-        assert_eq!(json["message"], "data cannot be null when len is non-zero");
-    }
-
-    #[test]
-    fn cache_request_rejects_invalid_utf8() {
-        let request = [0xff, 0x00];
-        let response = once_cache_put_blob_json(request.as_ptr().cast());
-        let json = response_json(response);
-
-        assert_eq!(json["status"], "error");
-        assert_eq!(json["message"], "request_json must be valid UTF-8");
-    }
-
-    #[test]
-    fn raw_strings_with_interior_null_bytes_return_error_json() {
-        let response = string_to_raw("before\0after");
-        let value = unsafe { CStr::from_ptr(response).to_string_lossy().into_owned() };
-        once_string_free(response);
-
-        assert_eq!(value, RESPONSE_SERIALIZATION_ERROR);
-    }
-
-    #[test]
-    fn put_blob_returns_digest() {
-        let _env_lock = crate::TEST_ENV_LOCK.lock().unwrap();
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::env::set_var("XDG_CACHE_HOME", tmp.path());
-        let request = serde_json::json!({
-            "bytes": [104, 101, 108, 108, 111]
-        })
-        .to_string();
-
-        let response = once_cache_put_blob_json(CString::new(request).unwrap().as_ptr());
-        let json = response_json(response);
-
-        assert_eq!(json["status"], "ok");
-        assert_eq!(json["value"], Digest::of_bytes(b"hello").to_hex());
-        std::env::remove_var("XDG_CACHE_HOME");
-    }
-
-    #[test]
-    fn cache_request_rejects_malformed_json() {
-        let request = CString::new("not json").unwrap();
-        let response = once_cache_put_blob_json(request.as_ptr());
-        let json = response_json(response);
-
-        assert_eq!(json["status"], "error");
-        assert!(!json["message"].as_str().unwrap().is_empty());
-    }
-
-    #[test]
-    fn cache_request_rejects_invalid_digest() {
-        let request = serde_json::json!({
-            "digest": "not-a-digest"
-        })
-        .to_string();
-
-        let response = once_cache_get_blob_json(CString::new(request).unwrap().as_ptr());
-        let json = response_json(response);
-
-        assert_eq!(json["status"], "error");
-        assert_eq!(json["message"], "invalid digest: not-a-digest");
-    }
-
-    #[test]
-    fn action_result_request_rejects_invalid_digest() {
-        let request = serde_json::json!({
-            "action_digest": "not-a-digest",
-            "result": {
-                "exit_code": 0,
-                "stdout": null,
-                "stderr": null,
-                "outputs": {}
-            }
-        })
-        .to_string();
-
-        let response = once_cache_put_action_result_json(CString::new(request).unwrap().as_ptr());
-        let json = response_json(response);
-
-        assert_eq!(json["status"], "error");
-        assert_eq!(json["message"], "invalid digest: not-a-digest");
-    }
-
-    #[test]
-    fn cache_calls_can_initialize_runtime_concurrently() {
-        let _env_lock = crate::TEST_ENV_LOCK.lock().unwrap();
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::env::set_var("XDG_CACHE_HOME", tmp.path());
-        let request = CString::new(r#"{"bytes":[104,101,108,108,111]}"#).unwrap();
-
-        std::thread::scope(|scope| {
-            for _ in 0..8 {
-                let request = &request;
-                scope.spawn(move || {
-                    let json = response_json(once_cache_put_blob_json(request.as_ptr()));
-                    assert_eq!(json["status"], "ok");
-                    assert_eq!(json["value"], Digest::of_bytes(b"hello").to_hex());
-                });
-            }
-        });
-
-        std::env::remove_var("XDG_CACHE_HOME");
-    }
-}
+mod tests;

--- a/crates/once/src/ffi/protocol.rs
+++ b/crates/once/src/ffi/protocol.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use once_cas::ActionResult;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct CacheSelection {
+    pub(super) local_cache_root: Option<PathBuf>,
+    pub(super) workspace_root: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct CacheRequest {
+    #[serde(flatten)]
+    pub(super) cache: CacheSelection,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BlobPutRequest {
+    #[serde(flatten)]
+    pub(super) cache: CacheSelection,
+    pub(super) bytes: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct DigestRequest {
+    #[serde(flatten)]
+    pub(super) cache: CacheSelection,
+    pub(super) digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct FilePutRequest {
+    #[serde(flatten)]
+    pub(super) cache: CacheSelection,
+    pub(super) path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BlobFileRequest {
+    #[serde(flatten)]
+    pub(super) cache: CacheSelection,
+    pub(super) digest: String,
+    pub(super) path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ActionResultPutRequest {
+    #[serde(flatten)]
+    pub(super) cache: CacheSelection,
+    pub(super) action_digest: String,
+    pub(super) result: ActionResult,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ActionDigestRequest {
+    #[serde(flatten)]
+    pub(super) cache: CacheSelection,
+    pub(super) action_digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ActionKeyRequest {
+    pub(super) namespace: String,
+    pub(super) inputs: Vec<ActionKeyInputRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(super) enum ActionKeyInputRequest {
+    Bytes { label: String, bytes: Vec<u8> },
+    Digest { label: String, digest: String },
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct BlobResponse {
+    pub(super) bytes: Vec<u8>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct StatsResponse {
+    pub(super) blob_count: u64,
+    pub(super) blob_bytes: u64,
+    pub(super) action_count: u64,
+    pub(super) action_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub(super) enum FfiResponse<T> {
+    Ok { value: T },
+    Error { message: String },
+}

--- a/crates/once/src/ffi/tests.rs
+++ b/crates/once/src/ffi/tests.rs
@@ -1,0 +1,215 @@
+use super::*;
+
+fn response_json(response: *mut c_char) -> serde_json::Value {
+    let json = unsafe { CStr::from_ptr(response).to_string_lossy().into_owned() };
+    once_string_free(response);
+    serde_json::from_str(&json).unwrap()
+}
+
+#[test]
+fn version_returns_owned_string() {
+    let response = once_version();
+    let version = unsafe { CStr::from_ptr(response).to_string_lossy().into_owned() };
+    once_string_free(response);
+
+    assert_eq!(version, env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn digest_bytes_returns_json_response() {
+    let response = once_digest_bytes(b"hello".as_ptr(), 5);
+    let json = response_json(response);
+
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["value"], Digest::of_bytes(b"hello").to_hex());
+}
+
+#[test]
+fn digest_bytes_rejects_null_pointer_with_non_zero_length() {
+    let response = once_digest_bytes(std::ptr::null(), 1);
+    let json = response_json(response);
+
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["message"], "data cannot be null when len is non-zero");
+}
+
+#[test]
+fn action_key_matches_rust_builder() {
+    let request = serde_json::json!({
+        "namespace": "compile",
+        "inputs": [
+            {"kind": "bytes", "label": "tool", "bytes": [115, 119, 105, 102, 116, 99]},
+            {"kind": "digest", "label": "source", "digest": Digest::of_bytes(b"source").to_hex()}
+        ]
+    })
+    .to_string();
+    let response = once_action_key_json(CString::new(request).unwrap().as_ptr());
+    let json = response_json(response);
+    let mut expected = ActionKeyBuilder::new("compile");
+    expected
+        .push_bytes("tool", "swiftc")
+        .push_digest("source", Digest::of_bytes(b"source"));
+
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["value"], expected.finish().to_hex());
+}
+
+#[test]
+fn cache_request_rejects_invalid_utf8() {
+    let request = [0xff, 0x00];
+    let response = once_cache_put_blob_json(request.as_ptr().cast());
+    let json = response_json(response);
+
+    assert_eq!(json["status"], "error");
+    assert_eq!(
+        json["message"],
+        "request_json must use Unicode Transformation Format, 8-bit"
+    );
+}
+
+#[test]
+fn raw_strings_with_interior_null_bytes_return_error_json() {
+    let response = string_to_raw("before\0after");
+    let value = unsafe { CStr::from_ptr(response).to_string_lossy().into_owned() };
+    once_string_free(response);
+
+    assert_eq!(value, RESPONSE_SERIALIZATION_ERROR);
+}
+
+#[test]
+fn put_blob_returns_digest() {
+    let _env_lock = crate::TEST_ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("XDG_CACHE_HOME", tmp.path());
+    let request = serde_json::json!({
+        "bytes": [104, 101, 108, 108, 111]
+    })
+    .to_string();
+
+    let response = once_cache_put_blob_json(CString::new(request).unwrap().as_ptr());
+    let json = response_json(response);
+
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["value"], Digest::of_bytes(b"hello").to_hex());
+    std::env::remove_var("XDG_CACHE_HOME");
+}
+
+#[test]
+fn explicit_root_and_file_operations_roundtrip() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let cache_root = tmp.path().join("cache");
+    let input = tmp.path().join("input.bin");
+    let output = tmp.path().join("nested/output.bin");
+    std::fs::write(&input, b"file payload").unwrap();
+    let put_request = serde_json::json!({
+        "local_cache_root": cache_root,
+        "path": input
+    })
+    .to_string();
+
+    let put = response_json(once_cache_put_file_json(
+        CString::new(put_request).unwrap().as_ptr(),
+    ));
+    let get_request = serde_json::json!({
+        "local_cache_root": tmp.path().join("cache"),
+        "digest": put["value"],
+        "path": output
+    })
+    .to_string();
+    let get = response_json(once_cache_get_blob_to_file_json(
+        CString::new(get_request).unwrap().as_ptr(),
+    ));
+
+    assert_eq!(put["status"], "ok");
+    assert_eq!(get["status"], "ok");
+    assert_eq!(get["value"], 12);
+    assert_eq!(
+        std::fs::read(tmp.path().join("nested/output.bin")).unwrap(),
+        b"file payload"
+    );
+}
+
+#[test]
+fn cache_selection_rejects_two_roots() {
+    let request = serde_json::json!({
+        "local_cache_root": "/tmp/local",
+        "workspace_root": "/tmp/workspace",
+        "bytes": []
+    })
+    .to_string();
+
+    let response = response_json(once_cache_put_blob_json(
+        CString::new(request).unwrap().as_ptr(),
+    ));
+
+    assert_eq!(response["status"], "error");
+    assert!(response["message"]
+        .as_str()
+        .unwrap()
+        .contains("cannot be used together"));
+}
+
+#[test]
+fn cache_request_rejects_malformed_json() {
+    let request = CString::new("not json").unwrap();
+    let response = once_cache_put_blob_json(request.as_ptr());
+    let json = response_json(response);
+
+    assert_eq!(json["status"], "error");
+    assert!(!json["message"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn cache_request_rejects_invalid_digest() {
+    let request = serde_json::json!({
+        "digest": "not-a-digest"
+    })
+    .to_string();
+
+    let response = once_cache_get_blob_json(CString::new(request).unwrap().as_ptr());
+    let json = response_json(response);
+
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["message"], "invalid digest: not-a-digest");
+}
+
+#[test]
+fn action_result_request_rejects_invalid_digest() {
+    let request = serde_json::json!({
+        "action_digest": "not-a-digest",
+        "result": {
+            "exit_code": 0,
+            "stdout": null,
+            "stderr": null,
+            "outputs": {}
+        }
+    })
+    .to_string();
+
+    let response = once_cache_put_action_result_json(CString::new(request).unwrap().as_ptr());
+    let json = response_json(response);
+
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["message"], "invalid digest: not-a-digest");
+}
+
+#[test]
+fn cache_calls_can_initialize_runtime_concurrently() {
+    let _env_lock = crate::TEST_ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("XDG_CACHE_HOME", tmp.path());
+    let request = CString::new(r#"{"bytes":[104,101,108,108,111]}"#).unwrap();
+
+    std::thread::scope(|scope| {
+        for _ in 0..8 {
+            let request = &request;
+            scope.spawn(move || {
+                let json = response_json(once_cache_put_blob_json(request.as_ptr()));
+                assert_eq!(json["status"], "ok");
+                assert_eq!(json["value"], Digest::of_bytes(b"hello").to_hex());
+            });
+        }
+    });
+
+    std::env::remove_var("XDG_CACHE_HOME");
+}

--- a/crates/once/src/lib.rs
+++ b/crates/once/src/lib.rs
@@ -1,7 +1,7 @@
 //! Embed Once in Rust, Swift, Objective-C, or C.
 //!
-//! The Rust API gives embedders a small, stable entry point for cache
-//! access.
+//! The Rust programming interface gives embedders a small, stable entry point
+//! for cache access.
 //!
 //! ```no_run
 //! # async fn example() -> once::Result<()> {
@@ -13,154 +13,13 @@
 //! # }
 //! ```
 
-use std::path::{Path, PathBuf};
+pub use action_key::ActionKeyBuilder;
+pub use cache::{digest_from_hex, Cache, Error, Result};
+pub use once_cas::{ActionResult, CacheProvider, Digest, Stats, TuistCacheConfig};
 
-pub use once_cas::{ActionResult, CacheProvider, Digest, Stats};
-
+mod action_key;
+mod cache;
 mod ffi;
 
 #[cfg(test)]
 static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Result type used by the high-level Once SDK.
-pub type Result<T> = std::result::Result<T, Error>;
-
-/// Errors returned by the high-level Once SDK.
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("invalid digest: {0}")]
-    InvalidDigest(String),
-    #[error(transparent)]
-    Cache(#[from] once_cas::Error),
-}
-
-/// Embeddable Once cache client.
-///
-/// `Cache` is cheap to clone and can be reused across many cache
-/// operations. The default constructor opens the local filesystem cache
-/// at `$XDG_CACHE_HOME/once/cas`, or `$HOME/.cache/once/cas` when
-/// `XDG_CACHE_HOME` is not set.
-#[derive(Clone)]
-pub struct Cache {
-    cache: CacheProvider,
-}
-
-impl Cache {
-    /// Create a client backed by Once's default XDG local cache.
-    pub fn new() -> Self {
-        Self::with_provider(CacheProvider::open_local(default_cache_root()))
-    }
-
-    /// Create a client with an explicit cache provider.
-    pub fn with_provider(cache: CacheProvider) -> Self {
-        Self { cache }
-    }
-
-    /// Cache provider used by this client.
-    pub fn provider(&self) -> &CacheProvider {
-        &self.cache
-    }
-
-    /// Root directory used by the underlying provider.
-    pub fn root(&self) -> &Path {
-        self.cache.root()
-    }
-
-    /// Store a blob and return its content digest.
-    pub async fn put_blob(&self, bytes: &[u8]) -> Result<Digest> {
-        Ok(self.cache.put_blob(bytes).await?)
-    }
-
-    /// Read a blob by digest.
-    pub async fn get_blob(&self, digest: Digest) -> Result<Vec<u8>> {
-        Ok(self.cache.get_blob(&digest).await?)
-    }
-
-    /// Return whether a blob exists.
-    pub async fn has_blob(&self, digest: Digest) -> Result<bool> {
-        Ok(self.cache.has_blob(&digest).await?)
-    }
-
-    /// Store the cached result for an action digest.
-    pub async fn put_action_result(&self, action: Digest, result: &ActionResult) -> Result<()> {
-        Ok(self.cache.put_action_result(&action, result).await?)
-    }
-
-    /// Read the cached result for an action digest.
-    pub async fn get_action_result(&self, action: Digest) -> Result<Option<ActionResult>> {
-        Ok(self.cache.get_action_result(&action).await?)
-    }
-
-    /// Remove one cached action result, leaving referenced blobs intact.
-    pub async fn forget_action(&self, action: Digest) -> Result<bool> {
-        Ok(self.cache.forget_action(&action).await?)
-    }
-
-    /// Return local cache statistics.
-    pub async fn stats(&self) -> Result<Stats> {
-        Ok(self.cache.stats().await?)
-    }
-}
-
-impl Default for Cache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Parse a lowercase BLAKE3 hex digest.
-pub fn digest_from_hex(hex: &str) -> Result<Digest> {
-    Digest::from_hex(hex).ok_or_else(|| Error::InvalidDigest(hex.to_string()))
-}
-
-fn default_cache_root() -> PathBuf {
-    once_core::Xdg::from_env().once_cas()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::BTreeMap;
-
-    #[test]
-    fn default_cache_uses_xdg_cas_root() {
-        let _env_lock = TEST_ENV_LOCK.lock().unwrap();
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::env::set_var("XDG_CACHE_HOME", tmp.path());
-        let cache = Cache::new();
-
-        assert_eq!(cache.root(), tmp.path().join("once").join("cas"));
-        std::env::remove_var("XDG_CACHE_HOME");
-    }
-
-    #[tokio::test]
-    async fn stores_and_reads_blobs() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let cache = Cache::with_provider(CacheProvider::open_local(tmp.path()));
-
-        let digest = cache.put_blob(b"hello").await.unwrap();
-
-        assert!(cache.has_blob(digest).await.unwrap());
-        assert_eq!(cache.get_blob(digest).await.unwrap(), b"hello");
-    }
-
-    #[tokio::test]
-    async fn stores_and_reads_action_results() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let cache = Cache::with_provider(CacheProvider::open_local(tmp.path()));
-        let stdout = cache.put_blob(b"out").await.unwrap();
-        let action = Digest::of_bytes(b"action");
-        let result = ActionResult {
-            exit_code: 0,
-            stdout: Some(stdout),
-            stderr: None,
-            outputs: BTreeMap::new(),
-        };
-
-        cache.put_action_result(action, &result).await.unwrap();
-
-        assert_eq!(cache.get_action_result(action).await.unwrap(), Some(result));
-        assert!(cache.forget_action(action).await.unwrap());
-        assert_eq!(cache.get_action_result(action).await.unwrap(), None);
-    }
-}

--- a/crates/once/swift/Once.swift
+++ b/crates/once/swift/Once.swift
@@ -7,11 +7,28 @@ public enum OnceError: Error, Equatable {
 }
 
 public struct OnceCache: Sendable {
-    /// Creates a cache client backed by the default XDG cache location.
+    private let localCacheRoot: String?
+    private let workspaceRoot: String?
+
+    /// Creates a cache client backed by the default base-directory cache location.
     ///
     /// The local cache root is `$XDG_CACHE_HOME/once/cas` when
     /// `XDG_CACHE_HOME` is set, and `$HOME/.cache/once/cas` otherwise.
     public init() {
+        self.localCacheRoot = nil
+        self.workspaceRoot = nil
+    }
+
+    /// Creates a cache client backed by a caller-owned local root.
+    public init(localCacheRoot: URL) {
+        self.localCacheRoot = localCacheRoot.path
+        self.workspaceRoot = nil
+    }
+
+    /// Creates a cache client using the effective provider for a workspace.
+    public init(workspaceRoot: URL) {
+        self.localCacheRoot = nil
+        self.workspaceRoot = workspaceRoot.path
     }
 
     /// Returns the linked Once version.
@@ -41,20 +58,59 @@ public struct OnceCache: Sendable {
     /// Stores bytes and returns their content digest.
     @discardableResult
     public func putBlob(_ bytes: Data) async throws -> String {
-        let request = BlobPutRequest(bytes: Array(bytes))
+        let request = BlobPutRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
+            bytes: Array(bytes)
+        )
         return try await decodeRequestAsync(request, with: once_cache_put_blob_json, as: String.self)
+    }
+
+    /// Stores a file without loading its complete contents into Swift memory.
+    @discardableResult
+    public func putBlob(contentsOf url: URL) async throws -> String {
+        let request = FilePutRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
+            path: url.path
+        )
+        return try await decodeRequestAsync(request, with: once_cache_put_file_json, as: String.self)
     }
 
     /// Reads bytes for a digest.
     public func getBlob(_ digest: String) async throws -> Data {
-        let request = DigestRequest(digest: digest)
+        let request = DigestRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
+            digest: digest
+        )
         let response = try await decodeRequestAsync(request, with: once_cache_get_blob_json, as: BlobResponse.self)
         return Data(response.bytes)
     }
 
+    /// Materializes a blob at a file location and returns the number of bytes written.
+    @discardableResult
+    public func getBlob(_ digest: String, writeTo url: URL) async throws -> UInt64 {
+        let request = BlobFileRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
+            digest: digest,
+            path: url.path
+        )
+        return try await decodeRequestAsync(
+            request,
+            with: once_cache_get_blob_to_file_json,
+            as: UInt64.self
+        )
+    }
+
     /// Returns whether a blob exists.
     public func hasBlob(_ digest: String) async throws -> Bool {
-        let request = DigestRequest(digest: digest)
+        let request = DigestRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
+            digest: digest
+        )
         return try await decodeRequestAsync(request, with: once_cache_has_blob_json, as: Bool.self)
     }
 
@@ -62,6 +118,8 @@ public struct OnceCache: Sendable {
     @discardableResult
     public func putActionResult(_ result: OnceActionResult, for actionDigest: String) async throws -> Bool {
         let request = ActionResultPutRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
             actionDigest: actionDigest,
             result: result
         )
@@ -70,7 +128,11 @@ public struct OnceCache: Sendable {
 
     /// Returns a cached result when one exists.
     public func getActionResult(_ actionDigest: String) async throws -> OnceActionResult? {
-        let request = ActionDigestRequest(actionDigest: actionDigest)
+        let request = ActionDigestRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
+            actionDigest: actionDigest
+        )
         return try await decodeRequestAsync(
             request,
             with: once_cache_get_action_result_json,
@@ -81,13 +143,58 @@ public struct OnceCache: Sendable {
     /// Removes one cached action result.
     @discardableResult
     public func forgetAction(_ actionDigest: String) async throws -> Bool {
-        let request = ActionDigestRequest(actionDigest: actionDigest)
+        let request = ActionDigestRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot,
+            actionDigest: actionDigest
+        )
         return try await decodeRequestAsync(request, with: once_cache_forget_action_json, as: Bool.self)
     }
 
     /// Returns local cache statistics.
     public func stats() async throws -> OnceCacheStats {
-        return try await decodeRequestAsync(EmptyRequest(), with: once_cache_stats_json, as: OnceCacheStats.self)
+        let request = CacheRequest(
+            localCacheRoot: localCacheRoot,
+            workspaceRoot: workspaceRoot
+        )
+        return try await decodeRequestAsync(request, with: once_cache_stats_json, as: OnceCacheStats.self)
+    }
+}
+
+public struct OnceActionKey: Sendable {
+    private let namespace: String
+    private var inputs: [ActionKeyInputRequest]
+
+    public init(namespace: String) {
+        self.namespace = namespace
+        self.inputs = []
+    }
+
+    public mutating func add(bytes: Data, label: String) {
+        inputs.append(
+            ActionKeyInputRequest(
+                kind: "bytes",
+                label: label,
+                bytes: Array(bytes),
+                digest: nil
+            )
+        )
+    }
+
+    public mutating func add(digest: String, label: String) {
+        inputs.append(
+            ActionKeyInputRequest(
+                kind: "digest",
+                label: label,
+                bytes: nil,
+                digest: digest
+            )
+        )
+    }
+
+    public func digest() async throws -> String {
+        let request = ActionKeyRequest(namespace: namespace, inputs: inputs)
+        return try await decodeRequestAsync(request, with: once_action_key_json, as: String.self)
     }
 }
 
@@ -119,11 +226,21 @@ public struct OnceCacheStats: Decodable, Sendable, Equatable {
 
 private typealias CJSONFunction = @convention(c) (UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
-private struct EmptyRequest: Encodable, Sendable {
+private struct CacheRequest: Encodable, Sendable {
+    let localCacheRoot: String?
+    let workspaceRoot: String?
 }
 
 private struct BlobPutRequest: Encodable, Sendable {
+    let localCacheRoot: String?
+    let workspaceRoot: String?
     let bytes: [UInt8]
+}
+
+private struct FilePutRequest: Encodable, Sendable {
+    let localCacheRoot: String?
+    let workspaceRoot: String?
+    let path: String
 }
 
 private struct BlobResponse: Decodable, Sendable {
@@ -131,16 +248,41 @@ private struct BlobResponse: Decodable, Sendable {
 }
 
 private struct DigestRequest: Encodable, Sendable {
+    let localCacheRoot: String?
+    let workspaceRoot: String?
     let digest: String
 }
 
+private struct BlobFileRequest: Encodable, Sendable {
+    let localCacheRoot: String?
+    let workspaceRoot: String?
+    let digest: String
+    let path: String
+}
+
 private struct ActionResultPutRequest: Encodable, Sendable {
+    let localCacheRoot: String?
+    let workspaceRoot: String?
     let actionDigest: String
     let result: OnceActionResult
 }
 
 private struct ActionDigestRequest: Encodable, Sendable {
+    let localCacheRoot: String?
+    let workspaceRoot: String?
     let actionDigest: String
+}
+
+private struct ActionKeyRequest: Encodable, Sendable {
+    let namespace: String
+    let inputs: [ActionKeyInputRequest]
+}
+
+private struct ActionKeyInputRequest: Encodable, Sendable {
+    let kind: String
+    let label: String
+    let bytes: [UInt8]?
+    let digest: String?
 }
 
 private enum OnceResponse<Value: Decodable>: Decodable {

--- a/docs/guide/sdk/c.md
+++ b/docs/guide/sdk/c.md
@@ -59,9 +59,8 @@ these optional fields to any cache request:
 | `local_cache_root` | Opens an isolated local cache at this path. |
 | `workspace_root` | Resolves the same effective provider as the command line for this workspace. |
 
-The workspace selection considers the process override, workspace
-infrastructure, compatible Tuist project configuration, and the user default
-in that order.
+The workspace selection follows the provider precedence described in the
+[language-library overview](/guide/sdk/).
 
 ## Blobs
 
@@ -98,4 +97,8 @@ be passed to the action-result functions:
 | `once_cache_put_action_result_json` | Stores action metadata under `action_digest`. |
 | `once_cache_get_action_result_json` | Returns action metadata when it exists. |
 | `once_cache_forget_action_json` | Removes action metadata without deleting referenced blobs. |
-| `once_cache_stats_json` | Returns statistics for the local cache tier. |
+
+## Statistics
+
+`once_cache_stats_json` reports statistics for the local cache tier. It takes
+no action digest and describes the local tier only.

--- a/docs/guide/sdk/c.md
+++ b/docs/guide/sdk/c.md
@@ -83,7 +83,7 @@ Use the file functions for payloads whose size is not tightly bounded.
 {
   "namespace": "example.compile",
   "inputs": [
-    { "kind": "bytes", "label": "compiler", "bytes": [115, 119, 105, 102, 116, 99] },
+    { "kind": "bytes", "label": "tool", "bytes": [99, 111, 109, 112, 105, 108, 101, 114] },
     { "kind": "digest", "label": "source", "digest": "<64 lowercase hexadecimal characters>" }
   ]
 }

--- a/docs/guide/sdk/c.md
+++ b/docs/guide/sdk/c.md
@@ -1,0 +1,101 @@
+---
+prev: false
+next: false
+---
+
+# C Software Development Kit
+
+The C library is the lowest-level supported language binding. Link `libonce`
+and include `once.h` when an application needs direct cache access without a
+language wrapper. Script and graph execution remain command-line features.
+
+Build or obtain the shared or static `libonce` library, then use `once.h` from
+the matching tagged source distribution. Add both to the host build system.
+
+## Store A First Blob
+
+This complete example stores `hello` in the default local cache and prints the
+response:
+
+```c
+#include <once.h>
+#include <stdio.h>
+
+int main(void) {
+    const char *request = "{\"bytes\":[104,101,108,108,111]}";
+    char *response = once_cache_put_blob_json(request);
+
+    puts(response);
+    once_string_free(response);
+    return 0;
+}
+```
+
+## Ownership And Responses
+
+Every `once_*` function that returns `char *` returns an owned
+[Unicode Transformation Format, 8-bit](https://www.unicode.org/faq/utf_bom.html#UTF8)
+string. Release it with `once_string_free`, including error responses.
+
+Cache and action-key requests use
+[JavaScript Object Notation](https://www.json.org/json-en.html). Responses have
+one of these shapes:
+
+```json
+{ "status": "ok", "value": "..." }
+```
+
+```json
+{ "status": "error", "message": "..." }
+```
+
+## Cache Selection
+
+Omit cache-selection fields to use the default local cache. Add exactly one of
+these optional fields to any cache request:
+
+| Field | Use |
+| --- | --- |
+| `local_cache_root` | Opens an isolated local cache at this path. |
+| `workspace_root` | Resolves the same effective provider as the command line for this workspace. |
+
+The workspace selection considers the process override, workspace
+infrastructure, compatible Tuist project configuration, and the user default
+in that order.
+
+## Blobs
+
+| Function | Use |
+| --- | --- |
+| `once_digest_bytes` | Hashes a byte buffer without touching storage. |
+| `once_cache_put_blob_json` | Stores the `bytes` array from a request. |
+| `once_cache_put_file_json` | Stores the file at `path` without structured-text byte expansion. |
+| `once_cache_get_blob_json` | Returns a blob as a `bytes` array. |
+| `once_cache_get_blob_to_file_json` | Writes a blob to `path` and returns its byte count. |
+| `once_cache_has_blob_json` | Returns whether a digest exists. |
+
+Use the file functions for payloads whose size is not tightly bounded.
+
+## Action Keys And Results
+
+`once_action_key_json` accepts a namespace and ordered inputs:
+
+```json
+{
+  "namespace": "example.compile",
+  "inputs": [
+    { "kind": "bytes", "label": "compiler", "bytes": [115, 119, 105, 102, 116, 99] },
+    { "kind": "digest", "label": "source", "digest": "<64 lowercase hexadecimal characters>" }
+  ]
+}
+```
+
+Input order is significant and must be deterministic. The returned digest can
+be passed to the action-result functions:
+
+| Function | Use |
+| --- | --- |
+| `once_cache_put_action_result_json` | Stores action metadata under `action_digest`. |
+| `once_cache_get_action_result_json` | Returns action metadata when it exists. |
+| `once_cache_forget_action_json` | Removes action metadata without deleting referenced blobs. |
+| `once_cache_stats_json` | Returns statistics for the local cache tier. |

--- a/docs/guide/sdk/index.md
+++ b/docs/guide/sdk/index.md
@@ -12,7 +12,12 @@ sessions.
 
 The language libraries intentionally expose the same small cache surface:
 
+- Open the default local cache, an isolated local root, or the effective
+  provider configured for a workspace.
 - Store and retrieve content-addressed byte payloads.
+- Store and materialize files without loading their complete contents into the
+  host language.
+- Build versioned action keys from labeled values and content digests.
 - Associate an action digest with a completed action result.
 - Remove an action result without deleting its referenced payloads.
 - Inspect local cache statistics.
@@ -27,17 +32,32 @@ They do not execute commands or load the repository graph.
 | Swift | `Once.xcframework` and the matching Swift wrapper | Asynchronous | [Swift](/guide/sdk/swift) |
 | Ruby | `buildonce` gem | Synchronous | [Ruby](/guide/sdk/ruby) |
 | JavaScript | `buildonce` package for Node.js | Promise-based | [JavaScript](/guide/sdk/javascript) |
+| C | `libonce` and `once.h` | Synchronous | [C](/guide/sdk/c) |
 
-Choose the binding used by the process that owns the integration. All four
+Choose the binding used by the process that owns the integration. All
 bindings use compatible digests and action-result concepts, so separate tools
 can share a configured cache without translating records.
 
+## Choose A Cache
+
+The default constructor preserves the lightweight local behavior of earlier
+releases. Use an explicit local root for test isolation or caller-owned cache
+lifetimes. Use a workspace constructor when the integration must share the
+same effective provider as the command line. Workspace selection considers
+the process override, workspace infrastructure, compatible Tuist project
+configuration, and the user default in that order.
+
+Statistics describe the local tier. Remote uploads are best effort: a
+configured remote provider writes through the local tier and keeps the local
+write usable when the remote service is unavailable. Streamed inputs larger
+than eight mebibytes remain in the local tier to preserve bounded memory use.
+
 ## Before You Embed Once
 
-An application using the cache is responsible for defining stable action
-payloads and deciding which inputs affect them. The library stores completed
-results, but it cannot determine whether an application omitted an input or
-whether replaying a result is safe.
+Use the action-key builder to partition each integration by namespace and add
+every input that can affect the result. Input order is significant and must be
+deterministic. The library cannot determine whether an application omitted an
+input or whether replaying a result is safe.
 
 Start with the smallest useful operation in the language guide, then add
 action-result storage only after the application has a deterministic action

--- a/docs/guide/sdk/javascript.md
+++ b/docs/guide/sdk/javascript.md
@@ -36,27 +36,53 @@ platforms. Set `ONCE_LIBRARY_PATH` when you need to load a custom
 
 ## Cache
 
-`Cache` opens the default local cache using the
-[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/). The default
-cache root is `$XDG_CACHE_HOME/once/cas` when `XDG_CACHE_HOME` is set, and
+`Cache` can open the default local cache, an explicit local root, or the
+effective provider for a workspace. The default follows the
+[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/):
+its cache root is `$XDG_CACHE_HOME/once/cas` when `XDG_CACHE_HOME` is set, and
 `$HOME/.cache/once/cas` otherwise.
 
 `version()` and `digest(bytes)` are synchronous. Cache storage operations
 return promises and must be awaited. When `bytes` is a string, the library
-encodes it as UTF-8 before hashing or storing it.
+encodes it using [Unicode Transformation Format, 8-bit](https://www.unicode.org/faq/utf_bom.html#UTF8)
+before hashing or storing it.
 
 | Application programming interface | Use |
 | --- | --- |
 | `new Cache()` | Opens the default local cache using the operating-system convention. |
+| `new Cache({ localCacheRoot })` | Opens an isolated local cache at a caller-owned root. |
+| `new Cache({ workspaceRoot })` | Resolves the effective provider for a workspace. |
 | `version()` | Synchronously returns the linked Once version. |
 | `digest(bytes)` | Synchronously returns the content digest for bytes without writing them to the cache. |
 | `putBlob(bytes)` | Stores bytes and returns a promise for their content digest. |
+| `putFile(path)` | Stores a file without loading its complete contents into JavaScript memory. |
 | `getBlob(digest)` | Reads bytes for a digest and returns a promise. |
+| `getBlobToFile(digest, path)` | Writes a blob to a file and returns a promise for its byte count. |
 | `hasBlob(digest)` | Returns a promise for whether a blob exists. |
 | `putActionResult(result, actionDigest)` | Stores a cached result for an action digest and returns a promise. |
 | `getActionResult(actionDigest)` | Returns a promise for a cached result when one exists. |
 | `forgetAction(actionDigest)` | Removes one cached action result and returns a promise. Referenced blobs are left intact. |
 | `stats()` | Returns a promise for local cache statistics. |
+
+Prefer `putFile` and `getBlobToFile` for logs, archives, compiler outputs, and
+other payloads whose size is not tightly bounded.
+
+## Action Keys
+
+`ActionKey` builds a synchronous, versioned identity from ordered, labeled
+inputs:
+
+```js
+const { ActionKey } = require("buildonce");
+
+const source = await cache.putFile("Sources/App.swift");
+const actionDigest = new ActionKey("example.compile")
+  .addBytes("compiler", "swiftc")
+  .addDigest("source", source)
+  .digest();
+```
+
+Input order is significant and must be deterministic.
 
 ## Types
 

--- a/docs/guide/sdk/javascript.md
+++ b/docs/guide/sdk/javascript.md
@@ -75,9 +75,9 @@ inputs:
 ```js
 const { ActionKey } = require("buildonce");
 
-const source = await cache.putFile("Sources/App.swift");
+const source = await cache.putFile("inputs/source");
 const actionDigest = new ActionKey("example.compile")
-  .addBytes("compiler", "swiftc")
+  .addBytes("tool", "compiler")
   .addDigest("source", source)
   .digest();
 ```

--- a/docs/guide/sdk/ruby.md
+++ b/docs/guide/sdk/ruby.md
@@ -68,9 +68,9 @@ and other payloads whose size is not tightly bounded.
 `Once::ActionKey` builds a versioned identity from ordered, labeled inputs:
 
 ```ruby
-source = cache.put_file("Sources/App.swift")
+source = cache.put_file("inputs/source")
 action_digest = Once::ActionKey.new("example.compile")
-                               .add_bytes("compiler", "swiftc")
+                               .add_bytes("tool", "compiler")
                                .add_digest("source", source)
                                .digest
 ```

--- a/docs/guide/sdk/ruby.md
+++ b/docs/guide/sdk/ruby.md
@@ -33,9 +33,10 @@ Set `ONCE_LIBRARY_PATH` when you need to load a custom `libonce` build.
 
 ## Cache
 
-`Once::Cache` opens the default local cache using the
-[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/). The
-default cache root is `$XDG_CACHE_HOME/once/cas` when `XDG_CACHE_HOME` is
+`Once::Cache` can open the default local cache, an explicit local root, or the
+effective provider for a workspace. The default follows the
+[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/):
+its cache root is `$XDG_CACHE_HOME/once/cas` when `XDG_CACHE_HOME` is
 set, and `$HOME/.cache/once/cas` otherwise.
 
 Ruby methods are synchronous. `digest(bytes)` only hashes bytes and
@@ -45,15 +46,36 @@ string's byte representation.
 | Application programming interface | Use |
 | --- | --- |
 | `Once::Cache.new` | Opens the default local cache using the operating-system convention. |
+| `Once::Cache.new(local_cache_root:)` | Opens an isolated local cache at a caller-owned root. |
+| `Once::Cache.new(workspace_root:)` | Resolves the effective provider for a workspace. |
 | `version` | Returns the linked Once version. |
 | `digest(bytes)` | Returns the content digest for bytes without writing them to the cache. |
 | `put_blob(bytes)` | Stores bytes and returns their content digest. |
+| `put_file(path)` | Stores a file without loading its complete contents into Ruby memory. |
 | `get_blob(digest)` | Reads bytes for a digest. |
+| `get_blob_to_file(digest, path)` | Writes a blob to a file and returns its byte count. |
 | `has_blob?(digest)` | Returns whether a blob exists. |
 | `put_action_result(result, action_digest:)` | Stores a cached result for an action digest. |
 | `get_action_result(action_digest)` | Returns a cached result when one exists. |
 | `forget_action(action_digest)` | Removes one cached action result. Referenced blobs are left intact. |
 | `stats` | Returns local cache statistics. |
+
+Prefer `put_file` and `get_blob_to_file` for logs, archives, compiler outputs,
+and other payloads whose size is not tightly bounded.
+
+## Action Keys
+
+`Once::ActionKey` builds a versioned identity from ordered, labeled inputs:
+
+```ruby
+source = cache.put_file("Sources/App.swift")
+action_digest = Once::ActionKey.new("example.compile")
+                               .add_bytes("compiler", "swiftc")
+                               .add_digest("source", source)
+                               .digest
+```
+
+Input order is significant and must be deterministic.
 
 ## Types
 

--- a/docs/guide/sdk/rust.md
+++ b/docs/guide/sdk/rust.md
@@ -49,7 +49,7 @@ constructor uses the same effective configuration as the command line.
 | --- | --- |
 | `Cache::new()` | Opens the default local cache using the operating-system convention. |
 | `Cache::local(root)` | Opens an isolated local cache at a caller-owned root. |
-| `Cache::from_workspace(root)` | Resolves the effective workspace, user, or process-selected provider. |
+| `Cache::from_workspace(root)` | Resolves the same effective provider as the command line for this workspace. |
 | `Cache::with_provider(cache)` | Wraps an existing `CacheProvider`. |
 
 The default follows the

--- a/docs/guide/sdk/rust.md
+++ b/docs/guide/sdk/rust.md
@@ -93,10 +93,10 @@ Start with a namespace owned by the integration, then add labeled values and
 content digests in deterministic order.
 
 ```rust
-let source = cache.put_file("Sources/App.swift").await?;
+let source = cache.put_file("inputs/source").await?;
 let mut key = once::ActionKeyBuilder::new("example.compile");
-key.push_bytes("compiler", "swiftc")
-    .push_bytes("configuration", "debug")
+key.push_bytes("tool", "compiler")
+    .push_bytes("configuration", "release")
     .push_digest("source", source);
 let action = key.finish();
 ```

--- a/docs/guide/sdk/rust.md
+++ b/docs/guide/sdk/rust.md
@@ -42,17 +42,19 @@ be reused across blob and action-result operations.
 
 ### Constructors
 
-Choose a constructor based on who owns the cache location. Most
-applications should use the default based on the
-[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/)
-and only pass a path when they need isolation or deterministic test setup.
+Choose a constructor based on who owns provider selection. The workspace
+constructor uses the same effective configuration as the command line.
 
 | Application programming interface | Use |
 | --- | --- |
 | `Cache::new()` | Opens the default local cache using the operating-system convention. |
+| `Cache::local(root)` | Opens an isolated local cache at a caller-owned root. |
+| `Cache::from_workspace(root)` | Resolves the effective workspace, user, or process-selected provider. |
 | `Cache::with_provider(cache)` | Wraps an existing `CacheProvider`. |
 
-The default cache root is `$XDG_CACHE_HOME/once/cas` when
+The default follows the
+[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/):
+its cache root is `$XDG_CACHE_HOME/once/cas` when
 `XDG_CACHE_HOME` is set, and `$HOME/.cache/once/cas` otherwise.
 
 ### Introspection
@@ -75,8 +77,32 @@ them by digest from action results, manifests, or other integration state.
 | Application programming interface | Use |
 | --- | --- |
 | `put_blob(bytes)` | Stores bytes and returns their content digest. |
+| `put_stream(reader)` | Stores an asynchronous reader with bounded memory use. |
+| `put_file(path)` | Stores a file without loading it completely into memory. |
 | `get_blob(digest)` | Reads bytes for a digest. |
+| `get_blob_to_file(digest, path)` | Writes a blob to a file and returns its byte count. |
 | `has_blob(digest)` | Returns whether a blob exists. |
+
+Prefer the file and stream methods for logs, archives, compiler outputs, and
+other payloads whose size is not tightly bounded.
+
+### Action Keys
+
+`ActionKeyBuilder` gives cached automation a versioned, unambiguous identity.
+Start with a namespace owned by the integration, then add labeled values and
+content digests in deterministic order.
+
+```rust
+let source = cache.put_file("Sources/App.swift").await?;
+let mut key = once::ActionKeyBuilder::new("example.compile");
+key.push_bytes("compiler", "swiftc")
+    .push_bytes("configuration", "debug")
+    .push_digest("source", source);
+let action = key.finish();
+```
+
+Changing the namespace, a label, an input value, a digest, or input order
+produces a different action key.
 
 ### Action Results
 
@@ -90,7 +116,9 @@ use std::collections::BTreeMap;
 async fn main() -> once::Result<()> {
     let cache = once::Cache::new();
     let stdout = cache.put_blob(b"compiled").await?;
-    let action = once::Digest::of_bytes(br#"{"tool":"example"}"#);
+    let mut key = once::ActionKeyBuilder::new("example.compile");
+    key.push_bytes("tool", "example");
+    let action = key.finish();
     let result = once::ActionResult {
         exit_code: 0,
         stdout: Some(stdout),
@@ -107,8 +135,8 @@ async fn main() -> once::Result<()> {
 ```
 
 The action-result methods store and retrieve metadata for a completed action.
-They do not run commands. The caller is responsible for defining the
-action payload, hashing it, executing any work, and deciding which blob
+They do not run commands. The caller is responsible for executing work,
+including every relevant input in the action key, and deciding which blob
 digests belong in the cached result.
 
 | Application programming interface | Use |
@@ -130,6 +158,8 @@ level Once modules.
 | `ActionResult` | Stores an action exit code, stdout digest, stderr digest, and output digests. |
 | `Stats` | Reports local cache size and entry counts. |
 | `CacheProvider` | Provides lower-level cache access for integrations that already own a provider. |
+| `TuistCacheConfig` | Configures a manually constructed Tuist cache provider. |
+| `ActionKeyBuilder` | Builds a versioned action digest from ordered, labeled inputs. |
 | `Result<T>` | Library result alias. |
 | `Error` | Reports invalid digest strings and cache provider errors. |
 

--- a/docs/guide/sdk/swift.md
+++ b/docs/guide/sdk/swift.md
@@ -66,17 +66,21 @@ module from the binary target and gives callers the high-level Swift interface.
 
 `OnceCache` is the Swift cache client.
 
-`OnceCache` opens the default local cache using the
-[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/).
+Choose the initializer based on who owns provider selection. A workspace-bound
+client uses the same effective configuration as the command line.
 
 All cache operations that touch storage are `async throws`.
 
 | Application programming interface | Use |
 | --- | --- |
 | `init()` | Opens the default local cache using the operating-system convention. |
+| `init(localCacheRoot:)` | Opens an isolated local cache at a caller-owned file location. |
+| `init(workspaceRoot:)` | Resolves the effective provider for a workspace file location. |
 | `version` | Returns the linked Once version. |
 
-The default cache root is `$XDG_CACHE_HOME/once/cas` when
+The default follows the
+[X Desktop Group base-directory convention](https://specifications.freedesktop.org/basedir-spec/latest/):
+its cache root is `$XDG_CACHE_HOME/once/cas` when
 `XDG_CACHE_HOME` is set, and `$HOME/.cache/once/cas` otherwise.
 
 ## Blobs
@@ -88,8 +92,28 @@ them by digest from action results, manifests, or other integration state.
 | --- | --- |
 | `digest(bytes:)` | Returns the content digest for bytes without writing them to the cache. |
 | `putBlob(_:)` | Stores bytes and returns their content digest. |
+| `putBlob(contentsOf:)` | Stores a file without loading its complete contents into Swift memory. |
 | `getBlob(_:)` | Reads bytes for a digest. |
+| `getBlob(_:writeTo:)` | Writes a blob to a file location and returns its byte count. |
 | `hasBlob(_:)` | Returns whether a blob exists. |
+
+Prefer the file methods for logs, archives, compiler outputs, and other
+payloads whose size is not tightly bounded.
+
+## Action Keys
+
+`OnceActionKey` builds a versioned identity from ordered, labeled inputs:
+
+```swift
+let cache = OnceCache(workspaceRoot: workspaceURL)
+let source = try await cache.putBlob(contentsOf: sourceURL)
+var key = OnceActionKey(namespace: "example.compile")
+key.add(bytes: Data("swiftc".utf8), label: "compiler")
+key.add(digest: source, label: "source")
+let actionDigest = try await key.digest()
+```
+
+Input order is significant and must be deterministic.
 
 ## Action Results
 
@@ -113,5 +137,6 @@ interface directly.
 | Type | Use |
 | --- | --- |
 | `OnceActionResult` | Stores an action exit code, stdout digest, stderr digest, and output digests. |
+| `OnceActionKey` | Builds a versioned action digest from ordered, labeled inputs. |
 | `OnceCacheStats` | Reports local cache size and entry counts. |
 | `OnceError` | Reports Swift wrapper failures. |

--- a/docs/site.js
+++ b/docs/site.js
@@ -234,6 +234,7 @@ export const site = {
             text: '<span class="sidebar-target-link sidebar-target-link-javascript"><span class="sidebar-target-icon"></span><span>JavaScript</span></span>',
             link: "/guide/sdk/javascript",
           },
+          { text: "C", link: "/guide/sdk/c" },
         ],
       },
     ],

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -1,7 +1,7 @@
-# Once JavaScript SDK
+# Once JavaScript Software Development Kit
 
 `buildonce` exposes Once primitives to Node.js. It loads the same
-native Once library used by the other SDKs and does not expose script
+native Once library used by the other language libraries and does not expose script
 execution.
 
 ```js
@@ -19,6 +19,8 @@ async function example() {
 The package looks for a bundled native library under `prebuilds/`. Set
 `ONCE_LIBRARY_PATH` to load a custom `libonce` build.
 
-`putBlob` sends bytes to the native library through the JSON SDK ABI. This
-keeps the package portable across platforms, but it means very large blobs are
-materialized as JSON byte arrays before crossing into Rust.
+Use `new Cache({ workspaceRoot })` to share the effective provider configured
+for a repository, or `new Cache({ localCacheRoot })` for isolation. Use
+`putFile` and `getBlobToFile` for large payloads so the host does not need to
+hold their complete contents in JavaScript memory. `ActionKey` builds a stable
+digest from ordered, labeled inputs.

--- a/packages/js/lib/index.d.ts
+++ b/packages/js/lib/index.d.ts
@@ -14,21 +14,28 @@ export interface CacheStats {
 
 export class OnceError extends Error {}
 
+export interface CacheOptions {
+  localCacheRoot?: string;
+  workspaceRoot?: string;
+}
+
 export class Cache {
+  constructor(options?: CacheOptions);
   version(): string;
   /**
-   * Strings are encoded as UTF-8 before hashing.
+   * Strings use Unicode Transformation Format, 8-bit before hashing.
    */
   digest(bytes: Buffer | Uint8Array | string): string;
   /**
-   * Strings are encoded as UTF-8 before being stored.
+   * Strings use Unicode Transformation Format, 8-bit before being stored.
    *
-   * Blob bytes currently cross the native boundary as JSON arrays, so very
-   * large blobs should use the Rust SDK or CLI until the JavaScript SDK has a
-   * streaming native ABI.
+   * Use putFile for large blobs to avoid loading the complete payload into
+   * JavaScript memory.
    */
   putBlob(bytes: Buffer | Uint8Array | string): Promise<string>;
+  putFile(path: string): Promise<string>;
   getBlob(digest: string): Promise<Buffer>;
+  getBlobToFile(digest: string, path: string): Promise<number>;
   hasBlob(digest: string): Promise<boolean>;
   putActionResult(result: ActionResult, actionDigest: string): Promise<boolean>;
   getActionResult(actionDigest: string): Promise<ActionResult | null>;
@@ -36,7 +43,14 @@ export class Cache {
   stats(): Promise<CacheStats>;
 }
 
+export class ActionKey {
+  constructor(namespace: string);
+  addBytes(label: string, bytes: Buffer | Uint8Array | string): this;
+  addDigest(label: string, digest: string): this;
+  digest(): string;
+}
+
 /**
- * Strings are encoded as UTF-8 before hashing.
+ * Strings use Unicode Transformation Format, 8-bit before hashing.
  */
 export function digest(bytes: Buffer | Uint8Array | string): string;

--- a/packages/js/lib/index.js
+++ b/packages/js/lib/index.js
@@ -15,6 +15,26 @@ const native = loadNative();
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 
 class Cache {
+  constructor(options = {}) {
+    if (options == null || typeof options !== "object" || Array.isArray(options)) {
+      throw new TypeError("Cache options must be an object");
+    }
+    const { localCacheRoot, workspaceRoot } = options;
+    if (localCacheRoot != null && workspaceRoot != null) {
+      throw new TypeError("localCacheRoot and workspaceRoot cannot be used together");
+    }
+    if (localCacheRoot != null && typeof localCacheRoot !== "string") {
+      throw new TypeError("localCacheRoot must be a string");
+    }
+    if (workspaceRoot != null && typeof workspaceRoot !== "string") {
+      throw new TypeError("workspaceRoot must be a string");
+    }
+    this.selection = {
+      ...(localCacheRoot == null ? {} : { local_cache_root: localCacheRoot }),
+      ...(workspaceRoot == null ? {} : { workspace_root: workspaceRoot }),
+    };
+  }
+
   version() {
     return native.once_version() || "";
   }
@@ -28,19 +48,43 @@ class Cache {
     const buffer = toBuffer(bytes, "Cache#putBlob bytes");
     return decodeRequest(
       native.once_cache_put_blob_json,
-      { bytes: Array.from(buffer) },
+      { ...this.selection, bytes: Array.from(buffer) },
     );
+  }
+
+  async putFile(filePath) {
+    validatePath(filePath, "filePath");
+    return decodeRequest(native.once_cache_put_file_json, {
+      ...this.selection,
+      path: filePath,
+    });
   }
 
   async getBlob(digest) {
     validateDigest(digest, "digest");
-    const response = decodeRequest(native.once_cache_get_blob_json, { digest });
+    const response = decodeRequest(native.once_cache_get_blob_json, {
+      ...this.selection,
+      digest,
+    });
     return Buffer.from(response.bytes);
+  }
+
+  async getBlobToFile(digest, filePath) {
+    validateDigest(digest, "digest");
+    validatePath(filePath, "filePath");
+    return decodeRequest(native.once_cache_get_blob_to_file_json, {
+      ...this.selection,
+      digest,
+      path: filePath,
+    });
   }
 
   async hasBlob(digest) {
     validateDigest(digest, "digest");
-    return decodeRequest(native.once_cache_has_blob_json, { digest });
+    return decodeRequest(native.once_cache_has_blob_json, {
+      ...this.selection,
+      digest,
+    });
   }
 
   async putActionResult(result, actionDigest) {
@@ -48,6 +92,7 @@ class Cache {
     return decodeRequest(
       native.once_cache_put_action_result_json,
       {
+        ...this.selection,
         action_digest: actionDigest,
         result: actionResultToNative(result),
       },
@@ -58,7 +103,7 @@ class Cache {
     validateDigest(actionDigest, "actionDigest");
     const result = decodeRequest(
       native.once_cache_get_action_result_json,
-      { action_digest: actionDigest },
+      { ...this.selection, action_digest: actionDigest },
     );
     return result === null ? null : actionResultFromNative(result);
   }
@@ -67,18 +112,49 @@ class Cache {
     validateDigest(actionDigest, "actionDigest");
     return decodeRequest(
       native.once_cache_forget_action_json,
-      { action_digest: actionDigest },
+      { ...this.selection, action_digest: actionDigest },
     );
   }
 
   async stats() {
-    const stats = decodeRequest(native.once_cache_stats_json, {});
+    const stats = decodeRequest(native.once_cache_stats_json, this.selection);
     return {
       blobCount: stats.blob_count,
       blobBytes: stats.blob_bytes,
       actionCount: stats.action_count,
       actionBytes: stats.action_bytes,
     };
+  }
+}
+
+class ActionKey {
+  constructor(namespace) {
+    if (typeof namespace !== "string") {
+      throw new TypeError("ActionKey namespace must be a string");
+    }
+    this.namespace = namespace;
+    this.inputs = [];
+  }
+
+  addBytes(label, bytes) {
+    validateLabel(label);
+    const buffer = toBuffer(bytes, "ActionKey#addBytes bytes");
+    this.inputs.push({ kind: "bytes", label, bytes: Array.from(buffer) });
+    return this;
+  }
+
+  addDigest(label, digest) {
+    validateLabel(label);
+    validateDigest(digest, "digest");
+    this.inputs.push({ kind: "digest", label, digest });
+    return this;
+  }
+
+  digest() {
+    return decodeRequest(native.once_action_key_json, {
+      namespace: this.namespace,
+      inputs: this.inputs,
+    });
   }
 }
 
@@ -103,7 +179,9 @@ function decodeResponse(pointer) {
   try {
     response = JSON.parse(pointer);
   } catch (error) {
-    throw new OnceError(`native Once response must be valid JSON: ${error.message}`);
+    throw new OnceError(
+      `native Once response must be valid JavaScript Object Notation: ${error.message}`,
+    );
   }
   if (response.status === "ok") {
     return response.value;
@@ -135,6 +213,18 @@ function validateDigest(value, name) {
   }
 }
 
+function validateLabel(value) {
+  if (typeof value !== "string") {
+    throw new TypeError("ActionKey input label must be a string");
+  }
+}
+
+function validatePath(value, name) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+}
+
 function toBuffer(bytes, name) {
   if (Buffer.isBuffer(bytes)) {
     return bytes;
@@ -159,13 +249,26 @@ function loadNative() {
       "const void *",
       "size_t",
     ]),
+    once_action_key_json: library.func("once_action_key_json", onceString, [
+      "str",
+    ]),
     once_cache_put_blob_json: library.func(
       "once_cache_put_blob_json",
       onceString,
       ["str"],
     ),
+    once_cache_put_file_json: library.func(
+      "once_cache_put_file_json",
+      onceString,
+      ["str"],
+    ),
     once_cache_get_blob_json: library.func(
       "once_cache_get_blob_json",
+      onceString,
+      ["str"],
+    ),
+    once_cache_get_blob_to_file_json: library.func(
+      "once_cache_get_blob_to_file_json",
       onceString,
       ["str"],
     ),
@@ -229,6 +332,7 @@ function libraryName() {
 }
 
 module.exports = {
+  ActionKey,
   Cache,
   OnceError,
   digest,

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "buildonce",
   "version": "0.0.0",
-  "description": "JavaScript SDK for Once cache access",
+  "description": "JavaScript software development kit for Once cache access",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/js/test.js
+++ b/packages/js/test.js
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 const os = require("node:os");
 const fs = require("node:fs");
 const childProcess = require("node:child_process");
-const { Cache, OnceError, digest } = require("./lib");
+const { ActionKey, Cache, OnceError, digest } = require("./lib");
 
 async function assertRejectsOnceError(work) {
   await assert.rejects(work, OnceError);
@@ -33,6 +33,32 @@ async function main() {
   assert.equal(await cache.hasBlob(blobDigest), true);
   assert.deepEqual(await cache.getBlob(blobDigest), Buffer.from("hello"));
   assert.deepEqual(await cache.getBlob(digest("")), Buffer.alloc(0));
+
+  const explicitRoot = `${tmp}/explicit-cache`;
+  const fileCache = new Cache({ localCacheRoot: explicitRoot });
+  const inputPath = `${tmp}/input.bin`;
+  const outputPath = `${tmp}/nested/output.bin`;
+  fs.writeFileSync(inputPath, "file payload");
+  const fileDigest = await fileCache.putFile(inputPath);
+  assert.equal(await fileCache.getBlobToFile(fileDigest, outputPath), 12);
+  assert.deepEqual(fs.readFileSync(outputPath), Buffer.from("file payload"));
+  assert.equal(await cache.hasBlob(fileDigest), false);
+  assert.throws(
+    () => new Cache({ localCacheRoot: explicitRoot, workspaceRoot: tmp }),
+    /cannot be used together/,
+  );
+
+  const actionKey = new ActionKey("compile")
+    .addBytes("tool", "swiftc")
+    .addDigest("source", digest("source"));
+  assert.equal(actionKey.digest(), actionKey.digest());
+  assert.notEqual(
+    actionKey.digest(),
+    new ActionKey("link")
+      .addBytes("tool", "swiftc")
+      .addDigest("source", digest("source"))
+      .digest(),
+  );
   await assertRejectsOnceError(() => cache.getBlob("not-a-digest"));
   await assertRejectsOnceError(() => cache.hasBlob("not-a-digest"));
 

--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -1,7 +1,7 @@
-# Once Ruby SDK
+# Once Ruby Software Development Kit
 
 `buildonce` exposes Once primitives to Ruby. It loads the same
-native Once library used by the other SDKs and does not expose script
+native Once library used by the other language libraries and does not expose script
 execution.
 
 ```ruby
@@ -16,3 +16,8 @@ raise unless bytes == "hello"
 
 The gem looks for a bundled native library under `prebuilds/`. Set
 `ONCE_LIBRARY_PATH` to load a custom `libonce` build.
+
+Use `Once::Cache.new(workspace_root:)` to share the effective provider
+configured for a repository, or `local_cache_root:` for isolation. Use
+`put_file` and `get_blob_to_file` for large payloads. `Once::ActionKey` builds
+a stable digest from ordered, labeled inputs.

--- a/packages/ruby/lib/buildonce.rb
+++ b/packages/ruby/lib/buildonce.rb
@@ -25,6 +25,17 @@ module Once
   CacheStats = Struct.new(:blob_count, :blob_bytes, :action_count, :action_bytes, keyword_init: true)
 
   class Cache
+    def initialize(local_cache_root: nil, workspace_root: nil)
+      if local_cache_root && workspace_root
+        raise ArgumentError, "local_cache_root and workspace_root cannot be used together"
+      end
+
+      @selection = {}
+      @selection[:local_cache_root] = local_cache_root.to_s if local_cache_root
+      @selection[:workspace_root] = workspace_root.to_s if workspace_root
+      @selection.freeze
+    end
+
     def version
       read_native_string(Native.once_version)
     end
@@ -37,37 +48,56 @@ module Once
 
     def put_blob(bytes)
       buffer = bytes.to_s.b
-      decode_request(:once_cache_put_blob_json, bytes: buffer.bytes)
+      decode_request(:once_cache_put_blob_json, selection(bytes: buffer.bytes))
+    end
+
+    def put_file(path)
+      decode_request(:once_cache_put_file_json, selection(path: path.to_s))
     end
 
     def get_blob(digest)
-      response = decode_request(:once_cache_get_blob_json, digest: digest)
+      response = decode_request(:once_cache_get_blob_json, selection(digest: digest))
       response.fetch("bytes").pack("C*")
     end
 
+    def get_blob_to_file(digest, path)
+      decode_request(
+        :once_cache_get_blob_to_file_json,
+        selection(digest: digest, path: path.to_s),
+      )
+    end
+
     def has_blob?(digest)
-      decode_request(:once_cache_has_blob_json, digest: digest)
+      decode_request(:once_cache_has_blob_json, selection(digest: digest))
     end
 
     def put_action_result(result, action_digest:)
       decode_request(
         :once_cache_put_action_result_json,
-        action_digest: action_digest,
-        result: normalize_action_result(result),
+        selection(
+          action_digest: action_digest,
+          result: normalize_action_result(result),
+        ),
       )
     end
 
     def get_action_result(action_digest)
-      response = decode_request(:once_cache_get_action_result_json, action_digest: action_digest)
+      response = decode_request(
+        :once_cache_get_action_result_json,
+        selection(action_digest: action_digest),
+      )
       response && action_result_from_native(response)
     end
 
     def forget_action(action_digest)
-      decode_request(:once_cache_forget_action_json, action_digest: action_digest)
+      decode_request(
+        :once_cache_forget_action_json,
+        selection(action_digest: action_digest),
+      )
     end
 
     def stats
-      response = decode_request(:once_cache_stats_json, {})
+      response = decode_request(:once_cache_stats_json, @selection)
       CacheStats.new(
         blob_count: response.fetch("blob_count"),
         blob_bytes: response.fetch("blob_bytes"),
@@ -77,6 +107,10 @@ module Once
     end
 
     private
+
+    def selection(request)
+      @selection.merge(request)
+    end
 
     def decode_request(function, request)
       decode_response(Native.public_send(function, JSON.generate(request)))
@@ -126,6 +160,49 @@ module Once
         stderr: result["stderr"],
         outputs: result.fetch("outputs", {}),
       )
+    end
+  end
+
+  class ActionKey
+    def initialize(namespace)
+      raise ArgumentError, "namespace must be a String" unless namespace.is_a?(String)
+
+      @namespace = namespace
+      @inputs = []
+    end
+
+    def add_bytes(label, bytes)
+      validate_label(label)
+      @inputs << { kind: "bytes", label: label, bytes: bytes.to_s.b.bytes }
+      self
+    end
+
+    def add_digest(label, digest)
+      validate_label(label)
+      @inputs << { kind: "digest", label: label, digest: digest }
+      self
+    end
+
+    def digest
+      pointer = Native.once_action_key_json(
+        JSON.generate(namespace: @namespace, inputs: @inputs),
+      )
+      raise Error, "native Once function returned null" if pointer.null?
+
+      response = JSON.parse(pointer.read_string)
+      return response.fetch("value") if response.fetch("status") == "ok"
+
+      raise Error, response.fetch("message")
+    rescue JSON::ParserError, KeyError => e
+      raise Error, e.message
+    ensure
+      Native.once_string_free(pointer) if pointer && !pointer.null?
+    end
+
+    private
+
+    def validate_label(label)
+      raise ArgumentError, "input label must be a String" unless label.is_a?(String)
     end
   end
 

--- a/packages/ruby/lib/once/native.rb
+++ b/packages/ruby/lib/once/native.rb
@@ -60,8 +60,11 @@ module Once
     attach_function :once_version, [], :pointer
     attach_function :once_string_free, [:pointer], :void
     attach_function :once_digest_bytes, %i[pointer size_t], :pointer
+    attach_function :once_action_key_json, [:string], :pointer
     attach_function :once_cache_put_blob_json, [:string], :pointer
+    attach_function :once_cache_put_file_json, [:string], :pointer
     attach_function :once_cache_get_blob_json, [:string], :pointer
+    attach_function :once_cache_get_blob_to_file_json, [:string], :pointer
     attach_function :once_cache_has_blob_json, [:string], :pointer
     attach_function :once_cache_put_action_result_json, [:string], :pointer
     attach_function :once_cache_get_action_result_json, [:string], :pointer

--- a/packages/ruby/once.gemspec
+++ b/packages/ruby/once.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name = "buildonce"
   spec.version = ENV.fetch("ONCE_VERSION", "0.0.0")
-  spec.summary = "Ruby SDK for Once"
+  spec.summary = "Ruby software development kit for Once"
   spec.description = "Embeds Once primitives in Ruby through the native Once library."
   spec.license = "MIT"
   spec.homepage = "https://github.com/tuist/once"

--- a/packages/ruby/test.rb
+++ b/packages/ruby/test.rb
@@ -32,6 +32,29 @@ Dir.mktmpdir("once-ruby-") do |dir|
   raise "blob missing" unless cache.has_blob?(blob_digest)
   raise "blob content mismatch" unless cache.get_blob(blob_digest) == "hello"
   raise "empty blob mismatch" unless cache.get_blob(Once.digest("")) == ""
+
+  explicit_cache = Once::Cache.new(local_cache_root: File.join(dir, "explicit-cache"))
+  input_path = File.join(dir, "input.bin")
+  output_path = File.join(dir, "nested", "output.bin")
+  File.binwrite(input_path, "file payload")
+  file_digest = explicit_cache.put_file(input_path)
+  raise "file byte count mismatch" unless explicit_cache.get_blob_to_file(file_digest, output_path) == 12
+  raise "file content mismatch" unless File.binread(output_path) == "file payload"
+  raise "explicit cache leaked into default cache" if cache.has_blob?(file_digest)
+  begin
+    Once::Cache.new(local_cache_root: dir, workspace_root: dir)
+    raise "expected conflicting cache roots to fail"
+  rescue ArgumentError
+  end
+
+  action_key = Once::ActionKey.new("compile")
+                              .add_bytes("tool", "swiftc")
+                              .add_digest("source", Once.digest("source"))
+  raise "action key is unstable" unless action_key.digest == action_key.digest
+  other_key = Once::ActionKey.new("link")
+                            .add_bytes("tool", "swiftc")
+                            .add_digest("source", Once.digest("source"))
+  raise "action key namespace was ignored" if action_key.digest == other_key.digest
   assert_raises_once_error { cache.get_blob("not-a-digest") }
   assert_raises_once_error { cache.has_blob?("not-a-digest") }
 


### PR DESCRIPTION
## What changed

Once's language libraries can now use the same effective cache provider as the command line, or an isolated caller-owned local cache.

The Rust, Swift, JavaScript, Ruby, and C surfaces now include versioned action-key builders and file-oriented blob operations. Cache provider resolution moved into the shared frontend so the command line and embedded clients follow one precedence order. The language-library guides now document the complete surface, including a new C guide with a compiled example.

## Why

The existing libraries exposed cache primitives, but integrations could not reuse workspace and user provider configuration. Callers also had to invent action digest formats and move file contents through in-memory language values. Those gaps made it harder for automation to share cache entries safely and efficiently with Once.

## Approach

The default constructors keep their existing local behavior. Additive constructors select an explicit local root or resolve a workspace provider. A shared action-key format partitions integrations by namespace and encodes ordered, labeled values and content digests. File methods keep complete payloads out of host-language memory.

The libraries remain centered on cache access. Command execution, runtime sessions, and graph loading stay on the command-line surface. Remote uploads remain best effort, and the guides describe the local-tier behavior for large streamed inputs.

## Impact

Existing integrations continue to work without migration. New integrations can share configured local or Tuist caches across languages, construct compatible action identities, and cache files without converting their contents into host-language byte collections.

## Validation

- `mise exec -- cargo test --workspace --no-fail-fast`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- Swift 6 strict concurrency type-checking with warnings treated as errors
- JavaScript and Ruby native binding tests against the debug Once library
- `aube run build`
- Compiled and executed the exact C example from the guide
- Rendered and visually inspected the overview, Rust, Swift, JavaScript, Ruby, and C guides in headless Google Chrome
- Verified the language-library documentation contains no em dashes or repository implementation paths
