### PR TITLE
feat: remote script execution across e2b, Daytona, and Microsandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,6 +3440,7 @@ name = "once-core"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base64",
  "futures",
  "jsonwebtoken",
  "microsandbox",
@@ -3440,9 +3451,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4188,6 +4201,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ once-frontend = { version = "0.0.0", path = "crates/once-frontend" }
 
 anyhow = "1"
 bazel-remote-apis = "0.27"
+base64 = "0.22"
 blake3 = "1"
 clap = { version = "4", features = ["derive"] }
 console = "0.16"
@@ -38,10 +39,11 @@ toon-rust = "0.1"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring"] }
 tree-sitter = "0.26.9"
 tree-sitter-cypher = "0.2.6"
-reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "multipart", "query", "rustls", "stream"] }
 sea-orm = { version = "1.1.20", default-features = false, features = ["macros", "runtime-tokio-rustls", "sqlx-sqlite"] }
 sea-orm-migration = { version = "1.1.20", default-features = false, features = ["runtime-tokio-rustls", "sqlx-sqlite"] }
 schlussel = { git = "https://github.com/tuist/schlussel.git", rev = "80a7bc1fc0b68bdc2cd2379b16240ddbfbe0267b" }
@@ -51,6 +53,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"]
 uuid = { version = "1", features = ["v7"] }
 walkdir = "2"
 zstd = "0.13"
