### PR TITLE
fix(apple): propagate framework runtime closures

### DIFF
--- a/crates/once-core/src/input_digest.rs
+++ b/crates/once-core/src/input_digest.rs
@@ -12,6 +12,9 @@ use std::path::Path;
 
 use once_cas::Digest;
 
+use crate::directory_blob::capture_directory_blob;
+use crate::OutputSymlinkMode;
+
 #[derive(Debug)]
 /// Build an input digest piece by piece.
 ///
@@ -57,18 +60,23 @@ impl InputDigestBuilder {
         self
     }
 
-    /// Hash a workspace-relative source file and append the result
-    /// keyed by the workspace-relative path. Streams the file through
-    /// [`Digest::of_reader`] so multi-megabyte sources never sit in
-    /// memory.
+    /// Hash a workspace-relative source file or directory and append
+    /// the result keyed by the workspace-relative path. Files stream
+    /// through [`Digest::of_reader`]; directories use the same stable
+    /// encoding as cached directory outputs.
     pub fn push_source<P: AsRef<Path>>(
         &mut self,
         workspace_root: P,
         ws_rel: &str,
     ) -> std::io::Result<&mut Self> {
         let abs = workspace_root.as_ref().join(ws_rel);
-        let file = std::fs::File::open(&abs)?;
-        let digest = Digest::of_reader(std::io::BufReader::new(file))?;
+        let digest = if std::fs::metadata(&abs)?.is_dir() {
+            let bytes = capture_directory_blob(&abs, OutputSymlinkMode::Preserve)?;
+            Digest::of_bytes(&bytes)
+        } else {
+            let file = std::fs::File::open(&abs)?;
+            Digest::of_reader(std::io::BufReader::new(file))?
+        };
         Ok(self.push_keyed(ws_rel.as_bytes(), &digest))
     }
 
@@ -132,6 +140,32 @@ mod tests {
             b.finish()
         };
         assert_ne!(first, third, "content change invalidates the digest");
+    }
+
+    #[test]
+    fn push_source_hashes_directory_contents() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("Framework.framework");
+        std::fs::create_dir_all(source.join("Modules")).unwrap();
+        std::fs::write(source.join("Framework"), b"binary").unwrap();
+        std::fs::write(
+            source.join("Modules/module.modulemap"),
+            b"module Framework {}",
+        )
+        .unwrap();
+
+        let digest = |tmp: &TempDir| {
+            let mut builder = InputDigestBuilder::new(b"test.input.v1");
+            builder
+                .push_source(tmp.path(), "Framework.framework")
+                .unwrap();
+            builder.finish()
+        };
+        let first = digest(&tmp);
+        assert_eq!(first, digest(&tmp));
+
+        std::fs::write(source.join("Framework"), b"changed").unwrap();
+        assert_ne!(first, digest(&tmp));
     }
 
     #[test]

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -1773,6 +1773,7 @@ def _apple_framework_impl(ctx):
     }
 
 def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesign, identifier_prefix):
+    embedded_paths = []
     embedded_stamps = []
     destination_sources = {}
     for bundle in _apple_collect_runtime_framework_bundles(deps):
@@ -1797,6 +1798,7 @@ def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesi
         if embedded_stamp not in embed_outputs:
             embed_outputs.append(embedded_stamp)
         embedded_framework_path = ctx["build_dir"] + "/" + embedded_relative_path
+        embedded_paths.append(embedded_framework_path)
         copy_path(
             framework_path,
             embedded_framework_path,
@@ -1813,7 +1815,10 @@ def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesi
             identifier = identifier_prefix + "_" + framework_basename,
         )
         embedded_stamps.append(embedded_stamp)
-    return embedded_stamps
+    return {
+        "paths": embedded_paths,
+        "stamps": embedded_stamps,
+    }
 
 def shell_quote_for_action(path):
     # Single-quote the path and escape any embedded single quotes by
@@ -2035,7 +2040,7 @@ def _apple_application_impl(ctx):
     write_path(info_plist, _render_plist(plist_entries, bool_entries, array_entries))
 
     codesign = _resolve_codesign(xcode_developer_dir)
-    embedded_stamps = _apple_embed_framework_bundles(
+    embedded_frameworks = _apple_embed_framework_bundles(
         ctx,
         deps,
         app_dir,
@@ -2049,7 +2054,7 @@ def _apple_application_impl(ctx):
     # resource envelope.
     app_cs_stamp = declare_output(app_dir + "/_CodeSignature/CodeResources")
     cs_inputs = [executable, info_plist]
-    for stamp in embedded_stamps:
+    for stamp in embedded_frameworks["stamps"]:
         cs_inputs.append(stamp)
     run_action(
         argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", ctx["build_dir"] + "/" + app_dir],
@@ -2262,7 +2267,7 @@ def _apple_test_bundle_impl(ctx):
     write_path(info_plist, _render_plist(plist_entries))
 
     codesign = _resolve_codesign(xcode_developer_dir)
-    embedded_stamps = _apple_embed_framework_bundles(
+    embedded_frameworks = _apple_embed_framework_bundles(
         ctx,
         deps,
         bundle_dir,
@@ -2275,7 +2280,7 @@ def _apple_test_bundle_impl(ctx):
     else:
         test_cs_stamp = declare_output(bundle_dir + "/_CodeSignature/CodeResources")
     test_codesign_inputs = [test_binary, info_plist]
-    test_codesign_inputs.extend(embedded_stamps)
+    test_codesign_inputs.extend(embedded_frameworks["stamps"])
     run_action(
         argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", test_bundle_path],
         inputs = test_codesign_inputs,
@@ -2347,6 +2352,7 @@ exit "$status"
             runner_type = runner_type,
         )
         test_inputs = [test_binary, info_plist, test_cs_stamp]
+        test_inputs.extend(embedded_frameworks["paths"])
         for src in swift_srcs:
             if src not in test_inputs:
                 test_inputs.append(src)

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -423,6 +423,81 @@ def _collect_transitive(deps, key, own_values):
                 out.append(value)
     return out
 
+def _apple_framework_bundle(path, module_name, files, label_id, absorbed_static_archives = []):
+    return {
+        "path": path,
+        "module_name": module_name,
+        "files": files,
+        "label_id": label_id,
+        "absorbed_static_archives": absorbed_static_archives,
+    }
+
+def _apple_legacy_framework_bundles(dep, include_transitive):
+    direct_path = dep.get("framework_path") or ""
+    paths = dep.get("transitive_frameworks") if include_transitive else None
+    if paths == None:
+        paths = [direct_path] if direct_path else []
+    out = []
+    for path in paths:
+        module_name = ""
+        files = []
+        absorbed_static_archives = []
+        if path == direct_path:
+            module_name = dep.get("framework_module_name") or ""
+            files = dep.get("framework_files") or []
+            absorbed_static_archives = dep.get("absorbed_static_archives") or []
+        out.append(_apple_framework_bundle(
+            path,
+            module_name,
+            files,
+            dep.get("label_id") or "",
+            absorbed_static_archives,
+        ))
+    return out
+
+def _apple_dep_framework_bundles(dep, key, include_transitive):
+    bundles = dep.get(key)
+    if bundles != None:
+        return bundles
+    return _apple_legacy_framework_bundles(dep, include_transitive)
+
+def _apple_collect_framework_bundles(deps, key, own_bundles, include_transitive):
+    seen = {}
+    out = []
+    for bundle in own_bundles:
+        path = bundle.get("path") or ""
+        if path and path not in seen:
+            seen[path] = True
+            out.append(bundle)
+    for dep in deps:
+        for bundle in _apple_dep_framework_bundles(dep, key, include_transitive):
+            path = bundle.get("path") or ""
+            if path and path not in seen:
+                seen[path] = True
+                out.append(bundle)
+    return out
+
+def _apple_collect_link_framework_bundles(deps, own_bundles = []):
+    return _apple_collect_framework_bundles(deps, "transitive_link_framework_bundles", own_bundles, False)
+
+def _apple_collect_runtime_framework_bundles(deps, own_bundles = []):
+    return _apple_collect_framework_bundles(deps, "transitive_framework_bundles", own_bundles, True)
+
+def _apple_framework_bundle_paths(bundles):
+    return [bundle["path"] for bundle in bundles]
+
+def _apple_validate_static_framework_diamonds(consumer_label, static_archives, framework_bundles):
+    absorbed_by = {}
+    for bundle in framework_bundles:
+        framework_label = bundle.get("label_id") or bundle.get("path") or "framework dependency"
+        for archive in bundle.get("absorbed_static_archives") or []:
+            if archive in static_archives:
+                fail(consumer_label + ": static archive `" + archive + "` is linked directly and is already part of dynamic framework `" + framework_label + "`; remove the duplicate static dependency or move the shared code behind one dynamic framework boundary")
+            previous_framework = absorbed_by.get(archive)
+            if previous_framework and previous_framework != framework_label:
+                fail(consumer_label + ": static archive `" + archive + "` is included by both dynamic framework `" + previous_framework + "` and `" + framework_label + "`; move the shared code behind one dynamic framework boundary")
+            absorbed_by[archive] = framework_label
+
 def _validate_apple_native_deps(deps, consumer_label):
     for dep in deps:
         if dep.get("target_kind") != "rust_library":
@@ -912,6 +987,16 @@ def _apple_library_impl(ctx):
         dylib = dep.get("plugin_dylib")
         if dylib and dylib not in plugin_dylibs:
             plugin_dylibs.append(dylib)
+    compile_framework_bundles = _apple_collect_link_framework_bundles(deps)
+    compile_framework_search_dirs = []
+    compile_framework_files = []
+    for bundle in compile_framework_bundles:
+        framework_parent = _parent_dir(bundle["path"])
+        if framework_parent and framework_parent not in compile_framework_search_dirs:
+            compile_framework_search_dirs.append(framework_parent)
+        for file in bundle.get("files") or []:
+            if file not in compile_framework_files:
+                compile_framework_files.append(file)
 
     # Own exported headers as workspace-relative paths, plus the
     # dirs we expose to consumers.
@@ -990,6 +1075,8 @@ def _apple_library_impl(ctx):
     transitive_linkopts = _collect_transitive(deps, "transitive_linkopts", linkopts)
     transitive_defines = _collect_transitive(deps, "transitive_defines", defines)
     transitive_alwayslink_archives = _collect_transitive(deps, "transitive_alwayslink_archives", [archive] if alwayslink else [])
+    transitive_link_framework_bundles = _apple_collect_link_framework_bundles(deps)
+    transitive_framework_bundles = _apple_collect_runtime_framework_bundles(deps)
 
     # --- Per-arch compile pipeline -----------------------------------
     # When a target requests a single architecture (the default,
@@ -1041,6 +1128,8 @@ def _apple_library_impl(ctx):
                 swift_base_argv.extend(["-weak_framework", framework])
             for dep_dir in compile_swiftmodule_dirs:
                 swift_base_argv.extend(["-I", dep_dir])
+            for framework_dir in compile_framework_search_dirs:
+                swift_base_argv.extend(["-F", framework_dir])
             # Header search paths flow through `-Xcc -I` so swiftc's
             # underlying Clang invocation (for bridging headers + ObjC
             # interop) can locate dep headers.
@@ -1080,6 +1169,9 @@ def _apple_library_impl(ctx):
             for dylib in plugin_dylibs:
                 if dylib not in swift_inputs:
                     swift_inputs.append(dylib)
+            for file in compile_framework_files:
+                if file not in swift_inputs:
+                    swift_inputs.append(file)
 
             swift_module_argv = list(swift_base_argv)
             swift_module_argv.extend([
@@ -1154,6 +1246,8 @@ def _apple_library_impl(ctx):
                     argv.extend(["-I", hdir])
                 for hdir in compile_header_dirs:
                     argv.extend(["-I", hdir])
+                for framework_dir in compile_framework_search_dirs:
+                    argv.extend(["-F", framework_dir])
                 for mmap in dep_modulemaps:
                     argv.append("-fmodule-map-file=" + mmap)
                 if hmap_path:
@@ -1169,6 +1263,9 @@ def _apple_library_impl(ctx):
                 for h in own_exported_headers:
                     if h not in inputs:
                         inputs.append(h)
+                for file in compile_framework_files:
+                    if file not in inputs:
+                        inputs.append(file)
                 run_action(
                     argv = argv,
                     inputs = inputs,
@@ -1267,6 +1364,9 @@ def _apple_library_impl(ctx):
         "transitive_sdk_dylibs": transitive_sdk_dylibs,
         "transitive_linkopts": transitive_linkopts,
         "transitive_defines": transitive_defines,
+        "transitive_link_framework_bundles": transitive_link_framework_bundles,
+        "transitive_framework_bundles": transitive_framework_bundles,
+        "transitive_frameworks": _apple_framework_bundle_paths(transitive_framework_bundles),
     }
 
 def _swift_macro_impl(ctx):
@@ -1436,15 +1536,15 @@ def _collect_dep_compile_inputs(deps, build_dir):
         for ar in dep.get("transitive_archives") or []:
             if ar and ar not in archives:
                 archives.append(ar)
-        framework_path = dep.get("framework_path")
-        if framework_path:
-            for f in dep.get("framework_files") or []:
+        for bundle in _apple_dep_framework_bundles(dep, "transitive_link_framework_bundles", False):
+            framework_path = bundle.get("path") or ""
+            for f in bundle.get("files") or []:
                 if f and f not in framework_files:
                     framework_files.append(f)
             framework_parent = _parent_dir(framework_path)
             if framework_parent and framework_parent not in framework_search_dirs:
                 framework_search_dirs.append(framework_parent)
-            module_name = dep.get("framework_module_name")
+            module_name = bundle.get("module_name") or ""
             if module_name and module_name not in framework_module_names:
                 framework_module_names.append(module_name)
         for fw in dep.get("transitive_sdk_frameworks") or []:
@@ -1526,6 +1626,7 @@ def _apple_framework_impl(ctx):
         dep_linkopts,
         plugin_dylibs,
     ) = _collect_dep_compile_inputs(deps, ctx["build_dir"])
+    _apple_validate_static_framework_diamonds(ctx["label"]["id"], dep_archives, _apple_collect_runtime_framework_bundles(deps))
 
     swift_argv = list(swiftc["argv"]) + [
         "-emit-library",
@@ -1635,15 +1736,23 @@ def _apple_framework_impl(ctx):
     )
 
     own_swiftmodule_dir = ctx["build_dir"] + "/" + framework_dir + "/Modules"
-    transitive_archives = _collect_transitive(deps, "transitive_archives", [])
+    absorbed_static_archives = _collect_transitive(deps, "transitive_archives", [])
     transitive_swiftmodule_dirs = _collect_transitive(deps, "transitive_swiftmodule_dirs", [own_swiftmodule_dir])
     transitive_sdk_frameworks = _collect_transitive(deps, "transitive_sdk_frameworks", sdk_frameworks_attr)
     transitive_weak_sdk_frameworks = _collect_transitive(deps, "transitive_weak_sdk_frameworks", weak_sdk_frameworks)
     transitive_sdk_dylibs = _collect_transitive(deps, "transitive_sdk_dylibs", sdk_dylibs_attr)
     transitive_linkopts = _collect_transitive(deps, "transitive_linkopts", linkopts)
-    transitive_frameworks = _collect_transitive(deps, "transitive_frameworks", [ctx["build_dir"] + "/" + framework_dir])
 
     framework_files = [dylib, swiftmodule, swiftdoc, modulemap, info_plist, cs_stamp]
+    own_framework_bundle = _apple_framework_bundle(
+        ctx["build_dir"] + "/" + framework_dir,
+        module_name,
+        framework_files,
+        ctx["label"]["id"],
+        absorbed_static_archives,
+    )
+    transitive_link_framework_bundles = [own_framework_bundle]
+    transitive_framework_bundles = _apple_collect_runtime_framework_bundles(deps, [own_framework_bundle])
 
     return {
         "label_id": ctx["label"]["id"],
@@ -1652,13 +1761,60 @@ def _apple_framework_impl(ctx):
         "framework_files": framework_files,
         "swiftmodule_dir": own_swiftmodule_dir,
         "transitive_swiftmodule_dirs": transitive_swiftmodule_dirs,
-        "transitive_archives": transitive_archives,
-        "transitive_frameworks": transitive_frameworks,
+        "transitive_archives": [],
+        "absorbed_static_archives": absorbed_static_archives,
+        "transitive_link_framework_bundles": transitive_link_framework_bundles,
+        "transitive_framework_bundles": transitive_framework_bundles,
+        "transitive_frameworks": _apple_framework_bundle_paths(transitive_framework_bundles),
         "transitive_sdk_frameworks": transitive_sdk_frameworks,
         "transitive_weak_sdk_frameworks": transitive_weak_sdk_frameworks,
         "transitive_sdk_dylibs": transitive_sdk_dylibs,
         "transitive_linkopts": transitive_linkopts,
     }
+
+def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesign, identifier_prefix):
+    embedded_stamps = []
+    destination_sources = {}
+    for bundle in _apple_collect_runtime_framework_bundles(deps):
+        framework_path = bundle["path"]
+        framework_basename = _basename(framework_path)
+        previous_source = destination_sources.get(framework_basename)
+        if previous_source and previous_source != framework_path:
+            fail(ctx["label"]["id"] + ": framework bundle collision for `" + framework_basename + "` between `" + previous_source + "` and `" + framework_path + "`")
+        destination_sources[framework_basename] = framework_path
+        source_files = bundle.get("files") or []
+        framework_prefix = framework_path + "/"
+        embedded_relative_path = bundle_dir + "/" + frameworks_dir + "/" + framework_basename
+        embed_outputs = []
+        for source in source_files:
+            if source == framework_path:
+                embed_outputs.append(declare_output(embedded_relative_path))
+                continue
+            if source.startswith(framework_prefix):
+                rel = source[len(framework_prefix):]
+                embed_outputs.append(declare_output(embedded_relative_path + "/" + rel))
+        embedded_stamp = declare_output(embedded_relative_path + "/_CodeSignature/CodeResources")
+        if embedded_stamp not in embed_outputs:
+            embed_outputs.append(embedded_stamp)
+        embedded_framework_path = ctx["build_dir"] + "/" + embedded_relative_path
+        prepare_path(embedded_framework_path, kind = "remove", identifier = identifier_prefix + "_clean_" + framework_basename)
+        copy_path(
+            framework_path,
+            embedded_framework_path,
+            kind = "tree",
+            inputs = source_files,
+            identifier = identifier_prefix + "_copy_" + framework_basename,
+        )
+        run_action(
+            argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", embedded_framework_path],
+            inputs = source_files,
+            outputs = embed_outputs,
+            env = codesign["env"],
+            toolchain_identity = codesign["identity"],
+            identifier = identifier_prefix + "_" + framework_basename,
+        )
+        embedded_stamps.append(embedded_stamp)
+    return embedded_stamps
 
 def shell_quote_for_action(path):
     # Single-quote the path and escape any embedded single quotes by
@@ -1784,6 +1940,7 @@ def _apple_application_impl(ctx):
         dep_linkopts,
         plugin_dylibs,
     ) = _collect_dep_compile_inputs(deps, ctx["build_dir"])
+    _apple_validate_static_framework_diamonds(ctx["label"]["id"], dep_archives, _apple_collect_runtime_framework_bundles(deps))
 
     swift_argv = list(swiftc["argv"]) + [
         "-module-name",
@@ -1878,58 +2035,15 @@ def _apple_application_impl(ctx):
     array_entries = {"UIDeviceFamily": device_family_codes}
     write_path(info_plist, _render_plist(plist_entries, bool_entries, array_entries))
 
-    # Embed each transitive dep framework into App.app/Frameworks/.
-    # Each framework is copied as a whole bundle directory and
-    # individually ad-hoc codesigned so the app's dyld loads them
-    # without rejecting the signature.
     codesign = _resolve_codesign(xcode_developer_dir)
-    embedded_stamps = []
-    dep_framework_paths = []
-    dep_framework_files = {}
-    for dep in deps:
-        framework_path = dep.get("framework_path")
-        if framework_path and framework_path not in dep_framework_paths:
-            dep_framework_paths.append(framework_path)
-            dep_framework_files[framework_path] = dep.get("framework_files") or []
-    for framework_path in dep_framework_paths:
-        framework_basename = _basename(framework_path)
-        source_files = dep_framework_files.get(framework_path) or []
-        # Declare every file that lands in the embedded framework so
-        # the Once runner preserves them. Map each source file
-        # (`<build_dir>/<fw>/<sub>`) to its embedded path
-        # (`<app>/Frameworks/<fw>/<sub>`) by stripping the framework
-        # path prefix.
-        framework_prefix = framework_path + "/"
-        embed_outputs = []
-        for source in source_files:
-            if source == framework_path:
-                embed_outputs.append(declare_output(app_dir + "/Frameworks/" + framework_basename))
-                continue
-            if source.startswith(framework_prefix):
-                rel = source[len(framework_prefix):]
-                embed_outputs.append(declare_output(app_dir + "/Frameworks/" + framework_basename + "/" + rel))
-        embedded_stamp = declare_output(app_dir + "/Frameworks/" + framework_basename + "/_CodeSignature/CodeResources")
-        if embedded_stamp not in embed_outputs:
-            embed_outputs.append(embedded_stamp)
-        embed_inputs = list(source_files)
-        embedded_framework_path = ctx["build_dir"] + "/" + app_dir + "/Frameworks/" + framework_basename
-        prepare_path(embedded_framework_path, kind = "remove", identifier = "apple_application_embed_clean_" + framework_basename)
-        copy_path(
-            framework_path,
-            embedded_framework_path,
-            kind = "tree",
-            inputs = embed_inputs,
-            identifier = "apple_application_embed_copy_" + framework_basename,
-        )
-        run_action(
-            argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", embedded_framework_path],
-            inputs = embed_inputs,
-            outputs = embed_outputs,
-            env = codesign["env"],
-            toolchain_identity = codesign["identity"],
-            identifier = "apple_application_embed_" + framework_basename,
-        )
-        embedded_stamps.append(embedded_stamp)
+    embedded_stamps = _apple_embed_framework_bundles(
+        ctx,
+        deps,
+        app_dir,
+        "Frameworks",
+        codesign,
+        "apple_application_embed",
+    )
 
     # Ad-hoc codesign the .app bundle itself. Must run after embedded
     # frameworks land so their signature is included in the bundle's
@@ -2002,9 +2116,13 @@ def _apple_test_bundle_impl(ctx):
     if platform == "macos" or platform == "macosx":
         test_binary = declare_output(bundle_dir + "/Contents/MacOS/" + product_name)
         info_plist = declare_output(bundle_dir + "/Contents/Info.plist")
+        framework_bundle_dir = "Contents/Frameworks"
+        framework_loader_path = "@loader_path/../Frameworks"
     else:
         test_binary = declare_output(bundle_dir + "/" + product_name)
         info_plist = declare_output(bundle_dir + "/Info.plist")
+        framework_bundle_dir = "Frameworks"
+        framework_loader_path = "@loader_path/Frameworks"
     test_bundle_path = ctx["build_dir"] + "/" + bundle_dir
     runner_type = "swift_testing" if swift_testing else "xctest"
     # `xctest` and `simctl` are macOS-only runtime tools. Resolve
@@ -2038,6 +2156,7 @@ def _apple_test_bundle_impl(ctx):
         dep_linkopts,
         plugin_dylibs,
     ) = _collect_dep_compile_inputs(deps, ctx["build_dir"])
+    _apple_validate_static_framework_diamonds(ctx["label"]["id"], dep_archives, _apple_collect_runtime_framework_bundles(deps))
 
     # An XCTest bundle is a Mach-O loadable bundle; swiftc takes
     # `-emit-library` and the linker `-bundle` flag is plumbed through
@@ -2066,6 +2185,10 @@ def _apple_test_bundle_impl(ctx):
         "-rpath",
         "-Xlinker",
         xctest_usr_lib_dir,
+        "-Xlinker",
+        "-rpath",
+        "-Xlinker",
+        framework_loader_path,
         "-framework",
         "XCTest",
         "-o",
@@ -2140,13 +2263,23 @@ def _apple_test_bundle_impl(ctx):
     write_path(info_plist, _render_plist(plist_entries))
 
     codesign = _resolve_codesign(xcode_developer_dir)
+    embedded_stamps = _apple_embed_framework_bundles(
+        ctx,
+        deps,
+        bundle_dir,
+        framework_bundle_dir,
+        codesign,
+        "apple_test_bundle_embed",
+    )
     if platform == "macos" or platform == "macosx":
         test_cs_stamp = declare_output(bundle_dir + "/Contents/_CodeSignature/CodeResources")
     else:
         test_cs_stamp = declare_output(bundle_dir + "/_CodeSignature/CodeResources")
+    test_codesign_inputs = [test_binary, info_plist]
+    test_codesign_inputs.extend(embedded_stamps)
     run_action(
         argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", test_bundle_path],
-        inputs = [test_binary, info_plist],
+        inputs = test_codesign_inputs,
         outputs = [test_cs_stamp],
         env = codesign["env"],
         toolchain_identity = codesign["identity"],

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -1782,7 +1782,7 @@ def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesi
         if previous_source and previous_source != framework_path:
             fail(ctx["label"]["id"] + ": framework bundle collision for `" + framework_basename + "` between `" + previous_source + "` and `" + framework_path + "`")
         destination_sources[framework_basename] = framework_path
-        source_files = bundle.get("files") or []
+        source_files = bundle.get("files") or [framework_path]
         framework_prefix = framework_path + "/"
         embedded_relative_path = bundle_dir + "/" + frameworks_dir + "/" + framework_basename
         embed_outputs = []
@@ -1797,7 +1797,6 @@ def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesi
         if embedded_stamp not in embed_outputs:
             embed_outputs.append(embedded_stamp)
         embedded_framework_path = ctx["build_dir"] + "/" + embedded_relative_path
-        prepare_path(embedded_framework_path, kind = "remove", identifier = identifier_prefix + "_clean_" + framework_basename)
         copy_path(
             framework_path,
             embedded_framework_path,
@@ -1807,7 +1806,7 @@ def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesi
         )
         run_action(
             argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", embedded_framework_path],
-            inputs = source_files,
+            inputs = [embedded_framework_path],
             outputs = embed_outputs,
             env = codesign["env"],
             toolchain_identity = codesign["identity"],
@@ -2280,7 +2279,7 @@ def _apple_test_bundle_impl(ctx):
     run_action(
         argv = [codesign["codesign_path"], "--force", "--sign", "-", "--timestamp=none", test_bundle_path],
         inputs = test_codesign_inputs,
-        outputs = [test_cs_stamp],
+        outputs = [test_binary, test_cs_stamp],
         env = codesign["env"],
         toolchain_identity = codesign["identity"],
         identifier = "apple_test_bundle_codesign_" + module_name,

--- a/crates/once-frontend/prelude/kotlin.star
+++ b/crates/once-frontend/prelude/kotlin.star
@@ -118,6 +118,13 @@ def _kotlin_apple_framework_impl(ctx):
         identifier = "kotlin_apple_framework:" + ctx["label"]["id"],
     )
 
+    framework_bundle = {
+        "path": framework_path,
+        "module_name": module_name,
+        "files": framework_files,
+        "label_id": ctx["label"]["id"],
+    }
+
     return {
         "label_id": ctx["label"]["id"],
         "target_kind": "kotlin_apple_framework",
@@ -128,7 +135,9 @@ def _kotlin_apple_framework_impl(ctx):
         "framework_path": ctx["build_dir"] + "/" + framework_dir,
         "framework_module_name": module_name,
         "framework_files": framework_files,
-        "transitive_frameworks": [ctx["build_dir"] + "/" + framework_dir],
+        "transitive_link_framework_bundles": [framework_bundle],
+        "transitive_framework_bundles": [framework_bundle],
+        "transitive_frameworks": [framework_path],
         "affected_inputs": sources,
     }
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -29,6 +29,10 @@ fn action_by_identifier<'a>(store: &'a AnalysisStore, identifier: &str) -> &'a D
         .unwrap_or_else(|| panic!("missing action `{identifier}`"))
 }
 
+fn action_has_input_suffix(action: &DeclaredAction, suffix: &str) -> bool {
+    action.inputs.iter().any(|input| input.ends_with(suffix))
+}
+
 fn assert_target_kind_attrs(kind: &str, expected: &[&str]) {
     let schema = built_in_target_kind_schema(kind)
         .unwrap_or_else(|| panic!("missing target kind schema `{kind}`"));
@@ -4310,6 +4314,7 @@ fn prelude_apple_link_reports_static_framework_diamonds() {
 
 #[cfg(unix)]
 #[test]
+#[allow(clippy::too_many_lines)]
 fn prelude_apple_test_bundle_stages_transitive_framework_runtime_closure() {
     let prelude = all_prelude_source();
     let workspace = TempDir::new().unwrap();
@@ -4323,6 +4328,8 @@ def host_which(name):
         return "/usr/bin/xcrun"
     if name == "codesign":
         return "/usr/bin/codesign"
+    if name == "sh":
+        return "/bin/sh"
     fail("unexpected host_which: " + name)
 
 def host_command(argv, env = None, merge_stderr = None):
@@ -4366,7 +4373,7 @@ ctx = {{
     }}],
     "srcs": ["Sources/**/*.swift"],
     "build_dir": ".once/out/tests/PluginTests",
-    "capability": "build",
+    "capability": "test",
 }}
 provider = _apple_test_bundle_impl(ctx)
 result = repr(provider["test_bundle_path"])
@@ -4390,7 +4397,7 @@ result = repr(provider["test_bundle_path"])
         .argv
         .windows(2)
         .any(|args| args == ["-framework", "Support"]));
-    action_by_identifier(&store, "apple_test_bundle_embed_Plugin.framework");
+    let plugin_embed = action_by_identifier(&store, "apple_test_bundle_embed_Plugin.framework");
     let support_copy =
         action_by_identifier(&store, "apple_test_bundle_embed_copy_Support.framework");
     assert_eq!(support_copy.inputs, [".once/out/support/Support.framework"]);
@@ -4400,13 +4407,27 @@ result = repr(provider["test_bundle_path"])
         [".once/out/tests/PluginTests/PluginTests.xctest/Contents/Frameworks/Support.framework"]
     );
     let codesign = action_by_identifier(&store, "apple_test_bundle_codesign_PluginTests");
-    assert!(codesign.inputs.iter().any(|input| input
-        .ends_with("Contents/Frameworks/Support.framework/_CodeSignature/CodeResources")));
+    assert!(action_has_input_suffix(
+        codesign,
+        "Contents/Frameworks/Support.framework/_CodeSignature/CodeResources"
+    ));
     assert!(codesign
         .outputs
         .iter()
         .any(|output| output.ends_with("Contents/MacOS/PluginTests")));
-    assert!(store.actions.iter().all(|action| action.cacheable));
+    let runner = action_by_identifier(&store, "apple_xctest:tests/PluginTests");
+    assert!(action_has_input_suffix(
+        runner,
+        "Contents/Frameworks/Plugin.framework"
+    ));
+    assert!(action_has_input_suffix(
+        runner,
+        "Contents/Frameworks/Support.framework"
+    ));
+    assert!(!runner.cacheable);
+    for action in [compile, plugin_embed, support_copy, support_embed, codesign] {
+        assert!(action.cacheable);
+    }
 }
 
 #[cfg(unix)]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -4347,7 +4347,6 @@ plugin = {{
 support = {{
     "path": ".once/out/support/Support.framework",
     "module_name": "Support",
-    "files": [".once/out/support/Support.framework/Support"],
     "label_id": "support/Support",
 }}
 ctx = {{
@@ -4373,7 +4372,11 @@ provider = _apple_test_bundle_impl(ctx)
 result = repr(provider["test_bundle_path"])
 "#
     );
-    let store = store_for(workspace.path(), "tests");
+    let store = AnalysisStore::new(
+        workspace.path().to_path_buf(),
+        "tests".to_string(),
+        ".once/out/tests/PluginTests".to_string(),
+    );
 
     let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
 
@@ -4388,10 +4391,22 @@ result = repr(provider["test_bundle_path"])
         .windows(2)
         .any(|args| args == ["-framework", "Support"]));
     action_by_identifier(&store, "apple_test_bundle_embed_Plugin.framework");
-    action_by_identifier(&store, "apple_test_bundle_embed_Support.framework");
+    let support_copy =
+        action_by_identifier(&store, "apple_test_bundle_embed_copy_Support.framework");
+    assert_eq!(support_copy.inputs, [".once/out/support/Support.framework"]);
+    let support_embed = action_by_identifier(&store, "apple_test_bundle_embed_Support.framework");
+    assert_eq!(
+        support_embed.inputs,
+        [".once/out/tests/PluginTests/PluginTests.xctest/Contents/Frameworks/Support.framework"]
+    );
     let codesign = action_by_identifier(&store, "apple_test_bundle_codesign_PluginTests");
     assert!(codesign.inputs.iter().any(|input| input
         .ends_with("Contents/Frameworks/Support.framework/_CodeSignature/CodeResources")));
+    assert!(codesign
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("Contents/MacOS/PluginTests")));
+    assert!(store.actions.iter().all(|action| action.cacheable));
 }
 
 #[cfg(unix)]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -4198,6 +4198,204 @@ result = repr(provider["app_path"])
 
 #[cfg(unix)]
 #[test]