+tar = "0.4"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/once-cli/src/cache_provider.rs
+++ b/crates/once-cli/src/cache_provider.rs
@@ -28,12 +28,19 @@ pub(crate) fn resolve_execution(
     xdg: &Xdg,
     explicit_provider: Option<&str>,
 ) -> Result<RemoteExecution> {
-    if let Some(provider) = explicit_provider.and_then(non_empty_str) {
-        return Ok(RemoteExecution::provider(provider));
-    }
-
     let workspace_config =
         once_frontend::load_infrastructure_config(workspace).context("loading infrastructure")?;
+    if let Some(provider) = explicit_provider.and_then(non_empty_str) {
+        return resolve_execution_binding(
+            xdg,
+            &workspace_config,
+            NamedCacheProviderConfig {
+                name: provider.to_string(),
+                account: None,
+                project: None,
+            },
+        );
+    }
     if let Some(binding) = workspace_config.execution.clone() {
         return resolve_execution_binding(xdg, &workspace_config, binding);
     }
@@ -67,14 +74,14 @@ pub(crate) fn resolve_auth_provider(
     let workspace_config =
         once_frontend::load_infrastructure_config(workspace).context("loading infrastructure")?;
     if let Some(provider) = workspace_config.providers.get(provider_name) {
-        return Ok(resolve_named_workspace_provider(
+        return resolve_named_workspace_provider(
             NamedCacheProviderConfig {
                 name: provider_name.to_string(),
                 account: None,
                 project: None,
             },
             provider.clone(),
-        ));
+        );
     }
 
     if let Some(mut config) = maybe_load_user_config(xdg)? {
@@ -184,22 +191,27 @@ fn resolve_named_provider(
 fn resolve_named_workspace_provider(
     binding: NamedCacheProviderConfig,
     provider: InfrastructureProviderConfig,
-) -> ResolvedCacheProviderConfig {
+) -> Result<ResolvedCacheProviderConfig> {
     let NamedCacheProviderConfig {
         name,
         account: binding_account,
         project: binding_project,
     } = binding;
     match provider {
-        InfrastructureProviderConfig::Local => ResolvedCacheProviderConfig::Local,
+        InfrastructureProviderConfig::Local => Ok(ResolvedCacheProviderConfig::Local),
+        InfrastructureProviderConfig::Microsandbox(_)
+        | InfrastructureProviderConfig::E2b(_)
+        | InfrastructureProviderConfig::Daytona(_) => {
+            bail!("infrastructure `{name}` provides execution but not shared caching")
+        }
         InfrastructureProviderConfig::Tuist(config) => {
-            ResolvedCacheProviderConfig::Tuist(default_tuist_config(
+            Ok(ResolvedCacheProviderConfig::Tuist(default_tuist_config(
                 name,
                 config.url,
                 binding_account.or(config.account),
                 binding_project.or(config.project),
                 config.oauth_client_id,
-            ))
+            )))
         }
     }
 }
@@ -258,11 +270,36 @@ fn remote_from_workspace_provider(
     match provider {
         InfrastructureProviderConfig::Local => RemoteExecution {
             provider: name,
+            executor: Some("local".to_string()),
+            environment: None,
+            account: binding_account,
+            project: binding_project,
+        },
+        InfrastructureProviderConfig::Microsandbox(config) => RemoteExecution {
+            provider: name,
+            executor: Some("microsandbox".to_string()),
+            environment: Some(config.image),
+            account: binding_account,
+            project: binding_project,
+        },
+        InfrastructureProviderConfig::E2b(config) => RemoteExecution {
+            provider: name,
+            executor: Some("e2b".to_string()),
+            environment: Some(config.template),
+            account: binding_account,
+            project: binding_project,
+        },
+        InfrastructureProviderConfig::Daytona(config) => RemoteExecution {
+            provider: name,
+            executor: Some("daytona".to_string()),
+            environment: Some(config.image),
             account: binding_account,
             project: binding_project,
         },
         InfrastructureProviderConfig::Tuist(config) => RemoteExecution {
             provider: name,
+            executor: Some("tuist".to_string()),
+            environment: None,
             account: binding_account.or(config.account),
             project: binding_project.or(config.project),
         },
@@ -283,6 +320,8 @@ fn remote_from_user_provider(
             account, project, ..
         } => RemoteExecution {
             provider: name,
+            executor: Some("tuist".to_string()),
+            environment: None,
             account: binding_account.or(account),
             project: binding_project.or(project),
         },
@@ -292,13 +331,15 @@ fn remote_from_user_provider(
 fn remote_from_binding(binding: NamedCacheProviderConfig) -> RemoteExecution {
     RemoteExecution {
         provider: binding.name,
+        executor: None,
+        environment: None,
         account: binding.account,
         project: binding.project,
     }
 }
 
 fn is_builtin_execution_provider(name: &str) -> bool {
-    matches!(name, "microsandbox" | "daytona")
+    matches!(name, "microsandbox" | "e2b" | "daytona")
 }
 
 fn default_tuist_config(
@@ -849,6 +890,8 @@ project = "default-app"
             remote,
             RemoteExecution {
                 provider: "tuist".to_string(),
+                executor: Some("tuist".to_string()),
+                environment: None,
                 account: Some("acme".to_string()),
                 project: Some("remote-builds".to_string()),
             }
@@ -863,6 +906,87 @@ project = "default-app"
         let remote = resolve_execution(tmp.path(), &xdg, None).unwrap();
 
         assert_eq!(remote, RemoteExecution::provider("microsandbox"));
+    }
+
+    #[test]
+    fn resolve_execution_uses_named_microsandbox_image() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructures.remote_tests]
+kind = "microsandbox"
+image = "node:22.18.0-alpine"
+"#,
+        );
+
+        let remote = resolve_execution(tmp.path(), &xdg, Some("remote_tests")).unwrap();
+
+        assert_eq!(
+            remote,
+            RemoteExecution {
+                provider: "remote_tests".to_string(),
+                executor: Some("microsandbox".to_string()),
+                environment: Some("node:22.18.0-alpine".to_string()),
+                account: None,
+                project: None,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_execution_uses_named_e2b_template() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructures.remote_tests]
+kind = "e2b"
+template = "vitest-v1"
+"#,
+        );
+
+        let remote = resolve_execution(tmp.path(), &xdg, Some("remote_tests")).unwrap();
+
+        assert_eq!(
+            remote,
+            RemoteExecution {
+                provider: "remote_tests".to_string(),
+                executor: Some("e2b".to_string()),
+                environment: Some("vitest-v1".to_string()),
+                account: None,
+                project: None,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_execution_uses_named_daytona_image() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        write_workspace(
+            tmp.path(),
+            r#"
+[infrastructures.remote_tests]
+kind = "daytona"
+image = "node:22-bookworm"
+"#,
+        );
+
+        let remote = resolve_execution(tmp.path(), &xdg, Some("remote_tests")).unwrap();
+
+        assert_eq!(
+            remote,
+            RemoteExecution {
+                provider: "remote_tests".to_string(),
+                executor: Some("daytona".to_string()),
+                environment: Some("node:22-bookworm".to_string()),
+                account: None,
+                project: None,
+            }
+        );
     }
 
     #[test]

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -24,7 +24,7 @@ use once_cas::{ActionResult, CacheProvider, Digest};
 use once_core::{
     tool_env, workspace_tool_command, workspace_tool_env, Action, CacheState, EvidenceSubject,
     InputDigestBuilder, OutputSymlinkMode, RemoteExecution, ResourceRequest, RunOpts, SandboxMode,
-    WorkspacePath,
+    WorkspacePath, Xdg,
 };
 use once_frontend::{parse_script_annotations, ScriptAnnotations};
 use serde::Serialize;
@@ -77,25 +77,28 @@ struct ScriptInvocation {
 }
 
 #[derive(Clone)]
-struct ScriptGraphOptions {
+struct ScriptGraphOptions<'a> {
     explicit_env: BTreeMap<String, String>,
     timeout_ms_override: Option<u64>,
     remote_override: Option<RemoteExecution>,
     sandbox: SandboxMode,
+    xdg: Option<&'a Xdg>,
 }
 
-struct ScriptExecutionOptions {
+struct ScriptExecutionOptions<'a> {
     explicit_env: Vec<(String, String)>,
     cwd_override: Option<WorkspacePath>,
     timeout_ms_override: Option<u64>,
     remote_override: Option<RemoteExecution>,
     sandbox: SandboxMode,
+    xdg: Option<&'a Xdg>,
 }
 
 #[derive(Clone)]
 struct DependencyFingerprint {
     script_path: String,
     digest: Digest,
+    outputs: Vec<WorkspacePath>,
 }
 
 #[derive(Debug)]
@@ -111,6 +114,7 @@ struct FingerprintShell {
 
 pub async fn exec(
     workspace: &Path,
+    xdg: &Xdg,
     cache: &CacheProvider,
     args: ExecArgs,
     output: Output,
@@ -118,7 +122,7 @@ pub async fn exec(
     let opts = RunOpts {
         cache_failures: args.cache_failures,
     };
-    let (workspace, action) = plan_exec_action(workspace, cache, opts, args).await?;
+    let (workspace, action) = plan_exec_action(workspace, xdg, cache, opts, args).await?;
     let streams_live = action_remote(&action).is_some() && output.format == Format::Human;
     let outcome = run_exec_action(cache, &workspace, opts, &action, streams_live).await?;
     crate::commands::evidence::record_outcome(
@@ -135,6 +139,7 @@ pub async fn exec(
 
 async fn plan_exec_action(
     workspace: &Path,
+    xdg: &Xdg,
     cache: &CacheProvider,
     opts: RunOpts,
     args: ExecArgs,
@@ -155,6 +160,7 @@ async fn plan_exec_action(
         timeout_ms_override: timeout_ms,
         remote_override: remote,
         sandbox,
+        xdg: Some(xdg),
     };
 
     if script {
@@ -179,7 +185,7 @@ async fn plan_exec_action(
                 resources: ResourceRequest::default(),
                 sandbox,
                 timeout_ms: options.timeout_ms_override,
-                remote: options.remote_override,
+                remote: options.remote_override.map(Box::new),
             },
         ))
     }
@@ -277,6 +283,7 @@ async fn script_action(
         timeout_ms_override,
         remote_override,
         SandboxMode::Off,
+        None,
         argv,
     )
     .await?;
@@ -286,7 +293,7 @@ async fn script_action(
         &[],
         &[],
     )?);
-    let action = action_from_script_invocation(&invocation, input_digest).await?;
+    let action = action_from_script_invocation(&invocation, input_digest, &[]).await?;
     Ok((invocation.workspace.clone(), action))
 }
 
@@ -294,14 +301,15 @@ async fn script_action_with_dependencies(
     workspace: &Path,
     cache: &CacheProvider,
     opts: RunOpts,
-    options: &ScriptExecutionOptions,
+    options: &ScriptExecutionOptions<'_>,
     argv: &[String],
 ) -> Result<(PathBuf, Action)> {
-    let graph_options = ScriptGraphOptions {
+    let mut graph_options = ScriptGraphOptions {
         explicit_env: options.explicit_env.iter().cloned().collect(),
         timeout_ms_override: options.timeout_ms_override,
         remote_override: options.remote_override.clone(),
         sandbox: options.sandbox,
+        xdg: options.xdg,
     };
     let invocation = script_invocation(
         workspace,
@@ -310,17 +318,26 @@ async fn script_action_with_dependencies(
         graph_options.timeout_ms_override,
         graph_options.remote_override.clone(),
         graph_options.sandbox,
+        graph_options.xdg,
         argv,
     )
     .await?;
+    if graph_options.remote_override.is_none() {
+        graph_options.remote_override = invocation.remote.clone();
+    }
     script_action_with_dependency_graph(cache, opts, invocation, graph_options).await
 }
 
 async fn action_from_script_invocation(
     invocation: &ScriptInvocation,
     input_digest: Option<Digest>,
+    dependencies: &[DependencyFingerprint],
 ) -> Result<Action> {
-    let mut argv = resolve_runtime(&invocation.workspace, &invocation.runtime).await?;
+    let mut argv = if invocation.remote.is_some() {
+        vec![invocation.runtime.clone()]
+    } else {
+        resolve_runtime(&invocation.workspace, &invocation.runtime).await?
+    };
     argv.extend(invocation.runtime_args.clone());
     argv.push(host_script_path(
         invocation.script_path.as_str(),
@@ -328,12 +345,21 @@ async fn action_from_script_invocation(
     )?);
     argv.extend(invocation.script_args.clone());
 
+    let mut inputs = invocation.inputs.clone();
+    inputs.extend(
+        dependencies
+            .iter()
+            .flat_map(|dependency| dependency.outputs.iter().cloned()),
+    );
+    inputs.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    inputs.dedup();
+
     Ok(Action::RunCommand {
         argv,
         env: invocation.env.clone(),
         cwd: Some(invocation.cwd.clone()),
         input_digest,
-        inputs: invocation.inputs.clone(),
+        inputs,
         outputs: invocation.outputs.clone(),
         stdout_path: None,
         stderr_path: None,
@@ -341,7 +367,7 @@ async fn action_from_script_invocation(
         resources: ResourceRequest::default(),
         sandbox: invocation.sandbox,
         timeout_ms: invocation.timeout_ms,
-        remote: invocation.remote.clone(),
+        remote: invocation.remote.clone().map(Box::new),
     })
 }
 
@@ -349,9 +375,29 @@ fn remote_execution(provider: Option<&str>) -> Option<RemoteExecution> {
     provider.map(RemoteExecution::provider)
 }
 
+fn resolve_script_remote(
+    workspace: &Path,
+    xdg: Option<&Xdg>,
+    remote_override: Option<RemoteExecution>,
+    annotation_provider: Option<&str>,
+) -> Result<Option<RemoteExecution>> {
+    if remote_override.is_some() {
+        return Ok(remote_override);
+    }
+    let Some(provider) = annotation_provider else {
+        return Ok(None);
+    };
+    match xdg {
+        Some(xdg) => crate::cache_provider::resolve_execution(workspace, xdg, Some(provider))
+            .map(Some)
+            .with_context(|| format!("resolving remote execution provider `{provider}`")),
+        None => Ok(remote_execution(Some(provider))),
+    }
+}
+
 fn action_remote(action: &Action) -> Option<&RemoteExecution> {
     match action {
-        Action::RunCommand { remote, .. } => remote.as_ref(),
+        Action::RunCommand { remote, .. } => remote.as_deref(),
         _ => None,
     }
 }
@@ -360,7 +406,7 @@ async fn autodetected_script_action(
     cache: &CacheProvider,
     opts: RunOpts,
     workspace: &Path,
-    options: &ScriptExecutionOptions,
+    options: &ScriptExecutionOptions<'_>,
     argv: &[String],
 ) -> Result<Option<(PathBuf, Action)>> {
     let Ok((_, _, script_arg, _)) = parse_script_exec_argv(workspace, argv) else {
@@ -388,7 +434,7 @@ async fn script_action_with_dependency_graph(
     cache: &CacheProvider,
     opts: RunOpts,
     invocation: ScriptInvocation,
-    graph_options: ScriptGraphOptions,
+    graph_options: ScriptGraphOptions<'_>,
 ) -> Result<(PathBuf, Action)> {
     let root_id = invocation.script_path.as_str().to_string();
     let graph = collect_script_graph(invocation, &graph_options).await?;
@@ -404,13 +450,14 @@ async fn script_action_with_dependency_graph(
         &dependency_fingerprints,
         &fingerprints,
     )?);
-    let action = action_from_script_invocation(root, input_digest).await?;
+    let action =
+        action_from_script_invocation(root, input_digest, &dependency_fingerprints).await?;
     Ok((root.workspace.clone(), action))
 }
 
 async fn collect_script_graph(
     root: ScriptInvocation,
-    graph_options: &ScriptGraphOptions,
+    graph_options: &ScriptGraphOptions<'_>,
 ) -> Result<BTreeMap<String, ScriptInvocation>> {
     let mut graph = BTreeMap::new();
     let mut stack = Vec::new();
@@ -420,7 +467,7 @@ async fn collect_script_graph(
 
 fn collect_script_node<'a>(
     invocation: ScriptInvocation,
-    graph_options: &'a ScriptGraphOptions,
+    graph_options: &'a ScriptGraphOptions<'a>,
     graph: &'a mut BTreeMap<String, ScriptInvocation>,
     stack: &'a mut Vec<String>,
 ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
@@ -449,7 +496,7 @@ fn collect_script_node<'a>(
 
 async fn dependency_script_invocation(
     workspace: &Path,
-    graph_options: &ScriptGraphOptions,
+    graph_options: &ScriptGraphOptions<'_>,
     script_path: &WorkspacePath,
 ) -> Result<ScriptInvocation> {
     let script_arg = script_path.as_str();
@@ -467,6 +514,7 @@ async fn dependency_script_invocation(
         graph_options.timeout_ms_override,
         graph_options.remote_override.clone(),
         graph_options.sandbox,
+        graph_options.xdg,
     )
     .await
 }
@@ -554,7 +602,8 @@ async fn run_dependency_script(
         &dependency_fingerprints,
         &run_fingerprint_commands(&invocation).await?,
     )?);
-    let action = action_from_script_invocation(&invocation, input_digest).await?;
+    let action =
+        action_from_script_invocation(&invocation, input_digest, &dependency_fingerprints).await?;
     let outcome = runner
         .run(&action)
         .await
@@ -568,6 +617,7 @@ async fn run_dependency_script(
     Ok(DependencyFingerprint {
         script_path: invocation.script_path.as_str().to_string(),
         digest: dependency_output_digest(&outcome),
+        outputs: invocation.outputs,
     })
 }
 
@@ -724,6 +774,7 @@ fn exit_status_text(status: std::process::ExitStatus) -> String {
         .map_or_else(|| "signal".to_string(), |code| format!("exit code {code}"))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn script_invocation(
     workspace: &Path,
     explicit_env: BTreeMap<String, String>,
@@ -731,6 +782,7 @@ async fn script_invocation(
     timeout_ms_override: Option<u64>,
     remote_override: Option<RemoteExecution>,
     sandbox: SandboxMode,
+    xdg: Option<&Xdg>,
     argv: &[String],
 ) -> Result<ScriptInvocation> {
     let (runtime, runtime_args, script_arg, script_args) = parse_script_exec_argv(workspace, argv)?;
@@ -748,6 +800,7 @@ async fn script_invocation(
         timeout_ms_override,
         remote_override,
         sandbox,
+        xdg,
     )
     .await
 }
@@ -764,6 +817,7 @@ async fn script_invocation_from_annotations(
     timeout_ms_override: Option<u64>,
     remote_override: Option<RemoteExecution>,
     sandbox: SandboxMode,
+    xdg: Option<&Xdg>,
 ) -> Result<ScriptInvocation> {
     let workspace =
         resolve_script_workspace(workspace, script_abs, &annotations, cwd_override.as_ref())?;
@@ -804,8 +858,20 @@ async fn script_invocation_from_annotations(
         None => resolve_script_cwd(&script_dir, annotations.cwd.as_deref())?,
     };
     let timeout_ms = timeout_ms_override;
-    let env = script_env(&workspace, &runtime, &annotations.env_vars, explicit_env).await?;
-    let remote = remote_override.or_else(|| remote_execution(annotations.remote.as_deref()));
+    let remote = resolve_script_remote(
+        &workspace,
+        xdg,
+        remote_override,
+        annotations.remote.as_deref(),
+    )?;
+    let env = script_env(
+        &workspace,
+        &runtime,
+        &annotations.env_vars,
+        explicit_env,
+        remote.is_some(),
+    )
+    .await?;
     let output_symlink_mode = output_symlink_mode(annotations.output_symlinks.as_deref())?;
 
     Ok(ScriptInvocation {
@@ -1186,9 +1252,12 @@ async fn script_env(
     runtime: &str,
     env_vars: &[String],
     explicit_env: BTreeMap<String, String>,
+    remote: bool,
 ) -> Result<BTreeMap<String, String>> {
     let env_keys = env_vars.iter().map(String::as_str).collect::<Vec<_>>();
-    let mut out = if runtime.contains('/') {
+    let mut out = if remote {
+        BTreeMap::new()
+    } else if runtime.contains('/') {
         tool_env(&env_keys)
     } else {
         workspace_tool_env(workspace, &[runtime], &env_keys)
@@ -1235,6 +1304,16 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    fn xdg_under(root: &Path) -> Xdg {
+        Xdg {
+            cache_home: root.join("cache"),
+            state_home: root.join("state"),
+            data_home: root.join("data"),
+            config_home: root.join("config"),
+            runtime_dir: root.join("runtime"),
+        }
+    }
 
     #[test]
     fn finds_script_after_runtime_args() {
@@ -1306,6 +1385,7 @@ mod tests {
                 timeout_ms_override: None,
                 remote_override: None,
                 sandbox: SandboxMode::default(),
+                xdg: None,
             },
             &["/bin/bash".to_string(), "scripts/build.sh".to_string()],
         )
@@ -1325,6 +1405,77 @@ mod tests {
         assert_eq!(argv, vec!["/bin/bash".to_string(), "build.sh".to_string()]);
         assert_eq!(cwd.unwrap().as_str(), "scripts");
         assert!(input_digest.is_some());
+    }
+
+    #[tokio::test]
+    async fn remote_script_resolves_named_executor_and_dependency_outputs() {
+        let tmp = TempDir::new().unwrap();
+        let xdg = xdg_under(tmp.path());
+        let script = tmp.path().join("scripts").join("test.sh");
+        fs::create_dir_all(script.parent().unwrap()).unwrap();
+        fs::write(
+            tmp.path().join("once.toml"),
+            r#"
+[infrastructures.remote_tests]
+kind = "microsandbox"
+image = "node:22.18.0-alpine"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            &script,
+            "#!/bin/sh\n# once remote \"remote_tests\"\n# once input \"../tests\"\ntrue\n",
+        )
+        .unwrap();
+        fs::create_dir(tmp.path().join("tests")).unwrap();
+
+        let invocation = script_invocation(
+            tmp.path(),
+            BTreeMap::new(),
+            None,
+            None,
+            None,
+            SandboxMode::Off,
+            Some(&xdg),
+            &["/bin/sh".to_string(), "scripts/test.sh".to_string()],
+        )
+        .await
+        .unwrap();
+        let action = action_from_script_invocation(
+            &invocation,
+            None,
+            &[DependencyFingerprint {
+                script_path: "scripts/install.sh".to_string(),
+                digest: Digest::of_bytes(b"dependencies"),
+                outputs: vec![WorkspacePath::try_from("node_modules").unwrap()],
+            }],
+        )
+        .await
+        .unwrap();
+
+        let Action::RunCommand {
+            argv,
+            env,
+            inputs,
+            remote,
+            ..
+        } = action
+        else {
+            panic!("script action should produce a command action");
+        };
+        assert_eq!(argv, vec!["/bin/sh".to_string(), "test.sh".to_string()]);
+        assert!(env.is_empty());
+        assert!(inputs.iter().any(|input| input.as_str() == "node_modules"));
+        assert_eq!(
+            remote,
+            Some(Box::new(RemoteExecution {
+                provider: "remote_tests".to_string(),
+                executor: Some("microsandbox".to_string()),
+                environment: Some("node:22.18.0-alpine".to_string()),
+                account: None,
+                project: None,
+            }))
+        );
     }
 
     #[tokio::test]
@@ -1478,6 +1629,7 @@ mod tests {
                 timeout_ms_override: None,
                 remote_override: None,
                 sandbox: SandboxMode::default(),
+                xdg: None,
             },
             &["/bin/bash".to_string(), "scripts/build.sh".to_string()],
         )
@@ -1504,6 +1656,7 @@ mod tests {
                 timeout_ms_override: None,
                 remote_override: None,
                 sandbox: SandboxMode::default(),
+                xdg: None,
             },
             &["/bin/sh".to_string(), "build.sh".to_string()],
         )

--- a/crates/once-cli/src/commands/run.rs
+++ b/crates/once-cli/src/commands/run.rs
@@ -140,7 +140,7 @@ async fn finish_run(
 
 fn set_remote(action: &mut Action, remote_execution: RemoteExecution) {
     if let Action::RunCommand { remote, .. } = action {
-        *remote = Some(remote_execution);
+        *remote = Some(Box::new(remote_execution));
     }
 }
 
@@ -152,7 +152,7 @@ fn set_sandbox(action: &mut Action, sandbox_mode: SandboxMode) {
 
 fn action_remote(action: &Action) -> Option<&RemoteExecution> {
     match action {
-        Action::RunCommand { remote, .. } => remote.as_ref(),
+        Action::RunCommand { remote, .. } => remote.as_deref(),
         _ => None,
     }
 }

--- a/crates/once-cli/src/commands/run/action/script.rs
+++ b/crates/once-cli/src/commands/run/action/script.rs
@@ -112,7 +112,7 @@ async fn file_script_action(
             resources,
             sandbox: SandboxMode::default(),
             timeout_ms,
-            remote,
+            remote: remote.map(Box::new),
         },
         output: String::new(),
         output_dir: None,

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -625,7 +625,7 @@ async fn dispatch_exec(
     args: commands::exec::ExecArgs,
 ) -> Result<ExitCode> {
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
-    commands::exec::exec(workspace, &cache, args, output).await
+    commands::exec::exec(workspace, xdg, &cache, args, output).await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/once-core/Cargo.toml
+++ b/crates/once-core/Cargo.toml
@@ -14,6 +14,7 @@ remote-microsandbox = ["dep:microsandbox"]
 once-cas.workspace = true
 
 anyhow.workspace = true
+base64.workspace = true
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -22,7 +23,10 @@ sea-orm.workspace = true
 sea-orm-migration.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tar.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 jsonwebtoken = { version = "10.2.0", default-features = false, features = ["rust_crypto"] }
 
@@ -30,7 +34,6 @@ jsonwebtoken = { version = "10.2.0", default-features = false, features = ["rust
 microsandbox = { git = "https://github.com/superradcompany/microsandbox.git", rev = "975b62bfd331df7111b2de9abc1416fc87d7790b", version = "0.5.1", default-features = false, features = ["prebuilt"], optional = true }
 
 [dev-dependencies]
-tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [lints]

--- a/crates/once-core/src/action.rs
+++ b/crates/once-core/src/action.rs
@@ -13,7 +13,7 @@ use crate::{ResourceRequest, WorkspacePath};
 /// that should invalidate the cache. Older action result JSON still
 /// deserializes through serde defaults; the domain only partitions new
 /// action lookups.
-pub(crate) const ACTION_DIGEST_DOMAIN: &[u8] = b"once.action.v7\0";
+pub(crate) const ACTION_DIGEST_DOMAIN: &[u8] = b"once.action.v8\0";
 
 static DEFAULT_RESOURCE_REQUEST: LazyLock<ResourceRequest> =
     LazyLock::new(ResourceRequest::default);
@@ -127,7 +127,7 @@ pub enum Action {
         /// part of the action key so local and remote runs never share
         /// a cache slot by accident.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        remote: Option<RemoteExecution>,
+        remote: Option<Box<RemoteExecution>>,
     },
     WriteFile {
         path: WorkspacePath,
@@ -219,7 +219,14 @@ impl Action {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct RemoteExecution {
+    /// Named infrastructure configuration used for placement and logs.
     pub provider: String,
+    /// Executor adapter. When absent, the provider name identifies the adapter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executor: Option<String>,
+    /// Immutable toolchain image, snapshot, or template used for this action.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -230,6 +237,8 @@ impl RemoteExecution {
     pub fn provider(provider: impl Into<String>) -> Self {
         Self {
             provider: provider.into(),
+            executor: None,
+            environment: None,
             account: None,
             project: None,
         }
@@ -280,5 +289,31 @@ mod tests {
         assert_ne!(base.digest(), with_stdout.digest());
         assert_ne!(base.digest(), with_stderr.digest());
         assert_ne!(with_stdout.digest(), with_stderr.digest());
+    }
+
+    #[test]
+    fn remote_environment_changes_action_digest() {
+        let mut first = action(OutputSymlinkMode::default());
+        let mut second = first.clone();
+        if let Action::RunCommand { remote, .. } = &mut first {
+            *remote = Some(Box::new(RemoteExecution {
+                provider: "remote_tests".to_string(),
+                executor: Some("microsandbox".to_string()),
+                environment: Some("node:22.18.0-alpine".to_string()),
+                account: None,
+                project: None,
+            }));
+        }
+        if let Action::RunCommand { remote, .. } = &mut second {
+            *remote = Some(Box::new(RemoteExecution {
+                provider: "remote_tests".to_string(),
+                executor: Some("microsandbox".to_string()),
+                environment: Some("node:24.4.1-alpine".to_string()),
+                account: None,
+                project: None,
+            }));
+        }
+
+        assert_ne!(first.digest(), second.digest());
     }
 }

--- a/crates/once-core/src/execute.rs
+++ b/crates/once-core/src/execute.rs
@@ -108,6 +108,7 @@ async fn execute_command(
         cwd,
         inputs,
         outputs,
+        resources,
         timeout_ms,
         remote,
         stdout_path,
@@ -128,10 +129,15 @@ async fn execute_command(
         (Some(remote), _, _) => {
             remote::execute_command(
                 remote,
-                argv,
-                env,
-                cwd.as_ref(),
-                *timeout_ms,
+                remote::PreparedCommand {
+                    argv,
+                    env,
+                    cwd: cwd.as_ref(),
+                    inputs,
+                    outputs,
+                    resources,
+                    timeout_ms: *timeout_ms,
+                },
                 workspace_root,
                 cache,
                 stream_to_parent,

--- a/crates/once-core/src/remote.rs
+++ b/crates/once-core/src/remote.rs
@@ -3,40 +3,56 @@ use std::path::Path;
 
 use once_cas::{ActionResult, CacheProvider};
 
-use crate::{Error, RemoteExecution, Result, WorkspacePath};
+use crate::{Error, RemoteExecution, ResourceRequest, Result, WorkspacePath};
 
+mod archive;
 mod daytona;
+mod e2b;
 mod microsandbox;
+mod output_install;
+mod path;
+#[cfg(test)]
+mod test_server;
 
-#[allow(clippy::too_many_arguments)]
+pub(crate) struct PreparedCommand<'a> {
+    pub argv: &'a [String],
+    pub env: &'a BTreeMap<String, String>,
+    pub cwd: Option<&'a WorkspacePath>,
+    pub inputs: &'a [WorkspacePath],
+    pub outputs: &'a [WorkspacePath],
+    pub resources: &'a ResourceRequest,
+    pub timeout_ms: Option<u64>,
+}
+
 pub(crate) async fn execute_command(
     remote: &RemoteExecution,
-    argv: &[String],
-    env: &BTreeMap<String, String>,
-    cwd: Option<&WorkspacePath>,
-    timeout_ms: Option<u64>,
+    command: PreparedCommand<'_>,
     workspace_root: &Path,
     cache: &CacheProvider,
     stream_to_parent: bool,
 ) -> Result<ActionResult> {
-    match remote.provider.as_str() {
+    let executor = remote.executor.as_deref().unwrap_or(&remote.provider);
+    tracing::debug!(
+        provider = %remote.provider,
+        executor,
+        environment = remote.environment.as_deref().unwrap_or("provider-default"),
+        inputs = command.inputs.len(),
+        outputs = command.outputs.len(),
+        "dispatching remote command"
+    );
+    match executor {
         "microsandbox" => {
-            microsandbox::execute_command(
-                argv,
-                env,
-                cwd,
-                timeout_ms,
-                workspace_root,
-                cache,
-                stream_to_parent,
-            )
-            .await
+            microsandbox::execute_command(remote, command, workspace_root, cache, stream_to_parent)
+                .await
         }
         "daytona" => {
-            daytona::execute_command(argv, env, cwd, timeout_ms, cache, stream_to_parent).await
+            daytona::execute_command(remote, command, workspace_root, cache, stream_to_parent).await
         }
-        provider => Err(Error::UnsupportedRemoteProvider {
-            provider: provider.to_string(),
+        "e2b" => {
+            e2b::execute_command(remote, command, workspace_root, cache, stream_to_parent).await
+        }
+        executor => Err(Error::UnsupportedRemoteProvider {
+            provider: executor.to_string(),
         }),
     }
 }

--- a/crates/once-core/src/remote/archive.rs
+++ b/crates/once-core/src/remote/archive.rs
@@ -1,0 +1,55 @@
+use std::path::Path;
+
+use tempfile::TempPath;
+
+use crate::{Error, Result};
+
+mod input;
+mod output;
+
+pub(super) use input::create_input_archive;
+pub(super) use output::install_output_archive;
+
+pub(super) struct TempArchive {
+    path: TempPath,
+    len: u64,
+}
+
+impl TempArchive {
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn len(&self) -> u64 {
+        self.len
+    }
+}
+
+pub(super) fn output_archive_file(workspace_root: &Path) -> Result<tempfile::NamedTempFile> {
+    let parent = workspace_root.join(".once/tmp");
+    std::fs::create_dir_all(&parent).map_err(|source| Error::FileAction {
+        action: "create_remote_archive_directory",
+        path: ".once/tmp".to_string(),
+        source,
+    })?;
+    tempfile::NamedTempFile::new_in(parent).map_err(|source| Error::FileAction {
+        action: "create_remote_output_archive",
+        path: ".once/tmp".to_string(),
+        source,
+    })
+}
+
+fn archive_error(provider: &'static str, message: String) -> Error {
+    Error::RemoteProviderApi {
+        provider: provider.to_string(),
+        message,
+    }
+}
+
+fn file_error(action: &'static str, path: &Path, source: std::io::Error) -> Error {
+    Error::FileAction {
+        action,
+        path: path.display().to_string(),
+        source,
+    }
+}

--- a/crates/once-core/src/remote/archive/input.rs
+++ b/crates/once-core/src/remote/archive/input.rs
@@ -1,0 +1,184 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::{archive_error, file_error, TempArchive};
+use crate::remote::path::relative_link_stays_within;
+use crate::{Result, WorkspacePath};
+
+pub(in crate::remote) async fn create_input_archive(
+    workspace_root: &Path,
+    inputs: &[WorkspacePath],
+    provider: &'static str,
+) -> Result<TempArchive> {
+    let workspace = workspace_root.to_path_buf();
+    let inputs = inputs.to_vec();
+    tokio::task::spawn_blocking(move || build_input_archive(&workspace, &inputs, provider))
+        .await
+        .map_err(|source| archive_error(provider, format!("input archive task failed: {source}")))?
+}
+
+fn build_input_archive(
+    workspace_root: &Path,
+    inputs: &[WorkspacePath],
+    provider: &'static str,
+) -> Result<TempArchive> {
+    let parent = workspace_root.join(".once/tmp");
+    std::fs::create_dir_all(&parent).map_err(|source| crate::Error::FileAction {
+        action: "create_remote_archive_directory",
+        path: ".once/tmp".to_string(),
+        source,
+    })?;
+    let file =
+        tempfile::NamedTempFile::new_in(parent).map_err(|source| crate::Error::FileAction {
+            action: "create_remote_input_archive",
+            path: ".once/tmp".to_string(),
+            source,
+        })?;
+    let declared_roots = inputs
+        .iter()
+        .map(|input| PathBuf::from(input.as_str()))
+        .collect::<Vec<_>>();
+    let mut entries = BTreeMap::new();
+    for input in inputs {
+        collect_entries(
+            &input.resolve(workspace_root),
+            Path::new(input.as_str()),
+            &mut entries,
+        )?;
+    }
+
+    let mut builder = tar::Builder::new(file);
+    builder.follow_symlinks(false);
+    for (relative, source) in entries {
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        let metadata = std::fs::symlink_metadata(&source)
+            .map_err(|source_error| file_error("read_remote_input", &relative, source_error))?;
+        if metadata.file_type().is_symlink() {
+            let target = std::fs::read_link(&source).map_err(|source_error| {
+                file_error("read_remote_input_link", &relative, source_error)
+            })?;
+            if !relative_link_stays_within(&relative, &target, &declared_roots) {
+                return Err(archive_error(
+                    provider,
+                    format!(
+                        "input symbolic link `{}` targets `{}` outside declared input trees",
+                        relative.display(),
+                        target.display()
+                    ),
+                ));
+            }
+        }
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            builder
+                .append_dir(&relative, &source)
+                .map_err(|source_error| {
+                    file_error("archive_remote_input", &relative, source_error)
+                })?;
+        } else if metadata.is_file() || metadata.file_type().is_symlink() {
+            builder
+                .append_path_with_name(&source, &relative)
+                .map_err(|source_error| {
+                    file_error("archive_remote_input", &relative, source_error)
+                })?;
+        } else {
+            return Err(archive_error(
+                provider,
+                format!(
+                    "input `{}` is not a file, directory, or symbolic link",
+                    relative.display()
+                ),
+            ));
+        }
+    }
+    builder.finish().map_err(|source| {
+        file_error(
+            "finish_remote_input_archive",
+            Path::new(".once/tmp"),
+            source,
+        )
+    })?;
+    let file = builder.into_inner().map_err(|source| {
+        file_error(
+            "finish_remote_input_archive",
+            Path::new(".once/tmp"),
+            source,
+        )
+    })?;
+    let len = file
+        .as_file()
+        .metadata()
+        .map_err(|source| file_error("read_remote_input_archive", Path::new(".once/tmp"), source))?
+        .len();
+    Ok(TempArchive {
+        path: file.into_temp_path(),
+        len,
+    })
+}
+
+fn collect_entries(
+    source: &Path,
+    relative: &Path,
+    entries: &mut BTreeMap<PathBuf, PathBuf>,
+) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(source)
+        .map_err(|source_error| file_error("read_remote_input", relative, source_error))?;
+    entries.insert(relative.to_path_buf(), source.to_path_buf());
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    let mut children = std::fs::read_dir(source)
+        .map_err(|source_error| file_error("read_remote_input_directory", relative, source_error))?
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|source_error| {
+            file_error("read_remote_input_directory", relative, source_error)
+        })?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let name = child.file_name();
+        let child_relative = relative.join(name);
+        collect_entries(&child.path(), &child_relative, entries)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn input_archive_preserves_a_dependency_tree() {
+        let workspace = tempfile::tempdir().unwrap();
+        let bin = workspace.path().join("node_modules/.bin");
+        let package = workspace.path().join("node_modules/vitest");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(package.join("runner.mjs"), "console.log('ok')").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("../vitest/runner.mjs", bin.join("vitest")).unwrap();
+
+        let archive = create_input_archive(
+            workspace.path(),
+            &[WorkspacePath::try_from("node_modules").unwrap()],
+            "test",
+        )
+        .await
+        .unwrap();
+        let destination = tempfile::tempdir().unwrap();
+        tar::Archive::new(std::fs::File::open(archive.path()).unwrap())
+            .unpack(destination.path())
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(destination.path().join("node_modules/vitest/runner.mjs"))
+                .unwrap(),
+            "console.log('ok')"
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            std::fs::read_link(destination.path().join("node_modules/.bin/vitest")).unwrap(),
+            PathBuf::from("../vitest/runner.mjs")
+        );
+    }
+}

--- a/crates/once-core/src/remote/archive/output.rs
+++ b/crates/once-core/src/remote/archive/output.rs
@@ -1,0 +1,201 @@
+use std::path::{Path, PathBuf};
+
+use super::archive_error;
+use crate::remote::output_install::OutputStaging;
+use crate::remote::path::{path_is_declared, relative_link_stays_within};
+use crate::{Error, Result, WorkspacePath};
+
+pub(in crate::remote) async fn install_output_archive(
+    archive_path: &Path,
+    workspace_root: &Path,
+    outputs: &[WorkspacePath],
+    provider: &'static str,
+) -> Result<()> {
+    let archive = archive_path.to_path_buf();
+    let workspace = workspace_root.to_path_buf();
+    let outputs = outputs.to_vec();
+    let staged_outputs = outputs.clone();
+    let staging = tokio::task::spawn_blocking(move || {
+        let staging = OutputStaging::create(&workspace)?;
+        extract_output_archive(&archive, staging.files(), &staged_outputs, provider)?;
+        Ok::<_, Error>(staging)
+    })
+    .await
+    .map_err(|source| archive_error(provider, format!("output archive task failed: {source}")))??;
+    staging.install(outputs.as_slice(), workspace_root).await
+}
+
+fn extract_output_archive(
+    archive_path: &Path,
+    staging_root: &Path,
+    outputs: &[WorkspacePath],
+    provider: &'static str,
+) -> Result<()> {
+    let declared_roots = outputs
+        .iter()
+        .map(|output| PathBuf::from(output.as_str()))
+        .collect::<Vec<_>>();
+    let file = std::fs::File::open(archive_path).map_err(|source| Error::FileAction {
+        action: "open_remote_output_archive",
+        path: archive_path.display().to_string(),
+        source,
+    })?;
+    let mut archive = tar::Archive::new(file);
+    for entry in archive.entries().map_err(|source| {
+        archive_error(
+            provider,
+            format!("cannot read remote output archive: {source}"),
+        )
+    })? {
+        let mut entry = entry.map_err(|source| {
+            archive_error(
+                provider,
+                format!("cannot read remote output entry: {source}"),
+            )
+        })?;
+        extract_output_entry(&mut entry, staging_root, &declared_roots, provider)?;
+    }
+    for output in outputs {
+        let path = output.resolve(staging_root);
+        std::fs::symlink_metadata(&path).map_err(|source| {
+            archive_error(
+                provider,
+                format!(
+                    "declared output `{}` was not returned: {source}",
+                    output.as_str()
+                ),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn extract_output_entry(
+    entry: &mut tar::Entry<'_, std::fs::File>,
+    staging_root: &Path,
+    declared_roots: &[PathBuf],
+    provider: &'static str,
+) -> Result<()> {
+    let raw_path = entry.path().map_err(|source| {
+        archive_error(
+            provider,
+            format!("remote output has an invalid path: {source}"),
+        )
+    })?;
+    let relative = {
+        let raw_path = raw_path.as_ref();
+        let raw = raw_path.to_str().ok_or_else(|| {
+            archive_error(
+                provider,
+                "remote output path is not valid UTF-8".to_string(),
+            )
+        })?;
+        let path = WorkspacePath::try_from(raw)
+            .map_err(|source| archive_error(provider, source.to_string()))?;
+        let relative = PathBuf::from(path.as_str());
+        if relative.as_os_str().is_empty() || !path_is_declared(&relative, declared_roots) {
+            return Err(archive_error(
+                provider,
+                format!(
+                    "remote output `{}` is outside declared output trees",
+                    raw_path.display()
+                ),
+            ));
+        }
+        relative
+    };
+    let kind = entry.header().entry_type();
+    if !(kind.is_file() || kind.is_dir() || kind.is_symlink()) {
+        return Err(archive_error(
+            provider,
+            format!(
+                "remote output `{}` has an unsupported type",
+                relative.display()
+            ),
+        ));
+    }
+    if kind.is_symlink() {
+        let target = entry
+            .link_name()
+            .map_err(|source| archive_error(provider, source.to_string()))?
+            .ok_or_else(|| archive_error(provider, "symbolic link has no target".to_string()))?;
+        if !relative_link_stays_within(&relative, &target, declared_roots) {
+            return Err(archive_error(
+                provider,
+                format!(
+                    "output symbolic link `{}` targets `{}` outside declared output trees",
+                    relative.display(),
+                    target.display()
+                ),
+            ));
+        }
+    }
+    let unpacked = entry.unpack_in(staging_root).map_err(|source| {
+        archive_error(
+            provider,
+            format!(
+                "cannot extract remote output `{}`: {source}",
+                relative.display()
+            ),
+        )
+    })?;
+    if !unpacked {
+        return Err(archive_error(
+            provider,
+            format!("remote output `{}` escaped staging", relative.display()),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_archive(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut archive = tar::Builder::new(file);
+        for (entry_path, contents) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(u64::try_from(contents.len()).unwrap());
+            header.set_mode(0o644);
+            header.set_cksum();
+            archive
+                .append_data(&mut header, entry_path, *contents)
+                .unwrap();
+        }
+        archive.finish().unwrap();
+    }
+
+    #[tokio::test]
+    async fn installs_only_declared_outputs() {
+        let workspace = tempfile::tempdir().unwrap();
+        let archive = workspace.path().join("outputs.tar");
+        write_archive(&archive, &[("./reports/result.txt", b"passed\n")]);
+        let outputs = vec![WorkspacePath::try_from("reports").unwrap()];
+
+        install_output_archive(&archive, workspace.path(), &outputs, "test")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("reports/result.txt")).unwrap(),
+            "passed\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_outputs_outside_declared_trees() {
+        let workspace = tempfile::tempdir().unwrap();
+        let archive = workspace.path().join("outputs.tar");
+        write_archive(&archive, &[("secrets.txt", b"no")]);
+        let outputs = vec![WorkspacePath::try_from("reports").unwrap()];
+
+        let error = install_output_archive(&archive, workspace.path(), &outputs, "test")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("outside declared output trees"));
+        assert!(!workspace.path().join("secrets.txt").exists());
+    }
+}

--- a/crates/once-core/src/remote/daytona/cleanup.rs
+++ b/crates/once-core/src/remote/daytona/cleanup.rs
@@ -1,0 +1,37 @@
+use super::client::Client;
+use crate::Result;
+
+pub(super) struct SandboxCleanup {
+    client: Client,
+    id: Option<String>,
+}
+
+impl SandboxCleanup {
+    pub(super) fn new(client: Client, id: String) -> Self {
+        Self {
+            client,
+            id: Some(id),
+        }
+    }
+
+    pub(super) async fn run(mut self) -> Result<()> {
+        let id = self.id.take().expect("cleanup sandbox is present");
+        self.client.delete(&id).await
+    }
+}
+
+impl Drop for SandboxCleanup {
+    fn drop(&mut self) {
+        let Some(id) = self.id.take() else {
+            return;
+        };
+        let client = self.client.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                if let Err(error) = client.delete(&id).await {
+                    tracing::warn!(provider = "daytona", sandbox = %id, %error, "failed to delete remote sandbox");
+                }
+            });
+        }
+    }
+}

--- a/crates/once-core/src/remote/daytona/client.rs
+++ b/crates/once-core/src/remote/daytona/client.rs
@@ -1,0 +1,217 @@
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, ResourceRequest, Result};
+
+#[derive(Clone)]
+pub(super) struct Config {
+    control_url: String,
+    pub(super) toolbox_url: String,
+    pub(super) api_key: String,
+}
+
+impl Config {
+    pub(super) fn from_env() -> Result<Self> {
+        Ok(Self {
+            control_url: std::env::var("ONCE_DAYTONA_CONTROL_URL")
+                .unwrap_or_else(|_| "https://app.daytona.io/api".to_string()),
+            toolbox_url: std::env::var("ONCE_DAYTONA_TOOLBOX_URL")
+                .or_else(|_| std::env::var("ONCE_DAYTONA_API_URL"))
+                .unwrap_or_else(|_| "https://proxy.app.daytona.io/toolbox".to_string()),
+            api_key: std::env::var("ONCE_DAYTONA_API_KEY")
+                .or_else(|_| std::env::var("DAYTONA_API_KEY"))
+                .map_err(|_| Error::RemoteProviderConfig {
+                    provider: "daytona".to_string(),
+                    message: "set ONCE_DAYTONA_API_KEY or DAYTONA_API_KEY".to_string(),
+                })?,
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test(control_url: String, toolbox_url: String) -> Self {
+        Self {
+            control_url,
+            toolbox_url,
+            api_key: "test-key".to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Client {
+    pub(super) http: reqwest::Client,
+    pub(super) config: Config,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Sandbox {
+    pub id: String,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    toolbox_proxy_url: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateRequest {
+    auto_delete_interval: i32,
+    auto_stop_interval: u64,
+    cpu: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    build_info: Option<BuildInfo>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildInfo {
+    dockerfile_content: String,
+}
+
+impl Client {
+    pub(super) fn new(config: Config) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .build()
+            .map_err(http_error)?;
+        Ok(Self { http, config })
+    }
+
+    pub(super) async fn create(
+        &self,
+        image: Option<&str>,
+        resources: &ResourceRequest,
+        timeout_ms: Option<u64>,
+    ) -> Result<Sandbox> {
+        let auto_stop_interval = timeout_ms
+            .map_or(15, |value| value.div_ceil(60_000).saturating_add(5))
+            .max(1);
+        let memory = (resources.memory_bytes > 0)
+            .then(|| resources.memory_bytes.div_ceil(1024 * 1024 * 1024));
+        let build_info = image.map(|image| BuildInfo {
+            dockerfile_content: format!("FROM {image}"),
+        });
+        let response = self
+            .http
+            .post(format!(
+                "{}/sandbox",
+                self.config.control_url.trim_end_matches('/')
+            ))
+            .bearer_auth(&self.config.api_key)
+            .timeout(Duration::from_mins(1))
+            .json(&CreateRequest {
+                auto_delete_interval: 0,
+                auto_stop_interval,
+                cpu: resources.cpu_slots.max(1),
+                memory,
+                build_info,
+            })
+            .send()
+            .await
+            .map_err(http_error)?;
+        let mut sandbox: Sandbox = decode(response).await?;
+        tracing::debug!(provider = "daytona", sandbox = %sandbox.id, "created remote sandbox");
+        let deadline = Instant::now() + Duration::from_secs(timeout_secs(timeout_ms));
+        while sandbox.state.as_deref() != Some("started") {
+            if matches!(
+                sandbox.state.as_deref(),
+                Some("error" | "build_failed" | "destroyed")
+            ) {
+                return Err(api_error(format!(
+                    "sandbox {} entered state {} while starting",
+                    sandbox.id,
+                    sandbox.state.as_deref().unwrap_or("unknown")
+                )));
+            }
+            if Instant::now() >= deadline {
+                return Err(Error::Timeout(Duration::from_secs(timeout_secs(
+                    timeout_ms,
+                ))));
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            sandbox = self.get(&sandbox.id).await?;
+        }
+        Ok(sandbox)
+    }
+
+    async fn get(&self, id: &str) -> Result<Sandbox> {
+        let response = self
+            .http
+            .get(format!(
+                "{}/sandbox/{id}",
+                self.config.control_url.trim_end_matches('/')
+            ))
+            .bearer_auth(&self.config.api_key)
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(http_error)?;
+        decode(response).await
+    }
+
+    pub(super) async fn delete(&self, id: &str) -> Result<()> {
+        let response = self
+            .http
+            .delete(format!(
+                "{}/sandbox/{id}",
+                self.config.control_url.trim_end_matches('/')
+            ))
+            .bearer_auth(&self.config.api_key)
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(http_error)?;
+        expect_success(response).await?;
+        tracing::debug!(provider = "daytona", sandbox = id, "deleted remote sandbox");
+        Ok(())
+    }
+
+    pub(super) fn toolbox_base(&self, sandbox: &Sandbox) -> String {
+        let root = sandbox
+            .toolbox_proxy_url
+            .as_deref()
+            .unwrap_or(&self.config.toolbox_url);
+        format!("{}/{}", root.trim_end_matches('/'), sandbox.id)
+    }
+}
+
+fn timeout_secs(timeout_ms: Option<u64>) -> u64 {
+    timeout_ms
+        .map_or(600, |value| value.div_ceil(1000).saturating_add(120))
+        .max(1)
+}
+
+async fn decode<T: for<'de> Deserialize<'de>>(response: reqwest::Response) -> Result<T> {
+    checked(response).await?.json().await.map_err(http_error)
+}
+
+pub(super) async fn checked(response: reqwest::Response) -> Result<reqwest::Response> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(api_error(format!("HTTP {status}: {body}")))
+}
+
+pub(super) async fn expect_success(response: reqwest::Response) -> Result<()> {
+    checked(response).await.map(|_| ())
+}
+
+pub(super) fn http_error(source: reqwest::Error) -> Error {
+    Error::RemoteProviderHttp {
+        provider: "daytona".to_string(),
+        source,
+    }
+}
+
+fn api_error(message: String) -> Error {
+    Error::RemoteProviderApi {
+        provider: "daytona".to_string(),
+        message,
+    }
+}

--- a/crates/once-core/src/remote/daytona/transport.rs
+++ b/crates/once-core/src/remote/daytona/transport.rs
@@ -201,8 +201,9 @@ mod tests {
 
     #[test]
     fn streams_prefer_artifacts_over_dedicated_fields() {
-        let response =
-            parse(r#"{"exitCode":0,"stdout":"out","artifacts":{"stdout":"a-out","stderr":"a-err"}}"#);
+        let response = parse(
+            r#"{"exitCode":0,"stdout":"out","artifacts":{"stdout":"a-out","stderr":"a-err"}}"#,
+        );
         let (stdout, stderr) = response.output_streams();
         assert_eq!(stdout, b"a-out");
         assert_eq!(stderr, b"a-err");

--- a/crates/once-core/src/remote/daytona/transport.rs
+++ b/crates/once-core/src/remote/daytona/transport.rs
@@ -1,0 +1,218 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Duration;
+
+use futures::StreamExt;
+use reqwest::multipart::{Form, Part};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio_util::io::ReaderStream;
+
+use super::client::{checked, expect_success, http_error, Client, Sandbox};
+use crate::{Error, Result};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ExecuteResponse {
+    #[serde(default)]
+    exit_code: Option<i32>,
+    #[serde(default)]
+    result: Option<String>,
+    #[serde(default)]
+    stdout: Option<String>,
+    #[serde(default)]
+    stderr: Option<String>,
+    #[serde(default)]
+    artifacts: Option<Artifacts>,
+}
+
+// Daytona has returned command output in several shapes across toolbox
+// versions. Prefer the structured artifact streams, then the dedicated
+// stdout/stderr fields, then the combined `result` fallback.
+#[derive(Deserialize)]
+struct Artifacts {
+    #[serde(default)]
+    stdout: Option<String>,
+    #[serde(default)]
+    stderr: Option<String>,
+}
+
+impl ExecuteResponse {
+    /// The reported process exit code, or an error when the toolbox
+    /// omitted it entirely. A missing exit code must never be treated as a
+    /// success, otherwise a failed command would be cached as if it passed.
+    pub(super) fn exit_code(&self) -> Result<i32> {
+        self.exit_code.ok_or_else(|| Error::RemoteProviderApi {
+            provider: "daytona".to_string(),
+            message: "Daytona response did not include an exit code".to_string(),
+        })
+    }
+
+    /// Splits the response into stdout and stderr byte streams, preferring
+    /// the richest representation the toolbox provided.
+    pub(super) fn output_streams(&self) -> (Vec<u8>, Vec<u8>) {
+        let stdout = self
+            .artifacts
+            .as_ref()
+            .and_then(|artifacts| artifacts.stdout.clone())
+            .or_else(|| self.stdout.clone())
+            .or_else(|| self.result.clone())
+            .unwrap_or_default()
+            .into_bytes();
+        let stderr = self
+            .artifacts
+            .as_ref()
+            .and_then(|artifacts| artifacts.stderr.clone())
+            .or_else(|| self.stderr.clone())
+            .unwrap_or_default()
+            .into_bytes();
+        (stdout, stderr)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExecuteRequest<'a> {
+    command: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<&'a str>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    envs: &'a BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout: Option<u64>,
+}
+
+impl Client {
+    pub(super) async fn upload(
+        &self,
+        sandbox: &Sandbox,
+        source: &Path,
+        len: u64,
+        destination: &str,
+    ) -> Result<()> {
+        let file = tokio::fs::File::open(source)
+            .await
+            .map_err(|source| file_error("open_remote_input_archive", source))?;
+        let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+        let form = Form::new().part(
+            "file",
+            Part::stream_with_length(body, len).file_name("once-inputs.tar"),
+        );
+        let response = self
+            .http
+            .post(format!("{}/files/upload", self.toolbox_base(sandbox)))
+            .bearer_auth(&self.config.api_key)
+            .query(&[("path", destination)])
+            .multipart(form)
+            .send()
+            .await
+            .map_err(http_error)?;
+        expect_success(response).await
+    }
+
+    pub(super) async fn execute(
+        &self,
+        sandbox: &Sandbox,
+        command: &str,
+        cwd: Option<&str>,
+        envs: &BTreeMap<String, String>,
+        timeout: Option<u64>,
+    ) -> Result<ExecuteResponse> {
+        let mut request = self
+            .http
+            .post(format!("{}/process/execute", self.toolbox_base(sandbox)))
+            .bearer_auth(&self.config.api_key)
+            .json(&ExecuteRequest {
+                command,
+                cwd,
+                envs,
+                timeout,
+            });
+        if let Some(timeout) = timeout {
+            request = request.timeout(Duration::from_secs(timeout.saturating_add(5)));
+        }
+        let response = request.send().await.map_err(http_error)?;
+        checked(response).await?.json().await.map_err(http_error)
+    }
+
+    pub(super) async fn download(
+        &self,
+        sandbox: &Sandbox,
+        source: &str,
+        destination: &Path,
+    ) -> Result<()> {
+        let response = self
+            .http
+            .get(format!("{}/files/download", self.toolbox_base(sandbox)))
+            .bearer_auth(&self.config.api_key)
+            .query(&[("path", source)])
+            .send()
+            .await
+            .map_err(http_error)?;
+        let response = checked(response).await?;
+        let mut file = tokio::fs::File::create(destination)
+            .await
+            .map_err(|source| file_error("create_remote_output_archive", source))?;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            file.write_all(&chunk.map_err(http_error)?)
+                .await
+                .map_err(|source| file_error("write_remote_output_archive", source))?;
+        }
+        file.flush()
+            .await
+            .map_err(|source| file_error("flush_remote_output_archive", source))
+    }
+}
+
+fn file_error(action: &'static str, source: std::io::Error) -> Error {
+    Error::FileAction {
+        action,
+        path: ".once/tmp".to_string(),
+        source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> ExecuteResponse {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn missing_exit_code_is_an_error() {
+        let response = parse(r#"{"result":"ok"}"#);
+        let error = response.exit_code().unwrap_err();
+        assert!(
+            matches!(error, Error::RemoteProviderApi { ref provider, .. } if provider == "daytona")
+        );
+        assert!(error.to_string().contains("exit code"));
+    }
+
+    #[test]
+    fn streams_prefer_dedicated_fields_over_result() {
+        let response = parse(r#"{"exitCode":0,"result":"combined","stdout":"out","stderr":"err"}"#);
+        let (stdout, stderr) = response.output_streams();
+        assert_eq!(stdout, b"out");
+        assert_eq!(stderr, b"err");
+    }
+
+    #[test]
+    fn streams_prefer_artifacts_over_dedicated_fields() {
+        let response =
+            parse(r#"{"exitCode":0,"stdout":"out","artifacts":{"stdout":"a-out","stderr":"a-err"}}"#);
+        let (stdout, stderr) = response.output_streams();
+        assert_eq!(stdout, b"a-out");
+        assert_eq!(stderr, b"a-err");
+    }
+
+    #[test]
+    fn stdout_falls_back_to_result() {
+        let response = parse(r#"{"exitCode":0,"result":"combined"}"#);
+        let (stdout, stderr) = response.output_streams();
+        assert_eq!(stdout, b"combined");
+        assert!(stderr.is_empty());
+    }
+}

--- a/crates/once-core/src/remote/e2b.rs
+++ b/crates/once-core/src/remote/e2b.rs
@@ -10,11 +10,12 @@ use crate::{Error, RemoteExecution, Result, WorkspacePath};
 
 mod cleanup;
 mod client;
+mod protocol;
 mod transport;
 
 use cleanup::SandboxCleanup;
 use client::{Client, Config};
-use transport::ExecuteResponse;
+use protocol::CommandResponse;
 
 const GUEST_ROOT: &str = "/workspace";
 const INPUT_ARCHIVE: &str = "/tmp/once-inputs.tar";
@@ -49,66 +50,57 @@ async fn execute_with_client(
     client: Client,
 ) -> Result<ActionResult> {
     let sandbox = client
-        .create(
-            remote.environment.as_deref(),
-            command.resources,
-            command.timeout_ms,
-        )
+        .create(remote.environment.as_deref(), command.timeout_ms)
         .await?;
     let cleanup = SandboxCleanup::new(client.clone(), sandbox.id.clone());
 
     let result = async {
-        let archive = create_input_archive(workspace_root, command.inputs, "daytona").await?;
+        let archive = create_input_archive(workspace_root, command.inputs, "e2b").await?;
         client
             .upload(&sandbox, archive.path(), archive.len(), INPUT_ARCHIVE)
             .await?;
-        ensure_success(
-            &client
-                .execute(
-                    &sandbox,
-                    &format!(
-                        "mkdir -p {} && tar -xf {} -C {}",
-                        shell_word(GUEST_ROOT),
-                        shell_word(INPUT_ARCHIVE),
-                        shell_word(GUEST_ROOT)
-                    ),
-                    None,
-                    &BTreeMap::new(),
-                    command.timeout_ms.map(timeout_secs),
-                )
-                .await?,
-            "staging declared inputs",
-        )?;
+        run_setup(
+            &client,
+            &sandbox,
+            "mkdir",
+            &["-p".to_string(), GUEST_ROOT.to_string()],
+            command.timeout_ms,
+        )
+        .await?;
+        run_setup(
+            &client,
+            &sandbox,
+            "tar",
+            &[
+                "-xf".to_string(),
+                INPUT_ARCHIVE.to_string(),
+                "-C".to_string(),
+                GUEST_ROOT.to_string(),
+            ],
+            command.timeout_ms,
+        )
+        .await?;
 
+        let (program, args) = command.argv.split_first().ok_or(Error::EmptyArgv)?;
         let response = client
             .execute(
                 &sandbox,
-                &command_line(command.argv)?,
+                program,
+                args,
                 Some(&workdir(command.cwd)),
                 command.env,
-                command.timeout_ms.map(timeout_secs),
+                command.timeout_ms,
             )
             .await?;
         let result = action_result(response, cache, stream_to_parent).await?;
         if result.exit_code == 0 && !command.outputs.is_empty() {
-            ensure_success(
-                &client
-                    .execute(
-                        &sandbox,
-                        &pack_outputs_command(command.outputs),
-                        None,
-                        &BTreeMap::new(),
-                        command.timeout_ms.map(timeout_secs),
-                    )
-                    .await?,
-                "packing declared outputs",
-            )?;
+            let args = pack_output_args(command.outputs);
+            run_setup(&client, &sandbox, "tar", &args, command.timeout_ms).await?;
             let archive = output_archive_file(workspace_root)?;
             client
                 .download(&sandbox, OUTPUT_ARCHIVE, archive.path())
                 .await?;
-            install_output_archive(archive.path(), workspace_root, command.outputs, "daytona")
-                .await?;
+            install_output_archive(archive.path(), workspace_root, command.outputs, "e2b").await?;
         }
         Ok(result)
     }
@@ -119,78 +111,68 @@ async fn execute_with_client(
         (Ok(result), Ok(())) => Ok(result),
         (Ok(_), Err(error)) | (Err(error), Ok(())) => Err(error),
         (Err(error), Err(cleanup_error)) => {
-            tracing::warn!(provider = "daytona", %cleanup_error, "failed to delete remote sandbox after execution failure");
+            tracing::warn!(provider = "e2b", %cleanup_error, "failed to delete remote sandbox after execution failure");
             Err(error)
         }
     }
 }
 
+async fn run_setup(
+    client: &Client,
+    sandbox: &client::Sandbox,
+    program: &str,
+    args: &[String],
+    timeout_ms: Option<u64>,
+) -> Result<()> {
+    let response = client
+        .execute(sandbox, program, args, None, &BTreeMap::new(), timeout_ms)
+        .await?;
+    if response.exit_code == 0 {
+        Ok(())
+    } else {
+        Err(Error::RemoteProviderApi {
+            provider: "e2b".to_string(),
+            message: format!(
+                "remote setup failed with exit code {}: {}",
+                response.exit_code,
+                String::from_utf8_lossy(&response.stderr)
+            ),
+        })
+    }
+}
+
 async fn action_result(
-    response: ExecuteResponse,
+    response: CommandResponse,
     cache: &CacheProvider,
     stream_to_parent: bool,
 ) -> Result<ActionResult> {
-    let exit_code = response.exit_code()?;
-    let (stdout, stderr) = response.output_streams();
-    stream::write_parent(&stdout, Destination::Stdout, stream_to_parent).await?;
-    stream::write_parent(&stderr, Destination::Stderr, stream_to_parent).await?;
-    let stdout = cache.put_blob(&stdout).await?;
-    let stderr = cache.put_blob(&stderr).await?;
+    stream::write_parent(&response.stdout, Destination::Stdout, stream_to_parent).await?;
+    stream::write_parent(&response.stderr, Destination::Stderr, stream_to_parent).await?;
+    let stdout = cache.put_blob(&response.stdout).await?;
+    let stderr = cache.put_blob(&response.stderr).await?;
     Ok(ActionResult {
-        exit_code,
+        exit_code: response.exit_code,
         stdout: Some(stdout),
         stderr: Some(stderr),
         outputs: BTreeMap::new(),
     })
 }
 
-fn ensure_success(response: &ExecuteResponse, operation: &str) -> Result<()> {
-    let exit_code = response.exit_code()?;
-    if exit_code == 0 {
-        return Ok(());
-    }
-    let (stdout, stderr) = response.output_streams();
-    let detail = String::from_utf8_lossy(&stderr);
-    let detail = if detail.trim().is_empty() {
-        String::from_utf8_lossy(&stdout)
-    } else {
-        detail
-    };
-    Err(Error::RemoteProviderApi {
-        provider: "daytona".to_string(),
-        message: format!("{operation} failed with exit code {exit_code}: {detail}"),
-    })
-}
-
-fn command_line(argv: &[String]) -> Result<String> {
-    if argv.is_empty() {
-        return Err(Error::EmptyArgv);
-    }
-    Ok(argv
-        .iter()
-        .map(|word| shell_word(word))
-        .collect::<Vec<_>>()
-        .join(" "))
-}
-
-fn pack_outputs_command(outputs: &[WorkspacePath]) -> String {
-    let paths = outputs
-        .iter()
-        .map(|path| {
-            let relative = if path.as_str().is_empty() {
-                ".".to_string()
-            } else {
-                format!("./{}", path.as_str())
-            };
-            shell_word(&relative)
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
-    format!(
-        "tar -cf {} -C {} {paths}",
-        shell_word(OUTPUT_ARCHIVE),
-        shell_word(GUEST_ROOT)
-    )
+fn pack_output_args(outputs: &[WorkspacePath]) -> Vec<String> {
+    let mut args = vec![
+        "-cf".to_string(),
+        OUTPUT_ARCHIVE.to_string(),
+        "-C".to_string(),
+        GUEST_ROOT.to_string(),
+    ];
+    args.extend(outputs.iter().map(|path| {
+        if path.as_str().is_empty() {
+            ".".to_string()
+        } else {
+            format!("./{}", path.as_str())
+        }
+    }));
+    args
 }
 
 fn workdir(cwd: Option<&WorkspacePath>) -> String {
@@ -200,14 +182,6 @@ fn workdir(cwd: Option<&WorkspacePath>) -> String {
     )
 }
 
-fn timeout_secs(timeout_ms: u64) -> u64 {
-    timeout_ms.div_ceil(1000).max(1)
-}
-
-fn shell_word(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,30 +189,23 @@ mod tests {
     use crate::ResourceRequest;
 
     #[test]
-    fn command_quotes_argv() {
-        let command = command_line(&[
-            "printf".to_string(),
-            "%s".to_string(),
-            "hello world".to_string(),
-        ])
-        .unwrap();
-        assert_eq!(command, "'printf' '%s' 'hello world'");
-    }
-
-    #[test]
     fn output_paths_cannot_become_options() {
-        let command = pack_outputs_command(&[WorkspacePath::try_from("-danger").unwrap()]);
-        assert!(command.ends_with("'./-danger'"));
+        let args = pack_output_args(&[WorkspacePath::try_from("-danger").unwrap()]);
+        assert_eq!(args.last().unwrap(), "./-danger");
     }
 
     #[tokio::test]
     async fn deletes_the_sandbox_after_success() {
+        let process = process_response(0);
         let (url, server) = test_server::spawn(vec![
-            Response::json(r#"{"id":"daytona-test","state":"started","toolboxProxyUrl":null}"#),
+            Response::json(
+                r#"{"sandboxID":"e2b-test","envdAccessToken":"access-token","envdVersion":"1.0.0"}"#,
+            ),
             Response::empty(200),
-            Response::json(r#"{"exitCode":0,"result":""}"#),
-            Response::json(r#"{"exitCode":0,"result":"ok"}"#),
-            Response::json(r#"{"exitCode":0,"result":""}"#),
+            process_response_spec(&process),
+            process_response_spec(&process),
+            process_response_spec(&process),
+            process_response_spec(&process),
             Response::tar_file("./reports/result.txt", b"passed\n"),
             Response::empty(204),
         ])
@@ -258,10 +225,10 @@ mod tests {
             resources: &resources,
             timeout_ms: None,
         };
-        let client = Client::new(Config::for_test(url.clone(), format!("{url}/toolbox"))).unwrap();
+        let client = Client::new(Config::for_test(url.clone(), url)).unwrap();
 
         let result = execute_with_client(
-            &RemoteExecution::provider("daytona"),
+            &RemoteExecution::provider("e2b"),
             command,
             workspace.path(),
             &cache,
@@ -277,17 +244,20 @@ mod tests {
             std::fs::read_to_string(workspace.path().join("reports/result.txt")).unwrap(),
             "passed\n"
         );
-        assert!(requests
-            .iter()
-            .any(|request| request.method == "DELETE" && request.path == "/sandbox/daytona-test"));
+        assert!(requests.iter().any(|request| {
+            request.method == "DELETE" && request.path == "/sandboxes/e2b-test"
+        }));
         let create: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
-        assert_eq!(create["autoDeleteInterval"], 0);
+        assert_eq!(create["autoPause"], false);
+        assert_eq!(create["autoResume"]["enabled"], false);
     }
 
     #[tokio::test]
     async fn deletes_the_sandbox_when_upload_fails() {
         let (url, server) = test_server::spawn(vec![
-            Response::json(r#"{"id":"daytona-test","state":"started","toolboxProxyUrl":null}"#),
+            Response::json(
+                r#"{"sandboxID":"e2b-test","envdAccessToken":"access-token","envdVersion":"1.0.0"}"#,
+            ),
             Response::empty(500),
             Response::empty(204),
         ])
@@ -306,10 +276,10 @@ mod tests {
             resources: &resources,
             timeout_ms: None,
         };
-        let client = Client::new(Config::for_test(url.clone(), format!("{url}/toolbox"))).unwrap();
+        let client = Client::new(Config::for_test(url.clone(), url)).unwrap();
 
         let error = execute_with_client(
-            &RemoteExecution::provider("daytona"),
+            &RemoteExecution::provider("e2b"),
             command,
             workspace.path(),
             &cache,
@@ -321,8 +291,31 @@ mod tests {
         let requests = server.await.unwrap();
 
         assert!(error.to_string().contains("500"));
-        assert!(requests
-            .iter()
-            .any(|request| request.method == "DELETE" && request.path == "/sandbox/daytona-test"));
+        assert!(requests.iter().any(|request| {
+            request.method == "DELETE" && request.path == "/sandboxes/e2b-test"
+        }));
+    }
+
+    fn process_response(exit_code: i32) -> Vec<u8> {
+        let payload = serde_json::to_vec(
+            &serde_json::json!({"event":{"end":{"exitCode":exit_code,"exited":true}}}),
+        )
+        .unwrap();
+        let mut result = vec![0];
+        result.extend(u32::try_from(payload.len()).unwrap().to_be_bytes());
+        result.extend(payload);
+        let end = b"{}";
+        result.push(2);
+        result.extend(u32::try_from(end.len()).unwrap().to_be_bytes());
+        result.extend(end);
+        result
+    }
+
+    fn process_response_spec(body: &[u8]) -> Response {
+        Response {
+            status: 200,
+            content_type: "application/connect+json",
+            body: body.to_vec(),
+        }
     }
 }

--- a/crates/once-core/src/remote/e2b/cleanup.rs
+++ b/crates/once-core/src/remote/e2b/cleanup.rs
@@ -1,0 +1,37 @@
+use super::client::Client;
+use crate::Result;
+
+pub(super) struct SandboxCleanup {
+    client: Client,
+    id: Option<String>,
+}
+
+impl SandboxCleanup {
+    pub(super) fn new(client: Client, id: String) -> Self {
+        Self {
+            client,
+            id: Some(id),
+        }
+    }
+
+    pub(super) async fn run(mut self) -> Result<()> {
+        let id = self.id.take().expect("cleanup sandbox is present");
+        self.client.delete(&id).await
+    }
+}
+
+impl Drop for SandboxCleanup {
+    fn drop(&mut self) {
+        let Some(id) = self.id.take() else {
+            return;
+        };
+        let client = self.client.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                if let Err(error) = client.delete(&id).await {
+                    tracing::warn!(provider = "e2b", sandbox = %id, %error, "failed to delete remote sandbox");
+                }
+            });
+        }
+    }
+}

--- a/crates/once-core/src/remote/e2b/client.rs
+++ b/crates/once-core/src/remote/e2b/client.rs
@@ -1,0 +1,189 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, Result};
+
+const ENV_DAEMON_PORT: &str = "49983";
+
+#[derive(Clone)]
+pub(super) struct Config {
+    control_url: String,
+    pub(super) sandbox_url: String,
+    pub(super) api_key: String,
+    default_template: String,
+}
+
+impl Config {
+    pub(super) fn from_env() -> Result<Self> {
+        let api_key = std::env::var("ONCE_E2B_API_KEY")
+            .or_else(|_| std::env::var("E2B_API_KEY"))
+            .map_err(|_| Error::RemoteProviderConfig {
+                provider: "e2b".to_string(),
+                message: "set ONCE_E2B_API_KEY or E2B_API_KEY".to_string(),
+            })?;
+        Ok(Self {
+            control_url: std::env::var("ONCE_E2B_API_URL")
+                .unwrap_or_else(|_| "https://api.e2b.app".to_string()),
+            sandbox_url: std::env::var("ONCE_E2B_SANDBOX_URL")
+                .unwrap_or_else(|_| "https://sandbox.e2b.app".to_string()),
+            api_key,
+            default_template: std::env::var("ONCE_E2B_TEMPLATE")
+                .unwrap_or_else(|_| "base".to_string()),
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test(control_url: String, sandbox_url: String) -> Self {
+        Self {
+            control_url,
+            sandbox_url,
+            api_key: "test-key".to_string(),
+            default_template: "base".to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Client {
+    pub(super) http: reqwest::Client,
+    pub(super) config: Config,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Sandbox {
+    #[serde(rename = "sandboxID")]
+    pub id: String,
+    #[serde(rename = "envdAccessToken")]
+    pub(super) access_token: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CreateRequest<'a> {
+    #[serde(rename = "templateID")]
+    template_id: &'a str,
+    timeout: u64,
+    secure: bool,
+    allow_internet_access: bool,
+    #[serde(rename = "autoPause")]
+    auto_pause: bool,
+    #[serde(rename = "autoResume")]
+    auto_resume: AutoResume,
+}
+
+#[derive(Serialize)]
+struct AutoResume {
+    enabled: bool,
+}
+
+impl Client {
+    pub(super) fn new(config: Config) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .build()
+            .map_err(http_error)?;
+        Ok(Self { http, config })
+    }
+
+    pub(super) async fn create(
+        &self,
+        template: Option<&str>,
+        timeout_ms: Option<u64>,
+    ) -> Result<Sandbox> {
+        let template = template.unwrap_or(&self.config.default_template);
+        let timeout = timeout_ms
+            .map_or(600, |value| value.div_ceil(1000).saturating_add(120))
+            .max(1);
+        let response = self
+            .http
+            .post(format!(
+                "{}/sandboxes",
+                self.config.control_url.trim_end_matches('/')
+            ))
+            .header("X-API-Key", &self.config.api_key)
+            .timeout(Duration::from_mins(1))
+            .json(&CreateRequest {
+                template_id: template,
+                timeout,
+                secure: true,
+                allow_internet_access: true,
+                auto_pause: false,
+                auto_resume: AutoResume { enabled: false },
+            })
+            .send()
+            .await
+            .map_err(http_error)?;
+        let sandbox: Sandbox = decode(response).await?;
+        tracing::debug!(provider = "e2b", sandbox = %sandbox.id, "created remote sandbox");
+        Ok(sandbox)
+    }
+
+    pub(super) async fn delete(&self, id: &str) -> Result<()> {
+        let response = self
+            .http
+            .delete(format!(
+                "{}/sandboxes/{id}",
+                self.config.control_url.trim_end_matches('/')
+            ))
+            .header("X-API-Key", &self.config.api_key)
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(http_error)?;
+        expect_success(response).await?;
+        tracing::debug!(provider = "e2b", sandbox = id, "deleted remote sandbox");
+        Ok(())
+    }
+
+    pub(super) fn sandbox_request(
+        &self,
+        method: reqwest::Method,
+        sandbox: &Sandbox,
+        path: &str,
+    ) -> reqwest::RequestBuilder {
+        let mut request = self
+            .http
+            .request(
+                method,
+                format!("{}{}", self.config.sandbox_url.trim_end_matches('/'), path),
+            )
+            .header("E2b-Sandbox-Id", &sandbox.id)
+            .header("E2b-Sandbox-Port", ENV_DAEMON_PORT);
+        if let Some(token) = &sandbox.access_token {
+            request = request.header("X-Access-Token", token);
+        }
+        request
+    }
+}
+
+async fn decode<T: for<'de> Deserialize<'de>>(response: reqwest::Response) -> Result<T> {
+    checked(response).await?.json().await.map_err(http_error)
+}
+
+pub(super) async fn checked(response: reqwest::Response) -> Result<reqwest::Response> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(api_error(format!("HTTP {status}: {body}")))
+}
+
+pub(super) async fn expect_success(response: reqwest::Response) -> Result<()> {
+    checked(response).await.map(|_| ())
+}
+
+pub(super) fn http_error(source: reqwest::Error) -> Error {
+    Error::RemoteProviderHttp {
+        provider: "e2b".to_string(),
+        source,
+    }
+}
+
+pub(super) fn api_error(message: String) -> Error {
+    Error::RemoteProviderApi {
+        provider: "e2b".to_string(),
+        message,
+    }
+}

--- a/crates/once-core/src/remote/e2b/protocol.rs
+++ b/crates/once-core/src/remote/e2b/protocol.rs
@@ -1,0 +1,219 @@
+use base64::Engine;
+use serde::Deserialize;
+
+use super::client::api_error;
+use crate::Result;
+
+pub(super) struct CommandResponse {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+#[derive(Deserialize)]
+struct StartResponse {
+    event: Option<ProcessEvent>,
+}
+
+#[derive(Deserialize)]
+struct ProcessEvent {
+    data: Option<DataEvent>,
+    end: Option<EndEvent>,
+}
+
+#[derive(Deserialize)]
+struct DataEvent {
+    stdout: Option<String>,
+    stderr: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EndEvent {
+    exit_code: i32,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+pub(super) fn decode_command_stream(body: &[u8]) -> Result<CommandResponse> {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut exit_code = None;
+    if body.first() == Some(&b'{') {
+        for line in body
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+        {
+            decode_event(line, &mut stdout, &mut stderr, &mut exit_code)?;
+        }
+    } else {
+        decode_envelopes(body, &mut stdout, &mut stderr, &mut exit_code)?;
+    }
+    let exit_code = exit_code
+        .ok_or_else(|| api_error("command stream ended without an exit code".to_string()))?;
+    Ok(CommandResponse {
+        exit_code,
+        stdout,
+        stderr,
+    })
+}
+
+fn decode_envelopes(
+    body: &[u8],
+    stdout: &mut Vec<u8>,
+    stderr: &mut Vec<u8>,
+    exit_code: &mut Option<i32>,
+) -> Result<()> {
+    let mut offset = 0;
+    while offset < body.len() {
+        if body.len() - offset < 5 {
+            return Err(api_error("truncated Connect response envelope".to_string()));
+        }
+        let flags = body[offset];
+        let len = u32::from_be_bytes(
+            body[offset + 1..offset + 5]
+                .try_into()
+                .expect("Connect envelope length is four bytes"),
+        ) as usize;
+        offset += 5;
+        if body.len() - offset < len {
+            return Err(api_error("truncated Connect response payload".to_string()));
+        }
+        let payload = &body[offset..offset + len];
+        offset += len;
+        if flags & 0b10 != 0 {
+            decode_end_stream(payload)?;
+        } else {
+            decode_event(payload, stdout, stderr, exit_code)?;
+        }
+    }
+    Ok(())
+}
+
+fn decode_end_stream(payload: &[u8]) -> Result<()> {
+    let value: serde_json::Value =
+        serde_json::from_slice(payload).map_err(|source| api_error(source.to_string()))?;
+    if let Some(error) = value.get("error") {
+        return Err(api_error(format!("Connect stream failed: {error}")));
+    }
+    Ok(())
+}
+
+fn decode_event(
+    payload: &[u8],
+    stdout: &mut Vec<u8>,
+    stderr: &mut Vec<u8>,
+    exit_code: &mut Option<i32>,
+) -> Result<()> {
+    let response: StartResponse =
+        serde_json::from_slice(payload).map_err(|source| api_error(source.to_string()))?;
+    let Some(event) = response.event else {
+        return Ok(());
+    };
+    if let Some(data) = event.data {
+        let engine = base64::engine::general_purpose::STANDARD;
+        if let Some(value) = data.stdout {
+            stdout.extend(
+                engine
+                    .decode(value)
+                    .map_err(|source| api_error(source.to_string()))?,
+            );
+        }
+        if let Some(value) = data.stderr {
+            stderr.extend(
+                engine
+                    .decode(value)
+                    .map_err(|source| api_error(source.to_string()))?,
+            );
+        }
+    }
+    if let Some(end) = event.end {
+        match end.error.filter(|error| !error.is_empty()) {
+            // An error string with no usable exit code means the process
+            // never ran to completion (for example an exec failure), so
+            // surfacing it as a hard error avoids reporting a false success.
+            Some(error) if end.exit_code == 0 => return Err(api_error(error)),
+            // The process terminated with a real exit code and an
+            // accompanying diagnostic (for example a signal). Keep the exit
+            // code and preserve the diagnostic on stderr rather than
+            // discarding both.
+            Some(error) => {
+                stderr.extend_from_slice(error.as_bytes());
+                if !error.ends_with('\n') {
+                    stderr.push(b'\n');
+                }
+                *exit_code = Some(end.exit_code);
+            }
+            None => *exit_code = Some(end.exit_code),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn envelope(flags: u8, value: &serde_json::Value) -> Vec<u8> {
+        let payload = serde_json::to_vec(value).unwrap();
+        let mut result = vec![flags];
+        result.extend(u32::try_from(payload.len()).unwrap().to_be_bytes());
+        result.extend(payload);
+        result
+    }
+
+    #[test]
+    fn decodes_connect_command_stream() {
+        let mut body = envelope(
+            0,
+            &serde_json::json!({"event":{"data":{"stdout":"aGVsbG8="}}}),
+        );
+        body.extend(envelope(
+            0,
+            &serde_json::json!({"event":{"data":{"stderr":"d2FybmluZw=="}}}),
+        ));
+        body.extend(envelope(
+            0,
+            &serde_json::json!({"event":{"end":{"exitCode":7,"exited":true}}}),
+        ));
+        body.extend(envelope(2, &serde_json::json!({})));
+
+        let result = decode_command_stream(&body).unwrap();
+
+        assert_eq!(result.exit_code, 7);
+        assert_eq!(result.stdout, b"hello");
+        assert_eq!(result.stderr, b"warning");
+    }
+
+    #[test]
+    fn end_error_with_exit_code_preserves_output() {
+        let mut body = envelope(
+            0,
+            &serde_json::json!({"event":{"data":{"stdout":"aGVsbG8="}}}),
+        );
+        body.extend(envelope(
+            0,
+            &serde_json::json!({"event":{"end":{"exitCode":137,"error":"killed by signal"}}}),
+        ));
+        body.extend(envelope(2, &serde_json::json!({})));
+
+        let result = decode_command_stream(&body).unwrap();
+
+        assert_eq!(result.exit_code, 137);
+        assert_eq!(result.stdout, b"hello");
+        assert_eq!(result.stderr, b"killed by signal\n");
+    }
+
+    #[test]
+    fn end_error_without_exit_code_is_a_hard_error() {
+        let mut body = envelope(
+            0,
+            &serde_json::json!({"event":{"end":{"exitCode":0,"error":"exec: node not found"}}}),
+        );
+        body.extend(envelope(2, &serde_json::json!({})));
+
+        let error = decode_command_stream(&body).map(|_| ()).unwrap_err();
+
+        assert!(error.to_string().contains("node not found"));
+    }
+}

--- a/crates/once-core/src/remote/e2b/transport.rs
+++ b/crates/once-core/src/remote/e2b/transport.rs
@@ -1,0 +1,119 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Duration;
+
+use futures::StreamExt;
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+use tokio_util::io::ReaderStream;
+
+use super::client::{checked, expect_success, http_error, Client, Sandbox};
+use super::protocol::{decode_command_stream, CommandResponse};
+use crate::{Error, Result};
+
+#[derive(Serialize)]
+struct StartRequest<'a> {
+    process: ProcessRequest<'a>,
+    stdin: bool,
+}
+
+#[derive(Serialize)]
+struct ProcessRequest<'a> {
+    cmd: &'a str,
+    args: &'a [String],
+    envs: &'a BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<&'a str>,
+}
+
+impl Client {
+    pub(super) async fn upload(
+        &self,
+        sandbox: &Sandbox,
+        source: &Path,
+        len: u64,
+        destination: &str,
+    ) -> Result<()> {
+        let file = tokio::fs::File::open(source)
+            .await
+            .map_err(|source| file_error("open_remote_input_archive", source))?;
+        let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+        let response = self
+            .sandbox_request(reqwest::Method::POST, sandbox, "/files")
+            .query(&[("path", destination)])
+            .header("Content-Type", "application/octet-stream")
+            .header("Content-Length", len)
+            .body(body)
+            .send()
+            .await
+            .map_err(http_error)?;
+        expect_success(response).await
+    }
+
+    pub(super) async fn execute(
+        &self,
+        sandbox: &Sandbox,
+        program: &str,
+        args: &[String],
+        cwd: Option<&str>,
+        envs: &BTreeMap<String, String>,
+        timeout_ms: Option<u64>,
+    ) -> Result<CommandResponse> {
+        let mut request = self
+            .sandbox_request(reqwest::Method::POST, sandbox, "/process.Process/Start")
+            .header("Connect-Protocol-Version", "1")
+            .header("Content-Type", "application/connect+json")
+            .json(&StartRequest {
+                process: ProcessRequest {
+                    cmd: program,
+                    args,
+                    envs,
+                    cwd,
+                },
+                stdin: false,
+            });
+        if let Some(timeout_ms) = timeout_ms {
+            request = request
+                .header("Connect-Timeout-Ms", timeout_ms)
+                .timeout(Duration::from_millis(timeout_ms.saturating_add(5_000)));
+        }
+        let response = request.send().await.map_err(http_error)?;
+        let body = checked(response).await?.bytes().await.map_err(http_error)?;
+        decode_command_stream(&body)
+    }
+
+    pub(super) async fn download(
+        &self,
+        sandbox: &Sandbox,
+        source: &str,
+        destination: &Path,
+    ) -> Result<()> {
+        let response = self
+            .sandbox_request(reqwest::Method::GET, sandbox, "/files")
+            .query(&[("path", source)])
+            .send()
+            .await
+            .map_err(http_error)?;
+        let response = checked(response).await?;
+        let mut file = tokio::fs::File::create(destination)
+            .await
+            .map_err(|source| file_error("create_remote_output_archive", source))?;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            file.write_all(&chunk.map_err(http_error)?)
+                .await
+                .map_err(|source| file_error("write_remote_output_archive", source))?;
+        }
+        file.flush()
+            .await
+            .map_err(|source| file_error("flush_remote_output_archive", source))
+    }
+}
+
+fn file_error(action: &'static str, source: std::io::Error) -> Error {
+    Error::FileAction {
+        action,
+        path: ".once/tmp".to_string(),
+        source,
+    }
+}

--- a/crates/once-core/src/remote/microsandbox.rs
+++ b/crates/once-core/src/remote/microsandbox.rs
@@ -1,15 +1,24 @@
-use std::collections::BTreeMap;
 use std::path::Path;
 
 use once_cas::{ActionResult, CacheProvider};
 
-use crate::{Error, Result, WorkspacePath};
+use crate::{Error, RemoteExecution, Result};
 
 #[cfg(all(
     feature = "remote-microsandbox",
     any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
 ))]
-use super::join_path;
+mod input;
+#[cfg(all(
+    feature = "remote-microsandbox",
+    any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
+))]
+mod output;
+#[cfg(all(
+    feature = "remote-microsandbox",
+    any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
+))]
+use super::{join_path, PreparedCommand};
 #[cfg(all(
     feature = "remote-microsandbox",
     any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
@@ -19,68 +28,130 @@ use crate::stream::{self, Destination};
     feature = "remote-microsandbox",
     any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
 ))]
+use std::collections::BTreeMap;
+#[cfg(all(
+    feature = "remote-microsandbox",
+    any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
+))]
 use std::time::Duration;
 
-#[allow(clippy::too_many_arguments)]
+#[cfg(all(
+    feature = "remote-microsandbox",
+    any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
+))]
+mod path {
+    use crate::WorkspacePath;
+
+    pub(super) fn guest_path(root: &str, path: &WorkspacePath) -> String {
+        super::super::join_path(root, path.as_str())
+    }
+
+    pub(super) fn guest_child(parent: &str, name: &str) -> String {
+        super::super::join_path(parent, name)
+    }
+}
+
 #[cfg(all(
     feature = "remote-microsandbox",
     any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
 ))]
 pub(super) async fn execute_command(
-    argv: &[String],
-    env: &BTreeMap<String, String>,
-    cwd: Option<&WorkspacePath>,
-    timeout_ms: Option<u64>,
+    remote: &RemoteExecution,
+    command: PreparedCommand<'_>,
     workspace_root: &Path,
     cache: &CacheProvider,
     stream_to_parent: bool,
 ) -> Result<ActionResult> {
-    let (program, rest) = argv.split_first().ok_or(Error::EmptyArgv)?;
-    let image = std::env::var("ONCE_MICROSANDBOX_IMAGE").unwrap_or_else(|_| "alpine".to_string());
+    let (program, rest) = command.argv.split_first().ok_or(Error::EmptyArgv)?;
+    let image = remote.environment.clone().unwrap_or_else(|| {
+        std::env::var("ONCE_MICROSANDBOX_IMAGE").unwrap_or_else(|_| "alpine".to_string())
+    });
     let guest_root =
         std::env::var("ONCE_MICROSANDBOX_WORKDIR").unwrap_or_else(|_| "/workspace".to_string());
-    let guest_cwd = cwd.map_or_else(
+    let guest_cwd = command.cwd.map_or_else(
         || guest_root.clone(),
         |cwd| join_path(&guest_root, cwd.as_str()),
     );
     let sandbox_name = sandbox_name();
-    let sandbox = microsandbox::Sandbox::builder(&sandbox_name)
+    let cpu_count =
+        u8::try_from(command.resources.cpu_slots.clamp(1, usize::from(u8::MAX))).unwrap_or(u8::MAX);
+    let mut builder = microsandbox::Sandbox::builder(&sandbox_name)
         .image(image)
-        .workdir(&guest_cwd)
-        .volume(&guest_root, |mount| mount.bind(workspace_root))
+        .workdir("/")
+        .cpus(cpu_count);
+    if command.resources.memory_bytes > 0 {
+        let memory_mib = u32::try_from(
+            command
+                .resources
+                .memory_bytes
+                .div_ceil(1024 * 1024)
+                .clamp(1, u64::from(u32::MAX)),
+        )
+        .unwrap_or(u32::MAX);
+        builder = builder.memory(memory_mib);
+    }
+    let sandbox = builder
         .create()
         .await
         .map_err(|source| microsandbox_error(&source))?;
     let cleanup = SandboxCleanup::new(sandbox.clone());
 
-    let work = async {
-        let mut handle = sandbox
-            .exec_stream_with(program, |exec| {
-                let exec = exec.args(rest.iter().cloned()).cwd(&guest_cwd);
-                env.iter()
-                    .fold(exec, |exec, (key, value)| exec.env(key, value))
-            })
+    let result = async {
+        input::stage_inputs(&sandbox.fs(), workspace_root, &guest_root, command.inputs).await?;
+        sandbox
+            .fs()
+            .mkdir(&guest_cwd)
             .await
             .map_err(|source| microsandbox_error(&source))?;
-        collect_output(&mut handle, cache, stream_to_parent).await
-    };
 
-    let result = match timeout_ms {
-        Some(ms) => {
-            let dur = Duration::from_millis(ms);
-            match tokio::time::timeout(dur, work).await {
-                Ok(result) => result,
-                Err(_) => Err(Error::Timeout(dur)),
+        let work = async {
+            let mut handle = sandbox
+                .exec_stream_with(program, |exec| {
+                    let exec = exec.args(rest.iter().cloned()).cwd(&guest_cwd);
+                    command
+                        .env
+                        .iter()
+                        .fold(exec, |exec, (key, value)| exec.env(key, value))
+                })
+                .await
+                .map_err(|source| microsandbox_error(&source))?;
+            collect_output(&mut handle, cache, stream_to_parent).await
+        };
+
+        let result = match command.timeout_ms {
+            Some(ms) => {
+                let dur = Duration::from_millis(ms);
+                match tokio::time::timeout(dur, work).await {
+                    Ok(result) => result,
+                    Err(_) => Err(Error::Timeout(dur)),
+                }
             }
+            None => work.await,
+        };
+
+        match result {
+            Ok(result) if result.exit_code == 0 => output::retrieve_outputs(
+                &sandbox.fs(),
+                workspace_root,
+                &guest_root,
+                command.outputs,
+            )
+            .await
+            .map(|()| result),
+            result => result,
         }
-        None => work.await,
-    };
+    }
+    .await;
 
     let cleanup = cleanup.run().await;
 
     match (result, cleanup) {
         (Ok(result), Ok(())) => Ok(result),
-        (Ok(_), Err(err)) | (Err(err), _) => Err(err),
+        (Ok(_), Err(error)) | (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(cleanup_error)) => {
+            tracing::warn!(provider = "microsandbox", %cleanup_error, "failed to remove remote sandbox after execution failure");
+            Err(error)
+        }
     }
 }
 
@@ -165,17 +236,14 @@ async fn cleanup_sandbox(sandbox: microsandbox::Sandbox) -> Result<()> {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::unused_async)]
 #[cfg(not(all(
     feature = "remote-microsandbox",
     any(target_os = "linux", all(target_os = "macos", target_arch = "aarch64"))
 )))]
 pub(super) async fn execute_command(
-    _argv: &[String],
-    _env: &BTreeMap<String, String>,
-    _cwd: Option<&WorkspacePath>,
-    _timeout_ms: Option<u64>,
+    _remote: &RemoteExecution,
+    _command: super::PreparedCommand<'_>,
     _workspace_root: &Path,
     _cache: &CacheProvider,
     _stream_to_parent: bool,
@@ -243,7 +311,14 @@ async fn collect_output(
         }
         stream::shutdown_pipe(&mut stdout_writer).await?;
         stream::shutdown_pipe(&mut stderr_writer).await?;
-        Ok::<_, Error>(exit_code.unwrap_or(-1))
+        // A stream that ends without an `Exited` event leaves the real exit
+        // status unknown. Surface that explicitly instead of inventing a -1,
+        // which would silently report a possibly successful command as failed
+        // and skip retrieving its declared outputs.
+        exit_code.ok_or_else(|| Error::RemoteProviderApi {
+            provider: "microsandbox".to_string(),
+            message: "command stream ended without an exit status".to_string(),
+        })
     };
     let stdout_store = async {
         cache

--- a/crates/once-core/src/remote/microsandbox/input.rs
+++ b/crates/once-core/src/remote/microsandbox/input.rs
@@ -1,0 +1,223 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use microsandbox::sandbox::{FsSetAttrs, SandboxFs};
+
+use crate::{Error, Result, WorkspacePath};
+
+use super::microsandbox_error;
+use super::path::guest_path;
+use crate::remote::path::relative_link_stays_within;
+
+enum HostEntry {
+    Directory {
+        relative: PathBuf,
+        mode: u32,
+    },
+    File {
+        source: PathBuf,
+        relative: PathBuf,
+        mode: u32,
+    },
+    Symlink {
+        relative: PathBuf,
+        target: PathBuf,
+    },
+}
+
+pub(super) async fn stage_inputs(
+    fs: &SandboxFs,
+    workspace_root: &Path,
+    guest_root: &str,
+    inputs: &[WorkspacePath],
+) -> Result<()> {
+    let (entries, declared_roots) = plan_inputs(workspace_root, inputs)?;
+    fs.mkdir(guest_root)
+        .await
+        .map_err(|source| microsandbox_error(&source))?;
+
+    let mut directory_modes = Vec::new();
+    for entry in entries.into_values() {
+        match entry {
+            HostEntry::Directory { relative, mode } => {
+                let guest = guest_for_relative(guest_root, &relative)?;
+                fs.mkdir(&guest)
+                    .await
+                    .map_err(|source| microsandbox_error(&source))?;
+                directory_modes.push((guest, mode));
+            }
+            HostEntry::File {
+                source,
+                relative,
+                mode,
+            } => {
+                let guest = guest_for_relative(guest_root, &relative)?;
+                ensure_guest_parent(fs, &guest).await?;
+                fs.copy_from_host(&source, &guest)
+                    .await
+                    .map_err(|source| microsandbox_error(&source))?;
+                set_mode(fs, &guest, mode).await?;
+            }
+            HostEntry::Symlink { relative, target } => {
+                if !relative_link_stays_within(&relative, &target, &declared_roots) {
+                    return Err(transfer_error(
+                        &relative,
+                        format!(
+                            "symbolic link target `{}` escapes the declared input trees",
+                            target.display()
+                        ),
+                    ));
+                }
+                let guest = guest_for_relative(guest_root, &relative)?;
+                ensure_guest_parent(fs, &guest).await?;
+                let target = target.to_str().ok_or_else(|| {
+                    transfer_error(&relative, "symbolic link target is not valid UTF-8")
+                })?;
+                fs.symlink(target, &guest)
+                    .await
+                    .map_err(|source| microsandbox_error(&source))?;
+            }
+        }
+    }
+
+    directory_modes.sort_by_key(|(path, _)| std::cmp::Reverse(path.matches('/').count()));
+    for (path, mode) in directory_modes {
+        set_mode(fs, &path, mode).await?;
+    }
+    Ok(())
+}
+
+fn plan_inputs(
+    workspace_root: &Path,
+    inputs: &[WorkspacePath],
+) -> Result<(BTreeMap<PathBuf, HostEntry>, Vec<PathBuf>)> {
+    let declared_roots = inputs
+        .iter()
+        .map(|input| PathBuf::from(input.as_str()))
+        .collect::<Vec<_>>();
+    let mut entries = BTreeMap::new();
+    for input in inputs {
+        let relative = PathBuf::from(input.as_str());
+        collect_entry(&input.resolve(workspace_root), &relative, &mut entries)?;
+    }
+    Ok((entries, declared_roots))
+}
+
+fn collect_entry(
+    source: &Path,
+    relative: &Path,
+    entries: &mut BTreeMap<PathBuf, HostEntry>,
+) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(source).map_err(|source_error| Error::FileAction {
+        action: "read_remote_input",
+        path: relative.display().to_string(),
+        source: source_error,
+    })?;
+    let mode = metadata_mode(&metadata);
+    if metadata.file_type().is_symlink() {
+        let target = std::fs::read_link(source).map_err(|source_error| Error::FileAction {
+            action: "read_remote_input_link",
+            path: relative.display().to_string(),
+            source: source_error,
+        })?;
+        entries.insert(
+            relative.to_path_buf(),
+            HostEntry::Symlink {
+                relative: relative.to_path_buf(),
+                target,
+            },
+        );
+        return Ok(());
+    }
+    if metadata.is_file() {
+        entries.insert(
+            relative.to_path_buf(),
+            HostEntry::File {
+                source: source.to_path_buf(),
+                relative: relative.to_path_buf(),
+                mode,
+            },
+        );
+        return Ok(());
+    }
+    if !metadata.is_dir() {
+        return Err(transfer_error(
+            relative,
+            "only files, directories, and symbolic links can be remote inputs",
+        ));
+    }
+
+    entries.insert(
+        relative.to_path_buf(),
+        HostEntry::Directory {
+            relative: relative.to_path_buf(),
+            mode,
+        },
+    );
+    let mut children = std::fs::read_dir(source)
+        .map_err(|source_error| Error::FileAction {
+            action: "read_remote_input_directory",
+            path: relative.display().to_string(),
+            source: source_error,
+        })?
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|source_error| Error::FileAction {
+            action: "read_remote_input_directory",
+            path: relative.display().to_string(),
+            source: source_error,
+        })?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let child_relative = relative.join(child.file_name());
+        collect_entry(&child.path(), &child_relative, entries)?;
+    }
+    Ok(())
+}
+
+async fn ensure_guest_parent(fs: &SandboxFs, path: &str) -> Result<()> {
+    let parent = Path::new(path)
+        .parent()
+        .and_then(Path::to_str)
+        .ok_or_else(|| transfer_error(Path::new(path), "input has no parent directory"))?;
+    fs.mkdir(parent)
+        .await
+        .map_err(|source| microsandbox_error(&source))
+}
+
+async fn set_mode(fs: &SandboxFs, path: &str, mode: u32) -> Result<()> {
+    fs.set_stat(
+        path,
+        false,
+        FsSetAttrs {
+            mode: Some(mode & 0o7777),
+            ..FsSetAttrs::default()
+        },
+    )
+    .await
+    .map_err(|source| microsandbox_error(&source))
+}
+
+fn guest_for_relative(root: &str, relative: &Path) -> Result<String> {
+    let relative = relative
+        .to_str()
+        .ok_or_else(|| transfer_error(relative, "input path is not valid UTF-8"))?;
+    let path = WorkspacePath::try_from(relative)?;
+    Ok(guest_path(root, &path))
+}
+
+#[cfg(unix)]
+fn metadata_mode(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode()
+}
+
+fn transfer_error(path: &Path, message: impl Into<String>) -> Error {
+    Error::RemoteProviderApi {
+        provider: "microsandbox".to_string(),
+        message: format!(
+            "cannot stage input `{}`: {}",
+            path.display(),
+            message.into()
+        ),
+    }
+}

--- a/crates/once-core/src/remote/microsandbox/output.rs
+++ b/crates/once-core/src/remote/microsandbox/output.rs
@@ -1,0 +1,189 @@
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+use microsandbox::sandbox::{FsEntryKind, SandboxFs};
+use tokio::io::AsyncWriteExt;
+
+use crate::{Error, Result, WorkspacePath};
+
+use super::path::{guest_child, guest_path};
+use crate::remote::output_install::OutputStaging;
+use crate::remote::path::relative_link_stays_within;
+
+pub(super) async fn retrieve_outputs(
+    fs: &SandboxFs,
+    workspace_root: &Path,
+    guest_root: &str,
+    outputs: &[WorkspacePath],
+) -> Result<()> {
+    let staging = OutputStaging::create(workspace_root)?;
+    let declared_roots = outputs
+        .iter()
+        .map(|output| PathBuf::from(output.as_str()))
+        .collect::<Vec<_>>();
+
+    for output in outputs {
+        let guest = guest_path(guest_root, output);
+        let relative = PathBuf::from(output.as_str());
+        retrieve_tree(fs, &guest, &relative, staging.files(), &declared_roots).await?;
+    }
+    staging.install(outputs, workspace_root).await
+}
+
+async fn retrieve_tree(
+    fs: &SandboxFs,
+    root_guest: &str,
+    root_relative: &Path,
+    staging_root: &Path,
+    declared_roots: &[PathBuf],
+) -> Result<()> {
+    let mut queue = VecDeque::from([(root_guest.to_string(), root_relative.to_path_buf())]);
+    let mut directory_modes = Vec::new();
+
+    while let Some((guest, relative)) = queue.pop_front() {
+        let metadata = fs
+            .stat_with_follow(&guest, false)
+            .await
+            .map_err(|source| output_error(&relative, source.to_string()))?;
+        let host = staging_root.join(&relative);
+        match metadata.kind {
+            FsEntryKind::File => {
+                if let Some(parent) = host.parent() {
+                    tokio::fs::create_dir_all(parent).await.map_err(|source| {
+                        host_error("create_remote_output_parent", &relative, source)
+                    })?;
+                }
+                let mut reader = fs
+                    .read_stream(&guest)
+                    .await
+                    .map_err(|source| output_error(&relative, source.to_string()))?;
+                let mut writer = tokio::fs::File::create(&host)
+                    .await
+                    .map_err(|source| host_error("create_remote_output", &relative, source))?;
+                while let Some(chunk) = reader
+                    .recv()
+                    .await
+                    .map_err(|source| output_error(&relative, source.to_string()))?
+                {
+                    writer
+                        .write_all(&chunk)
+                        .await
+                        .map_err(|source| host_error("write_remote_output", &relative, source))?;
+                }
+                writer
+                    .flush()
+                    .await
+                    .map_err(|source| host_error("flush_remote_output", &relative, source))?;
+                set_host_mode(&host, metadata.mode)?;
+            }
+            FsEntryKind::Directory => {
+                tokio::fs::create_dir_all(&host).await.map_err(|source| {
+                    host_error("create_remote_output_directory", &relative, source)
+                })?;
+                directory_modes.push((host, metadata.mode));
+                let mut children = fs
+                    .list(&guest)
+                    .await
+                    .map_err(|source| output_error(&relative, source.to_string()))?;
+                children.sort_by(|left, right| left.path.cmp(&right.path));
+                for child in children {
+                    let name = immediate_child_name(&guest, &child.path).ok_or_else(|| {
+                        output_error(
+                            &relative,
+                            format!("provider returned invalid child path `{}`", child.path),
+                        )
+                    })?;
+                    queue.push_back((guest_child(&guest, name), relative.join(name)));
+                }
+            }
+            FsEntryKind::Symlink => {
+                let target = fs
+                    .read_link(&guest)
+                    .await
+                    .map_err(|source| output_error(&relative, source.to_string()))?;
+                let target_path = Path::new(&target);
+                if !relative_link_stays_within(&relative, target_path, declared_roots) {
+                    return Err(output_error(
+                        &relative,
+                        format!("symbolic link target `{target}` escapes declared output trees"),
+                    ));
+                }
+                if let Some(parent) = host.parent() {
+                    tokio::fs::create_dir_all(parent).await.map_err(|source| {
+                        host_error("create_remote_output_parent", &relative, source)
+                    })?;
+                }
+                create_host_symlink(target_path, &host)
+                    .map_err(|source| host_error("create_remote_output_link", &relative, source))?;
+            }
+            FsEntryKind::Other => {
+                return Err(output_error(
+                    &relative,
+                    "provider returned an unsupported filesystem entry",
+                ));
+            }
+        }
+    }
+
+    directory_modes.sort_by_key(|(path, _)| std::cmp::Reverse(path.components().count()));
+    for (path, mode) in directory_modes {
+        set_host_mode(&path, mode)?;
+    }
+    Ok(())
+}
+
+fn immediate_child_name<'a>(parent: &str, child: &'a str) -> Option<&'a str> {
+    let child_path = Path::new(child);
+    if child_path.parent()? != Path::new(parent) {
+        return None;
+    }
+    child_path.file_name()?.to_str()
+}
+
+#[cfg(unix)]
+fn set_host_mode(path: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode & 0o7777))
+        .map_err(|source| host_error("set_remote_output_mode", path, source))
+}
+
+#[cfg(unix)]
+fn create_host_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+fn output_error(path: &Path, message: impl Into<String>) -> Error {
+    Error::RemoteProviderApi {
+        provider: "microsandbox".to_string(),
+        message: format!(
+            "cannot retrieve output `{}`: {}",
+            path.display(),
+            message.into()
+        ),
+    }
+}
+
+fn host_error(action: &'static str, path: &Path, source: std::io::Error) -> Error {
+    Error::FileAction {
+        action,
+        path: path.display().to_string(),
+        source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_immediate_guest_children() {
+        assert_eq!(
+            immediate_child_name("/workspace/out", "/workspace/out/result.txt"),
+            Some("result.txt")
+        );
+        assert_eq!(
+            immediate_child_name("/workspace/out", "/workspace/other/result.txt"),
+            None
+        );
+    }
+}

--- a/crates/once-core/src/remote/output_install.rs
+++ b/crates/once-core/src/remote/output_install.rs
@@ -1,0 +1,188 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::{Error, Result, WorkspacePath};
+
+pub(super) struct OutputStaging {
+    root: PathBuf,
+    files: PathBuf,
+    backup: PathBuf,
+}
+
+impl OutputStaging {
+    pub(super) fn create(workspace_root: &Path) -> Result<Self> {
+        let parent = workspace_root.join(".once/tmp");
+        std::fs::create_dir_all(&parent).map_err(|source| {
+            host_error(
+                "create_remote_output_staging",
+                Path::new(".once/tmp"),
+                source,
+            )
+        })?;
+        for attempt in 0..100 {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let root = parent.join(format!(
+                "remote-output-{}-{nanos}-{attempt}",
+                std::process::id()
+            ));
+            match std::fs::create_dir(&root) {
+                Ok(()) => {
+                    let files = root.join("files");
+                    let backup = root.join("backup");
+                    std::fs::create_dir(&files).map_err(|source| {
+                        host_error("create_remote_output_staging", Path::new("files"), source)
+                    })?;
+                    std::fs::create_dir(&backup).map_err(|source| {
+                        host_error("create_remote_output_staging", Path::new("backup"), source)
+                    })?;
+                    return Ok(Self {
+                        root,
+                        files,
+                        backup,
+                    });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(source) => {
+                    return Err(host_error(
+                        "create_remote_output_staging",
+                        Path::new(".once/tmp"),
+                        source,
+                    ));
+                }
+            }
+        }
+        Err(host_error(
+            "create_remote_output_staging",
+            Path::new(".once/tmp"),
+            std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "could not allocate a unique remote output staging directory",
+            ),
+        ))
+    }
+
+    pub(super) fn files(&self) -> &Path {
+        &self.files
+    }
+
+    pub(super) async fn install(
+        self,
+        outputs: &[WorkspacePath],
+        workspace_root: &Path,
+    ) -> Result<()> {
+        let files = self.files.clone();
+        let backup = self.backup.clone();
+        let workspace = workspace_root.to_path_buf();
+        let outputs = outputs.to_vec();
+        tokio::task::spawn_blocking(move || install_outputs(&files, &backup, &workspace, &outputs))
+            .await
+            .map_err(|source| {
+                host_error(
+                    "install_remote_outputs",
+                    Path::new(".once/tmp"),
+                    std::io::Error::other(source.to_string()),
+                )
+            })?
+    }
+}
+
+impl Drop for OutputStaging {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::remove_dir_all(&self.root) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(path = %self.root.display(), %error, "failed to remove remote output staging directory");
+            }
+        }
+    }
+}
+
+fn install_outputs(
+    files: &Path,
+    backup: &Path,
+    workspace: &Path,
+    outputs: &[WorkspacePath],
+) -> Result<()> {
+    let mut backed_up = Vec::new();
+    let mut installed = Vec::new();
+    for output in outputs {
+        if let Err(error) = install_output(
+            files,
+            backup,
+            workspace,
+            output,
+            &mut backed_up,
+            &mut installed,
+        ) {
+            rollback_outputs(&installed, &backed_up);
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+fn install_output(
+    files: &Path,
+    backup: &Path,
+    workspace: &Path,
+    output: &WorkspacePath,
+    backed_up: &mut Vec<(PathBuf, PathBuf)>,
+    installed: &mut Vec<PathBuf>,
+) -> Result<()> {
+    let destination = output.resolve(workspace);
+    if std::fs::symlink_metadata(&destination).is_ok() {
+        let saved = output.resolve(backup);
+        create_parent(&saved)?;
+        std::fs::rename(&destination, &saved).map_err(|source| {
+            host_error("backup_remote_output", Path::new(output.as_str()), source)
+        })?;
+        backed_up.push((destination.clone(), saved));
+    }
+    let source = output.resolve(files);
+    create_parent(&destination)?;
+    std::fs::rename(&source, &destination).map_err(|source| {
+        host_error("install_remote_output", Path::new(output.as_str()), source)
+    })?;
+    installed.push(destination);
+    Ok(())
+}
+
+fn rollback_outputs(installed: &[PathBuf], backed_up: &[(PathBuf, PathBuf)]) {
+    for path in installed.iter().rev() {
+        let _ = remove_host_path(path);
+    }
+    for (destination, saved) in backed_up.iter().rev() {
+        let _ = std::fs::rename(saved, destination);
+    }
+}
+
+fn create_parent(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|source| host_error("create_remote_output_parent", path, source))?;
+    }
+    Ok(())
+}
+
+fn remove_host_path(path: &Path) -> std::io::Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+}
+
+fn host_error(action: &'static str, path: &Path, source: std::io::Error) -> Error {
+    Error::FileAction {
+        action,
+        path: path.display().to_string(),
+        source,
+    }
+}

--- a/crates/once-core/src/remote/path.rs
+++ b/crates/once-core/src/remote/path.rs
@@ -1,0 +1,67 @@
+use std::path::{Component, Path, PathBuf};
+
+pub(super) fn relative_link_stays_within(
+    link: &Path,
+    target: &Path,
+    declared_roots: &[PathBuf],
+) -> bool {
+    if target.is_absolute() {
+        return false;
+    }
+    let Some(parent) = link.parent() else {
+        return false;
+    };
+    let Some(resolved) = normalize(&parent.join(target)) else {
+        return false;
+    };
+    declared_roots.iter().any(|root| resolved.starts_with(root))
+}
+
+pub(super) fn path_is_declared(path: &Path, declared_roots: &[PathBuf]) -> bool {
+    declared_roots.iter().any(|root| path.starts_with(root))
+}
+
+fn normalize(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_links_within_a_declared_tree() {
+        assert!(relative_link_stays_within(
+            Path::new("node_modules/.bin/vitest"),
+            Path::new("../vitest/bin.mjs"),
+            &[PathBuf::from("node_modules")],
+        ));
+    }
+
+    #[test]
+    fn rejects_links_that_escape_declared_trees() {
+        assert!(!relative_link_stays_within(
+            Path::new("node_modules/tool"),
+            Path::new("../../secret"),
+            &[PathBuf::from("node_modules")],
+        ));
+        assert!(!relative_link_stays_within(
+            Path::new("node_modules/tool"),
+            Path::new("/host/secret"),
+            &[PathBuf::from("node_modules")],
+        ));
+    }
+}

--- a/crates/once-core/src/remote/test_server.rs
+++ b/crates/once-core/src/remote/test_server.rs
@@ -1,0 +1,123 @@
+use std::collections::BTreeMap;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub(super) struct Response {
+    pub status: u16,
+    pub content_type: &'static str,
+    pub body: Vec<u8>,
+}
+
+impl Response {
+    pub(super) fn json(body: &str) -> Self {
+        Self {
+            status: 200,
+            content_type: "application/json",
+            body: body.as_bytes().to_vec(),
+        }
+    }
+
+    pub(super) fn empty(status: u16) -> Self {
+        Self {
+            status,
+            content_type: "application/octet-stream",
+            body: Vec::new(),
+        }
+    }
+
+    pub(super) fn tar_file(path: &str, contents: &[u8]) -> Self {
+        let mut archive = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(u64::try_from(contents.len()).unwrap());
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive.append_data(&mut header, path, contents).unwrap();
+        archive.finish().unwrap();
+        Self {
+            status: 200,
+            content_type: "application/x-tar",
+            body: archive.into_inner().unwrap(),
+        }
+    }
+}
+
+pub(super) struct Request {
+    pub method: String,
+    pub path: String,
+    pub body: Vec<u8>,
+}
+
+pub(super) async fn spawn(
+    responses: Vec<Response>,
+) -> (String, tokio::task::JoinHandle<Vec<Request>>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        let mut requests = Vec::new();
+        for response in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            let header_end = loop {
+                let mut chunk = [0_u8; 4096];
+                let read = stream.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "request closed before its headers arrived");
+                bytes.extend_from_slice(&chunk[..read]);
+                if let Some(index) = find_header_end(&bytes) {
+                    break index;
+                }
+            };
+            let headers = String::from_utf8_lossy(&bytes[..header_end]);
+            let mut lines = headers.lines();
+            let first = lines.next().unwrap();
+            let mut first = first.split_whitespace();
+            let method = first.next().unwrap().to_string();
+            let path = first.next().unwrap().to_string();
+            let header_map = lines
+                .filter_map(|line| line.split_once(':'))
+                .map(|(name, value)| (name.trim().to_ascii_lowercase(), value.trim().to_string()))
+                .collect::<BTreeMap<_, _>>();
+            let content_length = header_map
+                .get("content-length")
+                .and_then(|value| value.parse::<usize>().ok())
+                .unwrap_or(0);
+            while bytes.len() < header_end + 4 + content_length {
+                let mut chunk = [0_u8; 4096];
+                let read = stream.read(&mut chunk).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                bytes.extend_from_slice(&chunk[..read]);
+            }
+            let body_start = header_end + 4;
+            let body_end = (body_start + content_length).min(bytes.len());
+            requests.push(Request {
+                method,
+                path,
+                body: bytes[body_start..body_end].to_vec(),
+            });
+
+            let reason = match response.status {
+                200 => "OK",
+                204 => "No Content",
+                500 => "Internal Server Error",
+                _ => "Response",
+            };
+            let head = format!(
+                "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                response.status,
+                reason,
+                response.content_type,
+                response.body.len()
+            );
+            stream.write_all(head.as_bytes()).await.unwrap();
+            stream.write_all(&response.body).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+        requests
+    });
+    (format!("http://{address}"), task)
+}
+
+fn find_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|window| window == b"\r\n\r\n")
+}

--- a/crates/once-core/src/runner.rs
+++ b/crates/once-core/src/runner.rs
@@ -1017,7 +1017,7 @@ mod tests {
             resources: ResourceRequest::default(),
             sandbox: SandboxMode::default(),
             timeout_ms: None,
-            remote: Some(RemoteExecution::provider("unknown-remote")),
+            remote: Some(Box::new(RemoteExecution::provider("unknown-remote"))),
         };
 
         let error = run(&action, tmp.path(), &cas, RunOpts::default())

--- a/crates/once-frontend/src/cache_provider.rs
+++ b/crates/once-frontend/src/cache_provider.rs
@@ -39,8 +39,26 @@ pub struct TuistCacheProviderConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MicrosandboxExecutionProviderConfig {
+    pub image: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct E2bExecutionProviderConfig {
+    pub template: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaytonaExecutionProviderConfig {
+    pub image: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InfrastructureProviderConfig {
     Local,
+    Microsandbox(MicrosandboxExecutionProviderConfig),
+    E2b(E2bExecutionProviderConfig),
+    Daytona(DaytonaExecutionProviderConfig),
     Tuist(TuistCacheProviderConfig),
 }
 
@@ -83,6 +101,15 @@ pub(crate) enum DirectCacheProviderToml {
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub(crate) enum InfrastructureProviderToml {
     Local,
+    Microsandbox {
+        image: String,
+    },
+    E2b {
+        template: String,
+    },
+    Daytona {
+        image: String,
+    },
     Tuist {
         url: Option<String>,
         account: Option<String>,
@@ -138,9 +165,37 @@ impl NamedCacheProviderToml {
 }
 
 impl InfrastructureProviderToml {
-    pub(crate) fn into_config(self) -> InfrastructureProviderConfig {
-        match self {
+    pub(crate) fn into_config(
+        self,
+        display_name: &str,
+        provider_name: &str,
+    ) -> Result<InfrastructureProviderConfig> {
+        Ok(match self {
             Self::Local => InfrastructureProviderConfig::Local,
+            Self::Microsandbox { image } => {
+                let image = image.trim().to_string();
+                if image.is_empty() {
+                    return Err(Error::Eval {
+                        path: display_name.to_string(),
+                        message: format!(
+                            "microsandbox infrastructure `{provider_name}` image must not be empty"
+                        ),
+                    });
+                }
+                InfrastructureProviderConfig::Microsandbox(MicrosandboxExecutionProviderConfig {
+                    image,
+                })
+            }
+            Self::E2b { template } => {
+                let template =
+                    required_value(display_name, provider_name, "e2b", "template", &template)?;
+                InfrastructureProviderConfig::E2b(E2bExecutionProviderConfig { template })
+            }
+            Self::Daytona { image } => {
+                let image =
+                    required_value(display_name, provider_name, "daytona", "image", &image)?;
+                InfrastructureProviderConfig::Daytona(DaytonaExecutionProviderConfig { image })
+            }
             Self::Tuist {
                 url,
                 account,
@@ -152,8 +207,25 @@ impl InfrastructureProviderToml {
                 project: non_empty(project),
                 oauth_client_id: non_empty(oauth_client_id),
             }),
-        }
+        })
     }
+}
+
+fn required_value(
+    display_name: &str,
+    provider_name: &str,
+    kind: &str,
+    field: &str,
+    value: &str,
+) -> Result<String> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(Error::Eval {
+            path: display_name.to_string(),
+            message: format!("{kind} infrastructure `{provider_name}` {field} must not be empty"),
+        });
+    }
+    Ok(value)
 }
 
 fn non_empty(value: Option<String>) -> Option<String> {

--- a/crates/once-frontend/src/cache_resolution.rs
+++ b/crates/once-frontend/src/cache_resolution.rs
@@ -73,7 +73,7 @@ fn resolve_provider_config(
         )),
         CacheProviderConfig::Named(binding) => {
             if let Some(provider) = workspace_providers.get(&binding.name) {
-                return Ok(resolve_named_workspace_provider(binding, provider.clone()));
+                return resolve_named_workspace_provider(binding, provider.clone());
             }
             let mut config = load_user_config(user_config_path)?;
             let provider =
@@ -144,23 +144,29 @@ fn resolve_named_provider(
 fn resolve_named_workspace_provider(
     binding: NamedCacheProviderConfig,
     provider: InfrastructureProviderConfig,
-) -> ResolvedCacheProviderConfig {
+) -> Result<ResolvedCacheProviderConfig> {
     let NamedCacheProviderConfig {
         name,
         account: binding_account,
         project: binding_project,
     } = binding;
     match provider {
-        InfrastructureProviderConfig::Local => ResolvedCacheProviderConfig::Local,
-        InfrastructureProviderConfig::Tuist(config) => {
-            ResolvedCacheProviderConfig::Tuist(ResolvedTuistCacheProviderConfig {
+        InfrastructureProviderConfig::Local => Ok(ResolvedCacheProviderConfig::Local),
+        InfrastructureProviderConfig::Microsandbox(_)
+        | InfrastructureProviderConfig::E2b(_)
+        | InfrastructureProviderConfig::Daytona(_) => Err(Error::Eval {
+            path: name.clone(),
+            message: format!("infrastructure `{name}` provides execution but not shared caching"),
+        }),
+        InfrastructureProviderConfig::Tuist(config) => Ok(ResolvedCacheProviderConfig::Tuist(
+            ResolvedTuistCacheProviderConfig {
                 provider_name: name,
                 url: config.url,
                 account: binding_account.or(config.account),
                 project: binding_project.or(config.project),
                 oauth_client_id: config.oauth_client_id,
-            })
-        }
+            },
+        )),
     }
 }
 

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -27,8 +27,9 @@ pub const TOML_BUILD_FILE_NAME: &str = "once.toml";
 pub const BUILD_FILE_NAME: &str = TOML_BUILD_FILE_NAME;
 
 pub use cache_provider::{
-    CacheProviderConfig, ExecutionProviderConfig, InfrastructureConfig,
-    InfrastructureProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig,
+    CacheProviderConfig, DaytonaExecutionProviderConfig, E2bExecutionProviderConfig,
+    ExecutionProviderConfig, InfrastructureConfig, InfrastructureProviderConfig,
+    MicrosandboxExecutionProviderConfig, NamedCacheProviderConfig, TuistCacheProviderConfig,
     DEFAULT_TUIST_URL,
 };
 pub use cache_resolution::{

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -104,8 +104,12 @@ pub fn load_infrastructure_toml_str(
     let providers = manifest
         .infrastructures
         .into_iter()
-        .map(|(name, provider)| (name, provider.into_config()))
-        .collect();
+        .map(|(name, provider)| {
+            provider
+                .into_config(path, &name)
+                .map(|provider| (name, provider))
+        })
+        .collect::<Result<_>>()?;
     Ok(crate::cache_provider::InfrastructureConfig {
         cache,
         execution,
@@ -341,6 +345,111 @@ exclude = ["fixtures/**"]
 "#;
         let targets = load_toml_str("once.toml", src).unwrap();
         assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn loads_named_microsandbox_execution_provider() {
+        let config = load_infrastructure_toml_str(
+            "once.toml",
+            r#"
+[infrastructure.execution]
+provider = "remote_tests"
+
+[infrastructures.remote_tests]
+kind = "microsandbox"
+image = "node:22.18.0-alpine"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.execution,
+            Some(crate::cache_provider::NamedCacheProviderConfig {
+                name: "remote_tests".to_string(),
+                account: None,
+                project: None,
+            })
+        );
+        assert_eq!(
+            config.providers.get("remote_tests"),
+            Some(
+                &crate::cache_provider::InfrastructureProviderConfig::Microsandbox(
+                    crate::cache_provider::MicrosandboxExecutionProviderConfig {
+                        image: "node:22.18.0-alpine".to_string(),
+                    }
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_empty_microsandbox_image() {
+        let error = load_infrastructure_toml_str(
+            "once.toml",
+            r#"
+[infrastructures.remote_tests]
+kind = "microsandbox"
+image = "   "
+"#,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("image must not be empty"));
+    }
+
+    #[test]
+    fn loads_hosted_execution_providers() {
+        let config = load_infrastructure_toml_str(
+            "once.toml",
+            r#"
+[infrastructures.e2b_tests]
+kind = "e2b"
+template = "vitest-v1"
+
+[infrastructures.daytona_tests]
+kind = "daytona"
+image = "node:22-bookworm"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.providers.get("e2b_tests"),
+            Some(&crate::cache_provider::InfrastructureProviderConfig::E2b(
+                crate::cache_provider::E2bExecutionProviderConfig {
+                    template: "vitest-v1".to_string(),
+                }
+            ))
+        );
+        assert_eq!(
+            config.providers.get("daytona_tests"),
+            Some(
+                &crate::cache_provider::InfrastructureProviderConfig::Daytona(
+                    crate::cache_provider::DaytonaExecutionProviderConfig {
+                        image: "node:22-bookworm".to_string(),
+                    }
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_empty_hosted_provider_environments() {
+        for manifest in [
+            r#"
+[infrastructures.remote_tests]
+kind = "e2b"
+template = ""
+"#,
+            r#"
+[infrastructures.remote_tests]
+kind = "daytona"
+image = "   "
+"#,
+        ] {
+            let error = load_infrastructure_toml_str("once.toml", manifest).unwrap_err();
+            assert!(error.to_string().contains("must not be empty"));
+        }
     }
 
     #[test]

--- a/docs/guide/infrastructure/daytona.md
+++ b/docs/guide/infrastructure/daytona.md
@@ -1,0 +1,76 @@
+# Daytona
+
+[Daytona](https://www.daytona.io/docs/en/sandboxes/) provides hosted sandboxes
+with process and filesystem operations. Once creates one sandbox for each
+action that misses the cache, transfers declared inputs, runs the command,
+retrieves declared outputs, and deletes the sandbox.
+
+## Configure An Image
+
+Choose a Linux container image that contains the stable tools shared by your
+actions. A Vitest workflow can use a pinned Node.js image:
+
+```toml
+[infrastructures.remote_tests]
+kind = "daytona"
+image = "node:22.18.0-bookworm"
+
+[infrastructure.execution]
+provider = "remote_tests"
+```
+
+Once asks Daytona to build the sandbox environment from that image. The image
+must provide `tar`. Repository dependencies remain declared action outputs and
+inputs, so changing a package lock invalidates the correct action.
+
+## Authenticate
+
+Set the provider access key outside the script:
+
+```sh
+export DAYTONA_API_KEY=...
+```
+
+`ONCE_DAYTONA_API_KEY` takes precedence when both variables are present. Once
+does not forward the key to the action process.
+
+## Run
+
+Use the workspace default:
+
+```sh
+once exec --remote -- node --version
+```
+
+Or select the provider for one invocation:
+
+```sh
+once exec --remote --compute remote_tests -- node --version
+```
+
+An annotated script can select it with:
+
+```sh
+# once remote "remote_tests"
+```
+
+See [Remote Execution](/guide/infrastructure/remote-execution) for a two-action
+Vitest example.
+
+Daytona's command endpoint returns standard output and standard error as one
+combined result. Once exposes that result as standard output.
+
+## Lifecycle
+
+Once marks each Daytona sandbox as ephemeral and sets immediate deletion after
+stop. It also sends an explicit delete request after success, command failure,
+timeout, or transfer failure. The ephemeral policy is a provider-side safety
+net if the client disappears first. Daytona describes this behavior in its
+[sandbox lifecycle guide](https://www.daytona.io/docs/en/sandboxes/#ephemeral-sandboxes).
+
+The sandbox receives an automatic stop interval derived from the action
+timeout, with extra time for provisioning and transfers. Actions without an
+explicit timeout use Daytona's short-lived execution policy.
+
+Self-hosted or test endpoints can override the control and toolbox addresses
+with `ONCE_DAYTONA_CONTROL_URL` and `ONCE_DAYTONA_TOOLBOX_URL`.

--- a/docs/guide/infrastructure/e2b.md
+++ b/docs/guide/infrastructure/e2b.md
@@ -1,0 +1,78 @@
+# E2B
+
+[E2B](https://e2b.dev/docs) provides hosted Linux sandboxes created from
+templates. Once creates one sandbox for each action that misses the cache,
+transfers declared inputs, runs the command, retrieves declared outputs, and
+deletes the sandbox.
+
+## Prepare A Template
+
+Create an [E2B template](https://e2b.dev/docs/template) containing the stable
+tools shared by your actions. A Vitest template should provide Node.js, npm,
+and `tar`. Keep repository dependencies such as `node_modules` in the action
+graph instead of baking them into the template.
+
+Add the template name or identifier to the repository root `once.toml`:
+
+```toml
+[infrastructures.remote_tests]
+kind = "e2b"
+template = "vitest-node-22"
+
+[infrastructure.execution]
+provider = "remote_tests"
+```
+
+Pin the template contents so two executions with the same action identity see
+the same tools.
+
+## Authenticate
+
+Set the provider access key outside the script:
+
+```sh
+export E2B_API_KEY=e2b_...
+```
+
+`ONCE_E2B_API_KEY` takes precedence when both variables are present. The key
+authenticates sandbox creation, file transfer, and deletion. Once does not
+forward it to the action process.
+
+## Run
+
+Use the workspace default:
+
+```sh
+once exec --remote -- node --version
+```
+
+Or select the provider for one invocation:
+
+```sh
+once exec --remote --compute remote_tests -- node --version
+```
+
+An annotated script can select it with:
+
+```sh
+# once remote "remote_tests"
+```
+
+See [Remote Execution](/guide/infrastructure/remote-execution) for a two-action
+Vitest example.
+
+## Lifecycle And Network Access
+
+Once creates E2B sandboxes with secure system communication, outbound network
+access, a finite lifetime, and kill-on-timeout behavior. Outbound access lets
+an installation action download packages. Declare downloaded dependencies as
+outputs so later actions receive them explicitly.
+
+Once sends an explicit delete request after success, command failure, timeout,
+or transfer failure. The finite E2B lifetime remains a provider-side safety
+net if the client disappears before it can delete the sandbox. E2B documents
+the distinction between killed and paused sandboxes in its
+[persistence guide](https://e2b.dev/docs/sandbox/persistence).
+
+Self-hosted or test endpoints can override the control and sandbox addresses
+with `ONCE_E2B_API_URL` and `ONCE_E2B_SANDBOX_URL`.

--- a/docs/guide/infrastructure/index.md
+++ b/docs/guide/infrastructure/index.md
@@ -4,34 +4,41 @@ prev: false
 
 # Infrastructure
 
-Once uses a local cache by default. You do not need infrastructure
-configuration to run a cacheable script or graph target on one machine.
+Once works locally without configuration. Infrastructure becomes useful when
+you want to run an action on another machine or share a cached result with
+another developer or coding agent.
 
-## Start Locally
+## Run An Action Somewhere Else
 
-Run the [scripted workflow](/guide/scripted/) twice:
+Choose a named execution provider in the repository root `once.toml`:
 
-```sh
-./scripts/greet.sh
-./scripts/greet.sh
+```toml
+[infrastructures.remote_tests]
+kind = "e2b"
+template = "vitest-node-22"
+
+[infrastructure.execution]
+provider = "remote_tests"
 ```
 
-The first run reports a cache miss. The second reports a cache hit and restores
-the declared output from the local cache.
-
-This local behavior remains available after a shared provider is configured.
-Set `ONCE_CACHE_PROVIDER=local` for one process when you want to bypass the
-workspace's remote cache setting:
+Then run a literal command through that provider:
 
 ```sh
-ONCE_CACHE_PROVIDER=local ./scripts/greet.sh
+once exec --remote -- node --version
 ```
+
+Annotated scripts can select the same provider with
+`# once remote "remote_tests"`. Once creates a clean execution root, transfers
+only declared inputs, runs the command, retrieves declared outputs after a
+successful exit, and deletes the machine.
+
+Read [Remote Execution](/guide/infrastructure/remote-execution) for the full
+action lifecycle and a real Vitest workflow.
 
 ## Share Results Across Machines
 
-Add a named provider to the repository root `once.toml` when teammates or
-automation runners on different machines should reuse the same results. Bind
-the cache capability to that provider:
+A cache provider lets another machine reuse an action result instead of
+running it again:
 
 ```toml
 [infrastructures.tuist]
@@ -43,44 +50,33 @@ project = "app"
 provider = "tuist"
 ```
 
-The provider table holds shared connection settings. The capability table
-chooses which named provider supplies the cache.
-
-After authenticating, run the same script on two machines with identical
-inputs. The first machine reports a cache miss and uploads the result. A second
-machine whose local cache has not seen the result should report a cache hit and
-restore the output. That hit verifies that the configured provider supplied the
-result.
-
-## Configure Remote Execution Separately
-
-A provider can supply more than one capability. Bind remote execution only when
-commands should also run on that provider:
-
-```toml
-[infrastructure.execution]
-provider = "tuist"
-project = "preview-execution"
-```
-
-The capability can override the provider's default project. With this
-configuration, `--remote` uses the bound execution provider:
-
-```sh
-once exec --remote -- bash scripts/greet.sh
-```
-
-Pass `--compute <provider>` to choose a different execution provider for one
-command.
+The execution and cache capabilities are independent. A repository can run
+actions through E2B or Daytona while storing reusable results through Tuist.
+It can also use either capability on its own.
 
 ## Available Providers
 
-- [Tuist](/guide/infrastructure/tuist) provides shared cache and remote
-  execution.
+| Provider | Capability | Environment | Best fit |
+| --- | --- | --- | --- |
+| [Microsandbox](/guide/infrastructure/microsandbox) | Execution | Local image | Validate an action boundary on the current computer. |
+| [E2B](/guide/infrastructure/e2b) | Execution | Hosted template | Start a prepared hosted environment quickly. |
+| [Daytona](/guide/infrastructure/daytona) | Execution | Hosted container image | Build a hosted environment from a familiar image. |
+| [Tuist](/guide/infrastructure/tuist) | Shared cache | Not applicable | Reuse action results across machines. |
+
+## Keep A Local Escape Hatch
+
+The local cache remains available after a shared cache is configured. Set
+`ONCE_CACHE_PROVIDER=local` for one invocation:
+
+```sh
+ONCE_CACHE_PROVIDER=local ./scripts/greet.sh
+```
+
+For execution, omit `--remote` to run on the current computer. Pass
+`--compute <provider>` with `--remote` to choose a different named execution
+provider for one invocation.
 
 ## Next
 
-Follow the [Tuist setup guide](/guide/infrastructure/tuist) to configure
-authentication and verify a shared result. Continue to
-[Memory](/guide/memory/) to inspect the evidence that Once records after work
-runs.
+Start with [Remote Execution](/guide/infrastructure/remote-execution), then
+open the setup guide for the provider you want to use.

--- a/docs/guide/infrastructure/microsandbox.md
+++ b/docs/guide/infrastructure/microsandbox.md
@@ -1,0 +1,102 @@
+# Microsandbox
+
+[Microsandbox](https://github.com/microsandbox/microsandbox) runs a command in
+an isolated micro-virtual-machine on the local computer. It is useful for
+validating the same declared input and output contract used by the hosted E2B
+and Daytona executors.
+
+## Configure An Execution Environment
+
+Give the infrastructure a name based on its role. The name is a policy label,
+not the name of the test framework:
+
+```toml
+[infrastructures.remote_tests]
+kind = "microsandbox"
+image = "node:22.18.0-alpine"
+
+[infrastructure.execution]
+provider = "remote_tests"
+```
+
+The provider definition selects the Microsandbox executor adapter and the
+image that supplies tools such as [Node.js](https://nodejs.org/). Pin the image
+to an immutable digest for reproducible shared workflows.
+
+Run one command through the configured provider:
+
+```sh
+once exec --remote -- node --version
+```
+
+## Select The Provider From A Script
+
+An annotated script can name the same infrastructure directly:
+
+```sh
+#!/bin/sh
+# once remote "remote_tests"
+# once input "../src"
+# once input "../tests"
+# once output "../coverage"
+# once cwd ".."
+
+./node_modules/.bin/vitest run
+```
+
+Once resolves `remote_tests` through the root manifest. The command uses the
+Node.js executable from the configured image. Once does not copy a
+machine-specific interpreter path or import the host tool environment.
+
+## Model Package Dependencies As An Action
+
+The image should contain tools that are stable across many actions. Repository
+dependencies belong in the action graph. For example, an install script can
+use the [npm package manager](https://www.npmjs.com/) to produce `node_modules`:
+
+```sh
+#!/bin/sh
+# once input "../package.json"
+# once input "../package-lock.json"
+# once output "../node_modules"
+# once cwd ".."
+# once remote "remote_tests"
+
+npm clean-install
+```
+
+The test script then declares the install script as a dependency:
+
+```sh
+# once needs "./install.sh"
+```
+
+Once runs the install action first. Its declared `node_modules` output becomes
+a declared input of the test action and contributes to that action's cache
+identity. A cache hit can restore the dependency output without running the
+installer again.
+
+This is preferable to copying the host's `node_modules` by default. Package
+trees can contain platform-specific native files and symbolic links into a
+package manager store. If an existing workflow must copy such a tree, declare
+it as an `input`; Once transfers it recursively and rejects symbolic links that
+escape the declared input trees.
+
+## Filesystem Boundary
+
+The Microsandbox executor starts with a clean workspace. Before execution,
+Once creates the declared working directory and transfers only declared input
+files, directories, and safe symbolic links. After a successful command, Once
+retrieves only declared outputs and installs them into the workspace through a
+staging directory.
+
+The local adapter streams these trees through the Microsandbox filesystem
+service. Hosted E2B and Daytona adapters package the same declared trees into
+archives for transfer. A future hosted executor can use a content-addressed
+missing-file exchange without changing the script contract.
+
+Once stops the micro-virtual-machine and removes its persisted state after
+success, failure, or timeout.
+
+Microsandbox is currently available through Once on Linux and Apple Silicon
+macOS.

--- a/docs/guide/infrastructure/remote-execution.md
+++ b/docs/guide/infrastructure/remote-execution.md
@@ -1,0 +1,112 @@
+# Remote Execution
+
+Remote execution in Once means that the script contract stays in the
+repository while the process runs in a fresh environment supplied by an
+infrastructure provider.
+
+The important boundary is the action, not the test framework. Vitest is the
+program being run. Microsandbox, E2B, and Daytona are execution providers.
+
+## What Moves To The Machine
+
+For each remote action, Once performs this lifecycle:
+
+1. Resolve the named provider and immutable image or template.
+2. Create a fresh sandbox.
+3. Package only the declared input files, directories, executable modes, and
+   safe symbolic links.
+4. Transfer that package into a clean `/workspace` directory.
+5. Run the declared argument list with its working directory, selected
+   environment variables, resources, and timeout.
+6. After a successful exit, retrieve only the declared outputs into a local
+   staging area and validate them before installation.
+7. Delete the sandbox, whether the action succeeded or failed.
+
+Provider access keys configure the transport. They are not placed in the
+action environment or included in the action identity.
+
+## Run Real Vitest Tests
+
+Treat dependency installation and testing as separate actions. The install
+script uses the [npm package manager](https://www.npmjs.com/), consumes the
+package manifests, and produces `node_modules`:
+
+```sh
+#!/bin/sh
+# once input "../package.json"
+# once input "../package-lock.json"
+# once output "../node_modules"
+# once cwd ".."
+# once remote "remote_tests"
+
+npm clean-install --no-audit --no-fund
+```
+
+The test script depends on that action and consumes its output:
+
+```sh
+#!/bin/sh
+# once needs "./install.sh"
+# once input "../src"
+# once input "../tests"
+# once output "../reports"
+# once cwd ".."
+# once remote "remote_tests"
+
+./node_modules/.bin/vitest run \
+  --reporter=json \
+  --outputFile=reports/vitest.json
+```
+
+The provider environment supplies Node.js, npm, and basic operating-system
+tools. The install action supplies the exact repository dependencies. Its
+`node_modules` output becomes a declared input to the test action, including
+package-manager symbolic links and executable modes.
+
+This split means a package-lock change invalidates installation. A source or
+test change invalidates the test action without forcing installation to run
+again.
+
+## Choose A Provider
+
+Use [Microsandbox](/guide/infrastructure/microsandbox) to test the contract on
+a supported local computer. Use [E2B](/guide/infrastructure/e2b) when you have
+a prepared hosted template. Use [Daytona](/guide/infrastructure/daytona) when
+you want Once to start from a container image.
+
+All three adapters implement the same declared input and output boundary. E2B
+and Daytona use one archive for each transfer so large dependency trees do not
+require one network request per file. The hosted image or template must
+provide `tar` for unpacking and packing those archives.
+
+## Machine Cleanup
+
+Once waits for provider deletion after every normal success or failure. It
+also schedules deletion if the executing task is cancelled while a Tokio
+runtime is still active.
+
+The hosted providers add a second line of defense:
+
+- E2B receives a finite lifetime and a kill-on-timeout policy.
+- Daytona receives an ephemeral policy with immediate deletion after stop.
+
+If the provider refuses a delete request after an otherwise successful action,
+Once reports the action as failed. On an action failure, Once preserves the
+original failure and records a cleanup failure in its internal log.
+
+## How This Compares With Bazel
+
+[Bazel remote execution](https://bazel.build/remote/rbe) asks which
+content-addressed values are missing and uploads only those values. That is the
+right transport for a large shared worker fleet because unchanged files do not
+cross the network again.
+
+The E2B and Daytona adapters currently upload one complete archive of the
+declared inputs for each cache miss. This gives Once the same correctness
+boundary, but it is not yet as bandwidth-efficient as Bazel. The provider
+interface leaves room for a missing-content exchange so a future adapter can
+deduplicate files without changing script annotations.
+
+Once also keeps the executor boundary wider than the Bazel protocol. A local
+micro-virtual-machine, a hosted sandbox service, and a content-addressed worker
+fleet can all consume the same prepared action.

--- a/docs/guide/infrastructure/tuist.md
+++ b/docs/guide/infrastructure/tuist.md
@@ -1,8 +1,8 @@
 # Tuist
 
-[Tuist](https://tuist.dev) lets Once share cache entries and execute commands
-across machines. Start with the cache, verify that another checkout can reuse a
-result, then add remote execution if the project needs it.
+[Tuist](https://tuist.dev) lets Once share cache entries across machines.
+Configure it when developers and coding agents should reuse the same action
+results.
 
 ## Configure The Cache
 
@@ -96,26 +96,9 @@ steps:
 
 The resulting session remains available for the rest of the job.
 
-## Add Remote Execution
-
-Bind execution to the same provider when commands should run through Tuist:
-
-```toml
-[infrastructure.execution]
-provider = "tuist"
-project = "preview-execution"
-```
-
-The `project` override is optional. It lets cache and execution use different
-Tuist projects while sharing the provider's account and authentication.
-
-Run a command remotely with the configured provider:
-
-```sh
-once exec --remote -- bash scripts/greet.sh
-```
-
 ## Next
 
-Read [Memory](/guide/memory/) to inspect the status, cache state, and action
-identity that Once records for each run.
+Add an [execution provider](/guide/infrastructure/remote-execution) when the
+command should also run away from the current computer. Read
+[Memory](/guide/memory/) to inspect the status, cache state, and action identity
+that Once records for each run.

--- a/docs/guide/scripted/caching.md
+++ b/docs/guide/scripted/caching.md
@@ -47,9 +47,11 @@ npm run build
 ```
 
 Once runs independent dependencies concurrently. A dependency's declared
-output fingerprints become part of the dependent script's cache key. If the
-dependency runs again but produces the same outputs, the dependent script can
-still reuse its previous result.
+outputs become declared inputs of the dependent script, and their fingerprints
+become part of its cache key. This lets a remote test consume an installation
+script's `node_modules` output without exposing the rest of the host workspace.
+If the dependency runs again but produces the same outputs, the dependent
+script can still reuse its previous result.
 
 ## Choose How Symbolic Links Are Stored
 
@@ -79,6 +81,7 @@ at restore time.
 | `output-symlinks` | Uses `materialize-external` or `preserve` when capturing symbolic links in outputs. |
 | `env` | Forwards a selected environment variable and includes its value in the cache key. |
 | `cwd` | Chooses the working directory for the script body. |
+| `remote` | Selects a named remote execution infrastructure provider. |
 
 The script file itself is always part of the cache key, even when it has no
 `input` headers.
@@ -147,5 +150,7 @@ mise run build
 ## Next
 
 Configure [Infrastructure](/guide/infrastructure/) when these cacheable results
-should be shared across machines. If an existing tool must probe or populate
-the cache itself, continue to [Manual Cache Access](/guide/scripted/runtime).
+should be shared across machines, or use
+[Remote Execution](/guide/infrastructure/remote-execution) to run them in a
+fresh sandbox. If an existing tool must probe or populate the cache itself,
+continue to [Manual Cache Access](/guide/scripted/runtime).

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -64,4 +64,6 @@ targets while keeping the same cache, build, run, and test workflow.
 ## Next
 
 Continue with [Getting Started](/guide/getting-started) to install Once and
-reuse the result of a cacheable script.
+reuse the result of a cacheable script. If running work away from the current
+computer is your main interest, read
+[Remote Execution](/guide/infrastructure/remote-execution).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,9 @@ hero:
       text: Why Once
       link: /guide/why
     - theme: alt
+      text: Remote execution
+      link: /guide/infrastructure/remote-execution
+    - theme: alt
       text: Reference
       link: /reference/
 features:
@@ -23,6 +26,8 @@ features:
     details: Add an input and output contract to automation that already works, then run it through Once.
   - title: Reuse the result
     details: Restore content-addressed outputs locally or through a shared cache when the declared inputs have not changed.
+  - title: Run somewhere else
+    details: Send only declared inputs to a fresh local or hosted sandbox, retrieve declared outputs, and delete the machine.
   - title: Grow into a graph
     details: Move workflows into typed targets and capabilities when they need richer dependencies, queries, and diagnostics.
 ---

--- a/docs/reference/cli/exec.md
+++ b/docs/reference/cli/exec.md
@@ -10,7 +10,7 @@ once exec [OPTIONS] [ARGV]
 
 ## Description
 
-Low-level action surface for direct commands and script adapters. The cache key is the full argv, declared environment variables, optional working directory, and optional timeout. A second invocation with the same key reuses the captured stdout, stderr, and exit code. With `--script`, or when argv looks like `<runtime> <script> [args...]` and the file has `once` headers, Once applies script-aware parsing instead.
+Low-level action surface for direct commands and script adapters. The cache key is the full argument list, declared environment variables, optional working directory, optional timeout, declared input digest, and remote execution environment. A second invocation with the same key reuses the captured standard output, standard error, exit code, and declared outputs. With `--script`, or when the arguments look like `<runtime> <script> [args...]` and the file has `once` headers, Once applies script-aware parsing instead. Remote script actions receive only declared inputs and retrieve only declared outputs. Fresh hosted machines are deleted after success or failure.
 
 ## Arguments
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -43,6 +43,37 @@ the same definitions.
 See [Modules](/reference/modules/) and [Infrastructure](/guide/infrastructure/)
 for the contracts owned by those tables.
 
+An execution-only provider can select a sandbox adapter and immutable tool
+environment:
+
+```toml
+[infrastructures.remote_tests]
+kind = "microsandbox"
+image = "node:22.18.0-alpine"
+
+[infrastructure.execution]
+provider = "remote_tests"
+```
+
+The provider name is a workspace policy label. Script headers and command-line
+options can select it without coupling the script to Microsandbox.
+
+Hosted execution providers select their immutable environment with a template
+or image:
+
+```toml
+[infrastructures.e2b_tests]
+kind = "e2b"
+template = "vitest-node-22"
+
+[infrastructures.daytona_tests]
+kind = "daytona"
+image = "node:22.18.0-bookworm"
+```
+
+E2B, Daytona, and Microsandbox provide execution only. Tuist provides shared
+caching. Bind each capability independently when a workspace uses both.
+
 ## Targets
 
 The root manifest and package manifests can declare one or more targets:

--- a/docs/site.js
+++ b/docs/site.js
@@ -212,6 +212,10 @@ export const site = {
         collapsed: false,
         items: [
           { text: "Overview", link: "/guide/infrastructure/" },
+          { text: "Remote Execution", link: "/guide/infrastructure/remote-execution" },
+          { text: "Microsandbox", link: "/guide/infrastructure/microsandbox" },
+          { text: "E2B", link: "/guide/infrastructure/e2b" },
+          { text: "Daytona", link: "/guide/infrastructure/daytona" },
           { text: "Tuist", link: "/guide/infrastructure/tuist" },
         ],
       },

--- a/fixtures/exec/daytona/daytona_api.py
+++ b/fixtures/exec/daytona/daytona_api.py
@@ -1,44 +1,74 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
 import json
-import subprocess
+import pathlib
+import sys
+
+
+deleted_marker = pathlib.Path(sys.argv[1])
 
 
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *args):
         pass
 
-    def do_POST(self):
-        if self.path != "/toolbox/sandbox-1/process/execute":
-            self.send_error(404)
-            return
-        if self.headers.get("Authorization") != "Bearer token-1":
-            self.send_error(401)
-            return
+    def read_body(self):
         length = int(self.headers.get("Content-Length", "0"))
-        request = json.loads(self.rfile.read(length))
-        proc = subprocess.run(
-            request["command"],
-            shell=True,
-            cwd=request["cwd"],
-            capture_output=True,
-            text=True,
-        )
-        body = json.dumps(
-            {
-                "exitCode": proc.returncode,
-                "artifacts": {
-                    "stdout": proc.stdout,
-                    "stderr": "daytona stderr\n" + proc.stderr,
-                },
-            }
-        ).encode()
-        self.send_response(200)
+        return self.rfile.read(length)
+
+    def respond(self, status, value=None):
+        body = b"" if value is None else json.dumps(value).encode()
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
+    def authorized(self):
+        if self.headers.get("Authorization") == "Bearer token-1":
+            return True
+        self.respond(401)
+        return False
+
+    def do_POST(self):
+        if not self.authorized():
+            return
+        path = urlparse(self.path).path
+        if path == "/api/sandbox":
+            request = json.loads(self.read_body())
+            if request.get("autoDeleteInterval") != 0:
+                self.respond(400)
+                return
+            self.respond(
+                200,
+                {"id": "sandbox-1", "state": "started", "toolboxProxyUrl": None},
+            )
+            return
+        if path == "/toolbox/sandbox-1/files/upload":
+            self.read_body()
+            self.respond(200)
+            return
+        if path == "/toolbox/sandbox-1/process/execute":
+            request = json.loads(self.read_body())
+            if request["command"].startswith("mkdir "):
+                self.respond(200, {"exitCode": 0, "result": ""})
+            else:
+                value = request.get("envs", {}).get("VALUE", "missing")
+                self.respond(200, {"exitCode": 0, "result": f"daytona-{value}"})
+            return
+        self.respond(404)
+
+    def do_DELETE(self):
+        if not self.authorized():
+            return
+        if urlparse(self.path).path != "/api/sandbox/sandbox-1":
+            self.respond(404)
+            return
+        deleted_marker.write_text("deleted")
+        self.respond(204)
+
 
 server = HTTPServer(("127.0.0.1", 0), Handler)
 print(server.server_port, flush=True)
-server.handle_request()
+for _ in range(5):
+    server.handle_request()

--- a/fixtures/exec/remote_dependency/once.toml
+++ b/fixtures/exec/remote_dependency/once.toml
@@ -1,0 +1,6 @@
+[infrastructures.remote_tests]
+kind = "microsandbox"
+image = "node:22.18.0-alpine"
+
+[infrastructure.execution]
+provider = "remote_tests"

--- a/fixtures/exec/remote_dependency/package-lock.json
+++ b/fixtures/exec/remote_dependency/package-lock.json
@@ -1,0 +1,1292 @@
+{
+  "name": "once-remote-vitest-fixture",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "once-remote-vitest-fixture",
+      "devDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/fixtures/exec/remote_dependency/package.json
+++ b/fixtures/exec/remote_dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "once-remote-vitest-fixture",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "vitest": "4.1.10"
+  }
+}

--- a/fixtures/exec/remote_dependency/scripts/install.sh
+++ b/fixtures/exec/remote_dependency/scripts/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# once input "../package.json"
+# once input "../package-lock.json"
+# once output "../node_modules"
+# once cwd ".."
+# once remote "remote_tests"
+set -eu
+npm clean-install --no-audit --no-fund

--- a/fixtures/exec/remote_dependency/scripts/test.sh
+++ b/fixtures/exec/remote_dependency/scripts/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# once needs "./install.sh"
+# once input "../src"
+# once input "../tests"
+# once output "../reports"
+# once cwd ".."
+# once remote "remote_tests"
+set -eu
+test ! -e undeclared.txt
+./node_modules/.bin/vitest run --reporter=json --outputFile=reports/vitest.json >/dev/null
+node -e '
+  const fs = require("node:fs");
+  const report = JSON.parse(fs.readFileSync("reports/vitest.json", "utf8"));
+  if (!report.success || report.numPassedTests !== 1) process.exit(1);
+  process.stdout.write("source:test");
+'

--- a/fixtures/exec/remote_dependency/src/value.js
+++ b/fixtures/exec/remote_dependency/src/value.js
@@ -1,0 +1,3 @@
+export function decoratedValue() {
+  return "source:test";
+}

--- a/fixtures/exec/remote_dependency/tests/value.test.js
+++ b/fixtures/exec/remote_dependency/tests/value.test.js
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+
+import { decoratedValue } from "../src/value.js";
+
+test("uses the declared source input", () => {
+  expect(decoratedValue()).toBe("source:test");
+});

--- a/rfcs/0004-remote-execution.md
+++ b/rfcs/0004-remote-execution.md
@@ -1,0 +1,195 @@
+# Request for Comments 0004: Provider-Neutral Remote Execution
+
+## Summary
+
+Once should turn an annotated script or graph action into one provider-neutral
+execution request, then let an executor adapter place that request on a local
+Microsandbox, a hosted sandbox such as
+[Daytona](https://www.daytona.io/) or [E2B](https://e2b.dev/), or a service
+implementing Bazel's
+[Remote Execution protocol](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto).
+
+The action contract owns the command, declared environment, working directory,
+input tree, expected outputs, resources, timeout, and immutable execution
+environment. Infrastructure configuration owns provider placement,
+authentication, account, project, retry policy, and transport.
+
+Scripts remain the migration path. They should gain remote execution by adding
+headers, not by being rewritten as build graph rules.
+
+## Decision
+
+Once will preserve the immutable action model used by Bazel and Buck2 while
+making the executor boundary broad enough for sandbox providers:
+
+1. Resolve a script header or command option to a named infrastructure
+   provider.
+2. Prepare one normalized command with declared inputs and outputs.
+3. Select an executor adapter from the provider definition.
+4. Materialize only the declared input tree in a clean execution root.
+5. Run the exact argument list without a host shell unless the script runtime
+   itself is a shell.
+6. Stream standard output and standard error while the command runs.
+7. Retrieve only declared outputs after a successful exit.
+8. Store the result and output trees in content-addressed storage.
+
+An execution image or snapshot provides operating-system tools and language
+runtimes. Repository source and generated dependencies are action inputs.
+
+## What Bazel Gets Right
+
+[Bazel remote execution](https://bazel.build/remote/rbe) represents the
+command, input Merkle tree, and action as immutable content-addressed values.
+The client asks which values are missing, uploads only those values, and asks a
+remote service to execute the action digest. Results refer to output files and
+trees by digest.
+
+This is the correct network protocol for large shared fleets because it:
+
+- avoids sending unchanged files repeatedly;
+- makes upload work proportional to missing content;
+- lets execution and caching share one action identity;
+- permits independent workers to materialize the same action;
+- records outputs without trusting a worker to choose undeclared paths.
+
+Once should support this protocol natively rather than translating it through
+a shell-based worker.
+
+## What Buck2 Adds
+
+[Buck2 remote execution](https://buck2.build/docs/users/remote_execution/) and
+its [architecture](https://buck2.build/docs/concepts/architecture/) reinforce
+three useful distinctions:
+
+- analysis decides what the action means;
+- execution platform selection decides where it may run;
+- materialization decides when files must exist locally.
+
+Once should keep these decisions separate. A coding harness often needs the
+test result and captured streams, but it may not need every generated file
+materialized immediately.
+
+## Where Once Can Improve The Model
+
+Bazel's protocol is an excellent distributed transport, but it should not be
+the only executor interface. Daytona, E2B, and Microsandbox expose durable
+sandboxes, snapshots, and filesystem operations rather than the Bazel service
+shape. Once can normalize both families behind one prepared action:
+
+```text
+script or graph action
+  -> semantic action and execution requirements
+  -> named infrastructure binding
+  -> executor adapter
+     -> content-addressed remote service
+     -> sandbox filesystem service
+```
+
+Sandbox adapters may initially transfer a declared tree directly. A mature
+adapter should add content-addressed upload, missing-blob checks, cancellation,
+leases, and capability discovery when the provider supports them.
+
+Provider placement should eventually be excluded from semantic action
+identity. Two providers executing the same command in the same immutable
+environment should be able to share a result. The current implementation keeps
+the provider binding in the action key as a conservative safety boundary until
+environment and platform identity are mandatory and transport-independent.
+
+## Node.js And Vitest Example
+
+A [Vitest](https://vitest.dev/) workflow has two different dependency classes:
+
+1. The immutable execution image supplies Node.js and basic operating-system
+   tools.
+2. An install action consumes package manifests and produces `node_modules`.
+3. The test action consumes source files, test files, and the install action's
+   declared output.
+
+The test action never depends on the host's Node.js installation or ambient
+workspace. An undeclared file must be absent in the execution root. Changing a
+package lock invalidates the install action. If installation produces the same
+tree, the test action retains the same dependency fingerprint.
+
+This is better than putting `node_modules` into a long-lived provider snapshot.
+Snapshots are effective for toolchains, but mutable repository dependencies in
+a snapshot are difficult to inspect, key, share, and invalidate correctly.
+
+## Hosted Sandbox Research
+
+The first hosted adapters target E2B and Daytona because both expose the three
+operations the prepared action requires: create an isolated machine, transfer
+files, and destroy the machine.
+
+- [E2B sandboxes](https://e2b.dev/docs) use prepared templates, a filesystem
+  service, direct process arguments, and explicit kill semantics.
+- [Daytona sandboxes](https://www.daytona.io/docs/en/sandboxes/) use snapshots
+  or container-derived environments, a toolbox filesystem service, process
+  execution, and ephemeral deletion policy.
+- [Modal sandboxes](https://modal.com/docs/guide/sandboxes) also provide file
+  transfer and termination, but their primary integration is through Modal
+  language libraries. It remains a good candidate for a later adapter.
+- [Cloudflare Sandbox](https://developers.cloudflare.com/sandbox/) exposes a
+  capable sandbox inside the Cloudflare Workers object model. It is not a
+  direct replacement for an executor called by a local Once process.
+
+Provider popularity alone is not the contract. The deciding factor is whether
+Once can own the complete machine lifecycle and preserve declared filesystem
+boundaries without embedding a provider library in scripts.
+
+## Hosted Transfer And Cleanup
+
+E2B and Daytona receive one uncompressed archive containing only declared
+inputs. This preserves directory structure, executable modes, and safe
+symbolic links while avoiding one request per dependency file. A successful
+action packages only declared outputs into a second archive. Once validates
+that archive in a staging area before changing the workspace.
+
+This transport sends the full declared tree on every action cache miss. It is
+therefore less bandwidth-efficient than the missing-content exchange in the
+Bazel protocol. It is an adapter implementation detail, so a provider can add
+content-addressed transfer later without changing the prepared action or
+script annotations.
+
+Each hosted action owns a fresh machine. Once explicitly waits for deletion
+after success and failure. E2B also receives a finite lifetime with
+kill-on-timeout behavior. Daytona also receives an ephemeral policy with
+immediate deletion after stop. These provider policies are safety nets for
+client cancellation or process loss, not substitutes for explicit cleanup.
+
+## Security Boundary
+
+Declared paths are a security and correctness boundary, not only a cache hint.
+An executor must reject:
+
+- input or output paths that escape the workspace;
+- absolute symbolic-link targets;
+- relative symbolic links that escape every declared tree;
+- special filesystem entries it cannot reproduce safely;
+- provider output paths that were not requested.
+
+Outputs should be downloaded into a staging area and installed only after all
+requested trees have been validated. A failed installation must restore the
+previous workspace outputs.
+
+## Implemented Slice
+
+The first slice establishes the provider-neutral prepared command and validates
+it with a real local Microsandbox:
+
+- named Microsandbox infrastructure with an explicit image;
+- script annotations that resolve named infrastructure;
+- direct transfer of declared files, directories, modes, and safe symbolic
+  links;
+- clean execution roots with logical runtime names;
+- dependency outputs added to downstream action inputs;
+- declared output retrieval with staged installation and rollback;
+- a Node.js-backed workflow that installs and runs the real Vitest package;
+- E2B template configuration, declared filesystem transfer, direct command
+  execution, output retrieval, and deletion;
+- Daytona image configuration, declared filesystem transfer, command
+  execution, output retrieval, and deletion;
+- provider-level tests that verify deletion after both successful execution
+  and transfer failure.
+
+The Bazel Remote Execution protocol remains a future adapter over the same
+prepared command contract.

--- a/spec/exec_spec.sh
+++ b/spec/exec_spec.sh
@@ -191,16 +191,49 @@ SH
     The stderr should include 'cache miss'
   End
 
+  It 'transfers only declared script inputs and retrieves microsandbox outputs'
+    Skip if 'microsandbox specs are opt-in' microsandbox_specs_disabled
+    copy_exec_fixture remote_dependency
+    printf hidden > "$WORKSPACE/undeclared.txt"
+
+    When call once exec --script -- /bin/sh scripts/test.sh
+    The status should be success
+    The stdout should equal 'source:test'
+    The stderr should include 'cache miss'
+    The file "$WORKSPACE/reports/vitest.json" should be exist
+    The contents of file "$WORKSPACE/reports/vitest.json" should include '"numPassedTests":1'
+    The path "$WORKSPACE/node_modules/.bin/vitest" should be symlink
+  End
+
+  It 'restores remote dependency and test outputs from cache'
+    Skip if 'microsandbox specs are opt-in' microsandbox_specs_disabled
+    copy_exec_fixture remote_dependency
+    printf hidden > "$WORKSPACE/undeclared.txt"
+    if [ "${ONCE_RUN_MICROSANDBOX_SPECS:-}" = "1" ]; then
+      once exec --script -- /bin/sh scripts/test.sh >/dev/null 2>&1
+      rm -rf "$WORKSPACE/node_modules" "$WORKSPACE/reports"
+      printf changed > "$WORKSPACE/undeclared.txt"
+    fi
+
+    When call once exec --script -- /bin/sh scripts/test.sh
+    The status should be success
+    The stdout should equal 'source:test'
+    The stderr should include 'cache hit'
+    The file "$WORKSPACE/reports/vitest.json" should be exist
+    The contents of file "$WORKSPACE/reports/vitest.json" should include '"numPassedTests":1'
+    The path "$WORKSPACE/node_modules/.bin/vitest" should be symlink
+  End
+
   It 'runs a command through the daytona compute provider'
     copy_exec_fixture daytona
-    python3 "$WORKSPACE/daytona_api.py" > "$WORKSPACE/daytona_port" &
+    python3 "$WORKSPACE/daytona_api.py" "$WORKSPACE/daytona_deleted" > "$WORKSPACE/daytona_port" &
     while [ ! -s "$WORKSPACE/daytona_port" ]; do sleep 0.05; done
     port="$(cat "$WORKSPACE/daytona_port")"
-    When call env ONCE_DAYTONA_SANDBOX=sandbox-1 ONCE_DAYTONA_API_URL="http://127.0.0.1:$port" ONCE_DAYTONA_API_KEY=token-1 ONCE_DAYTONA_WORKDIR="$WORKSPACE" "$ONCE_BIN" -C "$WORKSPACE" exec --remote --compute daytona -e VALUE=output -- /bin/sh -c 'printf "daytona-$VALUE"'
+    When call env ONCE_DAYTONA_CONTROL_URL="http://127.0.0.1:$port/api" ONCE_DAYTONA_TOOLBOX_URL="http://127.0.0.1:$port/toolbox" ONCE_DAYTONA_API_KEY=token-1 "$ONCE_BIN" -C "$WORKSPACE" exec --remote --compute daytona -e VALUE=output -- /bin/sh -c 'printf "daytona-$VALUE"'
     The status should be success
     The stdout should equal 'daytona-output'
-    The stderr should include 'daytona stderr'
     The stderr should include 'cache miss'
+    The file "$WORKSPACE/daytona_deleted" should be exist
   End
 
   It 'propagates the underlying exit code'

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -25,12 +25,32 @@ setup_workspace() {
   XDG_CONFIG_HOME="$WORKSPACE/.xdg/config"
   XDG_RUNTIME_DIR="$WORKSPACE/.xdg/runtime"
   SPEC_ORIGINAL_HOME="${HOME:-}"
+  SPEC_ORIGINAL_MSB_PATH="${MSB_PATH:-}"
   HOME="$WORKSPACE/.home"
   mkdir -p "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_RUNTIME_DIR" "$HOME"
   export WORKSPACE XDG_CACHE_HOME XDG_STATE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_RUNTIME_DIR HOME SPEC_ORIGINAL_HOME
+  if [ "${ONCE_RUN_MICROSANDBOX_SPECS:-}" = "1" ]; then
+    MSB_HOME="$(mktemp -d /tmp/once-msb.XXXXXX)"
+    if [ -z "${MSB_PATH:-}" ] && [ -x "$SPEC_ORIGINAL_HOME/.microsandbox/bin/msb" ]; then
+      MSB_PATH="$SPEC_ORIGINAL_HOME/.microsandbox/bin/msb"
+    fi
+    export MSB_HOME MSB_PATH
+  fi
 }
 
 cleanup_workspace() {
+  case "${MSB_HOME:-}" in
+    /tmp/once-msb.*)
+      rm -rf -- "$MSB_HOME"
+      ;;
+  esac
+  unset MSB_HOME
+  if [ -n "${SPEC_ORIGINAL_MSB_PATH:-}" ]; then
+    MSB_PATH="$SPEC_ORIGINAL_MSB_PATH"
+    export MSB_PATH
+  else
+    unset MSB_PATH
+  fi
   if [ -n "${WORKSPACE:-}" ] && [ -d "$WORKSPACE" ]; then
     rm -rf "$WORKSPACE"
     unset WORKSPACE
@@ -41,7 +61,7 @@ cleanup_workspace() {
   else
     unset HOME
   fi
-  unset XDG_CACHE_HOME XDG_STATE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_RUNTIME_DIR SPEC_ORIGINAL_HOME
+  unset XDG_CACHE_HOME XDG_STATE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_RUNTIME_DIR SPEC_ORIGINAL_HOME SPEC_ORIGINAL_MSB_PATH
 }
 
 once() {


### PR DESCRIPTION
## What changed

This branch introduces remote script execution and lands the supporting graph and cache work that precedes it.

The headline change is remote execution for scripted actions. A scripted action can now run inside an isolated sandbox instead of on the host, across three backends behind named infrastructure bindings:

- **e2b** and **Daytona** hosted sandboxes, which receive a single archive of the declared input tree, run the command, and return a second archive of the declared outputs.
- The embedded **Microsandbox** provider, which stages the same declared tree into a local sandbox.

Each backend stages only the files a script declares with `# once input`, runs the command in a clean execution root, and retrieves only the declared outputs. Once owns the full sandbox lifecycle (create, stage, execute, pack, download, delete) per run.

The backends were also hardened against several correctness gaps found while reviewing the rewrite:

- Daytona streams stderr again and treats a response with no exit code as an error rather than silently reporting success.
- Input staging and output packing inherit the command timeout instead of a fixed 60 second cap, so large dependency trees no longer fail staging spuriously.
- e2b preserves the real exit code and diagnostics when a process ends with an error, instead of masking both behind a generic API error.
- Microsandbox surfaces a truncated exec stream explicitly instead of inventing an exit code of `-1` and skipping output retrieval.

Preceding commits on the branch add selective test execution and scheduling, expand typed ecosystem parity, integrate language library caching, and restore the main CI checks.

## Why

Scripts are the migration path onto Once, and running them on the host limits both reproducibility and the ability to fan work out to hosted infrastructure. Treating repository source and generated dependencies as declared action inputs lets the same action run identically on the host or in a sandbox, and lets a build move to e2b, Daytona, or Microsandbox by adding an infrastructure binding rather than rewriting the script.

## Approach

The design is captured in [RFC 0004](rfcs/0004-remote-execution.md). The action contract owns the command, declared environment, working directory, input tree, expected outputs, resources, and timeout, and that contract is the only executor interface. Declared paths are treated as a security and correctness boundary, not just a cache hint: an undeclared file must be absent in the execution root, and input or output paths that escape the workspace are rejected.

Two design choices are deliberate behavior changes versus `main`, both consistent with the RFC:

- Microsandbox stages only declared inputs rather than bind-mounting the whole workspace, so it matches the e2b and Daytona hermetic contract.
- Daytona provisions a fresh sandbox per run rather than attaching to a pre-provisioned one, so Once owns the machine lifecycle. The previous `ONCE_DAYTONA_SANDBOX` and `ONCE_DAYTONA_WORKDIR` variables are no longer used.

## Impact

- New capability: scripted actions can run remotely by binding a named e2b, Daytona, or Microsandbox infrastructure.
- Migration: a script that reads a file it does not declare with `# once input` will now fail under a sandbox, because the execution root contains only declared inputs. Scripts must declare every file they read.
- Migration: pipelines that pointed Daytona at a pre-warmed sandbox via `ONCE_DAYTONA_SANDBOX` should drop that assumption, since each run now provisions its own sandbox.

## Validation

- `cargo test -p once-core --features remote-microsandbox` — 157 tests pass, including new coverage for the Daytona exit-code and output-stream handling and the e2b end-of-process error handling.
- `cargo clippy -p once-core --features remote-microsandbox --tests` — clean.

Opened as a draft to avoid spending CI cycles until it is ready for review.