+fn prelude_apple_framework_stops_static_links_and_propagates_runtime_frameworks() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let package_dir = workspace.path().join("framework/Sources");
+    std::fs::create_dir_all(&package_dir).unwrap();
+    std::fs::write(package_dir.join("Plugin.swift"), "import Support\n").unwrap();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    if name == "codesign":
+        return "/usr/bin/codesign"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None, merge_stderr = None):
+    if "--find" in argv:
+        return "/toolchain/" + argv[len(argv) - 1] + "\n"
+    if "--show-sdk-path" in argv:
+        return "/sdks/iPhoneSimulator.sdk\n"
+    if "--version" in argv:
+        return "Swift version test\n"
+    fail("unexpected host_command: " + str(argv))
+
+support = {{
+    "path": ".once/out/support/Support.framework",
+    "module_name": "Support",
+    "files": [".once/out/support/Support.framework/Support"],
+    "label_id": "support/Support",
+}}
+ctx = {{
+    "label": {{
+        "package": "framework",
+        "name": "Plugin",
+        "id": "framework/Plugin",
+    }},
+    "attr": {{
+        "platform": "ios",
+        "bundle_id": "dev.once.Plugin",
+        "minimum_os": "17.0",
+        "sdk_variant": "simulator",
+    }},
+    "deps": [{{
+        "label_id": "static/Static",
+        "transitive_archives": [".once/out/static/Static.a"],
+        "transitive_link_framework_bundles": [support],
+        "transitive_framework_bundles": [support],
+    }}],
+    "srcs": ["Sources/**/*.swift"],
+    "build_dir": ".once/out/framework/Plugin",
+    "capability": "build",
+}}
+provider = _apple_framework_impl(ctx)
+result = repr([
+    provider["transitive_archives"],
+    provider["absorbed_static_archives"],
+    [bundle["path"] for bundle in provider["transitive_link_framework_bundles"]],
+    [bundle["path"] for bundle in provider["transitive_framework_bundles"]],
+])
+"#
+    );
+    let store = store_for(workspace.path(), "framework");
+
+    let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(
+        out.unwrap(),
+        "[[], [\".once/out/static/Static.a\"], [\".once/out/framework/Plugin/Plugin.framework\"], [\".once/out/framework/Plugin/Plugin.framework\", \".once/out/support/Support.framework\"]]"
+    );
+}
+
+#[test]
+fn prelude_apple_link_reports_static_framework_diamonds() {
+    let error = eval_prelude_function(
+        "_apple_validate_static_framework_diamonds",
+        r#"(
+            "app/App",
+            [".once/out/shared/Shared.a"],
+            [{
+                "path": ".once/out/plugin/Plugin.framework",
+                "label_id": "plugin/Plugin",
+                "absorbed_static_archives": [".once/out/shared/Shared.a"],
+            }],
+        )"#,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("app/App"), "{error}");
+    assert!(error.contains("plugin/Plugin"), "{error}");
+    assert!(
+        error.contains("remove the duplicate static dependency"),
+        "{error}"
+    );
+
+    let sibling_error = eval_prelude_function(
+        "_apple_validate_static_framework_diamonds",
+        r#"(
+            "app/App",
+            [],
+            [
+                {"label_id": "plugin/One", "absorbed_static_archives": ["Shared.a"]},
+                {"label_id": "plugin/Two", "absorbed_static_archives": ["Shared.a"]},
+            ],
+        )"#,
+    )
+    .unwrap_err();
+    assert!(sibling_error.contains("plugin/One"), "{sibling_error}");
+    assert!(sibling_error.contains("plugin/Two"), "{sibling_error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_apple_test_bundle_stages_transitive_framework_runtime_closure() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let package_dir = workspace.path().join("tests/Sources");
+    std::fs::create_dir_all(&package_dir).unwrap();
+    std::fs::write(package_dir.join("PluginTests.swift"), "import XCTest\n").unwrap();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    if name == "codesign":
+        return "/usr/bin/codesign"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None, merge_stderr = None):
+    if "--find" in argv:
+        if argv[len(argv) - 1] == "swiftc":
+            return "/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc\n"
+        return "/toolchain/" + argv[len(argv) - 1] + "\n"
+    if "--show-sdk-path" in argv:
+        return "/sdks/MacOSX.sdk\n"
+    if "--show-sdk-platform-path" in argv:
+        return "/Platforms/MacOSX.platform\n"
+    if "--version" in argv:
+        return "Swift version test\n"
+    fail("unexpected host_command: " + str(argv))
+
+plugin = {{
+    "path": ".once/out/plugin/Plugin.framework",
+    "module_name": "Plugin",
+    "files": [".once/out/plugin/Plugin.framework/Plugin"],
+    "label_id": "plugin/Plugin",
+}}
+support = {{
+    "path": ".once/out/support/Support.framework",
+    "module_name": "Support",
+    "files": [".once/out/support/Support.framework/Support"],
+    "label_id": "support/Support",
+}}
+ctx = {{
+    "label": {{
+        "package": "tests",
+        "name": "PluginTests",
+        "id": "tests/PluginTests",
+    }},
+    "attr": {{
+        "platform": "macos",
+        "minimum_os": "14.0",
+    }},
+    "deps": [{{
+        "label_id": "plugin/Plugin",
+        "transitive_link_framework_bundles": [plugin],
+        "transitive_framework_bundles": [plugin, support],
+    }}],
+    "srcs": ["Sources/**/*.swift"],
+    "build_dir": ".once/out/tests/PluginTests",
+    "capability": "build",
+}}
+provider = _apple_test_bundle_impl(ctx)
+result = repr(provider["test_bundle_path"])
+"#
+    );
+    let store = store_for(workspace.path(), "tests");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert!(out.unwrap().contains("PluginTests.xctest"));
+    let compile = action_by_identifier(&store, "apple_test_bundle_compile_PluginTests");
+    assert!(compile
+        .argv
+        .windows(2)
+        .any(|args| args == ["-framework", "Plugin"]));
+    assert!(!compile
+        .argv
+        .windows(2)
+        .any(|args| args == ["-framework", "Support"]));
+    action_by_identifier(&store, "apple_test_bundle_embed_Plugin.framework");
+    action_by_identifier(&store, "apple_test_bundle_embed_Support.framework");
+    let codesign = action_by_identifier(&store, "apple_test_bundle_codesign_PluginTests");
+    assert!(codesign.inputs.iter().any(|input| input
+        .ends_with("Contents/Frameworks/Support.framework/_CodeSignature/CodeResources")));
+}
+
+#[cfg(unix)]
+#[test]
 fn prelude_android_kotlin_compile_declares_merged_classes_action() {
     let prelude = android_prelude_source();
     let source = format!(

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -294,6 +294,13 @@ The implementation returns a dictionary of provider fields. Downstream
 target kinds should read provider fields from `ctx["deps"]` or
 `ctx["deps_by_role"]` instead of inspecting target identities.
 
+When an artifact has different link-time and runtime dependency closures,
+publish those closures as separate provider fields. Do not flatten them into
+one transitive list. Runtime bundle records should retain the owning target,
+bundle path, module name, and complete file outputs so final packaging actions
+can de-duplicate, materialize, and sign the closure without rediscovering the
+graph.
+
 ## Host Globals
 
 Target kind implementations can use these generic primitives:

--- a/docs/reference/prelude/apple_application.md
+++ b/docs/reference/prelude/apple_application.md
@@ -11,6 +11,11 @@ contain `sdk` configure the
 [Apple software development kit (SDK)](https://developer.apple.com/documentation/xcode)
 used for the build.
 
+Framework dependencies are transitive at runtime. Declare the framework the
+application imports directly. Once links the direct dynamic boundary, embeds
+its complete framework closure, removes duplicate paths, signs every embedded
+framework, and then signs the application.
+
 ## Attributes
 
 | Attribute | Type | Required | Default | Description |

--- a/docs/reference/prelude/apple_framework.md
+++ b/docs/reference/prelude/apple_framework.md
@@ -44,6 +44,28 @@ used for the build.
 The target emits `apple_linkable`, `apple_framework`, and
 `apple_bundle`.
 
+The provider separates link-time and runtime framework closures. A downstream
+link action links this framework, while the final application or test bundle
+receives every framework needed at runtime. Static archives consumed by this
+framework stop at the dynamic link boundary and are not linked into the final
+binary again.
+
+If a final link also reaches one of those absorbed archives through a separate
+static dependency, or two dynamic frameworks absorb the same archive, analysis
+reports the frameworks and duplicate archive, then explains how to repair the
+graph instead of producing two copies of the same code.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `framework_path` | string | Built framework directory |
+| `framework_module_name` | string | Module name used by direct consumers |
+| `framework_files` | list&lt;string&gt; | Framework outputs tracked by the action graph |
+| `transitive_archives` | list&lt;string&gt; | Empty after the dynamic link boundary |
+| `absorbed_static_archives` | list&lt;string&gt; | Static archives already linked into this framework |
+| `transitive_link_framework_bundles` | list&lt;record&gt; | Framework bundles a downstream link action must link directly |
+| `transitive_framework_bundles` | list&lt;record&gt; | De-duplicated runtime framework closure with paths, module names, files, and owning targets |
+| `transitive_frameworks` | list&lt;string&gt; | Compatibility view of runtime framework paths |
+
 ## Capabilities
 
 | Capability | Output groups |
@@ -61,6 +83,11 @@ The target emits `apple_linkable`, `apple_framework`, and
 | Module map | `.once/out/<target>/<product_name>.framework/Modules/module.modulemap` |
 | Property list | `.once/out/<target>/<product_name>.framework/Info.plist` |
 | Code signature | `.once/out/<target>/<product_name>.framework/_CodeSignature/CodeResources` |
+
+An application or test only needs to depend on the framework it uses directly.
+Once carries nested dynamic framework dependencies to the final bundle,
+de-duplicates them by framework path, embeds each bundle once, and signs the
+result.
 
 ## Limitations
 

--- a/docs/reference/prelude/apple_library.md
+++ b/docs/reference/prelude/apple_library.md
@@ -113,9 +113,14 @@ affected cache slots.
 | `transitive_sdk_dylibs` | list&lt;string&gt; | SDK dynamic libraries to link |
 | `transitive_linkopts` | list&lt;string&gt; | Extra linker flags |
 | `transitive_defines` | list&lt;string&gt; | Preprocessor / conditional compilation flags |
+| `transitive_link_framework_bundles` | list&lt;record&gt; | Dynamic framework bundles carried to the next link action |
+| `transitive_framework_bundles` | list&lt;record&gt; | Dynamic framework bundles carried to the final application or test bundle |
+| `transitive_frameworks` | list&lt;string&gt; | Compatibility view of runtime framework paths |
 
 Downstream Apple targets use this record to collect the complete compile and
-link context without inspecting the dependency's target kind.
+link context without inspecting the dependency's target kind. Dynamic
+framework dependencies continue through static libraries automatically, so a
+final application or test does not repeat dependencies that it never imports.
 
 ## Configurable attributes
 

--- a/docs/reference/prelude/apple_test_bundle.md
+++ b/docs/reference/prelude/apple_test_bundle.md
@@ -10,6 +10,11 @@ the
 [Apple software development kit (SDK)](https://developer.apple.com/documentation/xcode)
 used for the build.
 
+Tests do not need to repeat framework dependencies that belong to a plugin or
+library in their dependency graph. Once links only the direct framework
+boundary and stages the full runtime framework closure inside the test bundle
+before signing it.
+
 ## Attributes
 
 | Attribute | Type | Required | Default | Description |
@@ -58,6 +63,7 @@ The target emits `apple_test_bundle`, `apple_bundle`, and `once_test_info`.
 | Other Apple platform test binary | `.once/out/<target>/<product_name>.xctest/<product_name>` |
 | macOS property list | `.once/out/<target>/<product_name>.xctest/Contents/Info.plist` |
 | Other Apple platform property list | `.once/out/<target>/<product_name>.xctest/Info.plist` |
+| Runtime frameworks | The test bundle's `Frameworks` directory when dependencies require them |
 | macOS code signature | `.once/out/<target>/<product_name>.xctest/Contents/_CodeSignature/CodeResources` |
 | Other Apple platform code signature | `.once/out/<target>/<product_name>.xctest/_CodeSignature/CodeResources` |
 | Test results | `.once/out/<target>/test/test_results.json` after `once test` |

--- a/docs/reference/prelude/kotlin_apple_framework.md
+++ b/docs/reference/prelude/kotlin_apple_framework.md
@@ -53,6 +53,8 @@ The target emits `kotlin_native_framework`, `apple_framework`,
 | `framework_path` | string | Built framework directory |
 | `framework_module_name` | string | Module name linked by Apple consumers |
 | `framework_files` | list&lt;string&gt; | Framework file outputs tracked by the action graph |
+| `transitive_link_framework_bundles` | list&lt;record&gt; | Framework bundles a downstream link action must link directly |
+| `transitive_framework_bundles` | list&lt;record&gt; | Framework bundles a final application or test must embed and sign |
 | `transitive_frameworks` | list&lt;string&gt; | Frameworks exposed to downstream Apple targets |
 
 ## Outputs


### PR DESCRIPTION
## What changed

Apple target kinds now publish separate link-time and runtime framework closures. Static libraries carry dynamic framework records forward, dynamic frameworks stop propagating archives they already absorbed, and final application and test bundles embed and sign the complete runtime closure. Kotlin/Native framework providers expose the same contract.

The change also adds diagnostics for static archive diamonds and framework bundle name collisions, plus regression coverage and updated module references. Directory inputs now participate in action digests, which lets framework re-signing depend on the copied bundle without losing cacheability.

## Why

Targets should declare the framework they use directly. Tests and applications should not repeat nested framework dependencies merely to make linking or runtime loading succeed.

## Root cause

Framework providers flattened concerns with different propagation rules. Final consumers inspected only a direct framework path, so nested dynamic frameworks disappeared from packaging. At the same time, archives linked into a dynamic framework remained in the transitive archive list, which could place a second copy in the final binary.

Framework embedding also used an uncached cleanup action even though tree copies already replace their destination. Test bundle signing modified the test binary without declaring that binary as an output, so a cache hit could restore an unsigned binary beside a cached signature resource.

## Approach

Framework records now retain the owning target, module name, bundle path, complete outputs, and absorbed archives. Link actions consume only the next dynamic boundary, while packaging actions consume the de-duplicated runtime closure. Analysis rejects an archive reached both statically and through a dynamic framework, or absorbed by two dynamic frameworks, with an actionable repair.

This follows [Swift Build's current model](https://github.com/swiftlang/swift-build/tree/b6ae279e0a4bd9f4f19ef1d9afcd2bba662ce81b): it [flattens link inputs through static package boundaries](https://github.com/swiftlang/swift-build/blob/b6ae279e0a4bd9f4f19ef1d9afcd2bba662ce81b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift#L1522-L1610), [synthesizes transitive dynamic framework copies for final wrapper products](https://github.com/swiftlang/swift-build/blob/b6ae279e0a4bd9f4f19ef1d9afcd2bba662ce81b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SwiftPackageCopyFilesTaskProducer.swift#L22-L199), and [orders re-signing after copying with the copied product as its input](https://github.com/swiftlang/swift-build/blob/b6ae279e0a4bd9f4f19ef1d9afcd2bba662ce81b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift#L436-L504).

Once keeps the existing transitive framework path list as a compatibility view for project modules. Its generic action digest now accepts directory inputs using the same deterministic encoding as cached directory outputs.

## Impact

Applications and tests can depend only on their direct framework or plugin. Once automatically stages nested frameworks, adds the required runtime search path, signs embedded frameworks, and signs the enclosing bundle afterward. Graphs with ambiguous static linkage fail before execution instead of producing duplicate code.

The complete framework packaging path is cacheable. A repeated build restores signed framework and test bundle outputs without rerunning their actions.

## Validation

- `mise exec -- cargo test -p once-core -p once-frontend`, 436 tests passed
- `mise exec -- cargo clippy -p once-core -p once-frontend --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
- Built a real Apple graph with a static library, support framework, plugin framework, and test depending only on the plugin
- Confirmed the first complete build reported a cache miss and the identical second build reported a cache hit with the same action digest
- Verified the cached test bundle with `codesign --verify --deep --strict`
- Confirmed the test linked only the plugin and the plugin linked the support framework with `otool -L`
