### PR TITLE
feat(graph): make workspace setup agent-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ build the target.
 ```
 
 The harness can discover `rust_binary`, fetch the `rust-binary-with-crate`
-starter with `once_query_example`, write the files, validate the complete graph
-with `once_validate_workspace`, and verify the result with `once_build_target`.
+starter metadata, materialize it with `once_materialize_example`, validate the
+complete graph with `once_validate_workspace`, and verify the result with
+`once_build_target`. The materialization call keeps vendored dependencies and
+other large starter files out of the model context.
 
 The same live discovery loop supports a request such as “build an Android app
 with Once.” See the [coding harness guide](https://once.tuist.dev/guide/harness)

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -350,13 +350,14 @@ pub enum Cmd {
     /// ## Query Expressions
     ///
     /// `once query '<QUERY>'` accepts a read-only subset of Cypher backed
-    /// by the Cypher tree-sitter grammar. The first supported shape is a
-    /// single `MATCH` pattern with optional `WHERE` equality predicates
-    /// and explicit `RETURN` projections.
+    /// by the Cypher tree-sitter grammar. It accepts one `MATCH` pattern,
+    /// optional `WHERE` predicates joined with `AND` and `OR`, and explicit
+    /// `RETURN` projections.
     ///
     /// ```sh
     /// once query 'MATCH (app:Target {id: "services/api/Api"})-[:DEPENDS_ON*]->(dep:Target) RETURN dep.id, dep.kind'
     /// once query 'MATCH (t:Target)-[:EXPOSES]->(c:Capability {name: "test"}) RETURN t.id'
+    /// once query 'MATCH (t:Target) WHERE t.visibility CONTAINS "public" OR t.attrs.tier IN ["core", "shared"] RETURN t.id, t.attrs.tier'
     /// ```
     ///
     /// Supported labels are `Target`, `Capability`, and `Provider`. Labels
@@ -366,6 +367,11 @@ pub enum Cmd {
     /// relationships are `DEPENDS_ON`, `EXPOSES`, and `EMITS`. The `*`
     /// suffix on a relationship performs transitive traversal, for example
     /// `[:DEPENDS_ON*]`.
+    ///
+    /// Predicates support `=`, `<>`, `CONTAINS`, `IN`, `STARTS WITH`, and
+    /// `ENDS WITH`. `CONTAINS` checks a string substring or array membership.
+    /// `IN` checks whether a scalar is present in an array literal. Property
+    /// paths can inspect nested maps, for example `t.attrs.bundle_id`.
     ///
     /// String literals can be quoted with single or double quotes and
     /// support `\n`, `\r`, `\t`, `\\`, `\"`, and `\'` escapes. Other
@@ -399,7 +405,9 @@ pub enum Cmd {
     /// `edit apply` runs a batch of `create` / `update` / `delete`
     /// operations against a single `once.toml` atomically. The CLI
     /// reads its input JSON from `--file` or stdin and emits
-    /// structured diagnostics for failed edits.
+    /// structured diagnostics for failed edits. `edit
+    /// materialize-example` copies a target kind starter without
+    /// printing its file contents and refuses conflicting paths.
     #[command(arg_required_else_help = true)]
     Edit {
         #[command(subcommand)]

--- a/crates/once-cli/src/cli/edit.rs
+++ b/crates/once-cli/src/cli/edit.rs
@@ -16,12 +16,28 @@ pub enum EditCmd {
         #[arg(long, value_name = "PATH")]
         file: Option<PathBuf>,
     },
+
+    /// Materialize a target kind starter inside the workspace.
+    ///
+    /// Copies the complete example bundle without printing file contents.
+    /// Existing files with identical contents are kept. Any conflicting
+    /// file rejects the complete operation before Once writes anything.
+    MaterializeExample {
+        /// Target kind that owns the example.
+        kind: String,
+        /// Example slug from `once query schema`.
+        slug: String,
+        /// Workspace-relative directory that receives the example.
+        #[arg(long, default_value = "", value_name = "DIR")]
+        destination: String,
+    },
 }
 
 impl EditCmd {
     pub fn surface_path(&self) -> Vec<&'static str> {
         match self {
             Self::Apply { .. } => vec!["apply"],
+            Self::MaterializeExample { .. } => vec!["materialize-example"],
         }
     }
 }

--- a/crates/once-cli/src/cli/query.rs
+++ b/crates/once-cli/src/cli/query.rs
@@ -4,6 +4,14 @@ use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum QueryCmd {
+    /// Describe the configured workspace and graph loading state.
+    ///
+    /// Reports the exact workspace root, root manifest state, normalized
+    /// target operating system and architecture, ordered selection tokens,
+    /// loaded packages, target count, graph loading errors, and suggested
+    /// discovery or validation calls.
+    Workspace,
+
     /// List declared graph targets.
     Targets {
         /// Only include targets with this target kind.
@@ -64,6 +72,11 @@ pub enum QueryCmd {
     Tests,
 
     /// List test targets likely affected by changed workspace paths.
+    ///
+    /// Uses declared target inputs, package ownership, and reverse dependency
+    /// traversal. An otherwise unowned path belongs to its nearest package.
+    /// The root manifest, configured graph modules, and paths outside every
+    /// known package conservatively select every test.
     AffectedTests {
         /// Changed workspace-relative path. Repeat for multiple paths.
         #[arg(long = "changed-path", value_name = "PATH")]
@@ -164,6 +177,7 @@ pub enum QueryCmd {
 impl QueryCmd {
     pub fn surface_path(&self) -> Vec<&'static str> {
         match self {
+            Self::Workspace => vec!["workspace"],
             Self::Targets { .. } => vec!["targets"],
             Self::Capabilities { .. } => vec!["capabilities"],
             Self::Schema { .. } => vec!["schema"],

--- a/crates/once-cli/src/commands/edit.rs
+++ b/crates/once-cli/src/commands/edit.rs
@@ -11,6 +11,8 @@ use crate::cli::{Format, Output};
 use crate::commands::query;
 use crate::render;
 
+mod example;
+
 #[derive(Debug, Deserialize)]
 struct ApplyInput {
     package: String,
@@ -22,6 +24,7 @@ struct ApplyInput {
 enum ApplyResult {
     Applied {
         applied: bool,
+        changed: bool,
         path: String,
     },
     Rejected {
@@ -55,13 +58,17 @@ pub async fn apply(workspace: &Path, output: Output, file: Option<PathBuf>) -> R
         &schemas,
     ) {
         Ok(new_src) => {
-            std::fs::create_dir_all(&package_dir).with_context(|| {
-                format!("creating package directory `{}`", package_dir.display())
-            })?;
-            std::fs::write(&manifest_path, &new_src)
-                .with_context(|| format!("writing `{}`", manifest_path.display()))?;
+            let changed = new_src != existing;
+            if changed {
+                std::fs::create_dir_all(&package_dir).with_context(|| {
+                    format!("creating package directory `{}`", package_dir.display())
+                })?;
+                std::fs::write(&manifest_path, &new_src)
+                    .with_context(|| format!("writing `{}`", manifest_path.display()))?;
+            }
             ApplyResult::Applied {
                 applied: true,
+                changed,
                 path: manifest_path.to_string_lossy().into_owned(),
             }
         }
@@ -72,6 +79,24 @@ pub async fn apply(workspace: &Path, output: Output, file: Option<PathBuf>) -> R
     };
     write_body(output, || render_apply_human(&result), &result).await
 }
+
+pub async fn materialize_example(
+    workspace: &Path,
+    output: Output,
+    kind: &str,
+    slug: &str,
+    destination: &str,
+) -> Result<()> {
+    let result = example::materialize_example_value(workspace, kind, slug, destination)?;
+    write_body(
+        output,
+        || example::render_materialize_example_human(&result),
+        &result,
+    )
+    .await
+}
+
+pub(crate) use example::materialize_example_json;
 
 pub(crate) fn resolve_package_dir(workspace: &Path, package: &str) -> Result<PathBuf> {
     if package.is_empty() {

--- a/crates/once-cli/src/commands/edit/example.rs
+++ b/crates/once-cli/src/commands/edit/example.rs
@@ -1,0 +1,283 @@
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+mod paths;
+mod relocation;
+
+use paths::{
+    example_manifest_packages, join_display_path, normalize_relative_path, resolve_example_path,
+    unsafe_path_reason,
+};
+use relocation::relocate_manifest_references;
+
+#[derive(Debug, Serialize)]
+pub(super) struct MaterializeExampleResult {
+    materialized: bool,
+    kind: String,
+    slug: String,
+    destination: String,
+    created_files: Vec<String>,
+    unchanged_files: Vec<String>,
+    conflicts: Vec<FileConflict>,
+    targets: Vec<MaterializedTarget>,
+    workspace_validation: Option<Value>,
+    suggested_calls: Vec<SuggestedCall>,
+}
+
+#[derive(Debug, Serialize)]
+struct FileConflict {
+    path: String,
+    reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MaterializedTarget {
+    id: String,
+    kind: String,
+    capabilities: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SuggestedCall {
+    tool: &'static str,
+    arguments: Value,
+    reason: String,
+}
+
+struct PendingFile {
+    relative_path: String,
+    path: PathBuf,
+    contents: String,
+}
+
+struct ExamplePreparation {
+    destination_label: String,
+    pending: Vec<PendingFile>,
+    conflicts: Vec<FileConflict>,
+    unchanged_files: Vec<String>,
+}
+
+pub(crate) fn materialize_example_json(
+    workspace: &Path,
+    kind: &str,
+    slug: &str,
+    destination: &str,
+) -> Result<Value> {
+    Ok(serde_json::to_value(materialize_example_value(
+        workspace,
+        kind,
+        slug,
+        destination,
+    )?)?)
+}
+
+pub(super) fn materialize_example_value(
+    workspace: &Path,
+    kind: &str,
+    slug: &str,
+    destination: &str,
+) -> Result<MaterializeExampleResult> {
+    let ExamplePreparation {
+        destination_label,
+        pending,
+        conflicts,
+        mut unchanged_files,
+    } = prepare_example(workspace, kind, slug, destination)?;
+
+    if !conflicts.is_empty() {
+        return Ok(MaterializeExampleResult {
+            materialized: false,
+            kind: kind.to_string(),
+            slug: slug.to_string(),
+            destination: destination_label,
+            created_files: Vec::new(),
+            unchanged_files,
+            conflicts,
+            targets: Vec::new(),
+            workspace_validation: None,
+            suggested_calls: Vec::new(),
+        });
+    }
+
+    let mut created_files = Vec::with_capacity(pending.len());
+    for file in pending {
+        let parent = file
+            .path
+            .parent()
+            .context("example file path has no parent directory")?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating example directory `{}`", parent.display()))?;
+        std::fs::write(&file.path, file.contents)
+            .with_context(|| format!("writing example file `{}`", file.path.display()))?;
+        created_files.push(file.relative_path);
+    }
+
+    created_files.sort();
+    unchanged_files.sort();
+    let manifest_packages = example_manifest_packages(
+        &destination_label,
+        created_files.iter().chain(unchanged_files.iter()),
+    );
+    let graph = once_frontend::load_graph_workspace(workspace).context(
+        "loading the workspace after materializing the example; the files were written successfully",
+    )?;
+    let mut targets = graph
+        .iter()
+        .filter(|target| manifest_packages.contains(&target.label.package))
+        .map(|target| MaterializedTarget {
+            id: target.label.id.clone(),
+            kind: target.kind.clone(),
+            capabilities: target
+                .capabilities
+                .iter()
+                .map(|capability| capability.name.clone())
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    targets.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let diagnostics = once_frontend::validate_workspace_graph(workspace, &graph)?;
+    let workspace_validation = json!({
+        "valid": diagnostics.is_empty(),
+        "target_count": graph.len(),
+        "diagnostics": diagnostics,
+    });
+    let suggested_calls = suggested_calls(kind, &targets);
+
+    Ok(MaterializeExampleResult {
+        materialized: true,
+        kind: kind.to_string(),
+        slug: slug.to_string(),
+        destination: destination_label,
+        created_files,
+        unchanged_files,
+        conflicts: Vec::new(),
+        targets,
+        workspace_validation: Some(workspace_validation),
+        suggested_calls,
+    })
+}
+
+fn prepare_example(
+    workspace: &Path,
+    kind: &str,
+    slug: &str,
+    destination: &str,
+) -> Result<ExamplePreparation> {
+    let schema = once_frontend::target_kind_schemas_for_workspace(workspace)?
+        .into_iter()
+        .find(|schema| schema.kind == kind)
+        .with_context(|| format!("no target kind schema matches `{kind}`"))?;
+    let bundle = once_frontend::load_target_kind_example(&schema, slug)?;
+    let destination_dir = super::resolve_package_dir(workspace, destination)?;
+    let destination_label = normalize_relative_path(destination);
+    let mut files = bundle.files;
+    relocate_manifest_references(&mut files, &destination_label)?;
+
+    let mut pending = Vec::with_capacity(files.len());
+    let mut conflicts = Vec::new();
+    let mut unchanged_files = Vec::new();
+    for file in files {
+        let relative_path = join_display_path(&destination_label, &file.path);
+        let path = resolve_example_path(workspace, &destination_dir, &file.path)?;
+        if let Some(reason) = unsafe_path_reason(workspace, &path)? {
+            conflicts.push(FileConflict {
+                path: relative_path,
+                reason,
+            });
+            continue;
+        }
+        match std::fs::read(&path) {
+            Ok(existing) if existing == file.contents.as_bytes() => {
+                unchanged_files.push(relative_path);
+            }
+            Ok(_) => conflicts.push(FileConflict {
+                path: relative_path,
+                reason: "an existing file has different contents".to_string(),
+            }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                pending.push(PendingFile {
+                    relative_path,
+                    path,
+                    contents: file.contents,
+                });
+            }
+            Err(error) => conflicts.push(FileConflict {
+                path: relative_path,
+                reason: format!("could not read the existing path: {error}"),
+            }),
+        }
+    }
+
+    Ok(ExamplePreparation {
+        destination_label,
+        pending,
+        conflicts,
+        unchanged_files,
+    })
+}
+
+fn suggested_calls(kind: &str, targets: &[MaterializedTarget]) -> Vec<SuggestedCall> {
+    let mut suggested_calls = vec![SuggestedCall {
+        tool: "once_validate_workspace",
+        arguments: json!({}),
+        reason: "Confirm the complete workspace after any customization.".to_string(),
+    }];
+    for target in targets.iter().filter(|target| target.kind == kind) {
+        if target.capabilities.iter().any(|name| name == "build") {
+            suggested_calls.push(SuggestedCall {
+                tool: "once_build_target",
+                arguments: json!({ "target": target.id }),
+                reason: format!("Build the materialized `{}` target.", target.kind),
+            });
+        }
+        if target.capabilities.iter().any(|name| name == "run") {
+            suggested_calls.push(SuggestedCall {
+                tool: "once_run_target",
+                arguments: json!({ "target": target.id }),
+                reason: format!("Run the materialized `{}` target.", target.kind),
+            });
+        }
+        if target.capabilities.iter().any(|name| name == "test") {
+            suggested_calls.push(SuggestedCall {
+                tool: "once_run_tests",
+                arguments: json!({ "target": target.id }),
+                reason: format!("Test the materialized `{}` target.", target.kind),
+            });
+        }
+    }
+    suggested_calls
+}
+
+pub(super) fn render_materialize_example_human(result: &MaterializeExampleResult) -> String {
+    if !result.materialized {
+        let mut text = format!(
+            "example {} was not materialized ({} conflicts)\n",
+            result.slug,
+            result.conflicts.len()
+        );
+        for conflict in &result.conflicts {
+            writeln!(&mut text, "  {}: {}", conflict.path, conflict.reason).ok();
+        }
+        return text;
+    }
+    format!(
+        "materialized example {} at {} ({} created, {} unchanged, {} targets)\n",
+        result.slug,
+        if result.destination.is_empty() {
+            "."
+        } else {
+            &result.destination
+        },
+        result.created_files.len(),
+        result.unchanged_files.len(),
+        result.targets.len()
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/once-cli/src/commands/edit/example/paths.rs
+++ b/crates/once-cli/src/commands/edit/example/paths.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+pub(super) fn resolve_example_path(
+    workspace: &Path,
+    destination: &Path,
+    relative: &str,
+) -> Result<PathBuf> {
+    let relative = Path::new(relative);
+    if relative.is_absolute()
+        || relative.components().any(|component| {
+            matches!(
+                component,
+                Component::CurDir
+                    | Component::ParentDir
+                    | Component::RootDir
+                    | Component::Prefix(_)
+            )
+        })
+    {
+        anyhow::bail!("example file path must stay inside the destination");
+    }
+    let path = destination.join(relative);
+    if !path.starts_with(workspace) {
+        anyhow::bail!("example file path must stay inside the workspace");
+    }
+    Ok(path)
+}
+
+pub(super) fn unsafe_path_reason(workspace: &Path, path: &Path) -> Result<Option<String>> {
+    let relative = path
+        .strip_prefix(workspace)
+        .context("example path is outside the workspace")?;
+    let mut current = workspace.to_path_buf();
+    for component in relative.components() {
+        current.push(component);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Ok(Some("the path traverses a symbolic link".to_string()));
+            }
+            Ok(metadata) if current != path && !metadata.is_dir() => {
+                return Ok(Some("a parent path is not a directory".to_string()));
+            }
+            Ok(metadata) if current == path && metadata.is_dir() => {
+                return Ok(Some(
+                    "an existing directory occupies the file path".to_string(),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(None)
+}
+
+pub(super) fn normalize_relative_path(path: &str) -> String {
+    Path::new(path)
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+pub(super) fn join_display_path(prefix: &str, path: &str) -> String {
+    if prefix.is_empty() {
+        path.to_string()
+    } else {
+        format!("{prefix}/{path}")
+    }
+}
+
+pub(super) fn example_manifest_packages<'a>(
+    destination: &str,
+    paths: impl Iterator<Item = &'a String>,
+) -> BTreeSet<String> {
+    paths
+        .filter_map(|path| {
+            let path = Path::new(path);
+            (path.file_name()?.to_str()? == once_frontend::TOML_BUILD_FILE_NAME)
+                .then(|| path.parent().unwrap_or_else(|| Path::new("")))
+        })
+        .map(|path| normalize_relative_path(path.to_string_lossy().as_ref()))
+        .map(|package| {
+            if destination.is_empty() || package.starts_with(destination) {
+                package
+            } else {
+                join_display_path(destination, &package)
+            }
+        })
+        .collect()
+}

--- a/crates/once-cli/src/commands/edit/example/relocation.rs
+++ b/crates/once-cli/src/commands/edit/example/relocation.rs
@@ -1,0 +1,107 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use super::paths::{join_display_path, normalize_relative_path};
+
+pub(super) fn relocate_manifest_references(
+    files: &mut [once_frontend::TargetKindExampleFile],
+    destination: &str,
+) -> Result<()> {
+    if destination.is_empty() {
+        return Ok(());
+    }
+    let mut example_targets = BTreeSet::new();
+    for file in files.iter() {
+        if Path::new(&file.path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            != Some(once_frontend::TOML_BUILD_FILE_NAME)
+        {
+            continue;
+        }
+        let package = manifest_package(&file.path);
+        let document: toml::Value = toml::from_str(&file.contents)
+            .with_context(|| format!("parsing example manifest `{}`", file.path))?;
+        for target in document
+            .get("target")
+            .and_then(toml::Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if let Some(name) = target
+                .as_table()
+                .and_then(|target| target.get("name"))
+                .and_then(toml::Value::as_str)
+            {
+                example_targets.insert(once_frontend::target_id(&package, name));
+            }
+        }
+    }
+
+    for file in files.iter_mut() {
+        if Path::new(&file.path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            != Some(once_frontend::TOML_BUILD_FILE_NAME)
+        {
+            continue;
+        }
+        let package = manifest_package(&file.path);
+        let mut document: toml::Value = toml::from_str(&file.contents)
+            .with_context(|| format!("parsing example manifest `{}`", file.path))?;
+        for target in document
+            .get_mut("target")
+            .and_then(toml::Value::as_array_mut)
+            .into_iter()
+            .flatten()
+        {
+            let Some(target) = target.as_table_mut() else {
+                continue;
+            };
+            if let Some(deps) = target.get_mut("deps") {
+                relocate_dependency_value(deps, &package, destination, &example_targets)?;
+            }
+            if let Some(dependencies) = target
+                .get_mut("dependencies")
+                .and_then(toml::Value::as_table_mut)
+            {
+                for (_, deps) in dependencies.iter_mut() {
+                    relocate_dependency_value(deps, &package, destination, &example_targets)?;
+                }
+            }
+        }
+        file.contents = toml::to_string_pretty(&document)
+            .with_context(|| format!("rendering relocated example manifest `{}`", file.path))?;
+    }
+    Ok(())
+}
+
+fn relocate_dependency_value(
+    value: &mut toml::Value,
+    package: &str,
+    destination: &str,
+    example_targets: &BTreeSet<String>,
+) -> Result<()> {
+    let Some(dependencies) = value.as_array_mut() else {
+        return Ok(());
+    };
+    for dependency in dependencies {
+        let Some(raw) = dependency.as_str() else {
+            continue;
+        };
+        let normalized = once_frontend::normalize_manifest_target(package, raw)
+            .with_context(|| format!("normalizing example dependency `{raw}`"))?;
+        if example_targets.contains(&normalized) {
+            *dependency = toml::Value::String(join_display_path(destination, &normalized));
+        }
+    }
+    Ok(())
+}
+
+fn manifest_package(path: &str) -> String {
+    Path::new(path).parent().map_or_else(String::new, |parent| {
+        normalize_relative_path(parent.to_string_lossy().as_ref())
+    })
+}

--- a/crates/once-cli/src/commands/edit/example/tests.rs
+++ b/crates/once-cli/src/commands/edit/example/tests.rs
@@ -1,0 +1,97 @@
+use super::*;
+use tempfile::TempDir;
+
+#[test]
+fn materializes_a_starter_and_returns_targets_and_next_calls() {
+    let temporary = TempDir::new().unwrap();
+
+    let result =
+        materialize_example_value(temporary.path(), "rust_library", "rust-library-minimal", "")
+            .unwrap();
+
+    assert!(result.materialized);
+    assert!(!result.created_files.is_empty());
+    assert!(temporary.path().join("crates/hello/once.toml").is_file());
+    assert!(result
+        .targets
+        .iter()
+        .any(|target| target.id == "crates/hello/hello"));
+    assert!(result
+        .suggested_calls
+        .iter()
+        .any(|call| call.tool == "once_build_target"));
+    assert_eq!(result.workspace_validation.as_ref().unwrap()["valid"], true);
+}
+
+#[test]
+fn an_identical_retry_is_idempotent() {
+    let temporary = TempDir::new().unwrap();
+    materialize_example_value(temporary.path(), "rust_library", "rust-library-minimal", "")
+        .unwrap();
+
+    let retried =
+        materialize_example_value(temporary.path(), "rust_library", "rust-library-minimal", "")
+            .unwrap();
+
+    assert!(retried.materialized);
+    assert!(retried.created_files.is_empty());
+    assert!(!retried.unchanged_files.is_empty());
+}
+
+#[test]
+fn a_conflict_rejects_every_write() {
+    let temporary = TempDir::new().unwrap();
+    std::fs::create_dir_all(temporary.path().join("crates/hello")).unwrap();
+    std::fs::write(temporary.path().join("crates/hello/once.toml"), "different").unwrap();
+
+    let result =
+        materialize_example_value(temporary.path(), "rust_library", "rust-library-minimal", "")
+            .unwrap();
+
+    assert!(!result.materialized);
+    assert!(!result.conflicts.is_empty());
+    assert!(!temporary.path().join("crates/hello/src/lib.rs").exists());
+}
+
+#[test]
+fn a_nested_starter_relocates_internal_target_references() {
+    let temporary = TempDir::new().unwrap();
+
+    let result = materialize_example_value(
+        temporary.path(),
+        "go_binary",
+        "go-comprehensive",
+        "samples/go",
+    )
+    .unwrap();
+
+    assert!(result.materialized);
+    assert_eq!(result.workspace_validation.as_ref().unwrap()["valid"], true);
+    assert!(result
+        .targets
+        .iter()
+        .any(|target| target.id == "samples/go/Hello"));
+    let manifest = std::fs::read_to_string(temporary.path().join("samples/go/once.toml")).unwrap();
+    assert!(manifest.contains("samples/go/Greeting"));
+}
+
+#[test]
+fn suggested_execution_calls_exclude_helper_target_kinds() {
+    let temporary = TempDir::new().unwrap();
+
+    let result = materialize_example_value(
+        temporary.path(),
+        "rust_binary",
+        "rust-binary-with-crate",
+        "",
+    )
+    .unwrap();
+
+    let execution_targets = result
+        .suggested_calls
+        .iter()
+        .filter(|call| call.tool == "once_build_target" || call.tool == "once_run_target")
+        .map(|call| call.arguments["target"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(execution_targets, ["apps/hello/hello", "apps/hello/hello"]);
+}

--- a/crates/once-cli/src/commands/graph/action.rs
+++ b/crates/once-cli/src/commands/graph/action.rs
@@ -185,6 +185,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: vec![Capability {
                 name: "build".to_string(),

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -316,6 +316,7 @@ pub(super) fn run_declared_actions<'a>(
             aggregate_result.outputs.extend(outcome.result.outputs);
         }
 
+        deduplicate_outputs(&mut all_outputs);
         let cache_state = aggregate_cache_state.unwrap_or(EvidenceCacheState::Miss);
         Ok(BuildOutcome {
             provider,
@@ -327,6 +328,11 @@ pub(super) fn run_declared_actions<'a>(
             result: aggregate_result,
         })
     })
+}
+
+fn deduplicate_outputs(outputs: &mut Vec<String>) {
+    outputs.sort();
+    outputs.dedup();
 }
 
 async fn expose_target_tools(
@@ -1453,6 +1459,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn capability_outputs_are_sorted_and_deduplicated() {
+        let mut outputs = vec![
+            ".once/out/Root/run".to_string(),
+            ".once/out/Root/run/stdout.log".to_string(),
+            ".once/out/Root/run".to_string(),
+        ];
+
+        deduplicate_outputs(&mut outputs);
+
+        assert_eq!(
+            outputs,
+            [".once/out/Root/run", ".once/out/Root/run/stdout.log"]
+        );
+    }
+
+    #[test]
     fn tool_execution_wraps_command_actions_only() {
         let command: DeclaredAction = serde_json::from_value(serde_json::json!({
             "argv": ["rustc", "--version"],
@@ -2030,6 +2052,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),
@@ -2128,6 +2151,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),
@@ -2216,6 +2240,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),
@@ -2301,6 +2326,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),

--- a/crates/once-cli/src/commands/graph/analysis/tests.rs
+++ b/crates/once-cli/src/commands/graph/analysis/tests.rs
@@ -89,6 +89,7 @@ fn target_with_capabilities(
         deps: deps.iter().map(|dep| (*dep).to_string()).collect(),
         dependency_edges: BTreeMap::new(),
         srcs: srcs.iter().map(|src| (*src).to_string()).collect(),
+        visibility: Vec::new(),
         attrs: attrs.into_iter().collect(),
         capabilities: capabilities
             .iter()

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -471,6 +471,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: capabilities
                 .iter()

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -14,7 +14,7 @@
 //! build, test, run, or start persisted runtime sessions and return session ids
 //! agents can use to query status, read logs, or stop the process later.
 
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -28,7 +28,38 @@ use tools::{tool_definitions, tool_requires_allow_run};
 
 /// MCP protocol version we negotiate.
 const PROTOCOL_VERSION: &str = "2025-11-25";
-const SERVER_INSTRUCTIONS: &str = "Once is a self-describing build graph and cacheable automation server. For a new typed graph with no named upstream rule, start with once_list_target_kinds. Pass its optional query when the request names ecosystems, target-kind families, or intent; include every named native test runner in one query when adopting a mixed test repository, then call once_query_schema and once_query_example for each chosen kind. When the request already points to a specific external rule or plugin, skip the target-kind catalog: call once_query_module_contract, fetch its authoritative source with once_fetch_external_source, write a project-local module, and call once_validate_module. Model only the requested dependency closure. Record upstream source_references and the returned content digest when the source was not truncated, then re-fetch and compare the digest before future maintenance. Materialize target files, inspect canonical ids with once_query_targets, call once_validate_workspace, and use capability tools to build, run, or test. New test targets intentionally begin with one whole-target batch. Run each target completely once, then inspect next_plan in the completed once_run_tests response to see the automatic file or case batches established for later runs. The plan field always describes the work that just ran. Before change-scoped testing, inspect conservative selection, unmatched paths, and stable batches with once_query_test_plan; once_run_tests returns that execution plan, the refreshed next plan, a duration-informed dynamic schedule, and execution results. Pass one listed unit with one explicit target to plan or run an exact filtered test when the target kind declares filtering support. Use jobs only to cap local concurrency; it does not change plan or batch identity. For annotated automation, call once_validate_script before once_exec_script. Stateful tools require --allow-run. Evidence subjects are target ids with an optional capability suffix; script execution returns its evidence subject directly. once_validate_target checks one proposed table, once_validate_workspace checks the loaded graph, and successful execution remains the authoritative current check. Evidence is historical provenance, so do not treat an older record as proof that inputs are unchanged.";
+const SERVER_INSTRUCTIONS: &str = concat!(
+    "Once is a self-describing build graph and cacheable automation server. ",
+    "Call once_query_workspace first to confirm the exact configured root and current graph state. ",
+    "For a new typed graph with no named upstream rule, continue with once_list_target_kinds. ",
+    "Pass its optional query when the request names ecosystems, target-kind families, or intent; ",
+    "include every named native test runner in one query when adopting a mixed test repository, ",
+    "then call once_query_schema for each chosen kind. For an unchanged starter, call ",
+    "once_materialize_example when it is advertised; it keeps large file bundles out of model ",
+    "context and returns canonical targets, workspace validation, and suggested next calls. ",
+    "Use once_query_example only when you need to inspect or adapt the starter contents yourself. ",
+    "When the request already points to a specific external rule or plugin, skip the target-kind ",
+    "catalog: call once_query_module_contract, fetch its authoritative source with ",
+    "once_fetch_external_source, write a project-local module, and call once_validate_module. ",
+    "Model only the requested dependency closure. Record upstream source_references and the ",
+    "returned content digest when the source was not truncated, then re-fetch and compare the ",
+    "digest before future maintenance. After custom edits, inspect canonical ids with ",
+    "once_query_targets, call once_validate_workspace, and use capability tools to build, run, ",
+    "or test. New test targets intentionally begin with one whole-target batch. Run each target ",
+    "completely once, then inspect next_plan in the completed once_run_tests response to see the ",
+    "automatic file or case batches established for later runs. The plan field always describes ",
+    "the work that just ran. Before change-scoped testing, inspect conservative selection, ",
+    "unmatched paths, and stable batches with once_query_test_plan; once_run_tests returns that ",
+    "execution plan, the refreshed next plan, a duration-informed dynamic schedule, and execution ",
+    "results. Pass one listed unit with one explicit target to plan or run an exact filtered test ",
+    "when the target kind declares filtering support. Use jobs only to cap local concurrency; it ",
+    "does not change plan or batch identity. For annotated automation, call once_validate_script ",
+    "before once_exec_script. Stateful tools require --allow-run. Evidence subjects are target ids ",
+    "with an optional capability suffix; script execution returns its evidence subject directly. ",
+    "once_validate_target checks one proposed table, once_validate_workspace checks the loaded ",
+    "graph, and successful execution remains the authoritative current check. Evidence is ",
+    "historical provenance, so do not treat an older record as proof that inputs are unchanged."
+);
 
 fn negotiated_protocol_version(params: Option<&Value>) -> String {
     let requested = params
@@ -129,7 +160,10 @@ impl Server {
                         "protocolVersion": protocol_version,
                         "capabilities": { "tools": {} },
                         "serverInfo": { "name": "once-mcp", "version": env!("CARGO_PKG_VERSION") },
-                        "instructions": SERVER_INSTRUCTIONS,
+                        "instructions": format!(
+                            "{SERVER_INSTRUCTIONS} Configured workspace root: `{}`.",
+                            self.workspace.display()
+                        ),
                     }),
                 )
             }
@@ -173,6 +207,7 @@ impl Server {
             );
         }
         let result = match call.name.as_str() {
+            "once_query_workspace" => crate::commands::query::workspace_value(&self.workspace),
             "once_query_targets" => self.tool_query_targets(&call.arguments),
             "once_query_capabilities" => self.tool_query_capabilities(&call.arguments),
             "once_get_target" => self.tool_get_target(&call.arguments),
@@ -200,6 +235,7 @@ impl Server {
             "once_runtime_logs" => self.tool_runtime_logs(&call.arguments),
             "once_stop_runtime" => self.tool_stop_runtime(&call.arguments),
             "once_apply_edit" => self.tool_apply_edit(&call.arguments),
+            "once_materialize_example" => self.tool_materialize_example(&call.arguments),
             "once_query_schema" => tool_query_schema(&self.workspace, &call.arguments),
             "once_query_example" => tool_query_example(&self.workspace, &call.arguments),
             "once_list_target_kinds" | "once_list_rules" => {
@@ -216,7 +252,7 @@ impl Server {
                     "structuredContent": { "result": value },
                 }),
             ),
-            Err(error) => tool_error(id, &error.to_string()),
+            Err(error) => tool_error_from_error(id, &error),
         }
     }
 
@@ -271,6 +307,16 @@ impl Server {
         let operations: Vec<once_frontend::EditOperation> = serde_json::from_value(raw_ops.clone())
             .map_err(|err| anyhow::anyhow!("invalid `operations`: {err}"))?;
         apply_edit_to_package(&self.workspace, package, &operations)
+    }
+
+    fn tool_materialize_example(&self, args: &Value) -> Result<Value> {
+        let args: MaterializeExampleArgs = serde_json::from_value(tool_args(args))?;
+        crate::commands::edit::materialize_example_json(
+            &self.workspace,
+            &args.kind,
+            &args.slug,
+            &args.destination,
+        )
     }
 
     fn tool_query_tests(&self) -> Result<Value> {
@@ -553,6 +599,8 @@ fn run_graph_target_with_exe(
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let (record, record_parse_error) = parse_json_record(&stdout);
+    let captured_stdout = captured_action_log(workspace, &record, "stdout.log");
+    let captured_stderr = captured_action_log(workspace, &record, "stderr.log");
     Ok(json!({
         "target": target,
         "capability": capability,
@@ -560,8 +608,77 @@ fn run_graph_target_with_exe(
         "success": output.status.success(),
         "record": record,
         "record_parse_error": record_parse_error,
+        "captured_stdout": captured_stdout,
+        "captured_stderr": captured_stderr,
         "stderr": stderr,
     }))
+}
+
+#[derive(Serialize)]
+struct CapturedActionLog {
+    path: String,
+    text: String,
+    byte_count: usize,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    read_error: Option<String>,
+}
+
+fn captured_action_log(
+    workspace: &std::path::Path,
+    record: &Value,
+    file_name: &str,
+) -> Option<CapturedActionLog> {
+    const MAX_CAPTURE_BYTES: usize = 64 * 1024;
+    let relative = record
+        .get("outputs")?
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_str)
+        .find(|path| {
+            Path::new(path).file_name().and_then(|name| name.to_str()) == Some(file_name)
+        })?;
+    let workspace_path = match once_core::WorkspacePath::try_from(relative) {
+        Ok(path) => path,
+        Err(error) => {
+            return Some(CapturedActionLog {
+                path: relative.to_string(),
+                text: String::new(),
+                byte_count: 0,
+                truncated: false,
+                read_error: Some(error.to_string()),
+            });
+        }
+    };
+    let path = workspace_path.resolve(workspace);
+    let mut bytes = Vec::with_capacity(MAX_CAPTURE_BYTES + 1);
+    let read = std::fs::File::open(&path).and_then(|file| {
+        file.take((MAX_CAPTURE_BYTES + 1) as u64)
+            .read_to_end(&mut bytes)
+    });
+    if let Err(error) = read {
+        return Some(CapturedActionLog {
+            path: relative.to_string(),
+            text: String::new(),
+            byte_count: 0,
+            truncated: false,
+            read_error: Some(error.to_string()),
+        });
+    }
+    let byte_count = std::fs::metadata(&path).map_or(bytes.len(), |metadata| {
+        usize::try_from(metadata.len()).unwrap_or(usize::MAX)
+    });
+    let truncated = bytes.len() > MAX_CAPTURE_BYTES;
+    if truncated {
+        bytes.truncate(MAX_CAPTURE_BYTES);
+    }
+    Some(CapturedActionLog {
+        path: relative.to_string(),
+        text: String::from_utf8_lossy(&bytes).into_owned(),
+        byte_count,
+        truncated,
+        read_error: None,
+    })
 }
 
 fn parse_json_record(stdout: &str) -> (Value, Option<String>) {
@@ -669,6 +786,15 @@ struct ValidateModuleArgs {
 struct TargetKindFilterArgs {
     #[serde(default)]
     query: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MaterializeExampleArgs {
+    kind: String,
+    slug: String,
+    #[serde(default)]
+    destination: String,
 }
 
 #[derive(Deserialize, Default)]
@@ -796,13 +922,17 @@ fn apply_edit_to_package(
         .context("loading target kind schemas")?;
     match once_frontend::apply_operations_with_schemas(&existing, operations, &schemas) {
         Ok(new_src) => {
-            std::fs::create_dir_all(&package_dir).with_context(|| {
-                format!("creating package directory `{}`", package_dir.display())
-            })?;
-            std::fs::write(&manifest_path, &new_src)
-                .with_context(|| format!("writing `{}`", manifest_path.display()))?;
+            let changed = new_src != existing;
+            if changed {
+                std::fs::create_dir_all(&package_dir).with_context(|| {
+                    format!("creating package directory `{}`", package_dir.display())
+                })?;
+                std::fs::write(&manifest_path, &new_src)
+                    .with_context(|| format!("writing `{}`", manifest_path.display()))?;
+            }
             Ok(json!({
                 "applied": true,
+                "changed": changed,
                 "path": manifest_path.to_string_lossy(),
             }))
         }
@@ -858,6 +988,32 @@ fn tool_error(id: Value, message: &str) -> JsonRpcResponse {
     )
 }
 
+fn tool_error_from_error(id: Value, error: &anyhow::Error) -> JsonRpcResponse {
+    let diagnostic = error.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<once_frontend::analysis::AnalysisFailure>()
+            .map(|failure| failure.diagnostic.clone())
+    });
+    let Some(diagnostic) = diagnostic else {
+        return tool_error(id, &error.to_string());
+    };
+    let code = diagnostic.code.clone();
+    JsonRpcResponse::ok(
+        id,
+        json!({
+            "isError": true,
+            "content": [text_content_str(&diagnostic.message)],
+            "structuredContent": {
+                "error": {
+                    "code": code,
+                    "message": diagnostic.message,
+                    "diagnostics": [diagnostic],
+                }
+            },
+        }),
+    )
+}
+
 fn text_content(value: &Value) -> Value {
     text_content_str(&serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()))
 }
@@ -909,6 +1065,7 @@ struct TargetView {
     kind: String,
     deps: Vec<String>,
     dependency_edges: std::collections::BTreeMap<String, Vec<String>>,
+    visibility: Vec<String>,
     capabilities: Vec<String>,
 }
 
@@ -921,6 +1078,7 @@ impl From<once_frontend::GraphTarget> for TargetView {
             kind: target.kind,
             deps: target.deps,
             dependency_edges: target.dependency_edges,
+            visibility: target.visibility,
             capabilities: target
                 .capabilities
                 .into_iter()
@@ -1099,6 +1257,10 @@ demo_kind = target_kind(
             .as_str()
             .unwrap()
             .contains("once_list_target_kinds"));
+        assert!(result["instructions"]
+            .as_str()
+            .unwrap()
+            .contains(tmp.path().to_string_lossy().as_ref()));
     }
 
     #[test]
@@ -1157,6 +1319,7 @@ demo_kind = target_kind(
         assert_eq!(
             names,
             vec![
+                "once_query_workspace".to_string(),
                 "once_query_targets".to_string(),
                 "once_query_capabilities".to_string(),
                 "once_query_schema".to_string(),
@@ -1423,6 +1586,7 @@ script_runtime = "sh"
         assert!(names.contains(&"once_stop_runtime".to_string()));
         assert!(names.contains(&"once_run_tests".to_string()));
         assert!(names.contains(&"once_apply_edit".to_string()));
+        assert!(names.contains(&"once_materialize_example".to_string()));
         assert!(names.contains(&"once_exec_script".to_string()));
 
         for tool in result["tools"].as_array().unwrap() {
@@ -1459,6 +1623,7 @@ script_runtime = "sh"
             "once_run_tests",
             "once_exec_script",
             "once_apply_edit",
+            "once_materialize_example",
         ] {
             let response = server(tmp.path().to_path_buf()).dispatch(request(
                 "tools/call",
@@ -1472,6 +1637,89 @@ script_runtime = "sh"
                 .unwrap()
                 .contains("--allow-run"));
         }
+    }
+
+    #[test]
+    fn analysis_tool_errors_include_structured_diagnostics() {
+        let diagnostic = once_frontend::Diagnostic::new(
+            "target_kind_analysis_failed",
+            "target kind implementation failed",
+        )
+        .with_target("App")
+        .with_attribute("mode")
+        .with_repair("Set a supported mode");
+        let error = anyhow::Error::new(once_frontend::analysis::AnalysisFailure { diagnostic });
+
+        let response = tool_error_from_error(json!(1), &error);
+        let result = response.result.expect("tool result");
+
+        assert_eq!(
+            result["structuredContent"]["error"]["code"],
+            "target_kind_analysis_failed"
+        );
+        assert_eq!(
+            result["structuredContent"]["error"]["diagnostics"][0]["attribute"],
+            "mode"
+        );
+    }
+
+    #[test]
+    fn materialize_example_creates_a_valid_workspace_without_returning_contents() {
+        let tmp = TempDir::new().unwrap();
+        let response = run_server(tmp.path().to_path_buf()).dispatch(request(
+            "tools/call",
+            json!({
+                "name": "once_materialize_example",
+                "arguments": {
+                    "kind": "rust_library",
+                    "slug": "rust-library-minimal"
+                }
+            }),
+        ));
+
+        assert!(response.error.is_none());
+        let result = response.result.unwrap()["structuredContent"]["result"].clone();
+        assert_eq!(result["materialized"], true);
+        assert_eq!(result["workspace_validation"]["valid"], true);
+        assert!(result["targets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|target| target["id"] == "crates/hello/hello"));
+        assert!(!result.to_string().contains("pub fn"));
+        assert!(tmp.path().join("crates/hello/src/lib.rs").is_file());
+    }
+
+    #[test]
+    fn query_workspace_makes_an_empty_configured_root_explicit() {
+        let tmp = TempDir::new().unwrap();
+        let response = server(tmp.path().to_path_buf()).dispatch(request(
+            "tools/call",
+            json!({
+                "name": "once_query_workspace",
+                "arguments": {}
+            }),
+        ));
+
+        let result = response.result.unwrap()["structuredContent"]["result"].clone();
+        assert_eq!(result["root"], tmp.path().to_string_lossy().as_ref());
+        assert_eq!(result["target_count"], 0);
+        assert_eq!(result["empty"], true);
+        assert_eq!(
+            result["suggested_calls"][0]["tool"],
+            "once_list_target_kinds"
+        );
+    }
+
+    #[test]
+    fn an_empty_edit_does_not_create_a_manifest() {
+        let tmp = TempDir::new().unwrap();
+
+        let result = apply_edit_to_package(tmp.path(), "new/package", &[]).unwrap();
+
+        assert_eq!(result["applied"], true);
+        assert_eq!(result["changed"], false);
+        assert!(!tmp.path().join("new/package/once.toml").exists());
     }
 
     #[test]
@@ -1570,7 +1818,7 @@ srcs = ["unit_spec.sh"]
         let args_file = shell_literal(args_path.to_str().unwrap());
         let cwd_file = shell_literal(cwd_path.to_str().unwrap());
         let script = format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {args_file}\npwd > {cwd_file}\ncapability=''\ntarget=''\nfor arg do\n  case \"$arg\" in build|run|test) capability=\"$arg\" ;;\n  *) target=\"$arg\" ;;\n  esac\ndone\nprintf '{{\"target\":\"%s\",\"capability\":\"%s\",\"status\":\"completed\"}}\\n' \"$target\" \"$capability\"\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {args_file}\npwd > {cwd_file}\ncapability=''\ntarget=''\nfor arg do\n  case \"$arg\" in build|run|test) capability=\"$arg\" ;;\n  *) target=\"$arg\" ;;\n  esac\ndone\nmkdir -p .once/out/mock/run\nprintf 'hello from target\\n' > .once/out/mock/run/stdout.log\nprintf '{{\"target\":\"%s\",\"capability\":\"%s\",\"status\":\"completed\",\"outputs\":[\".once/out/mock/run/stdout.log\"]}}\\n' \"$target\" \"$capability\"\n",
         );
         std::fs::write(&exe, script).unwrap();
         let mut permissions = std::fs::metadata(&exe).unwrap().permissions();
@@ -1589,6 +1837,7 @@ srcs = ["unit_spec.sh"]
         assert_eq!(run["success"], true);
         assert_eq!(run["record"]["target"], "apps/App");
         assert_eq!(run["record"]["capability"], "run");
+        assert_eq!(run["captured_stdout"]["text"], "hello from target\n");
 
         let args = std::fs::read_to_string(args_path).unwrap();
         assert!(args.contains("--format\njson\nrun\n--visible\napps/App\n"));
@@ -1779,7 +2028,7 @@ srcs = ["unit_spec.sh"]
         let tmp = TempDir::new().unwrap();
         let value = tool_list_target_kinds(
             tmp.path(),
-            &json!({ "query": "typed Rust library executable test" }),
+            &json!({ "query": "create a minimal runnable Rust command-line application" }),
         )
         .unwrap();
         let kinds = value

--- a/crates/once-cli/src/commands/mcp/tools.rs
+++ b/crates/once-cli/src/commands/mcp/tools.rs
@@ -39,6 +39,7 @@ pub(super) fn tool_requires_allow_run(name: &str) -> bool {
             | "once_runtime_logs"
             | "once_stop_runtime"
             | "once_apply_edit"
+            | "once_materialize_example"
     )
 }
 
@@ -60,7 +61,10 @@ fn tool_annotations(name: &str) -> Value {
     let idempotent = read_only
         || matches!(
             name,
-            "once_build_target" | "once_runtime_status" | "once_runtime_logs"
+            "once_build_target"
+                | "once_runtime_status"
+                | "once_runtime_logs"
+                | "once_materialize_example"
         );
     json!({
         "readOnlyHint": read_only,
@@ -90,9 +94,19 @@ pub struct ToolDefinition {
 pub fn tool_catalog() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
+            name: "once_query_workspace",
+            description: "Return the configured workspace root, root manifest state, graph loading state, and next calls.",
+            long_description: "Call this first when filesystem tools and the Once server may have different working directories. The result identifies the exact workspace every other Once tool uses, reports the target operating system, architecture, and ordered selection tokens, reports whether the root manifest exists, lists loaded packages and target count, preserves graph loading errors as data, and recommends the next discovery or validation call. The matching command-line operation is `once query workspace --format json`.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {}
+            }),
+            example_return: "{\n  \"root\": \"/work/project\",\n  \"configuration\": {\n    \"os\": \"linux\",\n    \"arch\": \"aarch64\",\n    \"tokens\": [\"linux-arm64\", \"linux-aarch64\", \"linux\", \"arm64\", \"aarch64\", \"default\"]\n  },\n  \"root_manifest\": { \"path\": \"/work/project/once.toml\", \"exists\": false },\n  \"target_count\": 0,\n  \"packages\": [],\n  \"empty\": true,\n  \"suggested_calls\": [\n    { \"tool\": \"once_list_target_kinds\", \"arguments\": {}, \"reason\": \"Discover a target kind and starter for this empty workspace.\" }\n  ]\n}",
+        },
+        ToolDefinition {
             name: "once_query_targets",
             description: "List every declared target in the workspace, optionally filtered by target kind.",
-            long_description: "Returns the same record shape as `once query targets --format json`: one entry per declared target with its canonical id, package, name, target kind, default dependencies, named dependency roles, and exposed capabilities. The optional `kind` argument narrows results to one target kind.",
+            long_description: "Returns the same record shape as `once query targets --format json`: one entry per declared target with its canonical id, package, name, target kind, visibility rules, default dependencies, named dependency roles, and exposed capabilities. The optional `kind` argument narrows results to one target kind.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -102,7 +116,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                     }
                 }
             }),
-            example_return: "[\n  { \"id\": \"packages/core/Core\", \"package\": \"packages/core\", \"name\": \"Core\",\n    \"kind\": \"library\", \"deps\": [], \"dependency_edges\": {}, \"capabilities\": [\"build\"] },\n  { \"id\": \"apps/service/Service\", \"package\": \"apps/service\", \"name\": \"Service\",\n    \"kind\": \"application\", \"deps\": [\"packages/core/Core\"],\n    \"dependency_edges\": { \"plugins\": [\"tools/compiler/Plugin\"] },\n    \"capabilities\": [\"build\", \"run\"] }\n]",
+            example_return: "[\n  { \"id\": \"packages/core/Core\", \"package\": \"packages/core\", \"name\": \"Core\",\n    \"kind\": \"library\", \"visibility\": [\"subtree:apps\"], \"deps\": [],\n    \"dependency_edges\": {}, \"capabilities\": [\"build\"] },\n  { \"id\": \"apps/service/Service\", \"package\": \"apps/service\", \"name\": \"Service\",\n    \"kind\": \"application\", \"visibility\": [], \"deps\": [\"packages/core/Core\"],\n    \"dependency_edges\": { \"plugins\": [\"tools/compiler/Plugin\"] },\n    \"capabilities\": [\"build\", \"run\"] }\n]",
         },
         ToolDefinition {
             name: "once_query_capabilities",
@@ -123,7 +137,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_query_schema",
             description: "Return the typed contract for a target kind: attributes, dep edges, providers, capabilities, source references, and runnable starters.",
-            long_description: "Returns the target kind schema (the typed contract a target of that kind must match) as `once query schema <kind> --format json` would. The record carries the target kind's documentation, attribute list (with types, required flag, and whether the attribute is configurable), expected dep providers, emitted providers, exposed capabilities, external source concepts that can guide partial adoption, and a lightweight list of runnable starter examples. Use `once_query_example` to fetch the full file tree for a chosen example.",
+            long_description: "Returns the target kind schema (the typed contract a target of that kind must match) as `once query schema <kind> --format json` would. The record carries the target kind's documentation, attribute list with types and required, configurable, and implemented flags, expected dep providers, emitted providers, exposed capabilities, required tools, external source concepts that can guide partial adoption, and a lightweight list of runnable starter examples. Attributes marked `implemented: false` are discoverable compatibility fields that validation rejects until their target kind gives them behavior. Use `once_materialize_example` to create an unchanged starter without loading its contents into model context, or `once_query_example` when the caller needs to inspect and adapt the files.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -134,12 +148,12 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 },
                 "required": ["kind"]
             }),
-            example_return: "{\n  \"kind\": \"library\",\n  \"docs\": \"Reusable library target...\",\n  \"attrs\": [\n    { \"name\": \"visibility\", \"ty\": \"string\", \"required\": true, \"configurable\": false }\n  ],\n  \"capabilities\": [ { \"name\": \"build\", \"output_groups\": [\"default\"], \"requires_outputs\": [] } ],\n  \"providers\": [\"linkable\", \"module\"],\n  \"source_references\": [\n    { \"system\": \"Example Build\", \"symbol\": \"example_library\",\n      \"url\": \"https://example.com/example_library\", \"use_when\": \"...\",\n      \"content_digest\": \"...\" }\n  ],\n  \"examples\": [\n    {\n      \"slug\": \"library-minimal\",\n      \"name\": \"Minimal library\",\n      \"use_when\": \"...\"\n    }\n  ]\n}",
+            example_return: "{\n  \"kind\": \"library\",\n  \"docs\": \"Reusable library target...\",\n  \"attrs\": [\n    { \"name\": \"mode\", \"ty\": \"string\", \"required\": false,\n      \"configurable\": true, \"implemented\": true }\n  ],\n  \"capabilities\": [ { \"name\": \"build\", \"output_groups\": [\"default\"], \"requires_outputs\": [] } ],\n  \"providers\": [\"linkable\", \"module\"],\n  \"source_references\": [\n    { \"system\": \"Example Build\", \"symbol\": \"example_library\",\n      \"url\": \"https://example.com/example_library\", \"use_when\": \"...\",\n      \"content_digest\": \"...\" }\n  ],\n  \"examples\": [\n    {\n      \"slug\": \"library-minimal\",\n      \"name\": \"Minimal library\",\n      \"use_when\": \"...\"\n    }\n  ]\n}",
         },
         ToolDefinition {
             name: "once_query_example",
             description: "Return the complete file bundle for one target kind starter example.",
-            long_description: "Returns the same record as `once query example <kind> <slug> --format json`: the selected example's slug, name, selection hint, and every text file a caller can copy to create the starter workspace. Example descriptors are discovered through `once_list_target_kinds` or `once_query_schema`; this tool fetches the file payload only after a caller chooses one.",
+            long_description: "Returns the same record as `once query example <kind> <slug> --format json`: the selected example's slug, name, selection hint, and every text file a caller can inspect or adapt. Example descriptors are discovered through `once_list_target_kinds` or `once_query_schema`. For direct setup, prefer `once_materialize_example`, which writes the bundle without sending large dependency payloads through model context.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -155,6 +169,31 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 "required": ["kind", "slug"]
             }),
             example_return: "{\n  \"slug\": \"library-minimal\",\n  \"name\": \"Minimal library\",\n  \"use_when\": \"...\",\n  \"files\": [\n    { \"path\": \"packages/core/once.toml\", \"contents\": \"[[target]]\\nname = \\\"Core\\\"\\nkind = \\\"library\\\"\\n...\" }\n  ]\n}",
+        },
+        ToolDefinition {
+            name: "once_materialize_example",
+            description: "Materialize a complete target kind starter directly inside the configured workspace.",
+            long_description: "This collision-safe setup tool is available only when the server starts with `once mcp --allow-run`. It copies the selected example without returning its file contents through model context. Existing files with identical contents are kept, making retries idempotent. If any path conflicts, Once reports every conflict and writes nothing. A successful result includes created and unchanged paths, canonical targets, complete-workspace validation, and exact suggested tool calls for targets of the requested kind. The matching command-line operation is `once edit materialize-example <kind> <slug> --destination <dir>`.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "description": "Target kind that owns the example."
+                    },
+                    "slug": {
+                        "type": "string",
+                        "description": "Example slug from `once_list_target_kinds` or `once_query_schema`."
+                    },
+                    "destination": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Workspace-relative destination directory. Use an empty string for the workspace root."
+                    }
+                },
+                "required": ["kind", "slug"]
+            }),
+            example_return: "{\n  \"materialized\": true,\n  \"kind\": \"library\",\n  \"slug\": \"library-minimal\",\n  \"destination\": \"\",\n  \"created_files\": [\"packages/core/once.toml\", \"packages/core/src/core.txt\"],\n  \"unchanged_files\": [],\n  \"conflicts\": [],\n  \"targets\": [\n    { \"id\": \"packages/core/Core\", \"kind\": \"library\", \"capabilities\": [\"build\"] }\n  ],\n  \"workspace_validation\": { \"valid\": true, \"target_count\": 1, \"diagnostics\": [] },\n  \"suggested_calls\": [\n    { \"tool\": \"once_validate_workspace\", \"arguments\": {}, \"reason\": \"Confirm the complete workspace after any customization.\" },\n    { \"tool\": \"once_build_target\", \"arguments\": { \"target\": \"packages/core/Core\" }, \"reason\": \"Build the materialized `library` target.\" }\n  ]\n}",
         },
         ToolDefinition {
             name: "once_list_target_kinds",
@@ -234,7 +273,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 },
                 "required": ["target"]
             }),
-            example_return: "{\n  \"label\": { \"package\": \"packages/core\", \"name\": \"Core\", \"id\": \"packages/core/Core\" },\n  \"kind\": \"library\",\n  \"srcs\": [\"src/**/*.src\"],\n  \"deps\": [],\n  \"dependency_edges\": { \"plugins\": [\"tools/compiler/Plugin\"] },\n  \"attrs\": { \"visibility\": \"public\" },\n  \"capabilities\": [ { \"name\": \"build\", \"output_groups\": [\"default\"], \"requires_outputs\": [] } ],\n  \"providers\": [\"linkable\", \"module\"]\n}",
+            example_return: "{\n  \"label\": { \"package\": \"packages/core\", \"name\": \"Core\", \"id\": \"packages/core/Core\" },\n  \"kind\": \"library\",\n  \"srcs\": [\"src/**/*.src\"],\n  \"visibility\": [\"subtree:apps\"],\n  \"deps\": [],\n  \"dependency_edges\": { \"plugins\": [\"tools/compiler/Plugin\"] },\n  \"attrs\": {},\n  \"capabilities\": [ { \"name\": \"build\", \"output_groups\": [\"default\"], \"requires_outputs\": [] } ],\n  \"providers\": [\"linkable\", \"module\"]\n}",
         },
         ToolDefinition {
             name: "once_query_tests",
@@ -249,7 +288,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_query_affected_tests",
             description: "Return test targets likely affected by a set of changed workspace paths.",
-            long_description: "Maps changed paths to test targets using graph relationships and declared inputs. A test is affected when a changed path belongs to the test target itself or to one of its declared dependencies. Declared source patterns are matched without requiring the changed file to still exist. Changes to manifests, configured graph modules, and paths without a declared owner conservatively select every test. Selection does not depend on a particular test runner.",
+            long_description: "Maps changed paths to test targets using graph relationships, declared inputs, and package ownership. A test is affected when a changed path belongs to the test target itself or to one of its declared dependencies. Declared source patterns are matched without requiring the changed file to still exist. An otherwise unowned path, including a package manifest, belongs to the nearest package and selects only that package's reverse dependency closure. The root manifest, configured graph modules, and paths outside every known package conservatively select every test. Selection does not depend on a particular test runner.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -284,7 +323,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                     }
                 }
             }),
-            example_return: "{\n  \"schema\": \"once.test_plan.v1\",\n  \"id\": \"<stable digest>\",\n  \"selection\": {\n    \"schema\": \"once.test_selection.v1\",\n    \"policy\": { \"mode\": \"affected\", \"safety\": \"conservative\", \"evidence\": \"declared_graph\" },\n    \"changed_paths\": [\"src/lib.src\"],\n    \"unmatched_paths\": [],\n    \"tests\": [{ \"id\": \"tests/unit\", \"kind\": \"test_suite\", \"reasons\": [\"changed dependency `lib` input `src/lib.src`\"] }]\n  },\n  \"batches\": [{ \"id\": \"<stable digest>\", \"target\": \"tests/unit\", \"test_filters\": [] }]\n}",
+            example_return: "{\n  \"schema\": \"once.test_plan.v1\",\n  \"id\": \"<stable digest>\",\n  \"selection\": {\n    \"schema\": \"once.test_selection.v1\",\n    \"policy\": { \"mode\": \"affected\", \"safety\": \"conservative\", \"evidence\": \"declared_graph_and_package_ownership\" },\n    \"changed_paths\": [\"src/lib.src\"],\n    \"unmatched_paths\": [],\n    \"tests\": [{ \"id\": \"tests/unit\", \"kind\": \"test_suite\", \"reasons\": [\"changed dependency `lib` input `src/lib.src`\"] }]\n  },\n  \"batches\": [{ \"id\": \"<stable digest>\", \"target\": \"tests/unit\", \"test_filters\": [] }]\n}",
         },
         ToolDefinition {
             name: "once_run_tests",
@@ -437,7 +476,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_build_target",
             description: "Build a target by running its generic `build` capability.",
-            long_description: "This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once build <target> --format json`, including dependency traversal, target actions, cache policy, and output groups. The result includes the exit status, standard error, and standard output parsed as structured data when possible. A failed build is returned as normal tool content with `success: false` so agents can inspect diagnostics.",
+            long_description: "This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once build <target> --format json`, including dependency traversal, target actions, cache policy, and output groups. Because cache identity follows declared content rather than workspace history, a first build in a new workspace can reuse an equivalent action produced elsewhere. The result includes the exit status, command diagnostics under `stderr`, and bounded declared action logs under `captured_stdout` and `captured_stderr`. A captured field is null when the target did not declare that log. A failed build is returned as normal tool content with `success: false` so agents can inspect diagnostics.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -468,7 +507,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_run_target",
             description: "Run a target by executing its generic `run` capability.",
-            long_description: "This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once run <target> --format json`, including prerequisite build outputs declared by the target's `run` capability. Set `visible` to request a visible interface when the target kind supports one. Uncacheable actions run again instead of replaying an action-cache hit. The result includes the exit status, standard error, and standard output parsed as structured data when possible.",
+            long_description: "This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once run <target> --format json`, including prerequisite build outputs declared by the target's `run` capability. Set `visible` to request a visible interface when the target kind supports one. Uncacheable actions run again instead of replaying an action-cache hit. The result includes command diagnostics under `stderr` and up to 64 kibibytes of each declared `stdout.log` or `stderr.log` output under `captured_stdout` and `captured_stderr`, so an agent can verify ordinary command output without a separate filesystem read. A captured field is null when the target did not declare that log.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -565,7 +604,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_validate_workspace",
             description: "Validate the complete workspace graph before execution.",
-            long_description: "Loads every manifest and target kind schema, then checks target attributes, duplicate target ids, missing dependencies, dependency provider compatibility, source patterns, and dependency cycles. Returns stable diagnostics with target and attribute scope plus suggested repairs. Call this after materializing a starter or applying edits and before build, run, or test. The matching command-line operation is `once query validate-workspace`.",
+            long_description: "Loads every manifest and target kind schema, then checks target attributes, target-valued attribute references, duplicate target identifiers, missing dependencies, dependency visibility, dependency provider compatibility, source patterns, and dependency cycles. Returns stable diagnostics with target and attribute scope plus suggested repairs. Call this after materializing a starter or applying edits and before build, run, or test. The matching command-line operation is `once query validate-workspace`.",
             input_schema: json!({
                 "type": "object",
                 "properties": {}
@@ -591,7 +630,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_apply_edit",
             description: "Apply a batch of `create` / `update` / `delete` operations to one `once.toml` atomically.",
-            long_description: "Reads the manifest at `<workspace>/<package>/once.toml`, creating it if needed, and applies the operations only if every operation succeeds. Returns `{ applied: true, path: <manifest path> }` on success or `{ applied: false, diagnostics: [...] }` with the structured diagnostic shape used by `once_validate_target`. A failed batch leaves the original file unchanged.",
+            long_description: "Reads the manifest at `<workspace>/<package>/once.toml` and applies the operations only if every operation succeeds. Returns `{ applied: true, changed: <bool>, path: <manifest path> }` on success. `changed` is false when the requested state already exists, in which case no manifest is written. Returns `{ applied: false, diagnostics: [...] }` with the structured diagnostic shape used by `once_validate_target` when the edit is invalid. A failed batch leaves the original file unchanged.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -607,7 +646,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 },
                 "required": ["package", "operations"]
             }),
-            example_return: "{\n  \"applied\": true,\n  \"path\": \"packages/core/once.toml\"\n}",
+            example_return: "{\n  \"applied\": true,\n  \"changed\": true,\n  \"path\": \"packages/core/once.toml\"\n}",
         },
     ]
 }

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -7,6 +7,7 @@ pub(crate) mod test_plan;
 
 pub(crate) use script::script_validation_value;
 
+use std::collections::BTreeSet;
 use std::fmt::Write as _;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -30,6 +31,7 @@ struct TargetRecord {
     kind: String,
     deps: Vec<String>,
     dependency_edges: std::collections::BTreeMap<String, Vec<String>>,
+    visibility: Vec<String>,
     capabilities: Vec<String>,
     tools: Vec<once_frontend::ToolRequirement>,
 }
@@ -52,6 +54,25 @@ struct WorkspaceValidation {
 }
 
 #[derive(Debug, Serialize)]
+struct WorkspaceSummary {
+    root: String,
+    configuration: once_frontend::BuildConfiguration,
+    root_manifest: RootManifestSummary,
+    target_count: Option<usize>,
+    packages: Vec<String>,
+    empty: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    load_error: Option<String>,
+    suggested_calls: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct RootManifestSummary {
+    path: String,
+    exists: bool,
+}
+
+#[derive(Debug, Serialize)]
 struct ModuleValidation {
     valid: bool,
     path: String,
@@ -70,6 +91,104 @@ pub async fn targets(workspace: &Path, output: Output, kind: Option<&str>) -> Re
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
     let records = target_records(graph, kind);
     write_body(output, || render_targets_human(&records), &records).await
+}
+
+pub async fn workspace(workspace: &Path, output: Output) -> Result<()> {
+    let summary = workspace_summary(workspace);
+    write_body(output, || render_workspace_summary(&summary), &summary).await
+}
+
+pub(crate) fn workspace_value(workspace: &Path) -> Result<serde_json::Value> {
+    Ok(serde_json::to_value(workspace_summary(workspace))?)
+}
+
+fn workspace_summary(workspace: &Path) -> WorkspaceSummary {
+    let root_manifest_path = workspace.join(once_frontend::TOML_BUILD_FILE_NAME);
+    let configuration = once_frontend::load_workspace_configuration(workspace).unwrap_or_default();
+    match once_frontend::load_graph_workspace(workspace) {
+        Ok(graph) => {
+            let packages = graph
+                .iter()
+                .map(|target| target.label.package.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let target_count = graph.len();
+            WorkspaceSummary {
+                root: workspace.to_string_lossy().into_owned(),
+                configuration,
+                root_manifest: RootManifestSummary {
+                    path: root_manifest_path.to_string_lossy().into_owned(),
+                    exists: root_manifest_path.is_file(),
+                },
+                target_count: Some(target_count),
+                packages,
+                empty: target_count == 0,
+                load_error: None,
+                suggested_calls: if target_count == 0 {
+                    vec![serde_json::json!({
+                        "tool": "once_list_target_kinds",
+                        "arguments": {},
+                        "reason": "Discover a target kind and starter for this empty workspace."
+                    })]
+                } else {
+                    vec![
+                        serde_json::json!({
+                            "tool": "once_query_targets",
+                            "arguments": {},
+                            "reason": "Inspect canonical target identifiers."
+                        }),
+                        serde_json::json!({
+                            "tool": "once_validate_workspace",
+                            "arguments": {},
+                            "reason": "Validate the complete loaded graph."
+                        }),
+                    ]
+                },
+            }
+        }
+        Err(error) => WorkspaceSummary {
+            root: workspace.to_string_lossy().into_owned(),
+            configuration,
+            root_manifest: RootManifestSummary {
+                path: root_manifest_path.to_string_lossy().into_owned(),
+                exists: root_manifest_path.is_file(),
+            },
+            target_count: None,
+            packages: Vec::new(),
+            empty: false,
+            load_error: Some(error.to_string()),
+            suggested_calls: vec![serde_json::json!({
+                "tool": "once_validate_workspace",
+                "arguments": {},
+                "reason": "Inspect the workspace loading or validation failure."
+            })],
+        },
+    }
+}
+
+fn render_workspace_summary(summary: &WorkspaceSummary) -> String {
+    let target_count = summary
+        .target_count
+        .map_or_else(|| "unavailable".to_string(), |count| count.to_string());
+    let mut text = format!(
+        "workspace: {}\nconfiguration: {}-{} [{}]\nroot manifest: {} ({})\ntargets: {}\n",
+        summary.root,
+        summary.configuration.os,
+        summary.configuration.arch,
+        summary.configuration.tokens.join(", "),
+        summary.root_manifest.path,
+        if summary.root_manifest.exists {
+            "present"
+        } else {
+            "absent"
+        },
+        target_count
+    );
+    if let Some(error) = &summary.load_error {
+        let _ = writeln!(text, "load error: {error}");
+    }
+    text
 }
 
 pub async fn expression(workspace: &Path, output: Output, query: &str) -> Result<()> {
@@ -198,8 +317,24 @@ fn module_validation(workspace: &Path, path: &str) -> Result<ModuleValidation> {
         anyhow::bail!("module path must name a Starlark file");
     }
     let source_path = relative.resolve(workspace);
-    let source = std::fs::read_to_string(&source_path)
-        .with_context(|| format!("reading module `{}`", source_path.display()))?;
+    let source = match std::fs::read_to_string(&source_path) {
+        Ok(source) => source,
+        Err(error) => {
+            return Ok(ModuleValidation {
+                valid: false,
+                path: relative.to_string(),
+                target_kinds: Vec::new(),
+                diagnostics: vec![ModuleDiagnostic {
+                    code: "module_read_failed",
+                    message: format!("reading module `{}`: {error}", source_path.display()),
+                    repairs: vec![
+                        "Create the module at the requested workspace-relative path.",
+                        "Ensure the module is readable UTF-8 text, then validate again.",
+                    ],
+                }],
+            });
+        }
+    };
     match once_frontend::validate_module_source(workspace, relative.as_str(), &source) {
         Ok(target_kinds) => Ok(ModuleValidation {
             valid: true,
@@ -278,6 +413,7 @@ fn target_records(graph: Vec<once_frontend::GraphTarget>, kind: Option<&str>) ->
             kind: target.kind,
             deps: target.deps,
             dependency_edges: target.dependency_edges,
+            visibility: target.visibility,
             capabilities: target
                 .capabilities
                 .into_iter()
@@ -379,6 +515,11 @@ pub(crate) fn matching_target_kind_schemas(
                 .any(|schema| target_kind_family(schema) == term.as_str())
         })
         .collect::<Vec<_>>();
+    if families.len() == 1 {
+        let family = families[0];
+        schemas.retain(|schema| target_kind_family(schema) == family.as_str());
+        return Ok(schemas);
+    }
     if !families.is_empty() {
         let specific_terms = terms
             .iter()
@@ -1045,9 +1186,14 @@ fn render_schema_human(schema: &once_frontend::TargetKindSchema) -> String {
             } else {
                 ""
             };
+            let availability = if attr.implemented {
+                ""
+            } else {
+                ", unavailable"
+            };
             writeln!(
                 out,
-                "  {}: {} ({required}{configurable})",
+                "  {}: {} ({required}{configurable}{availability})",
                 attr.name, attr.ty
             )
             .expect("writing to string cannot fail");
@@ -1502,6 +1648,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: std::collections::BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: capabilities
                 .iter()
@@ -1518,6 +1665,17 @@ mod tests {
     }
 
     #[test]
+    fn missing_modules_return_validation_diagnostics() {
+        let workspace = tempfile::TempDir::new().unwrap();
+
+        let validation = module_validation(workspace.path(), "modules/missing.star").unwrap();
+
+        assert!(!validation.valid);
+        assert_eq!(validation.diagnostics[0].code, "module_read_failed");
+        assert!(!validation.diagnostics[0].repairs.is_empty());
+    }
+
+    #[test]
     fn render_targets_human_reports_empty_and_populated() {
         assert_eq!(render_targets_human(&[]), "targets: none\n");
         let rendered = render_targets_human(&[TargetRecord {
@@ -1527,6 +1685,7 @@ mod tests {
             kind: "apple_application".to_string(),
             deps: Vec::new(),
             dependency_edges: std::collections::BTreeMap::new(),
+            visibility: Vec::new(),
             capabilities: vec!["build".to_string(), "run".to_string()],
             tools: Vec::new(),
         }]);
@@ -1589,6 +1748,7 @@ mod tests {
                 kind: "apple_application".to_string(),
                 deps: Vec::new(),
                 dependency_edges: std::collections::BTreeMap::new(),
+                visibility: Vec::new(),
                 capabilities: vec!["build".to_string(), "run".to_string()],
                 tools: Vec::new(),
             }]
@@ -1680,6 +1840,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: std::collections::BTreeMap::new(),
             srcs: vec!["tests/*.py".to_string()],
+            visibility: Vec::new(),
             attrs: std::collections::BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),

--- a/crates/once-cli/src/commands/query/expression.rs
+++ b/crates/once-cli/src/commands/query/expression.rs
@@ -98,6 +98,7 @@ mod tests {
             deps: deps.iter().map(|dep| (*dep).to_string()).collect(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: capabilities
                 .iter()
@@ -156,6 +157,45 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.columns, vec!["target"]);
+        assert_eq!(result.rows, vec![vec![json!("apps/AppTests")]]);
+    }
+
+    #[test]
+    fn evaluates_richer_predicates_and_nested_attributes() {
+        let mut app = target("apps/App", "apple_application", &[], &["build", "run"]);
+        app.visibility = vec!["//apps:*".to_string()];
+        app.attrs.insert(
+            "bundle_id".to_string(),
+            once_frontend::AttrValue::String("dev.once.app".to_string()),
+        );
+        let library = target("libs/Core", "apple_library", &[], &["build"]);
+        let graph = vec![app, library];
+
+        let result = evaluate(
+            r#"MATCH (t:Target) WHERE t.kind IN ["apple_application", "android_binary"] AND t.visibility CONTAINS "//apps:*" OR t.attrs.bundle_id STARTS WITH "dev.once" RETURN t.id, t.attrs.bundle_id"#,
+            &graph,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.rows,
+            vec![vec![json!("apps/App"), json!("dev.once.app")]]
+        );
+    }
+
+    #[test]
+    fn evaluates_not_equal_and_suffix_predicates() {
+        let graph = vec![
+            target("apps/App", "apple_application", &[], &["build"]),
+            target("apps/AppTests", "apple_test_bundle", &[], &["test"]),
+        ];
+
+        let result = evaluate(
+            r#"MATCH (t:Target) WHERE t.kind <> "apple_application" AND t.id ENDS WITH "Tests" RETURN t.id"#,
+            &graph,
+        )
+        .unwrap();
+
         assert_eq!(result.rows, vec![vec![json!("apps/AppTests")]]);
     }
 

--- a/crates/once-cli/src/commands/query/expression/ast.rs
+++ b/crates/once-cli/src/commands/query/expression/ast.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct ParsedQuery {
     pub(super) pattern: MatchPattern,
-    pub(super) predicates: Vec<Predicate>,
+    pub(super) predicate_groups: Vec<Vec<Predicate>>,
     pub(super) returns: Vec<ReturnItem>,
 }
 
@@ -47,7 +47,18 @@ pub(super) enum Direction {
 pub(super) struct Predicate {
     pub(super) alias: String,
     pub(super) property: String,
+    pub(super) operator: PredicateOperator,
     pub(super) value: Value,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum PredicateOperator {
+    Equal,
+    NotEqual,
+    Contains,
+    In,
+    StartsWith,
+    EndsWith,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/once-cli/src/commands/query/expression/model.rs
+++ b/crates/once-cli/src/commands/query/expression/model.rs
@@ -10,8 +10,8 @@ use once_frontend::GraphTarget;
 use serde_json::{json, Map, Value};
 
 use super::ast::{
-    Direction, MatchPattern, NodePattern, ParsedQuery, Predicate, Projection, RelationshipPattern,
-    ReturnItem,
+    Direction, MatchPattern, NodePattern, ParsedQuery, Predicate, PredicateOperator, Projection,
+    RelationshipPattern, ReturnItem,
 };
 
 #[derive(Debug)]
@@ -116,10 +116,12 @@ impl GraphModel {
         bindings
             .into_iter()
             .filter(|binding| {
-                query
-                    .predicates
-                    .iter()
-                    .all(|predicate| self.predicate_matches(binding, predicate))
+                query.predicate_groups.is_empty()
+                    || query.predicate_groups.iter().any(|group| {
+                        group
+                            .iter()
+                            .all(|predicate| self.predicate_matches(binding, predicate))
+                    })
             })
             .map(Ok)
             .collect()
@@ -196,7 +198,33 @@ impl GraphModel {
         let Some(node) = binding.nodes.get(&predicate.alias) else {
             return false;
         };
-        self.nodes[*node].properties.get(&predicate.property) == Some(&predicate.value)
+        let actual = property_value(&self.nodes[*node].properties, &predicate.property);
+        match predicate.operator {
+            PredicateOperator::Equal => actual == Some(&predicate.value),
+            PredicateOperator::NotEqual => actual != Some(&predicate.value),
+            PredicateOperator::Contains => actual.is_some_and(|actual| match actual {
+                Value::String(actual) => predicate
+                    .value
+                    .as_str()
+                    .is_some_and(|expected| actual.contains(expected)),
+                Value::Array(actual) => actual.contains(&predicate.value),
+                _ => false,
+            }),
+            PredicateOperator::In => predicate
+                .value
+                .as_array()
+                .is_some_and(|values| actual.is_some_and(|actual| values.contains(actual))),
+            PredicateOperator::StartsWith => {
+                string_predicate(actual, &predicate.value, |actual, expected| {
+                    actual.starts_with(expected)
+                })
+            }
+            PredicateOperator::EndsWith => {
+                string_predicate(actual, &predicate.value, |actual, expected| {
+                    actual.ends_with(expected)
+                })
+            }
+        }
     }
 
     pub(super) fn project(&self, binding: &Binding, item: &ReturnItem) -> Value {
@@ -207,11 +235,31 @@ impl GraphModel {
             Projection::Property { alias, property } => binding
                 .nodes
                 .get(alias)
-                .and_then(|index| self.nodes[*index].properties.get(property))
+                .and_then(|index| property_value(&self.nodes[*index].properties, property))
                 .cloned()
                 .unwrap_or(Value::Null),
         }
     }
+}
+
+fn property_value<'a>(properties: &'a BTreeMap<String, Value>, path: &str) -> Option<&'a Value> {
+    let mut parts = path.split('.');
+    let mut value = properties.get(parts.next()?)?;
+    for part in parts {
+        value = value.as_object()?.get(part)?;
+    }
+    Some(value)
+}
+
+fn string_predicate(
+    actual: Option<&Value>,
+    expected: &Value,
+    predicate: impl Fn(&str, &str) -> bool,
+) -> bool {
+    actual
+        .and_then(Value::as_str)
+        .zip(expected.as_str())
+        .is_some_and(|(actual, expected)| predicate(actual, expected))
 }
 
 fn target_properties(target: &GraphTarget) -> BTreeMap<String, Value> {
@@ -226,6 +274,7 @@ fn target_properties(target: &GraphTarget) -> BTreeMap<String, Value> {
             json!(target.dependency_edges),
         ),
         ("srcs".to_string(), json!(target.srcs)),
+        ("visibility".to_string(), json!(target.visibility)),
         ("attrs".to_string(), json!(target.attrs)),
         ("providers".to_string(), json!(target.providers)),
         (

--- a/crates/once-cli/src/commands/query/expression/parser.rs
+++ b/crates/once-cli/src/commands/query/expression/parser.rs
@@ -9,8 +9,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde_json::{json, Value};
 
 use super::ast::{
-    Direction, MatchPattern, NodePattern, ParsedQuery, Predicate, Projection, RelationshipPattern,
-    ReturnItem,
+    Direction, MatchPattern, NodePattern, ParsedQuery, Predicate, PredicateOperator, Projection,
+    RelationshipPattern, ReturnItem,
 };
 use super::scan::{
     keyword_pos, matching_delimiter, split_top_level, split_top_level_keyword, starts_with_keyword,
@@ -59,7 +59,7 @@ pub(super) fn parse_query(raw: &str) -> Result<ParsedQuery> {
     let pattern_start = match_pos + "MATCH".len();
     let pattern_end = where_pos.unwrap_or(return_pos);
     let pattern = parse_match_pattern(query[pattern_start..pattern_end].trim())?;
-    let predicates = if let Some(where_pos) = where_pos {
+    let predicate_groups = if let Some(where_pos) = where_pos {
         parse_predicates(query[where_pos + "WHERE".len()..return_pos].trim())?
     } else {
         Vec::new()
@@ -67,7 +67,7 @@ pub(super) fn parse_query(raw: &str) -> Result<ParsedQuery> {
     let returns = parse_returns(query[return_pos + "RETURN".len()..].trim())?;
     Ok(ParsedQuery {
         pattern,
-        predicates,
+        predicate_groups,
         returns,
     })
 }
@@ -190,24 +190,66 @@ fn parse_property_map(raw: &str) -> Result<BTreeMap<String, Value>> {
     Ok(properties)
 }
 
-fn parse_predicates(raw: &str) -> Result<Vec<Predicate>> {
+fn parse_predicates(raw: &str) -> Result<Vec<Vec<Predicate>>> {
     if raw.is_empty() {
         return Ok(Vec::new());
     }
-    split_top_level_keyword(raw, "AND")
+    split_top_level_keyword(raw, "OR")
         .into_iter()
-        .map(|predicate| {
-            let eq = top_level_char(predicate, '=')
-                .ok_or_else(|| anyhow!("WHERE predicates must use equality"))?;
-            let (alias, property) = parse_property_ref(predicate[..eq].trim())?;
-            let value = parse_literal(predicate[eq + 1..].trim())?;
-            Ok(Predicate {
-                alias,
-                property,
-                value,
-            })
+        .map(|group| {
+            split_top_level_keyword(group, "AND")
+                .into_iter()
+                .map(parse_predicate)
+                .collect()
         })
         .collect()
+}
+
+fn parse_predicate(raw: &str) -> Result<Predicate> {
+    let operators = [
+        ("STARTS WITH", PredicateOperator::StartsWith),
+        ("ENDS WITH", PredicateOperator::EndsWith),
+        ("CONTAINS", PredicateOperator::Contains),
+        ("IN", PredicateOperator::In),
+    ];
+    for (keyword, operator) in operators {
+        if let Some(position) = keyword_pos(raw, keyword, 0) {
+            return predicate_from_parts(
+                &raw[..position],
+                &raw[position + keyword.len()..],
+                operator,
+            );
+        }
+    }
+    if let Some(position) = top_level_operator(raw, "<>") {
+        return predicate_from_parts(
+            &raw[..position],
+            &raw[position + 2..],
+            PredicateOperator::NotEqual,
+        );
+    }
+    if let Some(position) = top_level_char(raw, '=') {
+        return predicate_from_parts(
+            &raw[..position],
+            &raw[position + 1..],
+            PredicateOperator::Equal,
+        );
+    }
+    bail!("WHERE predicates must use =, <>, CONTAINS, IN, STARTS WITH, or ENDS WITH")
+}
+
+fn predicate_from_parts(
+    property: &str,
+    value: &str,
+    operator: PredicateOperator,
+) -> Result<Predicate> {
+    let (alias, property) = parse_property_ref(property.trim())?;
+    Ok(Predicate {
+        alias,
+        property,
+        operator,
+        value: parse_literal(value.trim())?,
+    })
 }
 
 fn parse_returns(raw: &str) -> Result<Vec<ReturnItem>> {
@@ -235,7 +277,7 @@ fn parse_projection(raw: &str) -> Result<Projection> {
     if let Some((alias, property)) = raw.split_once('.') {
         return Ok(Projection::Property {
             alias: identifier(alias.trim())?,
-            property: identifier(property.trim())?,
+            property: property_path(property.trim())?,
         });
     }
     Ok(Projection::Node {
@@ -247,10 +289,22 @@ fn parse_property_ref(raw: &str) -> Result<(String, String)> {
     let (alias, property) = raw
         .split_once('.')
         .ok_or_else(|| anyhow!("property references must use `alias.property`"))?;
-    Ok((identifier(alias.trim())?, identifier(property.trim())?))
+    Ok((identifier(alias.trim())?, property_path(property.trim())?))
 }
 
 fn parse_literal(raw: &str) -> Result<Value> {
+    if raw.starts_with('[') && raw.ends_with(']') {
+        let inner = &raw[1..raw.len() - 1];
+        if inner.trim().is_empty() {
+            return Ok(Value::Array(Vec::new()));
+        }
+        return Ok(Value::Array(
+            split_top_level(inner, ',')?
+                .into_iter()
+                .map(parse_literal)
+                .collect::<Result<Vec<_>>>()?,
+        ));
+    }
     if raw.starts_with('"') || raw.starts_with('\'') {
         return parse_string_literal(raw).map(Value::String);
     }
@@ -267,6 +321,27 @@ fn parse_literal(raw: &str) -> Result<Value> {
         return Ok(json!(value));
     }
     bail!("unsupported literal `{raw}`");
+}
+
+fn property_path(raw: &str) -> Result<String> {
+    raw.split('.')
+        .map(str::trim)
+        .map(identifier)
+        .collect::<Result<Vec<_>>>()
+        .map(|parts| parts.join("."))
+}
+
+fn top_level_operator(input: &str, operator: &str) -> Option<usize> {
+    let first = operator.chars().next()?;
+    let mut start = 0;
+    while let Some(relative) = top_level_char(&input[start..], first) {
+        let position = start + relative;
+        if input[position..].starts_with(operator) {
+            return Some(position);
+        }
+        start = position + first.len_utf8();
+    }
+    None
 }
 
 fn parse_string_literal(raw: &str) -> Result<String> {

--- a/crates/once-cli/src/commands/query/test_plan.rs
+++ b/crates/once-cli/src/commands/query/test_plan.rs
@@ -234,6 +234,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             capabilities: Vec::new(),
             providers: Vec::new(),

--- a/crates/once-cli/src/commands/query/test_plan/inputs.rs
+++ b/crates/once-cli/src/commands/query/test_plan/inputs.rs
@@ -57,11 +57,9 @@ pub(super) fn workspace_graph_input_patterns(workspace: &Path) -> Result<Vec<Inp
 }
 
 pub(super) fn is_graph_input(path: &str, configured_patterns: &[InputPattern]) -> bool {
-    path == once_frontend::TOML_BUILD_FILE_NAME
-        || path.ends_with(&format!("/{}", once_frontend::TOML_BUILD_FILE_NAME))
-        || configured_patterns
-            .iter()
-            .any(|pattern| pattern.matches(path))
+    configured_patterns
+        .iter()
+        .any(|pattern| pattern.matches(path))
 }
 
 #[derive(Debug)]

--- a/crates/once-cli/src/commands/query/test_plan/selection.rs
+++ b/crates/once-cli/src/commands/query/test_plan/selection.rs
@@ -48,7 +48,7 @@ pub(super) fn selection_report(
             continue;
         }
 
-        let owners = target_patterns
+        let mut owners = target_patterns
             .iter()
             .filter_map(|(target_id, patterns)| {
                 patterns
@@ -57,6 +57,9 @@ pub(super) fn selection_report(
                     .then_some(target_id.as_str())
             })
             .collect::<Vec<_>>();
+        if owners.is_empty() {
+            owners = nearest_package_owners(path, graph);
+        }
         if owners.is_empty() {
             // Deliberately conservative: a path no target claims may still affect
             // any test (for example documentation compiled into doc-tests), so we
@@ -95,12 +98,45 @@ pub(super) fn selection_report(
         policy: TestSelectionPolicy {
             mode: "affected".to_string(),
             safety: "conservative".to_string(),
-            evidence: "declared_graph".to_string(),
+            evidence: "declared_graph_and_package_ownership".to_string(),
         },
         changed_paths,
         unmatched_paths,
         tests,
     })
+}
+
+fn nearest_package_owners<'a>(path: &str, graph: &'a [GraphTarget]) -> Vec<&'a str> {
+    let manifest_suffix = format!("/{}", once_frontend::TOML_BUILD_FILE_NAME);
+    let path_package = path
+        .strip_suffix(&manifest_suffix)
+        .unwrap_or_else(|| path.rsplit_once('/').map_or("", |(package, _)| package));
+    let longest = graph
+        .iter()
+        .filter(|target| package_contains_path(&target.label.package, path_package))
+        .map(|target| target.label.package.len())
+        .max();
+    let Some(longest) = longest else {
+        return Vec::new();
+    };
+    graph
+        .iter()
+        .filter(|target| {
+            target.label.package.len() == longest
+                && package_contains_path(&target.label.package, path_package)
+        })
+        .map(|target| target.label.id.as_str())
+        .collect()
+}
+
+fn package_contains_path(package: &str, path_package: &str) -> bool {
+    if package.is_empty() {
+        return path_package.is_empty();
+    }
+    path_package == package
+        || path_package
+            .strip_prefix(package)
+            .is_some_and(|rest| rest.starts_with('/'))
 }
 
 fn normalize_changed_paths(paths: &[String]) -> Vec<String> {

--- a/crates/once-cli/src/commands/query/test_plan/selection/tests.rs
+++ b/crates/once-cli/src/commands/query/test_plan/selection/tests.rs
@@ -84,15 +84,73 @@ fn test_plan_identity_is_stable_and_independent_of_changed_path_order() {
 }
 
 #[test]
-fn unmatched_paths_conservatively_select_every_test() {
+fn paths_outside_known_packages_conservatively_select_every_test() {
     let workspace = TempDir::new().unwrap();
-    let graph = vec![target("unit", "test", &["tests/**/*.rs"], &[], true)];
+    let graph = vec![target("tests/unit", "test", &["**/*.rs"], &[], true)];
 
-    let report = selection_report(workspace.path(), &graph, &["README.md".to_string()]).unwrap();
+    let report = selection_report(
+        workspace.path(),
+        &graph,
+        &["documentation/README.md".to_string()],
+    )
+    .unwrap();
 
     assert_eq!(report.tests.len(), 1);
     assert!(report.tests[0].reasons[0].contains("has no declared owner"));
-    assert_eq!(report.unmatched_paths, vec!["README.md"]);
+    assert_eq!(report.unmatched_paths, vec!["documentation/README.md"]);
+}
+
+#[test]
+fn package_manifest_changes_select_only_package_dependents() {
+    let workspace = TempDir::new().unwrap();
+    let graph = vec![
+        target("packages/core/Library", "library", &["src/**"], &[], false),
+        target(
+            "packages/core/UnitTests",
+            "test",
+            &["tests/**"],
+            &["packages/core/Library"],
+            true,
+        ),
+        target("apps/OtherTests", "test", &["tests/**"], &[], true),
+    ];
+
+    let report = selection_report(
+        workspace.path(),
+        &graph,
+        &["packages/core/once.toml".to_string()],
+    )
+    .unwrap();
+
+    assert_eq!(
+        report
+            .tests
+            .iter()
+            .map(|test| test.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["packages/core/UnitTests"]
+    );
+    assert!(report.unmatched_paths.is_empty());
+}
+
+#[test]
+fn unowned_files_use_the_nearest_package() {
+    let workspace = TempDir::new().unwrap();
+    let graph = vec![
+        target("packages/core/UnitTests", "test", &["tests/**"], &[], true),
+        target("apps/OtherTests", "test", &["tests/**"], &[], true),
+    ];
+
+    let report = selection_report(
+        workspace.path(),
+        &graph,
+        &["packages/core/README.md".to_string()],
+    )
+    .unwrap();
+
+    assert_eq!(report.tests[0].id, "packages/core/UnitTests");
+    assert_eq!(report.tests.len(), 1);
+    assert!(report.unmatched_paths.is_empty());
 }
 
 #[test]
@@ -135,16 +193,18 @@ fn configured_module_changes_select_every_test() {
 }
 
 fn target(id: &str, kind: &str, srcs: &[&str], deps: &[&str], test: bool) -> GraphTarget {
+    let (package, name) = id.rsplit_once('/').unwrap_or(("", id));
     GraphTarget {
         label: TargetLabel {
-            package: String::new(),
-            name: id.to_string(),
+            package: package.to_string(),
+            name: name.to_string(),
             id: id.to_string(),
         },
         kind: kind.to_string(),
         deps: deps.iter().map(ToString::to_string).collect(),
         dependency_edges: BTreeMap::new(),
         srcs: srcs.iter().map(ToString::to_string).collect(),
+        visibility: Vec::new(),
         attrs: BTreeMap::new(),
         capabilities: test
             .then(|| Capability {

--- a/crates/once-cli/src/commands/run/action/script.rs
+++ b/crates/once-cli/src/commands/run/action/script.rs
@@ -270,6 +270,7 @@ mod tests {
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: vec!["scripts/build.sh".to_string(), "src/input.txt".to_string()],
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs: BTreeMap::new(),
         }

--- a/crates/once-cli/src/commands/runtime/supervisor.rs
+++ b/crates/once-cli/src/commands/runtime/supervisor.rs
@@ -94,7 +94,7 @@ pub(crate) fn start_session(workspace: &Path, target: &str) -> Result<RuntimeSes
 }
 
 pub(crate) fn status_session(workspace: &Path, session: &str) -> Result<RuntimeSessionRecord> {
-    let dir = resolve_session_dir(workspace, session);
+    let dir = resolve_session_dir(workspace, session)?;
     read_session_record(&dir)
 }
 
@@ -111,7 +111,7 @@ pub(crate) fn logs_session(
             "runtime log source must be `stdout` or `stderr`"
         );
     }
-    let dir = resolve_session_dir(workspace, session);
+    let dir = resolve_session_dir(workspace, session)?;
     let session_id = read_session_record(&dir)?.session_id;
     let mut records = Vec::new();
     for stream in ["stdout", "stderr"] {
@@ -148,7 +148,7 @@ pub(crate) fn logs_session(
 }
 
 pub(crate) fn stop_session(workspace: &Path, session: &str) -> Result<RuntimeSessionRecord> {
-    let dir = resolve_session_dir(workspace, session);
+    let dir = resolve_session_dir(workspace, session)?;
     let mut record = read_session_record(&dir)?;
     if matches!(record.status.as_str(), "starting" | "running") {
         fs::write(dir.join(STOP_REQUEST_FILE), b"stop\n")
@@ -214,16 +214,15 @@ fn log_file(session_dir: &Path, source: &str) -> Result<File> {
         .with_context(|| format!("opening {}", path.display()))
 }
 
-fn resolve_session_dir(workspace: &Path, session: &str) -> PathBuf {
-    let raw = Path::new(session);
-    if raw.is_absolute() || session.contains('/') || session.contains('\\') {
-        return if raw.is_absolute() {
-            raw.to_path_buf()
-        } else {
-            workspace.join(raw)
-        };
-    }
-    workspace.join(CACHE_DIR).join("runtime").join(session)
+fn resolve_session_dir(workspace: &Path, session: &str) -> Result<PathBuf> {
+    anyhow::ensure!(
+        !session.is_empty()
+            && session.chars().all(
+                |character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+            ),
+        "runtime session id must contain only letters, numbers, `-`, or `_`"
+    );
+    Ok(workspace.join(CACHE_DIR).join("runtime").join(session))
 }
 
 fn read_session_record(session_dir: &Path) -> Result<RuntimeSessionRecord> {
@@ -277,6 +276,26 @@ mod tests {
         assert!(id.starts_with("apps-ios-App-Tests-"));
         assert!(!id.contains('/'));
         assert!(!id.contains(' '));
+    }
+
+    #[test]
+    fn session_paths_reject_workspace_escapes() {
+        let workspace = Path::new("/workspace");
+
+        for session in [
+            "",
+            "../outside",
+            "nested/session",
+            r"nested\session",
+            "/absolute",
+            "with.dot",
+        ] {
+            assert!(resolve_session_dir(workspace, session).is_err());
+        }
+        assert_eq!(
+            resolve_session_dir(workspace, "safe-session_1").unwrap(),
+            Path::new("/workspace/.once/runtime/safe-session_1")
+        );
     }
 
     #[test]

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -294,6 +294,9 @@ async fn run_query_command(
     command: Option<cli::QueryCmd>,
 ) -> Result<ExitCode> {
     match command {
+        Some(cli::QueryCmd::Workspace) => commands::query::workspace(workspace, output)
+            .await
+            .map(|()| ExitCode::SUCCESS),
         Some(cli::QueryCmd::Targets { kind }) => {
             commands::query::targets(workspace, output, kind.as_deref())
                 .await
@@ -422,6 +425,13 @@ async fn run_edit_command(
 ) -> Result<ExitCode> {
     match command {
         Some(cli::EditCmd::Apply { file }) => commands::edit::apply(workspace, output, file)
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Some(cli::EditCmd::MaterializeExample {
+            kind,
+            slug,
+            destination,
+        }) => commands::edit::materialize_example(workspace, output, &kind, &slug, &destination)
             .await
             .map(|()| ExitCode::SUCCESS),
         None => anyhow::bail!("edit subcommand required"),

--- a/crates/once-cli/src/main.rs
+++ b/crates/once-cli/src/main.rs
@@ -68,11 +68,19 @@ fn write_dispatch_error(format: cli::Format, error: &anyhow::Error) {
 }
 
 fn structured_dispatch_error(format: cli::Format, error: &anyhow::Error) -> String {
+    let analysis_diagnostic = error.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<once_frontend::analysis::AnalysisFailure>()
+            .map(|failure| &failure.diagnostic)
+    });
+    let code =
+        analysis_diagnostic.map_or("operation_failed", |diagnostic| diagnostic.code.as_str());
     let envelope = serde_json::json!({
         "schema": "once.error.v1",
         "error": {
-            "code": "operation_failed",
+            "code": code,
             "message": format!("{error:#}"),
+            "diagnostics": analysis_diagnostic.into_iter().collect::<Vec<_>>(),
         }
     });
     render::structured(format, &envelope).unwrap_or_else(|render_error| {
@@ -119,5 +127,26 @@ mod tests {
         assert_eq!(value["schema"], "once.error.v1");
         assert_eq!(value["error"]["code"], "operation_failed");
         assert_eq!(value["error"]["message"], "unknown test unit");
+        assert_eq!(value["error"]["diagnostics"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn structured_dispatch_errors_preserve_analysis_diagnostics() {
+        let diagnostic = once_frontend::Diagnostic::new(
+            "target_kind_analysis_failed",
+            "target kind implementation failed",
+        )
+        .with_target("App")
+        .with_repair("Correct the target");
+        let error = anyhow::Error::new(once_frontend::analysis::AnalysisFailure { diagnostic });
+
+        let rendered = structured_dispatch_error(cli::Format::Json, &error);
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+        assert_eq!(value["error"]["code"], "target_kind_analysis_failed");
+        assert_eq!(
+            value["error"]["diagnostics"][0]["target"],
+            serde_json::json!("App")
+        );
     }
 }

--- a/crates/once-cli/src/reference.rs
+++ b/crates/once-cli/src/reference.rs
@@ -368,6 +368,14 @@ fn file_path_for(out: &Path, path: &[String]) -> PathBuf {
 /// `tools/list`. Stable prose (transport, handshake, Claude Desktop
 /// wiring) stays hand-authored in `docs/reference/mcp/index.md`.
 fn write_mcp_tools_page(out: &Path) -> Result<()> {
+    let body = render_mcp_tools_page();
+    let path = out.join("tools.md");
+    fs::write(&path, body)
+        .with_context(|| format!("writing reference mcp tools page `{}`", path.display()))?;
+    Ok(())
+}
+
+fn render_mcp_tools_page() -> String {
     let mut body = String::new();
     writeln!(&mut body, "# Model Context Protocol Tools\n").ok();
     writeln!(
@@ -388,10 +396,7 @@ fn write_mcp_tools_page(out: &Path) -> Result<()> {
         writeln!(&mut body, "**Example return**\n").ok();
         writeln!(&mut body, "```json\n{}\n```\n", tool.example_return).ok();
     }
-    let path = out.join("tools.md");
-    fs::write(&path, body)
-        .with_context(|| format!("writing reference mcp tools page `{}`", path.display()))?;
-    Ok(())
+    format!("{}\n", body.trim_end())
 }
 
 fn write_index(out: &Path, bin: &str, entries: &[CommandEntry]) -> Result<()> {
@@ -617,5 +622,11 @@ mod tests {
         let build_pos = index.find("once build").expect("build entry");
         let cache_pos = index.find("once cache").expect("cache entry");
         assert!(build_pos < cache_pos);
+    }
+
+    #[test]
+    fn committed_mcp_tools_reference_matches_the_server_catalog() {
+        let committed = include_str!("../../../docs/reference/mcp/tools.md");
+        assert_eq!(committed, render_mcp_tools_page());
     }
 }

--- a/crates/once-frontend/prelude/android.star
+++ b/crates/once-frontend/prelude/android.star
@@ -14,7 +14,7 @@ def _android_is_select_shape(value):
     inner = value.get("select")
     return type(inner) == type({})
 
-def _android_config_tokens(attrs, label_id):
+def _android_config_tokens(ctx, attrs, label_id):
     for key in ["compile_sdk", "min_sdk_version", "build_type"]:
         if _android_is_select_shape(attrs.get(key)):
             fail(label_id + ": attribute `" + key + "` cannot use select() because the Android configuration depends on it")
@@ -27,8 +27,7 @@ def _android_config_tokens(attrs, label_id):
     if min_sdk:
         tokens.append("min_sdk_" + str(min_sdk))
     tokens.append(attrs.get("build_type") or "debug")
-    tokens.append("default")
-    return _unique(tokens)
+    return _configuration_tokens(ctx, tokens)
 
 def _android_select_branch(branches, tokens, label_id, attr_name):
     for token in tokens:
@@ -50,7 +49,7 @@ def _android_resolve_select(value, tokens, label_id, attr_name):
 def _android_resolve_attrs(ctx, non_configurable):
     attrs = ctx["attr"]
     label_id = ctx["label"]["id"]
-    tokens = _android_config_tokens(attrs, label_id)
+    tokens = _android_config_tokens(ctx, attrs, label_id)
     out = {}
     for key, value in attrs.items():
         if key in non_configurable and _android_is_select_shape(value):
@@ -2126,19 +2125,19 @@ _ANDROID_LOCAL_TEST_ATTRS = [
     attr("env_inherit", "list<string>", default = "[]", docs = "Host environment variable names inherited by the local test runner before explicit test environment values.", configurable = False),
     attr("test_env", "map<string,string>", default = "{}", docs = "Environment variables passed to the local test runner.", configurable = False),
     attr("args", "list<string>", default = "[]", docs = "Additional fully qualified class or `Class#method` filters passed to the local test runner.", configurable = False),
-    attr("custom_package", "string", docs = "Reserved for generated Android package overrides on local tests.", configurable = False),
-    attr("densities", "list<string>", default = "[]", docs = "Reserved for density filtering.", configurable = False),
-    attr("enable_data_binding", "bool", default = "false", docs = "Reserved for Android data binding support.", configurable = False),
+    attr("custom_package", "string", docs = "Reserved for generated Android package overrides on local tests.", configurable = False, implemented = False),
+    attr("densities", "list<string>", default = "[]", docs = "Reserved for density filtering.", configurable = False, implemented = False),
+    attr("enable_data_binding", "bool", default = "false", docs = "Reserved for Android data binding support.", configurable = False, implemented = False),
     attr("jvm_flags", "list<string>", default = "[]", docs = "Additional flags passed to the host Java virtual machine before the test classpath.", configurable = False),
-    attr("manifest", "string", docs = "Reserved for AndroidManifest.xml handling on local tests.", configurable = False),
-    attr("manifest_values", "map<string,string>", default = "{}", docs = "Reserved for manifest placeholder expansion.", configurable = False),
-    attr("nocompress_extensions", "list<string>", default = "[]", docs = "Reserved for no-compress packaging options.", configurable = False),
-    attr("plugins", "list<string>", default = "[]", docs = "Reserved for Java annotation processor support.", configurable = False),
-    attr("resource_configuration_filters", "list<string>", default = "[]", docs = "Reserved for resource filtering.", configurable = False),
-    attr("resource_jars", "list<string>", default = "[]", docs = "Reserved for resource jar inputs.", configurable = False),
-    attr("resource_strip_prefix", "string", docs = "Reserved for resource path prefix stripping.", configurable = False),
-    attr("runtime_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-style runtime-only dependencies.", configurable = False),
-    attr("stamp", "int", default = "0", docs = "Reserved for Bazel-style stamping.", configurable = False),
+    attr("manifest", "string", docs = "Reserved for AndroidManifest.xml handling on local tests.", configurable = False, implemented = False),
+    attr("manifest_values", "map<string,string>", default = "{}", docs = "Reserved for manifest placeholder expansion.", configurable = False, implemented = False),
+    attr("nocompress_extensions", "list<string>", default = "[]", docs = "Reserved for no-compress packaging options.", configurable = False, implemented = False),
+    attr("plugins", "list<string>", default = "[]", docs = "Reserved for Java annotation processor support.", configurable = False, implemented = False),
+    attr("resource_configuration_filters", "list<string>", default = "[]", docs = "Reserved for resource filtering.", configurable = False, implemented = False),
+    attr("resource_jars", "list<string>", default = "[]", docs = "Reserved for resource jar inputs.", configurable = False, implemented = False),
+    attr("resource_strip_prefix", "string", docs = "Reserved for resource path prefix stripping.", configurable = False, implemented = False),
+    attr("runtime_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-style runtime-only dependencies.", configurable = False, implemented = False),
+    attr("stamp", "int", default = "0", docs = "Reserved for Bazel-style stamping.", configurable = False, implemented = False),
     attr("test_class", "string", docs = "Optional fully qualified test class or `Class#method` filter.", configurable = False),
     attr("labels", "list<string>", default = "[]", docs = "Labels exposed through once_test_info for test discovery.", configurable = True),
     attr("timeout_ms", "int", docs = "Optional test timeout in milliseconds.", configurable = False),
@@ -2162,7 +2161,7 @@ _ANDROID_INSTRUMENTATION_TEST_ATTRS = [
     attr("test_env", "map<string,string>", default = "{}", docs = "Environment variables passed to the host instrumentation runner.", configurable = False),
     attr("args", "list<string>", default = "[]", docs = "Raw arguments appended to the Android instrumentation command before its component.", configurable = False),
     attr("support_apks", "list<string>", default = "[]", docs = "Package-relative application package globs installed before the instrumentation application.", configurable = False),
-    attr("target_device", "string", docs = "Reserved for Bazel-style device target selection.", configurable = False),
+    attr("target_device", "string", docs = "Reserved for Bazel-style device target selection.", configurable = False, implemented = False),
     attr("labels", "list<string>", default = "[]", docs = "Labels exposed through once_test_info for test discovery.", configurable = True),
     attr("timeout_ms", "int", docs = "Optional test timeout in milliseconds.", configurable = False),
 ]
@@ -2263,13 +2262,13 @@ android_library = target_kind(
         attr("custom_package", "string", docs = "Alias for the generated R package.", configurable = False),
         attr("package", "string", docs = "Generated R package fallback when namespace and custom_package are omitted.", configurable = False),
         attr("neverlink", "bool", default = "false", docs = "Keep the library on compile classpaths while omitting its runtime dependency closure from application classpaths.", configurable = False),
-        attr("enable_data_binding", "bool", default = "false", docs = "Reserved for Android data binding support.", configurable = False),
-        attr("idl_srcs", "list<string>", default = "[]", docs = "Reserved for Android Interface Definition Language support.", configurable = False),
-        attr("idl_import_root", "string", docs = "Reserved for Android Interface Definition Language support.", configurable = False),
-        attr("idl_parcelables", "list<string>", default = "[]", docs = "Reserved for Android Interface Definition Language support.", configurable = False),
-        attr("idl_preprocessed", "list<string>", default = "[]", docs = "Reserved for Android Interface Definition Language support.", configurable = False),
-        attr("plugins", "list<string>", default = "[]", docs = "Reserved for Java annotation processor support.", configurable = False),
-        attr("proguard_specs", "list<string>", default = "[]", docs = "Reserved for consumer ProGuard specs.", configurable = False),
+        attr("enable_data_binding", "bool", default = "false", docs = "Reserved for Android data binding support.", configurable = False, implemented = False),
+        attr("idl_srcs", "list<string>", default = "[]", docs = "Reserved for Android Interface Definition Language support.", configurable = False, implemented = False),
+        attr("idl_import_root", "string", docs = "Reserved for Android Interface Definition Language support.", configurable = False, implemented = False),
+        attr("idl_parcelables", "list<string>", default = "[]", docs = "Reserved for Android Interface Definition Language support.", configurable = False, implemented = False),
+        attr("idl_preprocessed", "list<string>", default = "[]", docs = "Reserved for Android Interface Definition Language support.", configurable = False, implemented = False),
+        attr("plugins", "list<string>", default = "[]", docs = "Reserved for Java annotation processor support.", configurable = False, implemented = False),
+        attr("proguard_specs", "list<string>", default = "[]", docs = "Reserved for consumer ProGuard specs.", configurable = False, implemented = False),
     ],
     deps = [
         dep("deps", ["android_library", "android_resource", "android_native_library"], "Android libraries, resources, and native libraries consumed by this library."),
@@ -2346,15 +2345,15 @@ android_binary = target_kind(
         attr("emulator", "string", docs = "Override Android emulator path used by visible runs.", configurable = False),
         attr("emulator_device", "string", docs = "Android Virtual Device name started by `once run --visible` before installing the app.", configurable = False),
         attr("launch_activity", "string", docs = "Optional Android activity component launched by once run. Defaults to the launcher intent for application_id.", configurable = False),
-        attr("enable_data_binding", "bool", default = "false", docs = "Reserved for Android data binding support.", configurable = False),
+        attr("enable_data_binding", "bool", default = "false", docs = "Reserved for Android data binding support.", configurable = False, implemented = False),
         attr("instruments", "target", docs = "Application target this APK instruments when used by android_instrumentation_test.", configurable = False),
-        attr("manifest_values", "map<string,string>", default = "{}", docs = "Reserved for manifest placeholder expansion.", configurable = False),
-        attr("proguard_specs", "list<string>", default = "[]", docs = "Reserved for shrinking and obfuscation.", configurable = False),
-        attr("resource_configuration_filters", "list<string>", default = "[]", docs = "Reserved for resource filtering.", configurable = False),
-        attr("densities", "list<string>", default = "[]", docs = "Reserved for density filtering.", configurable = False),
-        attr("nocompress_extensions", "list<string>", default = "[]", docs = "Reserved for no-compress packaging options.", configurable = False),
-        attr("startup_profiles", "list<string>", default = "[]", docs = "Reserved for ART startup profile packaging.", configurable = False),
-        attr("native_target", "target", docs = "Reserved for native Android split support.", configurable = False),
+        attr("manifest_values", "map<string,string>", default = "{}", docs = "Reserved for manifest placeholder expansion.", configurable = False, implemented = False),
+        attr("proguard_specs", "list<string>", default = "[]", docs = "Reserved for shrinking and obfuscation.", configurable = False, implemented = False),
+        attr("resource_configuration_filters", "list<string>", default = "[]", docs = "Reserved for resource filtering.", configurable = False, implemented = False),
+        attr("densities", "list<string>", default = "[]", docs = "Reserved for density filtering.", configurable = False, implemented = False),
+        attr("nocompress_extensions", "list<string>", default = "[]", docs = "Reserved for no-compress packaging options.", configurable = False, implemented = False),
+        attr("startup_profiles", "list<string>", default = "[]", docs = "Reserved for ART startup profile packaging.", configurable = False, implemented = False),
+        attr("native_target", "target", docs = "Reserved for native Android split support.", configurable = False, implemented = False),
     ],
     deps = [
         dep("deps", ["android_library", "android_resource", "android_native_library"], "Android libraries, resources, and native shared libraries packaged into the APK."),

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -545,7 +545,7 @@ def _is_select_shape(value):
 # them is a select-shape dict instead of resolving to a misleading
 # empty token list.
 
-def _apple_config_tokens(attrs, label_id):
+def _apple_config_tokens(ctx, attrs, label_id):
     for input_key in ["platform", "sdk_variant", "archs", "mac_catalyst"]:
         if _is_select_shape(attrs.get(input_key)):
             fail(label_id + ": attribute `" + input_key + "` cannot use select() because the configuration depends on it")
@@ -566,7 +566,7 @@ def _apple_config_tokens(attrs, label_id):
                 tokens.append(arch)
     if attrs.get("mac_catalyst"):
         tokens.append("mac_catalyst")
-    return tokens
+    return _configuration_tokens(ctx, tokens)
 
 def _select_branch_for_tokens(branches, tokens, label_id, attr_name):
     matching = []
@@ -606,8 +606,8 @@ def _resolve_select(value, tokens, label_id, attr_name):
         return {k: _resolve_select(v, tokens, label_id, attr_name) for k, v in value.items()}
     return value
 
-def _resolve_attrs(attrs, label_id, non_configurable):
-    tokens = _apple_config_tokens(attrs, label_id)
+def _resolve_attrs(ctx, attrs, label_id, non_configurable):
+    tokens = _apple_config_tokens(ctx, attrs, label_id)
     out = {}
     for key, value in attrs.items():
         if key in non_configurable and _is_select_shape(value):
@@ -894,7 +894,7 @@ def _apple_test_info(ctx, runner_type, command_argv, command_env, labels, result
     }
 
 def _apple_library_impl(ctx):
-    attrs = _resolve_attrs(ctx["attr"], ctx["label"]["id"], ["module_name"])
+    attrs = _resolve_attrs(ctx, ctx["attr"], ctx["label"]["id"], ["module_name"])
     platform = attrs["platform"]
     minimum_os = attrs.get("minimum_os") or "13.0"
     target_sdk_version = attrs.get("target_sdk_version") or minimum_os
@@ -1370,7 +1370,7 @@ def _apple_library_impl(ctx):
     }
 
 def _swift_macro_impl(ctx):
-    attrs = _resolve_attrs(ctx["attr"], ctx["label"]["id"], ["module_name"])
+    attrs = _resolve_attrs(ctx, ctx["attr"], ctx["label"]["id"], ["module_name"])
     minimum_os = attrs.get("minimum_os") or "13.0"
     xcode_developer_dir = attrs.get("xcode_developer_dir") or ""
     module_name = attrs.get("module_name") or ctx["label"]["name"]
@@ -1575,7 +1575,7 @@ def _collect_dep_compile_inputs(deps, build_dir):
     )
 
 def _apple_framework_impl(ctx):
-    attrs = _resolve_attrs(ctx["attr"], ctx["label"]["id"], ["product_name"])
+    attrs = _resolve_attrs(ctx, ctx["attr"], ctx["label"]["id"], ["product_name"])
     _reject_unsupported_attrs(attrs, ctx["label"]["id"], ["headers", "exported_headers", "resources", "asset_catalogs", "privacy_manifest"])
     platform = attrs["platform"]
     minimum_os = attrs.get("minimum_os") or "13.0"
@@ -1873,7 +1873,7 @@ printf '%s%s%s\\n' {record_prefix} "$simulator_id" {record_suffix} > {record}
     )
 
 def _apple_application_impl(ctx):
-    attrs = _resolve_attrs(ctx["attr"], ctx["label"]["id"], ["product_name"])
+    attrs = _resolve_attrs(ctx, ctx["attr"], ctx["label"]["id"], ["product_name"])
     _reject_unsupported_attrs(attrs, ctx["label"]["id"], ["resources", "asset_catalogs", "info_plist", "info_plist_substitutions", "entitlements", "provisioning_profile", "signing_identity"])
     if attrs.get("signing") and attrs.get("signing") != "ad_hoc":
         fail(ctx["label"]["id"] + ": attribute `signing` only supports `ad_hoc` today")
@@ -2072,7 +2072,7 @@ def _apple_application_impl(ctx):
     }
 
 def _apple_test_bundle_impl(ctx):
-    attrs = _resolve_attrs(ctx["attr"], ctx["label"]["id"], ["product_name"])
+    attrs = _resolve_attrs(ctx, ctx["attr"], ctx["label"]["id"], ["product_name"])
     _reject_unsupported_attrs(attrs, ctx["label"]["id"], ["test_host", "resources", "asset_catalogs", "info_plist", "entitlements", "destination", "test_plan"])
     platform = attrs["platform"]
     minimum_os = attrs.get("minimum_os") or "13.0"

--- a/crates/once-frontend/prelude/c.star
+++ b/crates/once-frontend/prelude/c.star
@@ -1,8 +1,5 @@
 def _c_attr(ctx, key, default):
-    value = ctx["attr"].get(key)
-    if value == None:
-        return default
-    return value
+    return _configured_attr(ctx, key, default)
 
 def _c_parent_dirs(paths):
     out = []
@@ -152,7 +149,7 @@ def _c_object_output(src):
     return declare_output("objects/" + src + _c_output_extension("object"))
 
 def _c_library_impl(ctx):
-    attrs = ctx["attr"]
+    attrs = _configured_attrs(ctx)
     sources = _c_sources(ctx)
     headers = _c_headers(ctx)
     compile_context = _c_compile_context(ctx, headers)

--- a/crates/once-frontend/prelude/common.star
+++ b/crates/once-frontend/prelude/common.star
@@ -1,4 +1,4 @@
-def attr(name, ty, required = False, default = None, docs = "", configurable = True):
+def attr(name, ty, required = False, default = None, docs = "", configurable = True, implemented = True):
     return {
         "name": name,
         "ty": ty,
@@ -6,6 +6,7 @@ def attr(name, ty, required = False, default = None, docs = "", configurable = T
         "default": default,
         "docs": docs,
         "configurable": configurable,
+        "implemented": implemented,
     }
 
 def dep(name, expected_providers, docs = ""):
@@ -157,6 +158,44 @@ def _unique(values):
             seen[value] = True
             out.append(value)
     return out
+
+def _configuration_tokens(ctx, extra = []):
+    configured = (ctx.get("configuration") or {}).get("tokens") or []
+    return _unique(extra + configured + ["default"])
+
+def _is_select_value(value):
+    return type(value) == type({}) and len(value) == 1 and type(value.get("select")) == type({})
+
+def _resolve_configured_value(value, tokens, label_id, attr_name):
+    if _is_select_value(value):
+        branches = value["select"]
+        for token in tokens:
+            if token in branches:
+                return _resolve_configured_value(branches[token], tokens, label_id, attr_name)
+        fail(label_id + ": attribute `" + attr_name + "` uses select() without a branch matching the target configuration or a `default` branch")
+    if type(value) == type([]):
+        return [_resolve_configured_value(item, tokens, label_id, attr_name) for item in value]
+    if type(value) == type({}):
+        return {key: _resolve_configured_value(item, tokens, label_id, attr_name) for key, item in value.items()}
+    return value
+
+def _configured_attr(ctx, name, default, extra_tokens = []):
+    value = ctx["attr"].get(name)
+    if value == None:
+        return default
+    return _resolve_configured_value(
+        value,
+        _configuration_tokens(ctx, extra_tokens),
+        ctx["label"]["id"],
+        name,
+    )
+
+def _configured_attrs(ctx, extra_tokens = []):
+    tokens = _configuration_tokens(ctx, extra_tokens)
+    return {
+        name: _resolve_configured_value(value, tokens, ctx["label"]["id"], name)
+        for name, value in ctx["attr"].items()
+    }
 
 def _test_unit_suffix(ctx, unit):
     prefix = ctx["label"]["id"] + "::"

--- a/crates/once-frontend/prelude/elixir.star
+++ b/crates/once-frontend/prelude/elixir.star
@@ -1,8 +1,10 @@
 def _elixir_attr(ctx, key, default):
-    value = ctx["attr"].get(key)
-    if value == None:
-        return default
-    return value
+    return _configured_attr(ctx, key, default)
+
+def _elixir_host_shell(ctx):
+    if host_os() == "windows":
+        fail(ctx["label"]["id"] + ": this Elixir action requires a POSIX-compatible shell provided by the configured toolchain")
+    return host_which("sh")
 
 def _elixir_app_name(ctx):
     return _elixir_attr(ctx, "app_name", ctx["label"]["name"].replace("-", "_").replace(".", "_"))
@@ -297,21 +299,14 @@ def _elixir_dep_symlink_script(apps, root_var, deps_root_var):
             lines.append("ln -s \"$" + root_var + "\"/" + _shell_quote(priv) + " " + app_dir + "/priv")
     return "\n".join(lines)
 
-def _elixir_copy_priv_script(ctx, priv_srcs, priv_dir):
-    if not priv_srcs:
-        return "mkdir -p \"$PRIV_OUT\""
-    lines = ["mkdir -p \"$PRIV_OUT\""]
+def _elixir_priv_destination(ctx, src, priv_dir):
     package = ctx["label"]["package"]
-    for src in priv_srcs:
-        rel = src
-        if package and rel.startswith(package + "/"):
-            rel = rel[len(package) + 1:]
-        if rel.startswith("priv/"):
-            rel = rel[len("priv/"):]
-        dest = "\"$PRIV_OUT\"/" + _shell_quote(rel)
-        lines.append("mkdir -p \"$(dirname " + dest + ")\"")
-        lines.append("cp \"$WORKSPACE_ROOT\"/" + _shell_quote(src) + " " + dest)
-    return "\n".join(lines)
+    rel = src
+    if package and rel.startswith(package + "/"):
+        rel = rel[len(package) + 1:]
+    if rel.startswith("priv/"):
+        rel = rel[len("priv/"):]
+    return priv_dir + "/" + rel
 
 def _elixir_erlang_atom(value):
     return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
@@ -322,35 +317,37 @@ def _elixir_erlang_string(value):
 def _elixir_erlang_atom_list(values):
     return "[" + ",".join([_elixir_erlang_atom(value) for value in values]) + "]"
 
-def _elixir_write_app_script(ctx, app_name, ebin_dir):
-    version = _elixir_attr(ctx, "version", "0.1.0")
-    description = _elixir_description(ctx)
-    applications = _elixir_applications(ctx)
-    included_applications = _elixir_attr(ctx, "included_applications", [])
-    registered = _elixir_attr(ctx, "registered", [])
-    app_file = app_name + ".app"
+def _elixir_app_writer_source():
+    return """
+defmodule Once.ElixirAppWriter do
+  def main do
+    ebin_dir = System.fetch_env!("ONCE_EBIN_DIR")
+    modules =
+      ebin_dir
+      |> Path.join("*.beam")
+      |> Path.wildcard()
+      |> Enum.map(&Path.basename(&1, ".beam"))
+      |> Enum.sort()
+      |> Enum.map(&("'" <> String.replace(&1, "'", "\\\\'") <> "'"))
+      |> Enum.join(",")
+
     lines = [
-        "MODULES_FILE=\"$STAGE_ROOT/modules.txt\"",
-        "find \"$EBIN_OUT\" -maxdepth 1 -type f -name '*.beam' | sort > \"$MODULES_FILE\"",
-        "modules=\"\"",
-        "while IFS= read -r beam; do",
-        "  name=$(basename \"$beam\" .beam)",
-        "  escaped=$(printf '%s' \"$name\" | sed \"s/'/\\\\'/g\")",
-        "  if [ -n \"$modules\" ]; then modules=\"$modules,\"; fi",
-        "  modules=\"$modules'$escaped'\"",
-        "done < \"$MODULES_FILE\"",
-        "{",
-        "  printf '%s\\n' " + _shell_quote("{application, " + _elixir_erlang_atom(app_name) + ","),
-        "  printf '%s\\n' " + _shell_quote(" [{description, " + _elixir_erlang_string(description) + "},"),
-        "  printf '%s\\n' " + _shell_quote("  {vsn, " + _elixir_erlang_string(version) + "},"),
-        "  printf '%s\\n' " + _shell_quote("  {registered, " + _elixir_erlang_atom_list(registered) + "},"),
-        "  printf '%s\\n' " + _shell_quote("  {applications, " + _elixir_erlang_atom_list(applications) + "},"),
-        "  printf '%s\\n' " + _shell_quote("  {included_applications, " + _elixir_erlang_atom_list(included_applications) + "},"),
-        "  printf '  {modules, [%s]},\\n' \"$modules\"",
-        "  printf '%s\\n' " + _shell_quote("  {env, []}]}." ),
-        "} > \"$EBIN_OUT\"/" + _shell_quote(app_file),
+      "{application, " <> System.fetch_env!("ONCE_APP_NAME") <> ",",
+      " [{description, " <> System.fetch_env!("ONCE_APP_DESCRIPTION") <> "},",
+      "  {vsn, " <> System.fetch_env!("ONCE_APP_VERSION") <> "},",
+      "  {registered, " <> System.fetch_env!("ONCE_APP_REGISTERED") <> "},",
+      "  {applications, " <> System.fetch_env!("ONCE_APP_APPLICATIONS") <> "},",
+      "  {included_applications, " <> System.fetch_env!("ONCE_APP_INCLUDED_APPLICATIONS") <> "},",
+      "  {modules, [" <> modules <> "]},",
+      "  {env, []}]}."
     ]
-    return "\n".join(lines)
+
+    File.write!(System.fetch_env!("ONCE_APP_FILE"), Enum.join(lines, "\\n") <> "\\n")
+  end
+end
+
+Once.ElixirAppWriter.main()
+"""
 
 def _elixir_stale_fingerprint_source():
     return """
@@ -702,46 +699,6 @@ end
 Once.ElixirCompiler.main()
 """
 
-def _elixir_stage_script(ctx, apps, module_dirs, priv_srcs, ebin_dir, priv_dir):
-    app_name = _elixir_app_name(ctx)
-    mix_env = _elixir_mix_env(ctx)
-    stage_root = ctx["scratch_dir"] + "/stage"
-    deps_root = ctx["scratch_dir"] + "/stage_deps"
-    user_env = _elixir_user_env(ctx)
-    copy_modules = []
-    for module_dir in module_dirs:
-        copy_modules.append("if [ -d \"$WORKSPACE_ROOT\"/" + _shell_quote(module_dir) + " ]; then find \"$WORKSPACE_ROOT\"/" + _shell_quote(module_dir) + " -maxdepth 1 -type f -name '*.beam' -exec cp {} \"$EBIN_OUT\"/ \\;; fi")
-    return """set -eu
-WORKSPACE_ROOT="$PWD"
-STAGE_ROOT={stage_root}
-DEPS_ROOT={deps_root}
-EBIN_OUT={ebin_dir}
-PRIV_OUT={priv_dir}
-rm -rf "$STAGE_ROOT" "$DEPS_ROOT" "$EBIN_OUT" "$PRIV_OUT"
-mkdir -p "$STAGE_ROOT" "$DEPS_ROOT" "$EBIN_OUT" "$PRIV_OUT"
-{dep_symlinks}
-cd {package}
-{user_env}
-export MIX_ENV={mix_env}
-export HEX_OFFLINE=true
-export ERL_LIBS="$WORKSPACE_ROOT/$DEPS_ROOT"
-{copy_modules}
-{write_app}
-{copy_priv}
-""".format(
-        stage_root = _shell_quote(stage_root),
-        deps_root = _shell_quote(deps_root),
-        ebin_dir = _shell_quote(ebin_dir),
-        priv_dir = _shell_quote(priv_dir),
-        dep_symlinks = _elixir_dep_symlink_script(apps, "WORKSPACE_ROOT", "DEPS_ROOT"),
-        package = _shell_quote(ctx["label"]["package"] or "."),
-        user_env = _elixir_export_env(user_env),
-        mix_env = _shell_quote(mix_env),
-        copy_modules = "\n".join(copy_modules),
-        write_app = _elixir_write_app_script(ctx, app_name, ebin_dir),
-        copy_priv = _elixir_copy_priv_script(ctx, priv_srcs, priv_dir),
-    )
-
 def _elixir_compile_args(ctx):
     return _elixir_attr(ctx, "compile_args", []) + _elixir_attr(ctx, "elixirc_opts", [])
 
@@ -887,13 +844,41 @@ def _elixir_library_impl(ctx):
         _elixir_stale_fingerprint_action(ctx, toolchain, metadata_path, config, ebin_dir, stale_fingerprint)
         compile_action_inputs = _unique(compile_action_inputs + [stale_fingerprint])
     _elixir_compile_action(ctx, toolchain, apps, srcs, static_compile_inputs, config, compile_args, compile_action_inputs, module_dir, metadata_path, warnings_path, consolidated_dir, compile_cacheable)
+    copy_path(
+        module_dirs,
+        ebin_dir,
+        kind = "tree",
+        toolchain_identity = toolchain["identity"] + "\x00elixir-stage-modules.v2",
+        identifier = ctx["label"]["id"] + ":elixir-stage-modules",
+    )
+    prepare_path(priv_dir, kind = "remove", identifier = ctx["label"]["id"] + ":elixir-stage-priv-clean")
+    prepare_path(priv_dir, kind = "directory", identifier = ctx["label"]["id"] + ":elixir-stage-priv")
+    for src in priv_srcs:
+        copy_path(
+            src,
+            _elixir_priv_destination(ctx, src, priv_dir),
+            inputs = [src],
+            toolchain_identity = toolchain["identity"] + "\x00elixir-stage-priv.v2",
+            identifier = ctx["label"]["id"] + ":elixir-stage-priv:" + src,
+        )
+    app_writer = ctx["scratch_dir"] + "/app_writer.exs"
+    app_file = ebin_dir + "/" + app_name + ".app"
+    write_path(app_writer, _elixir_app_writer_source())
     run_action(
-        argv = ["/bin/sh", "-c", _elixir_stage_script(ctx, apps, module_dirs, priv_srcs, ebin_dir, priv_dir)],
-        inputs = _unique(_elixir_optional_inputs(priv_srcs + [mix_config])),
-        outputs = [ebin_dir, priv_dir],
-        env = _elixir_action_env(toolchain),
-        toolchain_identity = toolchain["identity"] + "\x00elixir-stage.v1\x00mix_env\x00" + mix_env,
-        identifier = ctx["label"]["id"] + ":elixir-stage",
+        argv = [toolchain["elixir"], app_writer],
+        outputs = [app_file],
+        env = _elixir_action_env_with(ctx, toolchain, {
+            "ONCE_EBIN_DIR": ebin_dir,
+            "ONCE_APP_FILE": app_file,
+            "ONCE_APP_NAME": _elixir_erlang_atom(app_name),
+            "ONCE_APP_DESCRIPTION": _elixir_erlang_string(_elixir_description(ctx)),
+            "ONCE_APP_VERSION": _elixir_erlang_string(_elixir_attr(ctx, "version", "0.1.0")),
+            "ONCE_APP_REGISTERED": _elixir_erlang_atom_list(_elixir_attr(ctx, "registered", [])),
+            "ONCE_APP_APPLICATIONS": _elixir_erlang_atom_list(_elixir_applications(ctx)),
+            "ONCE_APP_INCLUDED_APPLICATIONS": _elixir_erlang_atom_list(_elixir_attr(ctx, "included_applications", [])),
+        }),
+        toolchain_identity = toolchain["identity"] + "\x00elixir-stage-app.v2\x00mix_env\x00" + mix_env,
+        identifier = ctx["label"]["id"] + ":elixir-stage-app",
     )
     app = {
         "app_name": app_name,
@@ -1131,7 +1116,7 @@ def _elixir_test_impl(ctx):
     provider["affected_inputs"] = _unique(_elixir_optional_inputs(input_srcs + config + data + tools + [mix_config]))
     provider["test_info"] = _elixir_test_info_for(ctx, toolchain["mix"] if mix_config else toolchain["elixir"], mix_config, srcs, results, log, native_results)
     run_action(
-        argv = ["/bin/sh", "-c", _elixir_test_script(ctx, toolchain, lib, apps, srcs, config, data, mix_config, results, log, native_results)],
+        argv = [_elixir_host_shell(ctx), "-c", _elixir_test_script(ctx, toolchain, lib, apps, srcs, config, data, mix_config, results, log, native_results)],
         inputs = provider["affected_inputs"],
         outputs = [test_dir, results, log, native_results],
         env = _elixir_action_env(toolchain),
@@ -1715,17 +1700,17 @@ _ELIXIR_LIBRARY_ATTRS = [
     attr("env", "map<string, string>", default = "{}", docs = "Environment variables exported before running Elixir compile and test commands.", configurable = False),
     attr("compile_args", "list<string>", default = "[]", docs = "Additional arguments appended to `elixirc`.", configurable = False),
     attr("elixirc_opts", "list<string>", default = "[]", docs = "Bazel-compatible alias for additional `elixirc` arguments.", configurable = False),
-    attr("app_src", "string", docs = "Reserved for Buck-compatible application source file generation.", configurable = False),
-    attr("app_src_vsn", "string", docs = "Reserved for Buck-compatible application source versions.", configurable = False),
-    attr("appup_src", "string", docs = "Reserved for Buck-compatible upgrade files.", configurable = False),
-    attr("erl_opts", "list<string>", default = "[]", docs = "Reserved for Erlang compiler options.", configurable = False),
-    attr("ez_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-compatible archive dependencies.", configurable = False),
-    attr("extra_includes", "list<string>", default = "[]", docs = "Reserved for Buck-compatible include directories.", configurable = False),
-    attr("extra_properties", "map<string, string>", default = "{}", docs = "Reserved for extra application metadata properties.", configurable = False),
-    attr("include_src", "bool", default = "false", docs = "Reserved for Buck-compatible source inclusion.", configurable = False),
-    attr("mod", "string", docs = "Reserved for application callback module metadata.", configurable = False),
-    attr("shell_configs", "list<string>", default = "[]", docs = "Reserved for Buck-compatible shell configuration files.", configurable = False),
-    attr("shell_libs", "list<string>", default = "[]", docs = "Reserved for Buck-compatible shell libraries.", configurable = False),
+    attr("app_src", "string", docs = "Reserved for Buck-compatible application source file generation.", configurable = False, implemented = False),
+    attr("app_src_vsn", "string", docs = "Reserved for Buck-compatible application source versions.", configurable = False, implemented = False),
+    attr("appup_src", "string", docs = "Reserved for Buck-compatible upgrade files.", configurable = False, implemented = False),
+    attr("erl_opts", "list<string>", default = "[]", docs = "Reserved for Erlang compiler options.", configurable = False, implemented = False),
+    attr("ez_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-compatible archive dependencies.", configurable = False, implemented = False),
+    attr("extra_includes", "list<string>", default = "[]", docs = "Reserved for Buck-compatible include directories.", configurable = False, implemented = False),
+    attr("extra_properties", "map<string, string>", default = "{}", docs = "Reserved for extra application metadata properties.", configurable = False, implemented = False),
+    attr("include_src", "bool", default = "false", docs = "Reserved for Buck-compatible source inclusion.", configurable = False, implemented = False),
+    attr("mod", "string", docs = "Reserved for application callback module metadata.", configurable = False, implemented = False),
+    attr("shell_configs", "list<string>", default = "[]", docs = "Reserved for Buck-compatible shell configuration files.", configurable = False, implemented = False),
+    attr("shell_libs", "list<string>", default = "[]", docs = "Reserved for Buck-compatible shell libraries.", configurable = False, implemented = False),
 ]
 
 _ELIXIR_TEST_ATTRS = [
@@ -1740,7 +1725,7 @@ _ELIXIR_TEST_ATTRS = [
     attr("elixir_opts", "list<string>", default = "[]", docs = "Bazel-compatible options passed to the direct Elixir interpreter before test files. Not supported with `mix_config`.", configurable = False),
     attr("setup", "string", default = "", docs = "Shell snippet run after the test environment is prepared and before ExUnit starts.", configurable = False),
     attr("no_start", "bool", default = "false", docs = "Pass `--no-start` to `mix test` when `mix_config` enables Mix mode.", configurable = False),
-    attr("ez_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-compatible archive dependencies.", configurable = False),
+    attr("ez_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-compatible archive dependencies.", configurable = False, implemented = False),
     attr("tools", "list<string>", default = "[]", docs = "Package-relative executable or support-file globs available to the test setup command.", configurable = False),
     attr("labels", "list<string>", default = "[]", docs = "Labels exposed through once_test_info for test discovery.", configurable = True),
     attr("timeout_ms", "int", docs = "Optional test timeout in milliseconds.", configurable = False),

--- a/crates/once-frontend/prelude/examples/go-binary-minimal/cmd/hello/main.go
+++ b/crates/once-frontend/prelude/examples/go-binary-minimal/cmd/hello/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, Once!")
+}

--- a/crates/once-frontend/prelude/examples/go-binary-minimal/go.mod
+++ b/crates/once-frontend/prelude/examples/go-binary-minimal/go.mod
@@ -1,0 +1,3 @@
+module example.com/once-go-minimal
+
+go 1.26.0

--- a/crates/once-frontend/prelude/examples/go-binary-minimal/once.toml
+++ b/crates/once-frontend/prelude/examples/go-binary-minimal/once.toml
@@ -1,0 +1,7 @@
+[[target]]
+name = "Hello"
+kind = "go_binary"
+srcs = ["cmd/hello/main.go"]
+
+[target.attrs]
+package = "./cmd/hello"

--- a/crates/once-frontend/prelude/examples/rust-binary-minimal/once.toml
+++ b/crates/once-frontend/prelude/examples/rust-binary-minimal/once.toml
@@ -1,0 +1,8 @@
+[[target]]
+name = "Hello"
+kind = "rust_binary"
+srcs = ["src/**/*.rs"]
+
+[target.attrs]
+crate_name = "hello"
+edition = "2021"

--- a/crates/once-frontend/prelude/examples/rust-binary-minimal/src/main.rs
+++ b/crates/once-frontend/prelude/examples/rust-binary-minimal/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, Once!");
+}

--- a/crates/once-frontend/prelude/go.star
+++ b/crates/once-frontend/prelude/go.star
@@ -72,7 +72,7 @@ def _go_target_arch(ctx):
 def _go_config_tokens(ctx):
     goos = _go_target_os(ctx)
     goarch = _go_target_arch(ctx)
-    return [goos + "-" + goarch, goos, goarch, "default"]
+    return _configuration_tokens(ctx, [goos + "-" + goarch, goos, goarch])
 
 def _go_trim_slashes(value):
     out = value.replace("\\", "/")
@@ -1448,6 +1448,14 @@ _GO_EXAMPLE = [
     ),
 ]
 
+_GO_BINARY_EXAMPLES = [
+    example(
+        "go-binary-minimal",
+        name = "Minimal Go executable",
+        use_when = "Start here for a runnable Go command with no external dependencies.",
+    ),
+] + _GO_EXAMPLE
+
 go_dependencies = target_kind(
     docs = "Locked Go module graph read from go.mod or go.work checksum files and materialized from vendor sources.",
     attrs = [
@@ -1523,7 +1531,7 @@ go_binary = target_kind(
     deps = _GO_DEP_EDGES,
     providers = ["go_package", "go_binary", "c_provider", "native_linkable", "apple_linkable", "android_native_library"],
     capabilities = [capability("build", ["binary"]), capability("run", ["default"], ["binary"])],
-    examples = _GO_EXAMPLE,
+    examples = _GO_BINARY_EXAMPLES,
     source_references = _GO_BINARY_REFERENCES,
     tools = [_GO_TOOL],
     impl = _go_binary_impl,

--- a/crates/once-frontend/prelude/javascript.star
+++ b/crates/once-frontend/prelude/javascript.star
@@ -25,6 +25,15 @@ def _javascript_env(ctx, test_dir, node):
         env[name] = value
     return env
 
+def _javascript_installed_package_entry(resolved, default):
+    normalized = resolved.replace("\\", "/")
+    bin_dir = _parent_dir(normalized)
+    node_modules_dir = _parent_dir(bin_dir)
+    prefix = "node_modules/"
+    if not bin_dir.endswith("/.bin") or not default.startswith(prefix):
+        return ""
+    return _resolve_host_executable(node_modules_dir + "/" + default[len(prefix):])
+
 def _javascript_runner(ctx, runner_type, default):
     requested = ctx["attr"].get("runner")
     if requested:
@@ -37,6 +46,9 @@ def _javascript_runner(ctx, runner_type, default):
         resolved = _resolve_host_executable(package_path)
         if not resolved:
             fail(ctx["label"]["id"] + ": " + runner_type + " runner `" + requested + "` was not found")
+        installed_entry = _javascript_installed_package_entry(resolved, default)
+        if installed_entry:
+            return (installed_entry, installed_entry.endswith(".js") or installed_entry.endswith(".mjs"), False)
         return (resolved if absolute else package_path, requested.endswith(".js") or requested.endswith(".mjs"), not absolute)
 
     package_path = _package_relative(ctx, default)
@@ -44,6 +56,9 @@ def _javascript_runner(ctx, runner_type, default):
         return (package_path, True, True)
     resolved = _resolve_host_executable(runner_type)
     if resolved:
+        installed_entry = _javascript_installed_package_entry(resolved, default)
+        if installed_entry:
+            return (installed_entry, installed_entry.endswith(".js") or installed_entry.endswith(".mjs"), False)
         return (resolved, False, False)
     fail(ctx["label"]["id"] + ": " + runner_type + " runner was not found; install it in the workspace or make `" + runner_type + "` available on PATH")
 

--- a/crates/once-frontend/prelude/javascript.star
+++ b/crates/once-frontend/prelude/javascript.star
@@ -1,8 +1,9 @@
 _JAVASCRIPT_TOOL = tool("node", executables = ["node"])
+_VITEST_TOOL = tool("vitest", executables = ["vitest"])
+_JEST_TOOL = tool("jest", executables = ["jest"])
 
 def _javascript_attr(ctx, name, default):
-    value = ctx["attr"].get(name)
-    return default if value == None else value
+    return _configured_attr(ctx, name, default)
 
 def _javascript_node(ctx):
     requested = _javascript_attr(ctx, "node", "node")
@@ -11,8 +12,11 @@ def _javascript_node(ctx):
         fail(ctx["label"]["id"] + ": Node.js executable `" + requested + "` was not found")
     return resolved
 
-def _javascript_env(ctx, test_dir):
+def _javascript_env(ctx, test_dir, node):
     env = {"HOME": test_dir + "/home", "CI": "1"}
+    node_dir = _parent_dir(node)
+    if node_dir:
+        env["PATH"] = node_dir
     for name in _javascript_attr(ctx, "env_inherit", []):
         value = host_env(name)
         if value:
@@ -21,15 +25,34 @@ def _javascript_env(ctx, test_dir):
         env[name] = value
     return env
 
-def _javascript_runner_path(ctx, default):
-    value = _javascript_attr(ctx, "runner", default)
-    return _package_relative(ctx, value)
+def _javascript_runner(ctx, runner_type, default):
+    requested = ctx["attr"].get("runner")
+    if requested:
+        if "/" not in requested and "\\" not in requested:
+            resolved = _resolve_host_executable(requested)
+            if resolved:
+                return (resolved, False, False)
+        absolute = requested.startswith("/") or (len(requested) > 2 and requested[1] == ":" and (requested[2] == "/" or requested[2] == "\\"))
+        package_path = requested if absolute else _package_relative(ctx, requested)
+        resolved = _resolve_host_executable(package_path)
+        if not resolved:
+            fail(ctx["label"]["id"] + ": " + runner_type + " runner `" + requested + "` was not found")
+        return (resolved if absolute else package_path, requested.endswith(".js") or requested.endswith(".mjs"), not absolute)
+
+    package_path = _package_relative(ctx, default)
+    if _resolve_host_executable(package_path):
+        return (package_path, True, True)
+    resolved = _resolve_host_executable(runner_type)
+    if resolved:
+        return (resolved, False, False)
+    fail(ctx["label"]["id"] + ": " + runner_type + " runner was not found; install it in the workspace or make `" + runner_type + "` available on PATH")
 
 def _javascript_discovery_inputs(ctx):
     return _unique(glob(ctx["srcs"]) + _file_globs(_javascript_attr(ctx, "config", [])) + _file_globs(_javascript_attr(ctx, "data", [])))
 
-def _javascript_test_inputs(ctx, runner, discovery_inputs):
-    return _unique(discovery_inputs + _file_globs(_javascript_attr(ctx, "dependencies", [])) + glob([runner]))
+def _javascript_test_inputs(ctx, runner, runner_is_workspace_input, discovery_inputs):
+    runner_inputs = glob([runner]) if runner_is_workspace_input else []
+    return _unique(discovery_inputs + _file_globs(_javascript_attr(ctx, "dependencies", [])) + runner_inputs)
 
 def _javascript_test_adapter():
     return '''import { spawnSync } from "node:child_process"
@@ -90,15 +113,17 @@ function main() {
   const files = units.length ? [...new Set(units.map(unit => unit.file))] : options.sources
   const names = units.map(unit => unit.name)
   const namePattern = names.length ? "^(?:" + names.map(escapePattern).join("|") + ")$" : null
-  let args
+  let runnerArgs
   if (options.runner_type === "vitest") {
-    args = [options.runner, "run", ...options.runnerArgs, "--no-cache", "--reporter=json", "--outputFile=" + options.native_results, ...files]
-    if (namePattern) args.push("--testNamePattern", namePattern)
+    runnerArgs = ["run", ...options.runnerArgs, "--no-cache", "--reporter=json", "--outputFile=" + options.native_results, ...files]
+    if (namePattern) runnerArgs.push("--testNamePattern", namePattern)
   } else {
-    args = [options.runner, ...options.runnerArgs, "--no-cache", "--runInBand", "--json", "--outputFile=" + options.native_results, "--runTestsByPath", ...files]
-    if (namePattern) args.push("--testNamePattern", namePattern)
+    runnerArgs = [...options.runnerArgs, "--no-cache", "--runInBand", "--json", "--outputFile=" + options.native_results, "--runTestsByPath", ...files]
+    if (namePattern) runnerArgs.push("--testNamePattern", namePattern)
   }
-  const execution = spawnSync(process.execPath, args, { encoding: "utf8", env: process.env })
+  const command = options.runner_via_node === "true" ? process.execPath : options.runner
+  const args = options.runner_via_node === "true" ? [options.runner, ...runnerArgs] : runnerArgs
+  const execution = spawnSync(command, args, { encoding: "utf8", env: process.env })
   if (execution.stdout) process.stdout.write(execution.stdout)
   if (execution.stderr) process.stderr.write(execution.stderr)
   const exitCode = execution.status ?? 1
@@ -177,7 +202,7 @@ def _javascript_test_info(ctx, runner_type, display_name, node, runner, adapter,
         "schema": "once.test_info.v1",
         "target": ctx["label"]["id"],
         "runner": {"type": runner_type, "display_name": display_name, "metadata": {}},
-        "command": {"argv": [node, adapter], "env": _javascript_env(ctx, test_dir), "cwd": "."},
+        "command": {"argv": [node, adapter], "env": _javascript_env(ctx, test_dir, node), "cwd": "."},
         "outputs": {"results": results, "logs": [log], "native_results": [native_results], "coverage": []},
         "listing": {"supported": True, "strategy": "normalized_results"},
         "filtering": {"case_filtering": "runner_args"},
@@ -190,9 +215,9 @@ def _javascript_test_info(ctx, runner_type, display_name, node, runner, adapter,
 
 def _javascript_test_impl(ctx, runner_type, display_name, default_runner):
     node = _javascript_node(ctx)
-    runner = _javascript_runner_path(ctx, default_runner)
+    runner, runner_via_node, runner_is_workspace_input = _javascript_runner(ctx, runner_type, default_runner)
     discovery_inputs = _javascript_discovery_inputs(ctx)
-    inputs = _javascript_test_inputs(ctx, runner, discovery_inputs)
+    inputs = _javascript_test_inputs(ctx, runner, runner_is_workspace_input, discovery_inputs)
     test_dir = _test_output_dir(ctx)
     results = test_dir + "/test_results.json"
     log = test_dir + "/" + runner_type + ".log"
@@ -203,7 +228,7 @@ def _javascript_test_impl(ctx, runner_type, display_name, default_runner):
     if ctx["capability"] != "test":
         return provider
     write_path(adapter, _javascript_test_adapter())
-    argv = [node, adapter, "--once-runner-type", runner_type, "--once-runner", runner, "--once-results", results, "--once-native-results", native_results, "--once-target", ctx["label"]["id"]]
+    argv = [node, adapter, "--once-runner-type", runner_type, "--once-runner", runner, "--once-runner-via-node", "true" if runner_via_node else "false", "--once-results", results, "--once-native-results", native_results, "--once-target", ctx["label"]["id"]]
     for source in glob(ctx["srcs"]):
         argv.extend(["--once-source", source])
     for unit in (ctx.get("test") or {}).get("filters") or []:
@@ -211,16 +236,18 @@ def _javascript_test_impl(ctx, runner_type, display_name, default_runner):
     argv.append("--")
     argv.extend(_javascript_attr(ctx, "args", []))
     version = host_command([node, "--version"]).strip()
+    runner_version_argv = ([node, runner] if runner_via_node else [runner]) + ["--version"]
+    runner_version = host_command(runner_version_argv, cwd = workspace_root()).strip() if runner_is_workspace_input else host_command(runner_version_argv).strip()
     run_action(
         argv = argv,
         inputs = _unique(inputs + [adapter]),
         outputs = [test_dir, results, log, native_results],
         clean_paths = [results, log, native_results],
         create_dirs = [test_dir, test_dir + "/home"],
-        env = _javascript_env(ctx, test_dir),
+        env = _javascript_env(ctx, test_dir, node),
         stdout = log,
         stderr = log,
-        toolchain_identity = "once." + runner_type + ".v1\x00" + node + "\x00" + version,
+        toolchain_identity = "once." + runner_type + ".v2\x00" + node + "\x00" + version + "\x00" + runner + "\x00" + runner_version,
         identifier = ctx["label"]["id"] + ":" + runner_type,
     )
     return provider
@@ -234,7 +261,7 @@ def _jest_impl(ctx):
 def _javascript_test_attrs(runner, display_name):
     return [
         attr("node", "string", default = "\"node\"", docs = "Node.js executable name, absolute path, or workspace-relative path.", configurable = False),
-        attr("runner", "string", default = "\"" + runner + "\"", docs = "Package-relative " + display_name + " entry point.", configurable = False),
+        attr("runner", "string", default = "\"" + runner + "\"", docs = "Package-relative " + display_name + " entry point or executable. When omitted, Once uses the package entry point when present, then searches PATH for the runner.", configurable = False),
         attr("config", "list<string>", default = "[\"package.json\", \"package-lock.json\", \"pnpm-lock.yaml\", \"yarn.lock\"]", docs = "Configuration and dependency inputs.", configurable = False),
         attr("dependencies", "list<string>", default = "[\"node_modules/**/*\"]", docs = "Installed runner and package files required during execution.", configurable = False),
         attr("data", "list<string>", default = "[]", docs = "Runtime data, setup, transform, snapshot, and runner package inputs.", configurable = False),
@@ -252,7 +279,7 @@ vitest_test = target_kind(
     deps = [dep("deps", [], "Targets whose inputs should affect this test suite.")],
     providers = ["once_test_info"],
     capabilities = [capability("test", ["default", "test_results", "logs"])],
-    tools = [_JAVASCRIPT_TOOL],
+    tools = [_JAVASCRIPT_TOOL, _VITEST_TOOL],
     examples = [example("vitest-test-minimal", name = "Minimal Vitest suite", use_when = "You want JavaScript or TypeScript tests scheduled by file through Once.")],
     impl = _vitest_impl,
 )
@@ -263,7 +290,7 @@ jest_test = target_kind(
     deps = [dep("deps", [], "Targets whose inputs should affect this test suite.")],
     providers = ["once_test_info"],
     capabilities = [capability("test", ["default", "test_results", "logs"])],
-    tools = [_JAVASCRIPT_TOOL],
+    tools = [_JAVASCRIPT_TOOL, _JEST_TOOL],
     examples = [example("jest-test-minimal", name = "Minimal Jest suite", use_when = "You want JavaScript or TypeScript Jest tests scheduled by file through Once.")],
     impl = _jest_impl,
 )

--- a/crates/once-frontend/prelude/kotlin.star
+++ b/crates/once-frontend/prelude/kotlin.star
@@ -66,7 +66,7 @@ def _kotlin_apple_java_env(attrs):
     return env
 
 def _kotlin_apple_framework_impl(ctx):
-    attrs = ctx["attr"]
+    attrs = _configured_attrs(ctx)
     platform = _kotlin_apple_attr(attrs, "platform", "")
     if not platform:
         fail(ctx["label"]["id"] + ": `platform` is required")
@@ -175,10 +175,7 @@ kotlin_apple_framework = target_kind(
 )
 
 def _kotlin_jvm_attr(ctx, key, default):
-    value = ctx["attr"].get(key)
-    if value == None:
-        return default
-    return value
+    return _configured_attr(ctx, key, default)
 
 def _kotlin_jvm_dependency_role(ctx, name):
     return (ctx.get("deps_by_role") or {}).get(name) or []

--- a/crates/once-frontend/prelude/python.star
+++ b/crates/once-frontend/prelude/python.star
@@ -1,8 +1,8 @@
 _PYTHON_TOOL = tool("python", executables = ["python3", "python"])
+_PYTEST_TOOL = tool("pytest", executables = ["pytest"])
 
 def _python_attr(ctx, name, default):
-    value = ctx["attr"].get(name)
-    return default if value == None else value
+    return _configured_attr(ctx, name, default)
 
 def _python_executable(ctx):
     requested = ctx["attr"].get("python")
@@ -11,11 +11,36 @@ def _python_executable(ctx):
         if not resolved:
             fail(ctx["label"]["id"] + ": Python interpreter `" + requested + "` was not found")
         return resolved
-    for candidate in [".venv/bin/python", ".venv/Scripts/python.exe", "python3", "python"]:
+
+    for candidate in [".venv/bin/python", ".venv/Scripts/python.exe"]:
         resolved = _resolve_host_executable(candidate)
         if resolved:
             return resolved
-    fail(ctx["label"]["id"] + ": no Python interpreter was found; create `.venv/bin/python` or set the `python` attribute")
+
+    pytest = ""
+    for candidate in [".venv/bin/pytest", ".venv/Scripts/pytest.exe", "pytest"]:
+        pytest = _resolve_host_executable(candidate)
+        if pytest:
+            break
+    if not pytest:
+        fail(ctx["label"]["id"] + ": pytest was not found; install it in the workspace or make `pytest` available on PATH")
+
+    first_line = host_file_read(pytest).split("\n")[0] if host_file_exists(pytest) and not _ends_with(pytest.lower(), ".exe") else ""
+    if first_line.startswith("#!"):
+        command = first_line[2:].strip().split(" ")
+        if command and command[0] == "/usr/bin/env" and len(command) > 1:
+            resolved = _resolve_host_executable(command[1])
+        else:
+            resolved = _resolve_host_executable(command[0]) if command else ""
+        if resolved:
+            return resolved
+
+    runner_dir = _parent_dir(pytest)
+    for candidate in [runner_dir + "/python", runner_dir + "/python.exe", "python3", "python"]:
+        resolved = _resolve_host_executable(candidate)
+        if resolved:
+            return resolved
+    fail(ctx["label"]["id"] + ": no Python interpreter capable of loading pytest was found; set the `python` attribute")
 
 def _python_env(ctx, test_dir):
     env = {"HOME": test_dir + "/home", "PYTHONDONTWRITEBYTECODE": "1"}
@@ -182,6 +207,7 @@ def _python_pytest_impl(ctx):
     argv.append("--")
     argv.extend(_python_attr(ctx, "args", []))
     version = host_command([python, "--version"], merge_stderr = True).strip()
+    pytest_version = host_command([python, "-c", "import pytest; print(pytest.__version__)"]).strip()
     run_action(
         argv = argv,
         inputs = _unique(inputs + [adapter]),
@@ -191,7 +217,7 @@ def _python_pytest_impl(ctx):
         env = _python_env(ctx, test_dir),
         stdout = log,
         stderr = log,
-        toolchain_identity = "once.pytest.v1\x00" + python + "\x00" + version,
+        toolchain_identity = "once.pytest.v2\x00" + python + "\x00" + version + "\x00pytest\x00" + pytest_version,
         identifier = ctx["label"]["id"] + ":pytest",
     )
     return provider
@@ -212,7 +238,7 @@ pytest_test = target_kind(
     deps = [dep("deps", [], "Targets whose inputs should affect this test suite.")],
     providers = ["once_test_info"],
     capabilities = [capability("test", ["default", "test_results", "logs"])],
-    tools = [_PYTHON_TOOL],
+    tools = [_PYTHON_TOOL, _PYTEST_TOOL],
     examples = [example("pytest-test-minimal", name = "Minimal pytest suite", use_when = "You want Python tests with exact case execution and automatic file batching.")],
     impl = _python_pytest_impl,
 )

--- a/crates/once-frontend/prelude/ruby.star
+++ b/crates/once-frontend/prelude/ruby.star
@@ -1,14 +1,21 @@
 _RUBY_TOOL = tool("ruby", executables = ["ruby"])
+_RSPEC_TOOL = tool("rspec", executables = ["rspec"])
 
 def _ruby_attr(ctx, name, default):
-    value = ctx["attr"].get(name)
-    return default if value == None else value
+    return _configured_attr(ctx, name, default)
 
 def _ruby_executable(ctx):
     requested = _ruby_attr(ctx, "ruby", "ruby")
     resolved = _resolve_host_executable(requested)
     if not resolved:
         fail(ctx["label"]["id"] + ": Ruby interpreter `" + requested + "` was not found")
+    return resolved
+
+def _ruby_rspec_executable(ctx):
+    requested = _ruby_attr(ctx, "runner", "rspec")
+    resolved = _resolve_host_executable(requested)
+    if not resolved:
+        fail(ctx["label"]["id"] + ": Ruby Specification runner `" + requested + "` was not found")
     return resolved
 
 def _ruby_env(ctx, test_dir):
@@ -27,12 +34,14 @@ def _ruby_test_inputs(ctx):
 def _ruby_rspec_adapter():
     return '''require "fileutils"
 require "json"
+require "open3"
 require "optparse"
 
 options = { sources: [], units: [] }
 parser = OptionParser.new do |opts|
   opts.on("--once-results PATH") { |value| options[:results] = value }
   opts.on("--once-native-results PATH") { |value| options[:native_results] = value }
+  opts.on("--once-runner PATH") { |value| options[:runner] = value }
   opts.on("--once-target TARGET") { |value| options[:target] = value }
   opts.on("--once-source PATH") { |value| options[:sources] << value }
   opts.on("--once-test-unit UNIT") { |value| options[:units] << value }
@@ -40,13 +49,6 @@ end
 parser.order!(ARGV)
 ARGV.shift if ARGV.first == "--"
 runner_args = ARGV
-
-begin
-  require "rspec/core"
-rescue LoadError => error
-  warn "unable to load Ruby Specification: #{error.message}"
-  exit 2
-end
 
 prefix = options.fetch(:target) + "::"
 selected = options[:units].map do |unit|
@@ -59,7 +61,10 @@ end
 selection = selected.empty? ? options[:sources] : selected
 native_results = options.fetch(:native_results)
 args = runner_args + selection + ["--format", "json", "--out", native_results]
-exit_code = RSpec::Core::Runner.run(args, $stderr, $stdout)
+stdout, stderr, status = Open3.capture3(options.fetch(:runner), *args)
+$stdout.write(stdout)
+$stderr.write(stderr)
+exit_code = status.exitstatus || 1
 native = File.exist?(native_results) ? JSON.parse(File.read(native_results)) : {"examples" => []}
 cases = native.fetch("examples", []).map do |example|
   id = example["id"] || "#{example["file_path"]}:#{example["line_number"]}"
@@ -178,7 +183,7 @@ def _ruby_test_info(ctx, runner_type, display_name, ruby, adapter, results, log,
         "metadata": {},
     }
 
-def _ruby_test_impl(ctx, runner_type, display_name, adapter_source, adapter_name, file_units):
+def _ruby_test_impl(ctx, runner_type, display_name, adapter_source, adapter_name, file_units, runner = None):
     ruby = _ruby_executable(ctx)
     inputs = _ruby_test_inputs(ctx)
     test_dir = _test_output_dir(ctx)
@@ -191,7 +196,10 @@ def _ruby_test_impl(ctx, runner_type, display_name, adapter_source, adapter_name
     if ctx["capability"] != "test":
         return provider
     write_path(adapter, adapter_source)
-    argv = [ruby, adapter, "--once-results", results, "--once-native-results", native_results, "--once-target", ctx["label"]["id"]]
+    argv = [ruby, adapter, "--once-results", results, "--once-native-results", native_results]
+    if runner:
+        argv.extend(["--once-runner", runner])
+    argv.extend(["--once-target", ctx["label"]["id"]])
     for source in glob(ctx["srcs"]):
         argv.extend(["--once-source", source])
     for unit in (ctx.get("test") or {}).get("filters") or []:
@@ -199,6 +207,9 @@ def _ruby_test_impl(ctx, runner_type, display_name, adapter_source, adapter_name
     argv.append("--")
     argv.extend(_ruby_attr(ctx, "args", []))
     version = host_command([ruby, "--version"]).strip()
+    runner_identity = ""
+    if runner:
+        runner_identity = "\x00runner\x00" + runner + "\x00" + host_command([runner, "--version"]).strip()
     run_action(
         argv = argv,
         inputs = _unique(inputs + [adapter]),
@@ -208,13 +219,13 @@ def _ruby_test_impl(ctx, runner_type, display_name, adapter_source, adapter_name
         env = _ruby_env(ctx, test_dir),
         stdout = log,
         stderr = log,
-        toolchain_identity = "once." + runner_type + ".v1\x00" + ruby + "\x00" + version,
+        toolchain_identity = "once." + runner_type + ".v2\x00" + ruby + "\x00" + version + runner_identity,
         identifier = ctx["label"]["id"] + ":" + runner_type,
     )
     return provider
 
 def _ruby_rspec_impl(ctx):
-    return _ruby_test_impl(ctx, "rspec", "Ruby Specification", _ruby_rspec_adapter(), "once_rspec_adapter.rb", False)
+    return _ruby_test_impl(ctx, "rspec", "Ruby Specification", _ruby_rspec_adapter(), "once_rspec_adapter.rb", False, _ruby_rspec_executable(ctx))
 
 def _ruby_minitest_impl(ctx):
     return _ruby_test_impl(ctx, "minitest", "Minitest", _ruby_minitest_adapter(), "once_minitest_adapter.rb", True)
@@ -233,11 +244,13 @@ _RUBY_TEST_ATTRS = [
 
 rspec_test = target_kind(
     docs = "Runs Ruby Specification examples through Once with exact example filtering, normalized results, and automatic batching.",
-    attrs = _RUBY_TEST_ATTRS,
+    attrs = _RUBY_TEST_ATTRS + [
+        attr("runner", "string", default = "\"rspec\"", docs = "Ruby Specification runner executable name, absolute path, or workspace-relative path.", configurable = False),
+    ],
     deps = [dep("deps", [], "Targets whose inputs should affect this test suite.")],
     providers = ["once_test_info"],
     capabilities = [capability("test", ["default", "test_results", "logs"])],
-    tools = [_RUBY_TOOL],
+    tools = [_RUBY_TOOL, _RSPEC_TOOL],
     examples = [example("rspec-test-minimal", name = "Minimal Ruby Specification suite", use_when = "You want Ruby examples with normalized results and automatic batching.")],
     impl = _ruby_rspec_impl,
 )

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -35,7 +35,7 @@ def _rust_attr(ctx, key, default):
     value = ctx["attr"].get(key)
     if value == None:
         return default
-    return _rust_resolve_select(value, _rust_config_tokens(_rust_target_raw(ctx)), ctx["label"]["id"], key)
+    return _rust_resolve_select(value, _rust_config_tokens(ctx, _rust_target_raw(ctx)), ctx["label"]["id"], key)
 
 def _rust_target_raw(ctx):
     value = ctx["attr"].get("target")
@@ -51,7 +51,7 @@ def _is_select_shape(value):
     inner = value.get("select")
     return type(inner) == type({})
 
-def _rust_config_tokens(target):
+def _rust_config_tokens(ctx, target):
     tokens = []
     if target:
         tokens.append(target)
@@ -74,8 +74,7 @@ def _rust_config_tokens(target):
         if arch == "arm64":
             tokens.append(os + "-aarch64")
             tokens.append("aarch64")
-    tokens.append("default")
-    return _unique(tokens)
+    return _configuration_tokens(ctx, tokens)
 
 def _rust_select_branch(branches, tokens, label_id, attr_name):
     for token in tokens:
@@ -2808,18 +2807,18 @@ _RUST_COMMON_ATTRS = [
     attr("cargo_package", "string", docs = "Cargo package name used to select direct external deps from a cargo_dependencies dependency set. Defaults to CARGO_PKG_NAME when present.", configurable = False),
     attr("build_script", "string", docs = "Package-relative Cargo build script path. Once compiles and runs it before rustc, consumes common cargo:rustc-* stdout directives, and passes direct dependency links metadata as DEP_* env vars.", configurable = False),
     attr("default_deps", "string", docs = "Reserved Buck-compatible default dependency mode.", configurable = False),
-    attr("doc_deps", "list<string>", default = "[]", docs = "Reserved for Rust documentation-only dependencies.", configurable = False),
-    attr("doc_env", "map<string, string>", default = "{}", docs = "Reserved for Rust documentation action environments.", configurable = False),
-    attr("doc_link_style", "string", docs = "Reserved for Rust documentation link style selection.", configurable = False),
-    attr("doc_linker_flags", "list<string>", default = "[]", docs = "Reserved for Rust documentation linker flags.", configurable = False),
-    attr("doc_named_deps", "map<string, string>", default = "{}", docs = "Reserved for Rust documentation dependency aliases.", configurable = False),
-    attr("link_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-style native link dependencies.", configurable = False),
-    attr("link_style", "string", docs = "Reserved for Buck-compatible Rust link style selection.", configurable = False),
-    attr("mapped_srcs", "map<string, string>", default = "{}", docs = "Reserved for Buck-compatible mapped source inputs.", configurable = False),
-    attr("proc_macro_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-style procedural macro dependency separation.", configurable = False),
-    attr("rpath", "bool", default = "false", docs = "Reserved for runtime library search path handling.", configurable = False),
-    attr("runtime_dependency_handling", "string", docs = "Reserved for Buck-compatible runtime dependency handling.", configurable = False),
-    attr("rustdoc_flags", "list<string>", default = "[]", docs = "Reserved for Rust documentation compiler flags.", configurable = False),
+    attr("doc_deps", "list<string>", default = "[]", docs = "Reserved for Rust documentation-only dependencies.", configurable = False, implemented = False),
+    attr("doc_env", "map<string, string>", default = "{}", docs = "Reserved for Rust documentation action environments.", configurable = False, implemented = False),
+    attr("doc_link_style", "string", docs = "Reserved for Rust documentation link style selection.", configurable = False, implemented = False),
+    attr("doc_linker_flags", "list<string>", default = "[]", docs = "Reserved for Rust documentation linker flags.", configurable = False, implemented = False),
+    attr("doc_named_deps", "map<string, string>", default = "{}", docs = "Reserved for Rust documentation dependency aliases.", configurable = False, implemented = False),
+    attr("link_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-style native link dependencies.", configurable = False, implemented = False),
+    attr("link_style", "string", docs = "Reserved for Buck-compatible Rust link style selection.", configurable = False, implemented = False),
+    attr("mapped_srcs", "map<string, string>", default = "{}", docs = "Reserved for Buck-compatible mapped source inputs.", configurable = False, implemented = False),
+    attr("proc_macro_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-style procedural macro dependency separation.", configurable = False, implemented = False),
+    attr("rpath", "bool", default = "false", docs = "Reserved for runtime library search path handling.", configurable = False, implemented = False),
+    attr("runtime_dependency_handling", "string", docs = "Reserved for Buck-compatible runtime dependency handling.", configurable = False, implemented = False),
+    attr("rustdoc_flags", "list<string>", default = "[]", docs = "Reserved for Rust documentation compiler flags.", configurable = False, implemented = False),
 ]
 
 _RUST_MOBILE_ATTRS = [
@@ -2947,6 +2946,11 @@ rust_binary = target_kind(
     ],
     tools = [_RUST_TOOL],
     examples = [
+        example(
+            "rust-binary-minimal",
+            name = "Minimal Rust executable",
+            use_when = "Start here for a runnable first-party Rust executable with no external dependencies.",
+        ),
         example(
             "rust-binary-with-crate",
             name = "Rust binary with Cargo dependencies",

--- a/crates/once-frontend/prelude/swift.star
+++ b/crates/once-frontend/prelude/swift.star
@@ -223,7 +223,7 @@ def _swift_android_collect_linkopts(deps, own_values):
     return out
 
 def _swift_android_library_impl(ctx):
-    attrs = ctx["attr"]
+    attrs = _configured_attrs(ctx, ["android"])
     _swift_android_reject_unsupported_attrs(attrs, ctx["label"]["id"], ["always_include_developer_search_paths", "alwayslink", "generated_header_name", "generates_header", "linkstatic", "plugins", "private_deps"])
     module_name = _swift_android_attr(attrs, "module_name", "") or ctx["label"]["name"]
     package_name = _swift_android_attr(attrs, "package_name", "")
@@ -386,14 +386,14 @@ swift_android_library = target_kind(
         attr("linkopts", "list<string>", default = "[]", docs = "Additional linker flags appended after Once-managed flags.", configurable = False),
         attr("data", "list<string>", default = "[]", docs = "Package-relative runtime data file globs propagated to downstream consumers.", configurable = False),
         attr("swiftc_inputs", "list<string>", default = "[]", docs = "Bazel-compatible extra Swift compiler input globs.", configurable = False),
-        attr("always_include_developer_search_paths", "bool", default = "false", docs = "Reserved for Bazel-compatible developer search path handling.", configurable = False),
-        attr("alwayslink", "bool", default = "false", docs = "Reserved for Bazel-compatible always-link semantics.", configurable = False),
-        attr("generated_header_name", "string", docs = "Reserved for generated Objective-C header naming.", configurable = False),
-        attr("generates_header", "bool", default = "false", docs = "Reserved for generated Objective-C header emission.", configurable = False),
+        attr("always_include_developer_search_paths", "bool", default = "false", docs = "Reserved for Bazel-compatible developer search path handling.", configurable = False, implemented = False),
+        attr("alwayslink", "bool", default = "false", docs = "Reserved for Bazel-compatible always-link semantics.", configurable = False, implemented = False),
+        attr("generated_header_name", "string", docs = "Reserved for generated Objective-C header naming.", configurable = False, implemented = False),
+        attr("generates_header", "bool", default = "false", docs = "Reserved for generated Objective-C header emission.", configurable = False, implemented = False),
         attr("library_evolution", "bool", default = "false", docs = "Enable Swift library evolution and emit a textual module interface.", configurable = False),
-        attr("linkstatic", "bool", default = "false", docs = "Reserved for Bazel-compatible static link selection.", configurable = False),
-        attr("plugins", "list<string>", default = "[]", docs = "Reserved for Swift compiler plugins.", configurable = False),
-        attr("private_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-compatible private dependencies.", configurable = False),
+        attr("linkstatic", "bool", default = "false", docs = "Reserved for Bazel-compatible static link selection.", configurable = False, implemented = False),
+        attr("plugins", "list<string>", default = "[]", docs = "Reserved for Swift compiler plugins.", configurable = False, implemented = False),
+        attr("private_deps", "list<string>", default = "[]", docs = "Reserved for Bazel-compatible private dependencies.", configurable = False, implemented = False),
     ],
     deps = [
         dep("deps", ["swift_module", "android_native_library"], "Swift modules and Android native libraries linked or packaged with this library."),

--- a/crates/once-frontend/prelude/zig.star
+++ b/crates/once-frontend/prelude/zig.star
@@ -1,8 +1,5 @@
 def _zig_attr(ctx, key, default):
-    value = ctx["attr"].get(key)
-    if value == None:
-        return default
-    return value
+    return _configured_attr(ctx, key, default)
 
 def _zig_label_suffix(ctx):
     return _zig_safe_name(ctx["label"]["id"])

--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -15,7 +15,7 @@ use starlark::values::Value;
 use super::globals::globals_for_prelude;
 use super::store::{with_active_store, AnalysisStore, DeclaredAction, HostCache};
 use super::values::{attr_value_to_starlark, json_to_value, value_to_json};
-use crate::graph::GraphTarget;
+use crate::graph::{Diagnostic, GraphTarget};
 
 type ResolverCallback<'a> =
     dyn FnMut(&GraphTarget, &BTreeMap<String, String>) -> Result<Option<JsonValue>> + 'a;
@@ -43,6 +43,19 @@ pub struct AnalysisResult {
     pub declared_outputs: Vec<String>,
 }
 
+#[derive(Debug)]
+pub struct AnalysisFailure {
+    pub diagnostic: Diagnostic,
+}
+
+impl fmt::Display for AnalysisFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.diagnostic.message)
+    }
+}
+
+impl std::error::Error for AnalysisFailure {}
+
 /// Command-scoped analysis helper.
 ///
 /// Construct this once for a graph command and reuse it for every
@@ -56,6 +69,7 @@ pub struct AnalysisEngine {
     target_kind_callbacks: TargetKindCallbacks,
     host_cache: HostCache,
     options: AnalysisOptions,
+    configuration: crate::manifest::BuildConfiguration,
 }
 
 impl fmt::Debug for AnalysisEngine {
@@ -66,6 +80,7 @@ impl fmt::Debug for AnalysisEngine {
             .field("target_kind_callbacks", &self.target_kind_callbacks)
             .field("host_cache", &self.host_cache)
             .field("options", &self.options)
+            .field("configuration", &self.configuration)
             .finish()
     }
 }
@@ -93,13 +108,17 @@ impl AnalysisEngine {
             &source,
             root,
             &HostCache::default(),
+            &crate::manifest::load_workspace_configuration(root)?,
             operation,
         )
     }
 
     pub fn for_workspace_with_options(root: &Path, options: AnalysisOptions) -> Result<Self> {
         let source = crate::modules::combined_module_source_for_workspace(root)?;
-        Self::from_source_with_path(crate::modules::COMBINED_MODULE_PATH, source, options)
+        let mut engine =
+            Self::from_source_with_path(crate::modules::COMBINED_MODULE_PATH, source, options)?;
+        engine.configuration = crate::manifest::load_workspace_configuration(root)?;
+        Ok(engine)
     }
 
     pub fn for_workspace_with_options_and_tool_paths(
@@ -141,6 +160,7 @@ impl AnalysisEngine {
             target_kind_callbacks,
             host_cache: HostCache::default(),
             options,
+            configuration: crate::manifest::BuildConfiguration::default(),
         })
     }
 
@@ -201,6 +221,7 @@ impl AnalysisEngine {
             dependency_providers,
             capability,
             options: self.options.clone(),
+            configuration: &self.configuration,
         };
         analyze_target_with_host_cache(
             &self.source_path,
@@ -250,6 +271,7 @@ struct TargetAnalysis<'a> {
     dependency_providers: &'a BTreeMap<String, Vec<JsonValue>>,
     capability: &'a str,
     options: AnalysisOptions,
+    configuration: &'a crate::manifest::BuildConfiguration,
 }
 
 fn analyze_target_with_host_cache(
@@ -341,10 +363,7 @@ fn analyze_in_starlark(
         let provider = eval
             .eval_function(impl_value, &[ctx], &[])
             .map_err(|error| {
-                anyhow!(
-                    "impl eval failed for {}: {error:?}",
-                    analysis.target.label.id
-                )
+                analysis_failure(analysis.target, "implementation", &error.to_string())
             })?;
         Ok(value_to_json(provider))
     })
@@ -355,6 +374,7 @@ fn resolve_targets_in_starlark<T>(
     source: &str,
     workspace_root: &Path,
     host_cache: &HostCache,
+    configuration: &crate::manifest::BuildConfiguration,
     operation: impl FnOnce(&mut ResolverCallback<'_>) -> Result<T>,
 ) -> Result<T> {
     Module::with_temp_heap(|module| {
@@ -380,10 +400,10 @@ fn resolve_targets_in_starlark<T>(
                 host_cache.clone(),
             );
             let (store, result) = with_active_store(store, || -> Result<Option<JsonValue>> {
-                let ctx = build_resolver_ctx(&eval, target, files);
-                let graph_data = eval.eval_function(resolver, &[ctx], &[]).map_err(|error| {
-                    anyhow!("resolver eval failed for {}: {error:?}", target.label.id)
-                })?;
+                let ctx = build_resolver_ctx(&eval, target, files, configuration);
+                let graph_data = eval
+                    .eval_function(resolver, &[ctx], &[])
+                    .map_err(|error| analysis_failure(target, "resolver", &error.to_string()))?;
                 Ok(Some(value_to_json(graph_data)))
             });
             let value = result?;
@@ -397,6 +417,49 @@ fn resolve_targets_in_starlark<T>(
         };
         operation(&mut resolve)
     })
+}
+
+fn analysis_failure(target: &GraphTarget, stage: &str, message: &str) -> anyhow::Error {
+    let (code, repair) = if message.contains("select()") && message.contains("no") {
+        (
+            "select_no_matching_branch",
+            "Add a branch matching the target configuration or add a `default` branch",
+        )
+    } else if message.contains("not found on PATH") {
+        (
+            "required_tool_not_found",
+            "Install the required tool or configure the target kind to use an available executable",
+        )
+    } else if message.contains("not implemented") {
+        (
+            "unimplemented_attr",
+            "Remove the unavailable attribute or choose a target kind that implements it",
+        )
+    } else {
+        (
+            "target_kind_analysis_failed",
+            "Inspect the target kind schema, correct the target attributes or toolchain configuration, and retry",
+        )
+    };
+    let mut diagnostic = Diagnostic::new(
+        code,
+        format!(
+            "target kind {stage} failed for `{}`: {message}",
+            target.label.id
+        ),
+    )
+    .with_target(&target.label.id)
+    .with_repair(repair);
+    if let Some(attribute) = quoted_attribute(message) {
+        diagnostic = diagnostic.with_attribute(attribute);
+    }
+    anyhow!(AnalysisFailure { diagnostic })
+}
+
+fn quoted_attribute(message: &str) -> Option<String> {
+    let rest = message.split_once("attribute `")?.1;
+    let (attribute, _) = rest.split_once('`')?;
+    (!attribute.is_empty()).then(|| attribute.to_string())
 }
 
 fn find_impl_for_kind<'v>(
@@ -446,6 +509,7 @@ fn build_resolver_ctx<'v>(
     eval: &Evaluator<'v, '_, '_>,
     target: &GraphTarget,
     files: &BTreeMap<String, String>,
+    configuration: &crate::manifest::BuildConfiguration,
 ) -> Value<'v> {
     let heap = eval.heap();
     let label = heap.alloc(AllocDict([
@@ -464,12 +528,14 @@ fn build_resolver_ctx<'v>(
         .map(|(path, contents)| (path.clone(), heap.alloc(contents.clone())))
         .collect::<Vec<_>>();
     let file_values = heap.alloc(AllocDict(file_pairs));
+    let configuration = configuration_value(eval, configuration);
     heap.alloc(AllocDict([
         ("label", label),
         ("attr", attr),
         ("attrs", attr),
         ("srcs", heap.alloc(target.srcs.clone())),
         ("files", file_values),
+        ("configuration", configuration),
     ]))
 }
 
@@ -529,6 +595,7 @@ fn build_ctx<'v>(
                 .map_or(Value::new_none(), |id| heap.alloc(id.clone())),
         ),
     ]));
+    let configuration = configuration_value(eval, analysis.configuration);
     heap.alloc(AllocDict([
         ("label", label),
         ("attr", attr),
@@ -540,5 +607,18 @@ fn build_ctx<'v>(
         ("capability", heap.alloc(analysis.capability.to_string())),
         ("run", run),
         ("test", test),
+        ("configuration", configuration),
+    ]))
+}
+
+fn configuration_value<'v>(
+    eval: &Evaluator<'v, '_, '_>,
+    configuration: &crate::manifest::BuildConfiguration,
+) -> Value<'v> {
+    let heap = eval.heap();
+    heap.alloc(AllocDict([
+        ("os", heap.alloc(configuration.os.clone())),
+        ("arch", heap.alloc(configuration.arch.clone())),
+        ("tokens", heap.alloc(configuration.tokens.clone())),
     ]))
 }

--- a/crates/once-frontend/src/analysis/mod.rs
+++ b/crates/once-frontend/src/analysis/mod.rs
@@ -20,7 +20,8 @@ use std::collections::BTreeMap;
 use crate::target::AttrValue;
 
 pub use engine::{
-    analyze_target, target_kind_has_impl, AnalysisEngine, AnalysisOptions, AnalysisResult,
+    analyze_target, target_kind_has_impl, AnalysisEngine, AnalysisFailure, AnalysisOptions,
+    AnalysisResult,
 };
 pub use globals::globals_for_prelude;
 pub use store::{

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -801,6 +801,7 @@ fn target(kind: &str) -> GraphTarget {
         deps: Vec::new(),
         dependency_edges: BTreeMap::new(),
         srcs: Vec::new(),
+        visibility: Vec::new(),
         attrs: BTreeMap::new(),
         capabilities: vec![Capability {
             name: "build".to_string(),
@@ -886,6 +887,92 @@ fn analyze_target_errors_on_unknown_target_kind() {
     assert!(
         err.contains("no target kind found for kind `mystery_kind`"),
         "{err}"
+    );
+}
+
+#[test]
+fn target_kind_failures_preserve_structured_diagnostics() {
+    let engine = AnalysisEngine::from_source(
+        r#"
+def _impl(ctx):
+    fail(ctx["label"]["id"] + ": attribute `mode` has no matching select() branch")
+
+custom = {
+    "_once_target_kind": True,
+    "kind": "custom",
+    "impl": _impl,
+}
+"#,
+    )
+    .unwrap();
+    let tmp = TempDir::new().unwrap();
+
+    let error = engine
+        .analyze_target(&target("custom"), tmp.path(), &[])
+        .unwrap_err();
+    let failure = error
+        .downcast_ref::<AnalysisFailure>()
+        .expect("structured analysis failure");
+
+    assert_eq!(failure.diagnostic.code, "select_no_matching_branch");
+    assert_eq!(
+        failure.diagnostic.target.as_deref(),
+        Some("apps/ios/Sample")
+    );
+    assert_eq!(failure.diagnostic.attribute.as_deref(), Some("mode"));
+    assert!(!failure.diagnostic.repairs.is_empty());
+}
+
+#[test]
+fn workspace_configuration_drives_common_select_resolution() {
+    let workspace = TempDir::new().unwrap();
+    std::fs::create_dir_all(workspace.path().join("modules")).unwrap();
+    std::fs::write(
+        workspace.path().join("once.toml"),
+        r#"[workspace.configuration]
+os = "linux"
+arch = "arm64"
+tokens = ["release"]
+
+[modules]
+paths = ["modules/*.star"]
+
+[[target]]
+name = "Configured"
+kind = "configured"
+
+[target.attrs]
+mode = { select = { release = "fast", default = "safe" } }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        workspace.path().join("modules/configured.star"),
+        r#"def _impl(ctx):
+    return {
+        "mode": _configured_attr(ctx, "mode", "missing"),
+        "os": ctx["configuration"]["os"],
+        "arch": ctx["configuration"]["arch"],
+    }
+
+configured = target_kind(
+    attrs = [attr("mode", "string")],
+    providers = ["configured"],
+    impl = _impl,
+)
+"#,
+    )
+    .unwrap();
+    let graph = crate::load_graph_workspace(workspace.path()).unwrap();
+    let engine = AnalysisEngine::for_workspace(workspace.path()).unwrap();
+
+    let result = engine
+        .analyze_target(&graph[0], workspace.path(), &[])
+        .unwrap();
+
+    assert_eq!(
+        result.provider,
+        serde_json::json!({"mode": "fast", "os": "linux", "arch": "aarch64"})
     );
 }
 

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -46,6 +46,9 @@ pub struct GraphTarget {
     /// Source file patterns declared by the target.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub srcs: Vec<String>,
+    /// Targets and packages allowed to depend on this target.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub visibility: Vec<String>,
     /// Typed target attributes parsed from the manifest.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub attrs: BTreeMap<String, AttrValue>,
@@ -259,6 +262,8 @@ pub struct AttrSchema {
     pub docs: String,
     /// Whether the value can vary by configuration.
     pub configurable: bool,
+    /// Whether the target kind currently implements the attribute.
+    pub implemented: bool,
 }
 
 /// Dependency metadata exposed by a target kind schema.
@@ -427,6 +432,7 @@ pub(crate) fn graph_target_from_schema(
         deps: target.deps.clone(),
         dependency_edges: target.dependency_edges.clone(),
         srcs: target.srcs.clone(),
+        visibility: target.visibility.clone(),
         attrs,
         capabilities: schema
             .as_ref()
@@ -445,6 +451,7 @@ fn graph_target_from_owned_schema(target: Target, schemas: &[TargetKindSchema]) 
         deps,
         dependency_edges,
         srcs,
+        visibility,
         attrs,
         typed_attrs,
     } = target;
@@ -493,6 +500,7 @@ fn graph_target_from_owned_schema(target: Target, schemas: &[TargetKindSchema]) 
         deps,
         dependency_edges,
         srcs,
+        visibility,
         attrs,
         capabilities: schema
             .as_ref()
@@ -777,6 +785,7 @@ fn attr_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<A
         default: optional_field_string(value, path, "default")?,
         docs: field_string(value, path, "docs")?,
         configurable: field_bool(value, path, "configurable")?,
+        implemented: field_bool(value, path, "implemented")?,
     })
 }
 
@@ -998,6 +1007,7 @@ fn attr(
         default: default.map(str::to_string),
         docs: docs.to_string(),
         configurable,
+        implemented: true,
     }
 }
 
@@ -1305,6 +1315,7 @@ demo_kind = target_kind(
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs: BTreeMap::new(),
         };
@@ -1331,6 +1342,7 @@ demo_kind = target_kind(
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs,
             typed_attrs: BTreeMap::new(),
         };
@@ -1351,6 +1363,7 @@ demo_kind = target_kind(
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::from([("script_runtime".to_string(), "python".to_string())]),
             typed_attrs: BTreeMap::new(),
         };
@@ -1375,6 +1388,7 @@ demo_kind = target_kind(
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs: BTreeMap::new(),
         });
@@ -1405,6 +1419,7 @@ demo_kind = target_kind(
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs,
             typed_attrs,
         };
@@ -1431,6 +1446,7 @@ demo_kind = target_kind(
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs,
         };

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -46,7 +46,10 @@ pub use graph::{
     TargetKindExampleFile, TargetKindExampleRoot, TargetKindExampleSource, TargetKindSchema,
     TargetLabel, ToolRequirement,
 };
-pub use manifest::{load_cache_provider_toml_str, load_infrastructure_toml_str, load_toml_str};
+pub use manifest::{
+    load_cache_provider_toml_str, load_infrastructure_toml_str, load_toml_str,
+    load_workspace_configuration, BuildConfiguration,
+};
 pub use manifest_editor::{
     apply_operations, apply_operations_with_schemas, EditOperation, TargetSpec, TargetUpdate,
 };

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -3,12 +3,13 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::cache_provider::{CacheProviderToml, InfrastructureProviderToml, InfrastructureToml};
 use crate::error::{Error, Result};
 use crate::target::{AttrValue, Target};
 use crate::target_ref::{normalize_manifest_target, validate_target_name};
+use crate::TOML_BUILD_FILE_NAME;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -27,6 +28,77 @@ struct Manifest {
 pub(crate) struct WorkspaceToml {
     pub include: Vec<String>,
     pub exclude: Vec<String>,
+    pub configuration: ConfigurationToml,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub(crate) struct ConfigurationToml {
+    os: Option<String>,
+    arch: Option<String>,
+    tokens: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BuildConfiguration {
+    pub os: String,
+    pub arch: String,
+    pub tokens: Vec<String>,
+}
+
+impl BuildConfiguration {
+    fn host() -> Self {
+        Self::new(std::env::consts::OS, std::env::consts::ARCH, Vec::new())
+    }
+
+    pub(crate) fn from_toml(configuration: ConfigurationToml) -> Result<Self> {
+        let os = configuration
+            .os
+            .unwrap_or_else(|| std::env::consts::OS.to_string());
+        let arch = configuration
+            .arch
+            .unwrap_or_else(|| std::env::consts::ARCH.to_string());
+        if os.trim().is_empty() || arch.trim().is_empty() {
+            return Err(Error::Eval {
+                path: TOML_BUILD_FILE_NAME.to_string(),
+                message:
+                    "workspace configuration operating system and architecture must be non-empty"
+                        .to_string(),
+            });
+        }
+        if configuration
+            .tokens
+            .iter()
+            .any(|token| token.trim().is_empty())
+        {
+            return Err(Error::Eval {
+                path: TOML_BUILD_FILE_NAME.to_string(),
+                message: "workspace configuration tokens must be non-empty".to_string(),
+            });
+        }
+        Ok(Self::new(&os, &arch, configuration.tokens))
+    }
+
+    fn new(os: &str, arch: &str, extra_tokens: Vec<String>) -> Self {
+        let os = normalize_os(os);
+        let arch = normalize_arch(arch);
+        let mut tokens = select_tokens_for(&os, &arch);
+        for token in extra_tokens {
+            if !tokens.contains(&token) {
+                tokens.push(token);
+            }
+        }
+        if !tokens.iter().any(|token| token == "default") {
+            tokens.push("default".to_string());
+        }
+        Self { os, arch, tokens }
+    }
+}
+
+impl Default for BuildConfiguration {
+    fn default() -> Self {
+        Self::host()
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -43,6 +115,7 @@ struct TargetToml {
     deps: Option<toml::Value>,
     dependencies: BTreeMap<String, toml::Value>,
     srcs: Vec<String>,
+    visibility: Vec<String>,
     attrs: BTreeMap<String, toml::Value>,
 }
 
@@ -53,8 +126,24 @@ pub fn load_toml_str(path: &str, src: &str) -> Result<Vec<Target>> {
 pub(crate) fn load_toml_with(
     display_name: &str,
     src: &str,
+    workspace_root: &Path,
+    package: &str,
+) -> Result<Vec<Target>> {
+    load_toml_with_configuration(
+        display_name,
+        src,
+        workspace_root,
+        package,
+        &BuildConfiguration::host(),
+    )
+}
+
+pub(crate) fn load_toml_with_configuration(
+    display_name: &str,
+    src: &str,
     _workspace_root: &Path,
     package: &str,
+    configuration: &BuildConfiguration,
 ) -> Result<Vec<Target>> {
     let manifest: Manifest = toml::from_str(src).map_err(|source| Error::Parse {
         path: display_name.to_string(),
@@ -69,7 +158,7 @@ pub(crate) fn load_toml_with(
     manifest
         .target
         .into_iter()
-        .map(|target| target.into_target(display_name, package))
+        .map(|target| target.into_target(display_name, package, configuration))
         .collect()
 }
 
@@ -140,8 +229,31 @@ pub(crate) fn load_workspace_toml_str(path: &str, src: &str) -> Result<Workspace
     Ok(manifest.workspace)
 }
 
+pub fn load_workspace_configuration(root: &Path) -> Result<BuildConfiguration> {
+    let path = root.join(TOML_BUILD_FILE_NAME);
+    let source = match std::fs::read_to_string(&path) {
+        Ok(source) => source,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(BuildConfiguration::host());
+        }
+        Err(source) => {
+            return Err(Error::Read {
+                path: path.display().to_string(),
+                source,
+            });
+        }
+    };
+    let workspace = load_workspace_toml_str(TOML_BUILD_FILE_NAME, &source)?;
+    BuildConfiguration::from_toml(workspace.configuration)
+}
+
 impl TargetToml {
-    fn into_target(self, display_name: &str, package: &str) -> Result<Target> {
+    fn into_target(
+        self,
+        display_name: &str,
+        package: &str,
+        configuration: &BuildConfiguration,
+    ) -> Result<Target> {
         if self.name.is_empty() {
             return Err(Error::Eval {
                 path: display_name.to_string(),
@@ -158,9 +270,20 @@ impl TargetToml {
             path: display_name.to_string(),
             message: source.to_string(),
         })?;
-        let deps = deps_from_toml(display_name, &self.name, package, self.deps.as_ref())?;
-        let dependency_edges =
-            dependency_edges_from_toml(display_name, &self.name, package, &self.dependencies)?;
+        let deps = deps_from_toml(
+            display_name,
+            &self.name,
+            package,
+            self.deps.as_ref(),
+            configuration,
+        )?;
+        let dependency_edges = dependency_edges_from_toml(
+            display_name,
+            &self.name,
+            package,
+            &self.dependencies,
+            configuration,
+        )?;
         let mut attrs = BTreeMap::new();
         let mut typed_attrs = BTreeMap::new();
         for (key, value) in self.attrs {
@@ -176,6 +299,7 @@ impl TargetToml {
             deps,
             dependency_edges,
             srcs: self.srcs,
+            visibility: self.visibility,
             attrs,
             typed_attrs,
         })
@@ -187,6 +311,7 @@ fn dependency_edges_from_toml(
     target_name: &str,
     package: &str,
     values: &BTreeMap<String, toml::Value>,
+    configuration: &BuildConfiguration,
 ) -> Result<BTreeMap<String, Vec<String>>> {
     let mut edges = BTreeMap::new();
     for (name, value) in values {
@@ -203,6 +328,7 @@ fn dependency_edges_from_toml(
             &format!("{target_name}` dependency role `{name}"),
             package,
             Some(value),
+            configuration,
         )?;
         edges.insert(name.clone(), dependencies);
     }
@@ -214,11 +340,13 @@ fn deps_from_toml(
     target_name: &str,
     package: &str,
     value: Option<&toml::Value>,
+    configuration: &BuildConfiguration,
 ) -> Result<Vec<String>> {
     let Some(value) = value else {
         return Ok(Vec::new());
     };
-    let selected = select_dep_value(display_name, target_name, value)?;
+    let selected =
+        select_dep_value_for_tokens(display_name, target_name, value, &configuration.tokens)?;
     let toml::Value::Array(deps) = selected else {
         return Err(Error::Eval {
             path: display_name.to_string(),
@@ -241,20 +369,11 @@ fn deps_from_toml(
         .collect()
 }
 
-fn select_dep_value<'a>(
-    display_name: &str,
-    target_name: &str,
-    value: &'a toml::Value,
-) -> Result<&'a toml::Value> {
-    let tokens = host_select_tokens();
-    select_dep_value_for_tokens(display_name, target_name, value, &tokens)
-}
-
 fn select_dep_value_for_tokens<'a>(
     display_name: &str,
     target_name: &str,
     value: &'a toml::Value,
-    tokens: &[&str],
+    tokens: &[String],
 ) -> Result<&'a toml::Value> {
     let toml::Value::Table(table) = value else {
         return Ok(value);
@@ -269,7 +388,7 @@ fn select_dep_value_for_tokens<'a>(
         });
     };
     for token in tokens {
-        if let Some(value) = branches.get(*token) {
+        if let Some(value) = branches.get(token) {
             return Ok(value);
         }
     }
@@ -281,11 +400,7 @@ fn select_dep_value_for_tokens<'a>(
     })
 }
 
-fn host_select_tokens() -> Vec<&'static str> {
-    select_tokens_for(std::env::consts::OS, std::env::consts::ARCH)
-}
-
-fn select_tokens_for(os: &str, arch: &str) -> Vec<&'static str> {
+fn select_tokens_for(os: &str, arch: &str) -> Vec<String> {
     match (os, arch) {
         ("macos", "aarch64") => vec!["macos-arm64", "macos-aarch64", "macos", "arm64", "aarch64"],
         ("macos", "x86_64") => vec!["macos-x86_64", "macos", "x86_64"],
@@ -303,6 +418,24 @@ fn select_tokens_for(os: &str, arch: &str) -> Vec<&'static str> {
         ("linux", _) => vec!["linux"],
         ("windows", _) => vec!["windows"],
         _ => Vec::new(),
+    }
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+fn normalize_os(value: &str) -> String {
+    match value {
+        "darwin" | "mac" | "macosx" => "macos".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn normalize_arch(value: &str) -> String {
+    match value {
+        "arm64" => "aarch64".to_string(),
+        "amd64" => "x86_64".to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -673,6 +806,26 @@ default = ["./portable"]
         .unwrap();
 
         assert_eq!(selected.as_array().unwrap()[0].as_str(), Some("./portable"));
+    }
+
+    #[test]
+    fn explicit_target_configuration_selects_dependencies() {
+        let configuration = BuildConfiguration::new("linux", "arm64", vec!["release".to_string()]);
+        let source = r#"
+[[target]]
+name = "App"
+kind = "plain"
+deps = { select = { release = ["./Optimized"], default = ["./Portable"] } }
+"#;
+
+        let targets =
+            load_toml_with_configuration("once.toml", source, Path::new("."), "", &configuration)
+                .unwrap();
+
+        assert_eq!(targets[0].deps, vec!["Optimized"]);
+        assert_eq!(configuration.os, "linux");
+        assert_eq!(configuration.arch, "aarch64");
+        assert!(configuration.tokens.contains(&"linux-arm64".to_string()));
     }
 
     #[test]

--- a/crates/once-frontend/src/manifest_editor.rs
+++ b/crates/once-frontend/src/manifest_editor.rs
@@ -46,6 +46,8 @@ pub struct TargetSpec {
     #[serde(default)]
     pub srcs: Vec<String>,
     #[serde(default)]
+    pub visibility: Vec<String>,
+    #[serde(default)]
     pub attrs: JsonMap<String, JsonValue>,
 }
 
@@ -60,6 +62,7 @@ pub struct TargetUpdate {
     pub deps: Option<Vec<String>>,
     pub dependencies: Option<BTreeMap<String, Vec<String>>>,
     pub srcs: Option<Vec<String>>,
+    pub visibility: Option<Vec<String>>,
     pub attrs: Option<JsonMap<String, JsonValue>>,
 }
 
@@ -263,6 +266,12 @@ fn apply_update(
     if let Some(srcs) = &set.srcs {
         table.insert("srcs", Item::Value(Value::Array(string_array(srcs))));
     }
+    if let Some(visibility) = &set.visibility {
+        table.insert(
+            "visibility",
+            Item::Value(Value::Array(string_array(visibility))),
+        );
+    }
     if let Some(attrs) = &set.attrs {
         let attrs_table = build_attrs_table(attrs, original_name)?;
         table.insert("attrs", Item::Table(attrs_table));
@@ -287,6 +296,12 @@ fn build_target_table(spec: &TargetSpec) -> Result<Table, Vec<Diagnostic>> {
     if !spec.srcs.is_empty() {
         table.insert("srcs", Item::Value(Value::Array(string_array(&spec.srcs))));
     }
+    if !spec.visibility.is_empty() {
+        table.insert(
+            "visibility",
+            Item::Value(Value::Array(string_array(&spec.visibility))),
+        );
+    }
     if !spec.attrs.is_empty() {
         let attrs_table = build_attrs_table(&spec.attrs, &spec.name)?;
         table.insert("attrs", Item::Table(attrs_table));
@@ -309,6 +324,7 @@ fn target_spec_from_table(table: &Table) -> TargetSpec {
         deps: string_vec_from_item(table.get("deps")),
         dependencies: dependencies_from_item(table.get("dependencies")),
         srcs: string_vec_from_item(table.get("srcs")),
+        visibility: string_vec_from_item(table.get("visibility")),
         attrs: attrs_from_item(table.get("attrs")),
     }
 }

--- a/crates/once-frontend/src/module_contract.rs
+++ b/crates/once-frontend/src/module_contract.rs
@@ -39,6 +39,7 @@ pub fn module_authoring_contract() -> ModuleAuthoringContract {
         declaration_source,
         schema_invariants: vec![
             "Supported attribute types are string, bool, int, float, list<string>, map<string,string>, target, and select values for configurable attributes.",
+            "Set implemented = False only for discoverable compatibility attributes that validation must reject until the target kind gives them behavior.",
             "attr.default is optional schema documentation and must be a string; it does not insert a runtime value. Implementations must use ctx[\"attr\"].get(...) when an optional attribute needs a fallback.",
             "Set configurable = False when analysis or output identity cannot safely vary through select.",
             "Dependency declarations name provider records accepted from ctx[\"deps\"] and ctx[\"deps_by_role\"], and implementations should consume provider fields instead of dependency target kind names.",
@@ -56,7 +57,7 @@ pub fn module_authoring_contract() -> ModuleAuthoringContract {
                 "Files selected by non-empty resolver_inputs, or srcs when resolver_inputs is empty or omitted, decoded as text and keyed relative to the owner package.",
             ),
             entry(
-                "[{name, kind, deps, dependencies, srcs, attrs}]",
+                "[{name, kind, deps, dependencies, srcs, visibility, attrs}]",
                 "Compact resolver return form containing synthetic targets.",
             ),
             entry(
@@ -76,6 +77,10 @@ pub fn module_authoring_contract() -> ModuleAuthoringContract {
             entry("ctx[\"build_dir\"]", "Workspace-relative durable output directory."),
             entry("ctx[\"scratch_dir\"]", "Workspace-relative action-private directory."),
             entry("ctx[\"capability\"]", "Capability being analyzed."),
+            entry(
+                "ctx[\"configuration\"]",
+                "Target operating system, architecture, and ordered select tokens configured by the workspace.",
+            ),
             entry("ctx[\"run\"][\"visible\"]", "Whether a visible runtime was requested."),
             entry(
                 "ctx[\"test\"][\"filters\"]",

--- a/crates/once-frontend/src/resolution.rs
+++ b/crates/once-frontend/src/resolution.rs
@@ -48,6 +48,8 @@ struct ResolvedTargetSpec {
     #[serde(default)]
     srcs: Vec<String>,
     #[serde(default)]
+    visibility: Vec<String>,
+    #[serde(default)]
     attrs: BTreeMap<String, AttrValue>,
 }
 
@@ -199,6 +201,7 @@ fn validate_resolver_owner(
         deps: target.deps.clone(),
         dependencies: target.dependency_edges.clone(),
         srcs: target.srcs.clone(),
+        visibility: target.visibility.clone(),
         attrs,
     };
     let mut diagnostics = crate::validate_target(&spec, schemas);
@@ -268,6 +271,7 @@ fn resolved_target(owner: &Target, spec: ResolvedTargetSpec) -> Result<Target> {
         deps,
         dependency_edges,
         srcs: spec.srcs,
+        visibility: spec.visibility,
         attrs: BTreeMap::new(),
         typed_attrs: spec.attrs,
     })
@@ -727,6 +731,7 @@ kind = "rust_library"
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: vec![source.to_string()],
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs: BTreeMap::new(),
         };
@@ -754,6 +759,7 @@ kind = "rust_library"
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: vec!["deps.lock".to_string(), "artifact.bin".to_string()],
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs,
         };
@@ -779,6 +785,7 @@ kind = "rust_library"
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: vec!["deps.lock".to_string()],
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs,
         };
@@ -803,6 +810,7 @@ kind = "rust_library"
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: vec!["declared.lock".to_string()],
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs: BTreeMap::new(),
         };
@@ -833,6 +841,7 @@ kind = "rust_library"
             deps: Vec::new(),
             dependency_edges: BTreeMap::new(),
             srcs: Vec::new(),
+            visibility: Vec::new(),
             attrs: BTreeMap::new(),
             typed_attrs,
         };

--- a/crates/once-frontend/src/target.rs
+++ b/crates/once-frontend/src/target.rs
@@ -18,6 +18,8 @@ pub struct Target {
     pub dependency_edges: BTreeMap<String, Vec<String>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub srcs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub visibility: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub attrs: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -80,6 +82,7 @@ mod tests {
             deps: vec![],
             dependency_edges: BTreeMap::new(),
             srcs: vec![],
+            visibility: vec![],
             attrs: BTreeMap::new(),
             typed_attrs: BTreeMap::new(),
         };

--- a/crates/once-frontend/src/target_validator.rs
+++ b/crates/once-frontend/src/target_validator.rs
@@ -18,27 +18,10 @@ use crate::target_ref::validate_target_name;
 pub fn validate_target(target: &TargetSpec, schemas: &[TargetKindSchema]) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
-    if target.name.trim().is_empty() {
-        diagnostics.push(
-            Diagnostic::new("target_name_required", "target `name` must not be empty")
-                .with_attribute("name"),
-        );
-    } else if let Err(err) = validate_target_name(&target.name) {
-        diagnostics.push(
-            Diagnostic::new("invalid_target_name", err.to_string())
-                .with_target(target.name.as_str())
-                .with_attribute("name"),
-        );
-    }
-
-    if target.kind.trim().is_empty() {
-        diagnostics.push(
-            Diagnostic::new("target_kind_required", "target `kind` must not be empty")
-                .with_target(target.name.as_str())
-                .with_attribute("kind"),
-        );
+    if !validate_target_identity(target, &mut diagnostics) {
         return diagnostics;
     }
+    validate_target_visibility(target, &mut diagnostics);
 
     let Some(schema) = schemas.iter().find(|s| s.kind == target.kind) else {
         diagnostics.push(
@@ -53,38 +36,8 @@ pub fn validate_target(target: &TargetSpec, schemas: &[TargetKindSchema]) -> Vec
         return diagnostics;
     };
 
-    for role in target.dependencies.keys() {
-        if role == "deps" || !schema.deps.iter().any(|edge| &edge.name == role) {
-            diagnostics.push(
-                Diagnostic::new(
-                    "unknown_dependency_role",
-                    format!(
-                        "target kind `{}` does not declare dependency role `{role}`",
-                        schema.kind
-                    ),
-                )
-                .with_target(target.name.as_str())
-                .with_attribute(format!("dependencies.{role}"))
-                .with_repair(suggest_known_dependency_roles(schema)),
-            );
-        }
-    }
-
-    for attr_schema in &schema.attrs {
-        if attr_schema.required && !target.attrs.contains_key(&attr_schema.name) {
-            diagnostics.push(
-                Diagnostic::new(
-                    "missing_required_attr",
-                    format!(
-                        "target kind `{}` requires attribute `{}`",
-                        schema.kind, attr_schema.name
-                    ),
-                )
-                .with_target(target.name.as_str())
-                .with_attribute(attr_schema.name.as_str()),
-            );
-        }
-    }
+    validate_dependency_roles(target, schema, &mut diagnostics);
+    validate_required_attrs(target, schema, &mut diagnostics);
 
     for (attr_name, attr_value) in &target.attrs {
         let Some(attr_schema) = schema.attrs.iter().find(|a| &a.name == attr_name) else {
@@ -108,6 +61,99 @@ pub fn validate_target(target: &TargetSpec, schemas: &[TargetKindSchema]) -> Vec
     diagnostics
 }
 
+fn validate_target_identity(target: &TargetSpec, diagnostics: &mut Vec<Diagnostic>) -> bool {
+    if target.name.trim().is_empty() {
+        diagnostics.push(
+            Diagnostic::new("target_name_required", "target `name` must not be empty")
+                .with_attribute("name"),
+        );
+    } else if let Err(err) = validate_target_name(&target.name) {
+        diagnostics.push(
+            Diagnostic::new("invalid_target_name", err.to_string())
+                .with_target(target.name.as_str())
+                .with_attribute("name"),
+        );
+    }
+
+    if target.kind.trim().is_empty() {
+        diagnostics.push(
+            Diagnostic::new("target_kind_required", "target `kind` must not be empty")
+                .with_target(target.name.as_str())
+                .with_attribute("kind"),
+        );
+        return false;
+    }
+    true
+}
+
+fn validate_target_visibility(target: &TargetSpec, diagnostics: &mut Vec<Diagnostic>) {
+    for entry in &target.visibility {
+        if crate::workspace_validator::visibility_entry_is_valid("", entry) {
+            continue;
+        }
+        diagnostics.push(
+            Diagnostic::new(
+                "invalid_visibility",
+                format!("target `{}` has invalid visibility entry `{entry}`", target.name),
+            )
+            .with_target(target.name.as_str())
+            .with_attribute("visibility")
+            .with_repair(
+                "Use `public`, `private`, an exact target such as `tools/Generator`, a package entry such as `package:apps`, or a subtree entry such as `subtree:apps`",
+            ),
+        );
+    }
+}
+
+fn validate_dependency_roles(
+    target: &TargetSpec,
+    schema: &TargetKindSchema,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for role in target.dependencies.keys() {
+        if role == "deps" || !schema.deps.iter().any(|edge| &edge.name == role) {
+            diagnostics.push(
+                Diagnostic::new(
+                    "unknown_dependency_role",
+                    format!(
+                        "target kind `{}` does not declare dependency role `{role}`",
+                        schema.kind
+                    ),
+                )
+                .with_target(target.name.as_str())
+                .with_attribute(format!("dependencies.{role}"))
+                .with_repair(suggest_known_dependency_roles(schema)),
+            );
+        }
+    }
+}
+
+fn validate_required_attrs(
+    target: &TargetSpec,
+    schema: &TargetKindSchema,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for attr_schema in &schema.attrs {
+        if attr_schema.required && !target.attrs.contains_key(&attr_schema.name) {
+            diagnostics.push(
+                Diagnostic::new(
+                    "missing_required_attr",
+                    format!(
+                        "target kind `{}` requires attribute `{}`",
+                        schema.kind, attr_schema.name
+                    ),
+                )
+                .with_target(target.name.as_str())
+                .with_attribute(attr_schema.name.as_str())
+                .with_repair(format!(
+                    "Set `target.attrs.{}` to a value of type `{}`",
+                    attr_schema.name, attr_schema.ty
+                )),
+            );
+        }
+    }
+}
+
 fn suggest_known_dependency_roles(schema: &TargetKindSchema) -> String {
     let roles = schema
         .deps
@@ -128,6 +174,23 @@ fn validate_attr(
     attr_schema: &AttrSchema,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    if !attr_schema.implemented {
+        diagnostics.push(
+            Diagnostic::new(
+                "unimplemented_attr",
+                format!(
+                    "target kind `{}` declares attribute `{attr_name}` for discovery, but does not implement it yet",
+                    target.kind
+                ),
+            )
+            .with_target(target.name.as_str())
+            .with_attribute(attr_name)
+            .with_repair(format!(
+                "Remove `target.attrs.{attr_name}` until the target kind implements it"
+            )),
+        );
+        return;
+    }
     if let Some(branches) = select_branches(attr_value) {
         validate_select_attr(target, attr_name, attr_schema, branches, diagnostics);
     } else if let Err(err) = check_type(attr_value, &attr_schema.ty) {
@@ -149,7 +212,11 @@ fn validate_select_attr(
                 format!("attribute `{attr_name}` is not configurable but uses `select()`"),
             )
             .with_target(target.name.as_str())
-            .with_attribute(attr_name),
+            .with_attribute(attr_name)
+            .with_repair(format!(
+                "Replace the select value with one `{}` value",
+                attr_schema.ty
+            )),
         );
         return;
     }
@@ -172,6 +239,9 @@ fn type_mismatch(target: &TargetSpec, attr_name: &str, ty: &str, err: &str) -> D
     )
     .with_target(target.name.as_str())
     .with_attribute(attr_name)
+    .with_repair(format!(
+        "Set `target.attrs.{attr_name}` to a value of type `{ty}`"
+    ))
 }
 
 fn select_branches(value: &JsonValue) -> Option<&serde_json::Map<String, JsonValue>> {
@@ -225,6 +295,13 @@ fn check_type(value: &JsonValue, ty: &str) -> Result<(), String> {
         "int" | "integer" => match value {
             JsonValue::Number(n) if n.is_i64() => Ok(()),
             _ => Err(format!("expected an integer, got {}", json_type(value))),
+        },
+        "float" => match value {
+            JsonValue::Number(n) if n.is_f64() => Ok(()),
+            _ => Err(format!(
+                "expected a floating-point number, got {}",
+                json_type(value)
+            )),
         },
         other => Err(format!(
             "unknown attribute type `{other}` declared by target kind schema"
@@ -296,6 +373,28 @@ mod tests {
             .expect("target kind exists")
     }
 
+    #[test]
+    fn unimplemented_attributes_fail_static_validation() {
+        let mut target = target("Library", "rust_library");
+        target
+            .attrs
+            .insert("doc_deps".to_string(), json!(["DocumentationOnly"]));
+
+        let diagnostics = validate_target(&target, &built_in_target_kind_schemas());
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unimplemented_attr")
+            .expect("unimplemented attribute diagnostic");
+
+        assert_eq!(diagnostic.attribute.as_deref(), Some("doc_deps"));
+        assert!(diagnostic.repairs[0].contains("Remove"));
+        assert!(schema_named("rust_library")
+            .attrs
+            .iter()
+            .find(|attr| attr.name == "doc_deps")
+            .is_some_and(|attr| !attr.implemented));
+    }
+
     fn target(name: &str, kind: &str) -> TargetSpec {
         TargetSpec {
             name: name.to_string(),
@@ -317,6 +416,8 @@ mod tests {
             })
             .expect("missing platform diagnostic");
         assert_eq!(missing.target.as_deref(), Some("Hello"));
+        assert!(missing.repairs[0].contains("target.attrs.platform"));
+        assert!(missing.repairs[0].contains("string"));
     }
 
     #[test]
@@ -384,6 +485,8 @@ mod tests {
             .expect("mismatch diagnostic");
         assert!(mismatch.message.contains("string"));
         assert!(mismatch.message.contains("number"));
+        assert!(mismatch.repairs[0].contains("target.attrs.platform"));
+        assert!(mismatch.repairs[0].contains("string"));
     }
 
     #[test]
@@ -470,6 +573,15 @@ mod tests {
             .find(|d| d.code == "select_on_non_configurable_attr")
             .expect("non-configurable select diagnostic");
         assert_eq!(diagnostic.attribute.as_deref(), Some("platform"));
+        assert!(!diagnostic.repairs.is_empty());
+    }
+
+    #[test]
+    fn float_types_match_the_public_module_contract() {
+        assert!(check_type(&json!(1.5), "float").is_ok());
+        assert!(check_type(&json!([1.5, 2.5]), "list<float>").is_ok());
+        assert!(check_type(&json!({ "ratio": 1.5 }), "map<string,float>").is_ok());
+        assert!(check_type(&json!(1), "float").is_err());
     }
 
     #[test]

--- a/crates/once-frontend/src/workspace.rs
+++ b/crates/once-frontend/src/workspace.rs
@@ -9,7 +9,7 @@ use crate::cache_provider::{CacheProviderConfig, InfrastructureConfig};
 use crate::error::{Error, Result};
 use crate::manifest::{
     load_cache_provider_toml_str, load_infrastructure_toml_str, load_toml_with,
-    load_workspace_toml_str,
+    load_toml_with_configuration, load_workspace_toml_str, BuildConfiguration,
 };
 use crate::target::Target;
 use crate::TOML_BUILD_FILE_NAME;
@@ -82,7 +82,8 @@ pub fn load_workspace(root: &Path) -> Result<Vec<Target>> {
         } else {
             format!("{pkg}/{filename}")
         };
-        let targets = load_toml_with(&display, &src, root, &pkg)?;
+        let targets =
+            load_toml_with_configuration(&display, &src, root, &pkg, &scan.configuration)?;
         all.extend(targets);
     }
     Ok(all)
@@ -92,6 +93,7 @@ pub fn load_workspace(root: &Path) -> Result<Vec<Target>> {
 struct WorkspaceScan {
     include: Vec<Pattern>,
     exclude: Vec<Pattern>,
+    configuration: BuildConfiguration,
 }
 
 impl WorkspaceScan {
@@ -108,7 +110,10 @@ fn load_workspace_scan(root: &Path) -> Result<WorkspaceScan> {
     let src = match std::fs::read_to_string(&path) {
         Ok(src) => src,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(WorkspaceScan::default());
+            return Ok(WorkspaceScan {
+                configuration: crate::manifest::load_workspace_configuration(root)?,
+                ..WorkspaceScan::default()
+            });
         }
         Err(source) => {
             return Err(Error::Read {
@@ -121,6 +126,7 @@ fn load_workspace_scan(root: &Path) -> Result<WorkspaceScan> {
     Ok(WorkspaceScan {
         include: compile_patterns(TOML_BUILD_FILE_NAME, "workspace.include", &raw.include)?,
         exclude: compile_patterns(TOML_BUILD_FILE_NAME, "workspace.exclude", &raw.exclude)?,
+        configuration: BuildConfiguration::from_toml(raw.configuration)?,
     })
 }
 

--- a/crates/once-frontend/src/workspace_validator.rs
+++ b/crates/once-frontend/src/workspace_validator.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use crate::{
-    load_graph_workspace, target_kind_schemas_for_workspace, Diagnostic, GraphTarget,
+    load_graph_workspace, target_kind_schemas_for_workspace, AttrValue, Diagnostic, GraphTarget,
     TargetKindSchema, TargetSpec,
 };
 
@@ -35,7 +35,9 @@ fn validate_graph(
 
     validate_unique_ids(graph, &mut diagnostics);
     validate_target_schemas(graph, schemas, &mut diagnostics);
+    validate_target_attributes(graph, schemas, &targets, &mut diagnostics);
     validate_dependencies(graph, schemas, &targets, &mut diagnostics);
+    validate_visibility(graph, &targets, &mut diagnostics);
     validate_sources(workspace, graph, &mut diagnostics);
     validate_cycles(graph, &targets, &mut diagnostics);
     diagnostics.sort_by(|left, right| {
@@ -48,6 +50,87 @@ fn validate_graph(
     });
     diagnostics.dedup();
     diagnostics
+}
+
+fn validate_target_attributes(
+    graph: &[GraphTarget],
+    schemas: &[TargetKindSchema],
+    targets: &BTreeMap<&str, &GraphTarget>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for target in graph {
+        let Some(schema) = schemas.iter().find(|schema| schema.kind == target.kind) else {
+            continue;
+        };
+        for attr in schema.attrs.iter().filter(|attr| attr.ty == "target") {
+            let Some(value) = target.attrs.get(&attr.name) else {
+                continue;
+            };
+            for raw in target_attribute_values(value) {
+                if raw.is_empty() {
+                    continue;
+                }
+                let normalized = match crate::normalize_manifest_target(&target.label.package, raw)
+                {
+                    Ok(normalized) => normalized,
+                    Err(error) => {
+                        diagnostics.push(
+                            Diagnostic::new(
+                                "invalid_target_attribute",
+                                format!(
+                                    "target `{}` attribute `{}` has invalid target reference `{raw}`: {error}",
+                                    target.label.id, attr.name
+                                ),
+                            )
+                            .with_target(&target.label.id)
+                            .with_attribute(&attr.name)
+                            .with_repair(format!(
+                                "Set `target.attrs.{}` to a valid workspace target",
+                                attr.name
+                            )),
+                        );
+                        continue;
+                    }
+                };
+                if !targets.contains_key(normalized.as_str()) {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            "missing_target_attribute",
+                            format!(
+                                "target `{}` attribute `{}` references missing target `{normalized}`",
+                                target.label.id, attr.name
+                            ),
+                        )
+                        .with_target(&target.label.id)
+                        .with_attribute(&attr.name)
+                        .with_repair(format!(
+                            "Declare target `{normalized}` or update `target.attrs.{}`",
+                            attr.name
+                        )),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn target_attribute_values(value: &AttrValue) -> Vec<&str> {
+    match value {
+        AttrValue::String(value) => vec![value],
+        AttrValue::Map(outer) if outer.len() == 1 => outer
+            .get("select")
+            .and_then(|value| match value {
+                AttrValue::Map(branches) => Some(
+                    branches
+                        .values()
+                        .filter_map(AttrValue::as_str)
+                        .collect::<Vec<_>>(),
+                ),
+                _ => None,
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
 }
 
 fn validate_target_schemas(
@@ -74,6 +157,7 @@ fn validate_target_schemas(
             deps: target.deps.clone(),
             dependencies: target.dependency_edges.clone(),
             srcs: target.srcs.clone(),
+            visibility: target.visibility.clone(),
             attrs,
         };
         diagnostics.extend(crate::validate_target(&spec, schemas).into_iter().map(
@@ -229,6 +313,135 @@ fn validate_dependency_role(
     }
 }
 
+fn validate_visibility(
+    graph: &[GraphTarget],
+    targets: &BTreeMap<&str, &GraphTarget>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for target in graph {
+        for entry in &target.visibility {
+            if visibility_entry_is_valid(&target.label.package, entry) {
+                continue;
+            }
+            diagnostics.push(
+                Diagnostic::new(
+                    "invalid_visibility",
+                    format!(
+                        "target `{}` has invalid visibility entry `{entry}`",
+                        target.label.id
+                    ),
+                )
+                .with_target(&target.label.id)
+                .with_attribute("visibility")
+                .with_repair(
+                    "Use `public`, `private`, an exact target such as `tools/Generator`, a package entry such as `package:apps`, or a subtree entry such as `subtree:apps`",
+                ),
+            );
+        }
+    }
+
+    for consumer in graph {
+        validate_visibility_edges(consumer, "deps", &consumer.deps, targets, diagnostics);
+        for (role, dependencies) in &consumer.dependency_edges {
+            validate_visibility_edges(
+                consumer,
+                &format!("dependencies.{role}"),
+                dependencies,
+                targets,
+                diagnostics,
+            );
+        }
+    }
+}
+
+fn validate_visibility_edges(
+    consumer: &GraphTarget,
+    attribute: &str,
+    dependency_ids: &[String],
+    targets: &BTreeMap<&str, &GraphTarget>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for dependency_id in dependency_ids {
+        let Some(dependency) = targets.get(dependency_id.as_str()) else {
+            continue;
+        };
+        if dependency_is_visible_to(dependency, consumer) {
+            continue;
+        }
+        diagnostics.push(
+            Diagnostic::new(
+                "dependency_not_visible",
+                format!(
+                    "target `{}` cannot depend on `{}` because the dependency is not visible to it",
+                    consumer.label.id, dependency.label.id
+                ),
+            )
+            .with_target(&consumer.label.id)
+            .with_attribute(attribute)
+            .with_repair(format!(
+                "Add `{}` to target `{}` visibility, or remove the dependency",
+                visibility_repair_for(consumer),
+                dependency.label.id
+            )),
+        );
+    }
+}
+
+pub(crate) fn visibility_entry_is_valid(package: &str, entry: &str) -> bool {
+    if matches!(entry, "public" | "private") {
+        return true;
+    }
+    if let Some(prefix) = entry.strip_prefix("subtree:") {
+        return !prefix.is_empty() && valid_package_pattern(prefix);
+    }
+    if let Some(prefix) = entry.strip_prefix("package:") {
+        return valid_package_pattern(prefix);
+    }
+    crate::normalize_manifest_target(package, entry).is_ok()
+}
+
+fn valid_package_pattern(value: &str) -> bool {
+    !value.starts_with('/')
+        && !value.ends_with('/')
+        && value
+            .split('/')
+            .all(|component| !component.is_empty() && component != "." && component != "..")
+}
+
+fn dependency_is_visible_to(dependency: &GraphTarget, consumer: &GraphTarget) -> bool {
+    if dependency.visibility.is_empty()
+        || dependency.visibility.iter().any(|entry| entry == "public")
+    {
+        return true;
+    }
+    dependency.visibility.iter().any(|entry| {
+        if entry == "private" {
+            return dependency.label.package == consumer.label.package;
+        }
+        if let Some(package) = entry.strip_prefix("package:") {
+            return consumer.label.package == package;
+        }
+        if let Some(package) = entry.strip_prefix("subtree:") {
+            return consumer.label.package == package
+                || consumer
+                    .label
+                    .package
+                    .strip_prefix(package)
+                    .is_some_and(|rest| rest.starts_with('/'));
+        }
+        crate::normalize_manifest_target(&dependency.label.package, entry)
+            .is_ok_and(|target| target == consumer.label.id)
+    })
+}
+
+fn visibility_repair_for(consumer: &GraphTarget) -> String {
+    if consumer.label.package.is_empty() {
+        consumer.label.name.clone()
+    } else {
+        format!("package:{}", consumer.label.package)
+    }
+}
+
 fn validate_sources(workspace: &Path, graph: &[GraphTarget], diagnostics: &mut Vec<Diagnostic>) {
     for target in graph {
         let package = workspace.join(&target.label.package);
@@ -333,6 +546,81 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    fn write_visibility_workspace(root: &Path, visibility: &str) {
+        std::fs::create_dir_all(root.join("modules")).unwrap();
+        std::fs::create_dir_all(root.join("packages/lib")).unwrap();
+        std::fs::create_dir_all(root.join("apps/client")).unwrap();
+        std::fs::write(
+            root.join("once.toml"),
+            "[modules]\npaths = [\"modules/*.star\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("modules/visibility.star"),
+            r#"library = target_kind(
+    docs = "Library",
+    providers = ["library"],
+)
+
+consumer = target_kind(
+    docs = "Consumer",
+    deps = [dep("deps", ["library"], "Libraries")],
+)
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("packages/lib/once.toml"),
+            format!(
+                r#"[[target]]
+name = "Library"
+kind = "library"
+visibility = [{visibility}]
+"#
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("apps/client/once.toml"),
+            r#"[[target]]
+name = "Client"
+kind = "consumer"
+deps = ["packages/lib/Library"]
+"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn private_targets_reject_cross_package_dependencies() {
+        let tmp = TempDir::new().unwrap();
+        write_visibility_workspace(tmp.path(), "\"private\"");
+
+        let diagnostics = validate_workspace(tmp.path()).unwrap();
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "dependency_not_visible")
+            .expect("visibility diagnostic");
+
+        assert_eq!(diagnostic.target.as_deref(), Some("apps/client/Client"));
+        assert!(diagnostic.repairs[0].contains("package:apps/client"));
+    }
+
+    #[test]
+    fn package_visibility_allows_matching_consumers() {
+        let tmp = TempDir::new().unwrap();
+        write_visibility_workspace(tmp.path(), "\"package:apps/client\"");
+
+        let diagnostics = validate_workspace(tmp.path()).unwrap();
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "dependency_not_visible"),
+            "{diagnostics:?}"
+        );
+    }
 
     #[test]
     fn reports_missing_dependencies_and_sources() {
@@ -524,5 +812,70 @@ consumer = target_kind(
             diagnostic.code == "unexpected_dependency"
                 && diagnostic.attribute.as_deref() == Some("dependencies.plugins")
         }));
+    }
+
+    #[test]
+    fn target_attributes_reference_existing_workspace_targets() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("modules")).unwrap();
+        std::fs::write(
+            tmp.path().join("once.toml"),
+            r#"[modules]
+paths = ["modules/*.star"]
+
+[[target]]
+name = "Present"
+kind = "plain"
+
+[[target]]
+name = "Valid"
+kind = "consumer"
+
+[target.attrs]
+peer = "./Present"
+
+[[target]]
+name = "Invalid"
+kind = "consumer"
+
+[target.attrs]
+peer = "./Missing"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("modules/targets.star"),
+            r#"plain = target_kind(
+    docs = "Plain target",
+    attrs = [],
+    deps = [],
+    providers = [],
+    capabilities = [],
+)
+
+consumer = target_kind(
+    docs = "References another target",
+    attrs = [attr("peer", "target", required = True, docs = "Referenced peer")],
+    deps = [],
+    providers = [],
+    capabilities = [],
+)
+"#,
+        )
+        .unwrap();
+
+        let diagnostics = validate_workspace(tmp.path()).unwrap();
+
+        let missing = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "missing_target_attribute")
+            .collect::<Vec<_>>();
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].target.as_deref(), Some("Invalid"));
+        assert_eq!(missing[0].attribute.as_deref(), Some("peer"));
+        assert_eq!(
+            missing[0].repairs,
+            vec!["Declare target `Missing` or update `target.attrs.peer`"]
+        );
     }
 }

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -4,10 +4,10 @@
 //! way that breaks one of the starter examples, this test fails and
 //! the example has to be updated alongside the target kind.
 //!
-//! Scope: parse + diagnostic check (cheap, runs anywhere). End-to-end
-//! build verification for examples whose target kind has an `impl` is
-//! intentional follow-up work; it needs an Apple toolchain in the test
-//! environment and a configured cache provider.
+//! Scope: this test performs the cheap parse and diagnostic checks that can
+//! run anywhere. The portable executable starter matrix runs through
+//! `mise run examples:verify-portable`. Platform-specific starters remain
+//! covered by their dedicated toolchain setup and action tests.
 
 use std::collections::BTreeMap;
 use std::fs;

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -129,6 +129,13 @@ fn all_prelude_source() -> String {
 }
 
 #[test]
+fn built_in_target_kinds_do_not_hardcode_a_posix_shell_path() {
+    let source = all_prelude_source();
+    assert!(!source.contains("\"/bin/sh\""));
+    assert!(!source.contains("'/bin/sh'"));
+}
+
+#[test]
 fn go_target_kind_schemas_cover_bazel_buck_and_locked_modules() {
     for kind in [
         "go_dependencies",
@@ -442,6 +449,7 @@ fn apple_application_exposes_build_and_run() {
         deps: vec!["apps/ios/AppKit".to_string()],
         dependency_edges: BTreeMap::new(),
         srcs: Vec::new(),
+        visibility: Vec::new(),
         attrs: BTreeMap::new(),
         typed_attrs: BTreeMap::new(),
     };
@@ -1146,6 +1154,22 @@ fn dynamic_language_test_schemas_are_discoverable() {
             .find(|attr| attr.name == "runner")
             .unwrap();
         assert_eq!(runner.default.as_deref(), Some(expected));
+    }
+
+    for (kind, executable) in [
+        ("pytest_test", "pytest"),
+        ("rspec_test", "rspec"),
+        ("vitest_test", "vitest"),
+        ("jest_test", "jest"),
+    ] {
+        let schema = built_in_target_kind_schema(kind).unwrap();
+        assert!(
+            schema
+                .tools
+                .iter()
+                .any(|tool| tool.executables.iter().any(|value| value == executable)),
+            "{kind} should declare its {executable} runner"
+        );
     }
 }
 
@@ -9173,7 +9197,7 @@ fn prelude_serialize_hmap_lays_out_canonical_header_and_entries() {
 fn prelude_apple_config_tokens_rejects_select_on_platform() {
     let err = eval_prelude_function(
         "_apple_config_tokens",
-        r#"({"platform": {"select": {"default": "ios"}}}, "tgt")"#,
+        r#"({}, {"platform": {"select": {"default": "ios"}}}, "tgt")"#,
     )
     .unwrap_err();
     assert!(
@@ -9643,8 +9667,8 @@ result = repr(provider["archive"])
 #[test]
 fn prelude_resolve_attrs_rejects_select_on_non_configurable_attr() {
     let err = eval_prelude_function(
-            "_resolve_attrs",
-            r#"({"platform": "ios", "module_name": {"select": {"ios": "X", "default": "Y"}}}, "tgt", ["module_name"])"#,
+        "_resolve_attrs",
+            r#"({}, {"platform": "ios", "module_name": {"select": {"ios": "X", "default": "Y"}}}, "tgt", ["module_name"])"#,
         )
         .unwrap_err();
     assert!(

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1174,6 +1174,34 @@ fn dynamic_language_test_schemas_are_discoverable() {
 }
 
 #[test]
+fn prelude_javascript_runner_uses_the_package_entry_behind_a_bin_shim() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let bin_dir = workspace.path().join("node_modules/.bin");
+    let entry_dir = workspace.path().join("node_modules/jest/bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    std::fs::create_dir_all(&entry_dir).unwrap();
+    let shim = bin_dir.join("jest");
+    let entry = entry_dir.join("jest.js");
+    std::fs::write(&shim, "package-manager shim\n").unwrap();
+    std::fs::write(&entry, "console.log('jest')\n").unwrap();
+    let source = format!(
+        r#"{prelude}
+result = repr(_javascript_installed_package_entry(
+    "{}",
+    "node_modules/jest/bin/jest.js",
+))
+"#,
+        shim.to_string_lossy()
+    );
+    let store = store_for(workspace.path(), "");
+
+    let (_, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), format!("\"{}\"", entry.to_string_lossy()));
+}
+
+#[test]
 fn rust_schemas_cover_upstream_parity_fields() {
     for kind in [
         "rust_library",

--- a/docs/guide/graph/index.md
+++ b/docs/guide/graph/index.md
@@ -69,6 +69,20 @@ root.
 Once validates each dependency against the contract declared by the target
 kind. This catches incompatible edges before a compiler or runner starts.
 
+Restrict a target when only selected packages should consume it:
+
+```toml
+[[target]]
+name = "InternalSupport"
+kind = "rust_library"
+visibility = ["package:apps/ios", "subtree:tests"]
+```
+
+An empty visibility list is public. `private` allows only the same package,
+`package:` grants one package, `subtree:` grants a package hierarchy, and an
+exact target grants one consumer. `once query validate-workspace` reports an
+attribute-scoped repair when a dependency crosses that boundary.
+
 ## Capabilities Become Actions
 
 A capability is an operation a target exposes:
@@ -118,17 +132,18 @@ The [Ecosystems guide](/guide/graph/ecosystems) compares these choices and
 helps you decide when a typed target is a better fit than a script.
 
 Every built-in target kind also ships a complete starter with manifests and
-source files. Discover the available slugs, then return one starter as
-structured data:
+source files. Discover the available slugs, then materialize one directly:
 
 ```sh
 once query target-kinds
-once query example apple_library apple-library-minimal --format json
+once edit materialize-example rust_binary rust-binary-minimal
+once build crates/hello/hello
 ```
 
-Use the starter when you want a complete copyable workspace. Use the guide
-when you want to understand how targets connect and which capability to invoke
-next.
+Use `once query example <kind> <slug> --format json` when a caller needs to
+inspect and adapt the files before writing them. Contributors can run
+`mise run examples:verify-portable` to materialize and execute every portable
+starter against the current release build.
 
 ## Select Configuration-Specific Values
 
@@ -141,9 +156,21 @@ platform without duplicating the target:
 sdk_frameworks = { select = { ios = ["UIKit"], macos = ["AppKit"] } }
 ```
 
-The target kind schema identifies configurable attributes and the tokens that
-are meaningful for that ecosystem. Attributes that determine the active
-configuration must remain literal so Once can select a branch unambiguously.
+The root manifest can describe a target platform independently of the host:
+
+```toml
+[workspace.configuration]
+os = "linux"
+arch = "arm64"
+tokens = ["release"]
+```
+
+`once query workspace` returns the normalized operating system, architecture,
+and ordered selection tokens used by dependency and attribute selection. The
+target kind schema identifies configurable attributes and any additional
+tokens meaningful for that ecosystem. Attributes marked `implemented: false`
+are compatibility fields that validation rejects until the target kind gives
+them behavior.
 
 ## Run Supported Targets
 

--- a/docs/guide/harness.md
+++ b/docs/guide/harness.md
@@ -61,6 +61,12 @@ Every advertised tool also carries a strict input schema, behavioral hints, an
 output schema, and structured content. A harness can therefore plan from the
 live protocol contract instead of scraping this guide.
 
+Call `once_query_workspace` before using filesystem tools. It returns the exact
+root configured for the server, whether the root manifest exists, the current
+target count, any graph loading error, and the next relevant calls. This avoids
+writing files under the harness working directory when the server was
+configured for a different directory.
+
 ## Run Headlessly with Codex and Claude
 
 Headless clients cannot stop to approve a tool call. Once marks
@@ -129,23 +135,31 @@ elsewhere.
 Use this loop for requests such as “build an Android app with Once” or “add a
 Rust command-line tool with Once”:
 
-1. Call `once_list_target_kinds` and choose a kind whose description and
+1. Call `once_query_workspace` and use its `root` for every filesystem
+   operation.
+2. Call `once_list_target_kinds` and choose a kind whose description and
    `use_when` text match the request. When the request names an ecosystem or
    target-kind family, include it in `query` so it takes priority over generic
    intent words and unrelated target kinds do not consume harness context.
-2. Call `once_query_schema` for its complete attribute, dependency, provider,
-   capability, and example contract.
-3. Call `once_query_example` for the best starter, then materialize every
-   returned file exactly as described.
-4. Call `once_query_targets` to obtain canonical target identifiers from the
+3. Call `once_query_schema` for its complete attribute, dependency, provider,
+   capability, and example contract. When several starters match, prefer the
+   narrowest `use_when` description that satisfies the request. Minimal
+   starters avoid unrelated targets and dependencies.
+4. For an unchanged starter, call `once_materialize_example`. It copies the
+   complete bundle without returning file contents through the model, refuses
+   all writes when any destination conflicts, and returns canonical targets,
+   workspace validation, and suggested next calls. Use `once_query_example`
+   only when the harness needs to inspect or adapt the starter files itself.
+5. Call `once_query_targets` to obtain canonical target identifiers from the
    loaded workspace.
-5. Call `once_validate_workspace`. Repair every structured diagnostic and
+6. Call `once_validate_workspace`. Repair every structured diagnostic and
    repeat until `valid` is `true`.
-6. Call `once_query_capabilities` for the chosen target and invoke
+7. Call `once_query_capabilities` for the chosen target and invoke
    `once_build_target`, `once_run_target`, or the testing tools as appropriate.
-7. Check `success`, `exit_code`, and the structured output record. Inspect any
-   output paths that matter to the user.
-8. Call `once_query_evidence` with the returned target or capability subject to
+8. Check `success`, `exit_code`, and the structured output record. Run calls
+   include bounded `captured_stdout` and `captured_stderr` records when the
+   target declares those logs.
+9. Call `once_query_evidence` with the returned target or capability subject to
    retain and inspect the durable result.
 
 Use `once_validate_target` before creating a proposed target table from
@@ -189,10 +203,11 @@ automatic batching.
 
 For an Android application, the live catalog leads the harness to
 `android_binary` and its runnable starter. The harness creates the returned
-manifest and sources, validates the complete graph, discovers the starter's
-canonical target identifier, builds it, and checks the Android application
-package output. Android-specific behavior remains in the target kind, so the
-harness follows the same loop for other ecosystems.
+manifest and sources with `once_materialize_example`, validates the complete
+graph, discovers the starter's canonical target identifier, builds it, and
+checks the Android application package output. Android-specific behavior
+remains in the target kind, so the harness follows the same loop for other
+ecosystems.
 
 ## Adopt an Unfamiliar External Rule
 
@@ -274,6 +289,7 @@ reused safely.
 A harness should report success only after all of these are true:
 
 - the requested workspace files exist;
+- the harness wrote them under the root returned by `once_query_workspace`;
 - every project-local module validates against the live authoring contract;
 - complete-workspace validation succeeds;
 - the requested capability returns `success: true` and exit code `0`;

--- a/docs/reference/cli/edit.md
+++ b/docs/reference/cli/edit.md
@@ -10,7 +10,7 @@ once edit [OPTIONS] <SUBCOMMAND>
 
 ## Description
 
-`edit apply` runs a batch of `create` / `update` / `delete` operations against a single `once.toml` atomically. The CLI reads its input JSON from `--file` or stdin and emits structured diagnostics for failed edits.
+`edit apply` runs a batch of `create` / `update` / `delete` operations against a single `once.toml` atomically. The CLI reads its input JSON from `--file` or stdin and emits structured diagnostics for failed edits. `edit materialize-example` copies a target kind starter without printing its file contents and refuses conflicting paths.
 
 ## Options
 
@@ -25,3 +25,4 @@ once edit [OPTIONS] <SUBCOMMAND>
 ## Subcommands
 
 - [`once edit apply`](/reference/cli/edit/apply)
+- [`once edit materialize-example`](/reference/cli/edit/materialize-example)

--- a/docs/reference/cli/edit/materialize-example.md
+++ b/docs/reference/cli/edit/materialize-example.md
@@ -1,25 +1,29 @@
-# `once query validate-actions`
+# `once edit materialize-example`
 
-Run scripted actions in a private validation sandbox and report filesystem contract repairs
+Materialize a target kind starter inside the workspace
 
 ## Synopsis
 
 ```text
-once query validate-actions [OPTIONS] <TARGET>
+once edit materialize-example [OPTIONS] <KIND> <SLUG>
 ```
+
+## Description
+
+Copies the complete example bundle without printing file contents. Existing files with identical contents are kept. Any conflicting file rejects the complete operation before Once writes anything.
 
 ## Arguments
 
 | Argument | Required | Description |
 | --- | --- | --- |
-| `<TARGET>` | yes | Target id whose scripted capability should be probed |
+| `<KIND>` | yes | Target kind that owns the example |
+| `<SLUG>` | yes | Example slug from `once query schema` |
 
 ## Options
 
 | Flag | Value | Default | Description |
 | --- | --- | --- | --- |
-| `--capability` | `<CAPABILITY>` | `build` | Capability to validate |
-| `--action` | `<ACTION>` |  | Validate only one zero-based action index |
+| `--destination` | `<DIR>` |  | Workspace-relative directory that receives the example |
 | `-C, --directory` | `<DIR>` |  | Project root. Defaults to the current directory; the cache lives under `<project>/.once/`. Mirrors `make -C` |
 | `--format` | `<FORMAT>` | `human` | Output format for Once's structured data (`cache stats`, `run`/`exec` trailers). Defaults to a human-readable rendering; pass `json` or `toon` to get machine-parseable output for scripting and for agent consumers |
 | `-v, --verbose` | (flag) | `0` | Increase log verbosity. Repeat for more (-v: info, -vv: debug, -vvv: trace). Overridden by `RUST_LOG` |

--- a/docs/reference/cli/exec.md
+++ b/docs/reference/cli/exec.md
@@ -10,7 +10,7 @@ once exec [OPTIONS] [ARGV]
 
 ## Description
 
-Low-level action surface for direct commands and script adapters. The cache key is the full argument list, declared environment variables, optional working directory, optional timeout, declared input digest, and remote execution environment. A second invocation with the same key reuses the captured standard output, standard error, exit code, and declared outputs. With `--script`, or when the arguments look like `<runtime> <script> [args...]` and the file has `once` headers, Once applies script-aware parsing instead. Remote script actions receive only declared inputs and retrieve only declared outputs. Fresh hosted machines are deleted after success or failure.
+Low-level action surface for direct commands and script adapters. The cache key is the full argv, declared environment variables, optional working directory, and optional timeout. A second invocation with the same key reuses the captured stdout, stderr, and exit code. With `--script`, or when argv looks like `<runtime> <script> [args...]` and the file has `once` headers, Once applies script-aware parsing instead.
 
 ## Arguments
 

--- a/docs/reference/cli/query.md
+++ b/docs/reference/cli/query.md
@@ -27,13 +27,14 @@ against the graph without scraping prose.
 ## Query Expressions
 
 `once query '<QUERY>'` accepts a read-only subset of Cypher backed
-by the Cypher tree-sitter grammar. The first supported shape is a
-single `MATCH` pattern with optional `WHERE` equality predicates
-and explicit `RETURN` projections.
+by the Cypher tree-sitter grammar. It accepts one `MATCH` pattern,
+optional `WHERE` predicates joined with `AND` and `OR`, and explicit
+`RETURN` projections.
 
 ```sh
 once query 'MATCH (app:Target {id: "services/api/Api"})-[:DEPENDS_ON*]->(dep:Target) RETURN dep.id, dep.kind'
 once query 'MATCH (t:Target)-[:EXPOSES]->(c:Capability {name: "test"}) RETURN t.id'
+once query 'MATCH (t:Target) WHERE t.visibility CONTAINS "public" OR t.attrs.tier IN ["core", "shared"] RETURN t.id, t.attrs.tier'
 ```
 
 Supported labels are `Target`, `Capability`, and `Provider`. Labels
@@ -43,6 +44,11 @@ without a colon are aliases, so `(Target)` binds a variable named
 relationships are `DEPENDS_ON`, `EXPOSES`, and `EMITS`. The `*`
 suffix on a relationship performs transitive traversal, for example
 `[:DEPENDS_ON*]`.
+
+Predicates support `=`, `<>`, `CONTAINS`, `IN`, `STARTS WITH`, and
+`ENDS WITH`. `CONTAINS` checks a string substring or array membership.
+`IN` checks whether a scalar is present in an array literal. Property
+paths can inspect nested maps, for example `t.attrs.bundle_id`.
 
 String literals can be quoted with single or double quotes and
 support `\n`, `\r`, `\t`, `\\`, `\"`, and `\'` escapes. Other
@@ -66,6 +72,7 @@ escape forms, including Unicode escapes, are rejected.
 
 ## Subcommands
 
+- [`once query workspace`](/reference/cli/query/workspace)
 - [`once query targets`](/reference/cli/query/targets)
 - [`once query capabilities`](/reference/cli/query/capabilities)
 - [`once query schema`](/reference/cli/query/schema)

--- a/docs/reference/cli/query/affected-tests.md
+++ b/docs/reference/cli/query/affected-tests.md
@@ -8,6 +8,10 @@ List test targets likely affected by changed workspace paths
 once query affected-tests [OPTIONS]
 ```
 
+## Description
+
+Uses declared target inputs, package ownership, and reverse dependency traversal. An otherwise unowned path belongs to its nearest package. The root manifest, configured graph modules, and paths outside every known package conservatively select every test.
+
 ## Options
 
 | Flag | Value | Default | Description |

--- a/docs/reference/cli/query/workspace.md
+++ b/docs/reference/cli/query/workspace.md
@@ -1,25 +1,21 @@
-# `once query validate-actions`
+# `once query workspace`
 
-Run scripted actions in a private validation sandbox and report filesystem contract repairs
+Describe the configured workspace and graph loading state
 
 ## Synopsis
 
 ```text
-once query validate-actions [OPTIONS] <TARGET>
+once query workspace [OPTIONS]
 ```
 
-## Arguments
+## Description
 
-| Argument | Required | Description |
-| --- | --- | --- |
-| `<TARGET>` | yes | Target id whose scripted capability should be probed |
+Reports the exact workspace root, root manifest state, normalized target operating system and architecture, ordered selection tokens, loaded packages, target count, graph loading errors, and suggested discovery or validation calls.
 
 ## Options
 
 | Flag | Value | Default | Description |
 | --- | --- | --- | --- |
-| `--capability` | `<CAPABILITY>` | `build` | Capability to validate |
-| `--action` | `<ACTION>` |  | Validate only one zero-based action index |
 | `-C, --directory` | `<DIR>` |  | Project root. Defaults to the current directory; the cache lives under `<project>/.once/`. Mirrors `make -C` |
 | `--format` | `<FORMAT>` | `human` | Output format for Once's structured data (`cache stats`, `run`/`exec` trailers). Defaults to a human-readable rendering; pass `json` or `toon` to get machine-parseable output for scripting and for agent consumers |
 | `-v, --verbose` | (flag) | `0` | Increase log verbosity. Repeat for more (-v: info, -vv: debug, -vvv: trace). Overridden by `RUST_LOG` |

--- a/docs/reference/cli/toolchain.md
+++ b/docs/reference/cli/toolchain.md
@@ -10,7 +10,7 @@ once toolchain [OPTIONS] <SUBCOMMAND>
 
 ## Description
 
-Reports the toolchains a project pins (Rust, Swift, mise) and the resolved versions Once will use when running actions from script adapters or graph target kinds. Once downloads and verifies its own release-pinned mise executable when it is first needed, so the command does not depend on a developer-installed mise. Pair with `once query schema` when debugging "why did the cache miss?" questions where the toolchain identity is suspect.
+Reports the toolchains a project pins (Rust, Swift, mise) and the resolved versions Once will use when running actions from script adapters or graph target kinds. Pair with `once query schema` when debugging "why did the cache miss?" questions where the toolchain identity is suspect.
 
 ## Options
 

--- a/docs/reference/cli/toolchain/inspect.md
+++ b/docs/reference/cli/toolchain/inspect.md
@@ -8,11 +8,6 @@ Print the toolchain contract derived from mise.toml
 once toolchain inspect [OPTIONS]
 ```
 
-## Description
-
-Shows the workspace tool requests, lock information, selected platform, and
-the mise version carried by this Once release.
-
 ## Options
 
 | Flag | Value | Default | Description |

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -31,6 +31,7 @@ These tables are read only from the root manifest:
 | Table | Purpose |
 | --- | --- |
 | `[workspace]` | Limits manifest discovery with `include` and `exclude`. |
+| `[workspace.configuration]` | Selects the target operating system, architecture, and additional configuration tokens. |
 | `[modules]` | Loads project target-kind modules from `paths`. |
 | `[infrastructures.<name>]` | Declares a named infrastructure provider. |
 | `[infrastructure.cache]` | Chooses the shared cache provider. |
@@ -42,6 +43,23 @@ the same definitions.
 
 See [Modules](/reference/modules/) and [Infrastructure](/guide/infrastructure/)
 for the contracts owned by those tables.
+
+The target configuration defaults to the host. Set it explicitly when
+analysis and dependency selection should describe another platform:
+
+```toml
+[workspace.configuration]
+os = "linux"
+arch = "arm64"
+tokens = ["release"]
+```
+
+Once normalizes common operating system and architecture names. For example,
+`darwin` becomes `macos`, `arm64` becomes `aarch64`, and `amd64` becomes
+`x86_64`. The ordered selection tokens include the most specific
+operating-system and architecture combinations, their aliases, the individual
+values, the additional `tokens`, and `default`. Use `once query workspace` to
+inspect the exact configuration seen by target kinds.
 
 An execution-only provider can select a sandbox adapter and immutable tool
 environment:
@@ -99,6 +117,7 @@ Every target accepts these common fields:
 | `srcs` | no | Package-relative source paths or glob patterns. |
 | `deps` | no | Target identifiers consumed by this target. |
 | `dependencies` | no | Named dependency roles declared by the target kind. Each role contains target identifiers and validates its own provider contract. |
+| `visibility` | no | Consumers allowed to depend on this target. An empty list is public. |
 | `attrs` | no | Target-kind-specific values validated against the selected schema. |
 
 Unknown manifest fields are rejected. Use
@@ -139,10 +158,38 @@ Dependency references resolve as follows:
 Use one of these identifiers with `once query target`, `once build`, `once
 run`, and `once test`.
 
+Target-valued entries under `[target.attrs]` use the same normalization rules.
+`once query validate-workspace` checks that these references resolve to a
+declared target.
+
+## Visibility
+
+Targets are public unless `visibility` restricts them:
+
+```toml
+[[target]]
+name = "Core"
+kind = "rust_library"
+visibility = ["package:apps/client", "subtree:tools", "tests/CoreTests"]
+```
+
+Each entry grants access to one class of consumer:
+
+- `public` grants access to every target.
+- `private` grants access to targets in the same package.
+- `package:apps/client` grants access to targets in that exact package.
+- `subtree:tools` grants access to targets in `tools` and its child packages.
+- `tests/CoreTests` grants access to one exact target.
+
+Exact targets use the same workspace-relative and package-relative
+normalization as dependencies. Complete-workspace validation returns
+`invalid_visibility` for malformed entries and `dependency_not_visible` when a
+dependency edge crosses the declared boundary.
+
 ## Conditional Values
 
 Target kinds can accept `select` values for configurable attributes. A target
-can also select dependencies for the current host:
+can also select dependencies for the workspace target configuration:
 
 ```toml
 [target.deps.select]
@@ -151,8 +198,11 @@ linux = ["./linux_support"]
 default = ["./portable_support"]
 ```
 
-The target-kind schema determines which attribute values are configurable.
-Each ecosystem guide documents its selection tokens and restrictions.
+The target-kind schema reports both `configurable` and `implemented` for every
+attribute. Validation rejects `select` on a non-configurable attribute and
+rejects an unavailable compatibility attribute marked `implemented = false`.
+Generic target kinds use the tokens returned by `once query workspace`.
+Ecosystem target kinds can add their own tokens and restrictions.
 
 ## Inspect
 

--- a/docs/reference/mcp/index.md
+++ b/docs/reference/mcp/index.md
@@ -36,7 +36,8 @@ versions back through `2024-11-05`. The expected sequence:
 1. Client → `initialize` request with its protocol version,
    capabilities, and client info.
 2. Server → `initialize` result with the negotiated protocol version,
-   the `tools` capability, server info, and cross-tool workflow instructions.
+   the `tools` capability, server info, the configured workspace root, and
+   cross-tool workflow instructions.
 3. Client → `notifications/initialized` (no reply).
 4. Client → `tools/list` to discover tools, then `tools/call` for
    each invocation.
@@ -83,16 +84,21 @@ A complete client/server exchange:
 → { "jsonrpc": "2.0", "id": 1, "method": "tools/list" }
 ← { "jsonrpc": "2.0", "id": 1, "result": { "tools": [ … ] } }
 → { "jsonrpc": "2.0", "id": 2, "method": "tools/call",
-    "params": { "name": "once_query_targets", "arguments": {} } }
+    "params": { "name": "once_query_workspace", "arguments": {} } }
 ← { "jsonrpc": "2.0", "id": 2,
     "result": { "content": [ { "type": "text",
-                               "text": "[ … target list … ]" } ],
-                "structuredContent": { "result": [ … target list … ] } } }
+                               "text": "{ … workspace state … }" } ],
+                "structuredContent": { "result": { … workspace state … } } } }
 ```
 
 Every advertised tool includes behavioral annotations, a strict root input
 schema, and an output schema. Text content remains available for older clients;
 newer clients can consume `structuredContent` directly.
+
+When editing and execution are enabled, `once_materialize_example` can create a
+complete starter without returning every file through the model context. It is
+idempotent for identical files and rejects the complete operation before
+writing when any destination conflicts.
 
 Some hosts probe optional resource, resource-template, or prompt catalogs even
 when a server does not advertise them. Once returns valid empty catalogs for

--- a/docs/reference/mcp/tools.md
+++ b/docs/reference/mcp/tools.md
@@ -2,23 +2,18 @@
 
 Every tool the [`once mcp`](/reference/cli/mcp) [Model Context Protocol](https://modelcontextprotocol.io/) server advertises in `tools/list`, with its input schema and a worked return example.
 
-## `once_validate_actions`
+## `once_query_workspace`
 
-Run scripted graph actions in an isolated validation workspace.
+Return the configured workspace root, root manifest state, graph loading state, and next calls.
 
-Runs the same declared action analysis as the graph, bypasses the action cache, checks isolated and project workspace changes, and returns structured input and output repairs. The matching command-line operation is `once query validate-actions <target> --capability <name>`. This tool requires `once mcp --allow-run` because it executes commands. Reads that leave no observable filesystem evidence remain a limitation of this validation mode.
+Call this first when filesystem tools and the Once server may have different working directories. The result identifies the exact workspace every other Once tool uses, reports the target operating system, architecture, and ordered selection tokens, reports whether the root manifest exists, lists loaded packages and target count, preserves graph loading errors as data, and recommends the next discovery or validation call. The matching command-line operation is `once query workspace --format json`.
 
 **Input schema**
 
 ```json
 {
-  "type": "object",
-  "properties": {
-    "target": { "type": "string" },
-    "capability": { "type": "string", "default": "build" },
-    "action": { "type": "integer", "minimum": 0 }
-  },
-  "required": ["target"]
+  "properties": {},
+  "type": "object"
 }
 ```
 
@@ -26,16 +21,19 @@ Runs the same declared action analysis as the graph, bypasses the action cache, 
 
 ```json
 {
-  "valid": false,
-  "target": "pkg/tool",
-  "capability": "build",
-  "actions_run": 1,
-  "diagnostics": [{
-    "code": "undeclared_write",
-    "target": "pkg/tool",
-    "attribute": "outputs",
-    "repairs": ["Declare this path as an output or stop writing it"]
-  }]
+  "root": "/work/project",
+  "configuration": {
+    "os": "linux",
+    "arch": "aarch64",
+    "tokens": ["linux-arm64", "linux-aarch64", "linux", "arm64", "aarch64", "default"]
+  },
+  "root_manifest": { "path": "/work/project/once.toml", "exists": false },
+  "target_count": 0,
+  "packages": [],
+  "empty": true,
+  "suggested_calls": [
+    { "tool": "once_list_target_kinds", "arguments": {}, "reason": "Discover a target kind and starter for this empty workspace." }
+  ]
 }
 ```
 
@@ -43,7 +41,7 @@ Runs the same declared action analysis as the graph, bypasses the action cache, 
 
 List every declared target in the workspace, optionally filtered by target kind.
 
-Returns the same record shape as `once query targets --format json`: one entry per declared target with its canonical id, package, name, target kind, default dependencies, named dependency roles, and exposed capabilities. The optional `kind` argument narrows results to one target kind.
+Returns the same record shape as `once query targets --format json`: one entry per declared target with its canonical id, package, name, target kind, visibility rules, default dependencies, named dependency roles, and exposed capabilities. The optional `kind` argument narrows results to one target kind.
 
 **Input schema**
 
@@ -64,9 +62,10 @@ Returns the same record shape as `once query targets --format json`: one entry p
 ```json
 [
   { "id": "packages/core/Core", "package": "packages/core", "name": "Core",
-    "kind": "library", "deps": [], "dependency_edges": {}, "capabilities": ["build"] },
+    "kind": "library", "visibility": ["subtree:apps"], "deps": [],
+    "dependency_edges": {}, "capabilities": ["build"] },
   { "id": "apps/service/Service", "package": "apps/service", "name": "Service",
-    "kind": "application", "deps": ["packages/core/Core"],
+    "kind": "application", "visibility": [], "deps": ["packages/core/Core"],
     "dependency_edges": { "plugins": ["tools/compiler/Plugin"] },
     "capabilities": ["build", "run"] }
 ]
@@ -114,7 +113,7 @@ Returns the same record `once query capabilities <target> --format json` emits: 
 
 Return the typed contract for a target kind: attributes, dep edges, providers, capabilities, source references, and runnable starters.
 
-Returns the target kind schema (the typed contract a target of that kind must match) as `once query schema <kind> --format json` would. The record carries the target kind's documentation, attribute list (with types, required flag, and whether the attribute is configurable), expected dep providers, emitted providers, exposed capabilities, external source concepts that can guide partial adoption, and a lightweight list of runnable starter examples. Use `once_query_example` to fetch the full file tree for a chosen example.
+Returns the target kind schema (the typed contract a target of that kind must match) as `once query schema <kind> --format json` would. The record carries the target kind's documentation, attribute list with types and required, configurable, and implemented flags, expected dep providers, emitted providers, exposed capabilities, required tools, external source concepts that can guide partial adoption, and a lightweight list of runnable starter examples. Attributes marked `implemented: false` are discoverable compatibility fields that validation rejects until their target kind gives them behavior. Use `once_materialize_example` to create an unchanged starter without loading its contents into model context, or `once_query_example` when the caller needs to inspect and adapt the files.
 
 **Input schema**
 
@@ -140,7 +139,8 @@ Returns the target kind schema (the typed contract a target of that kind must ma
   "kind": "library",
   "docs": "Reusable library target...",
   "attrs": [
-    { "name": "visibility", "ty": "string", "required": true, "configurable": false }
+    { "name": "mode", "ty": "string", "required": false,
+      "configurable": true, "implemented": true }
   ],
   "capabilities": [ { "name": "build", "output_groups": ["default"], "requires_outputs": [] } ],
   "providers": ["linkable", "module"],
@@ -163,7 +163,7 @@ Returns the target kind schema (the typed contract a target of that kind must ma
 
 Return the complete file bundle for one target kind starter example.
 
-Returns the same record as `once query example <kind> <slug> --format json`: the selected example's slug, name, selection hint, and every text file a caller can copy to create the starter workspace. Example descriptors are discovered through `once_list_target_kinds` or `once_query_schema`; this tool fetches the file payload only after a caller chooses one.
+Returns the same record as `once query example <kind> <slug> --format json`: the selected example's slug, name, selection hint, and every text file a caller can inspect or adapt. Example descriptors are discovered through `once_list_target_kinds` or `once_query_schema`. For direct setup, prefer `once_materialize_example`, which writes the bundle without sending large dependency payloads through model context.
 
 **Input schema**
 
@@ -196,6 +196,61 @@ Returns the same record as `once query example <kind> <slug> --format json`: the
   "use_when": "...",
   "files": [
     { "path": "packages/core/once.toml", "contents": "[[target]]\nname = \"Core\"\nkind = \"library\"\n..." }
+  ]
+}
+```
+
+## `once_materialize_example`
+
+Materialize a complete target kind starter directly inside the configured workspace.
+
+This collision-safe setup tool is available only when the server starts with `once mcp --allow-run`. It copies the selected example without returning its file contents through model context. Existing files with identical contents are kept, making retries idempotent. If any path conflicts, Once reports every conflict and writes nothing. A successful result includes created and unchanged paths, canonical targets, complete-workspace validation, and exact suggested tool calls for targets of the requested kind. The matching command-line operation is `once edit materialize-example <kind> <slug> --destination <dir>`.
+
+**Input schema**
+
+```json
+{
+  "properties": {
+    "destination": {
+      "default": "",
+      "description": "Workspace-relative destination directory. Use an empty string for the workspace root.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Target kind that owns the example.",
+      "type": "string"
+    },
+    "slug": {
+      "description": "Example slug from `once_list_target_kinds` or `once_query_schema`.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "kind",
+    "slug"
+  ],
+  "type": "object"
+}
+```
+
+**Example return**
+
+```json
+{
+  "materialized": true,
+  "kind": "library",
+  "slug": "library-minimal",
+  "destination": "",
+  "created_files": ["packages/core/once.toml", "packages/core/src/core.txt"],
+  "unchanged_files": [],
+  "conflicts": [],
+  "targets": [
+    { "id": "packages/core/Core", "kind": "library", "capabilities": ["build"] }
+  ],
+  "workspace_validation": { "valid": true, "target_count": 1, "diagnostics": [] },
+  "suggested_calls": [
+    { "tool": "once_validate_workspace", "arguments": {}, "reason": "Confirm the complete workspace after any customization." },
+    { "tool": "once_build_target", "arguments": { "target": "packages/core/Core" }, "reason": "Build the materialized `library` target." }
   ]
 }
 ```
@@ -381,9 +436,10 @@ Returns the same `GraphTarget` record `once_query_targets` emits, scoped to one 
   "label": { "package": "packages/core", "name": "Core", "id": "packages/core/Core" },
   "kind": "library",
   "srcs": ["src/**/*.src"],
+  "visibility": ["subtree:apps"],
   "deps": [],
   "dependency_edges": { "plugins": ["tools/compiler/Plugin"] },
-  "attrs": { "visibility": "public" },
+  "attrs": {},
   "capabilities": [ { "name": "build", "output_groups": ["default"], "requires_outputs": [] } ],
   "providers": ["linkable", "module"]
 }
@@ -423,7 +479,7 @@ Returns every target with a `test` capability, including its target kind, depend
 
 Return test targets likely affected by a set of changed workspace paths.
 
-Maps changed paths to test targets using graph relationships and declared inputs. A test is affected when a changed path belongs to the test target itself or to one of its declared dependencies. Declared source patterns are matched without requiring the changed file to still exist. Changes to manifests, configured graph modules, and paths without a declared owner conservatively select every test. Selection does not depend on a particular test runner.
+Maps changed paths to test targets using graph relationships, declared inputs, and package ownership. A test is affected when a changed path belongs to the test target itself or to one of its declared dependencies. Declared source patterns are matched without requiring the changed file to still exist. An otherwise unowned path, including a package manifest, belongs to the nearest package and selects only that package's reverse dependency closure. The root manifest, configured graph modules, and paths outside every known package conservatively select every test. Selection does not depend on a particular test runner.
 
 **Input schema**
 
@@ -493,7 +549,7 @@ Returns the selection policy, normalized changed paths, unmatched paths, selecte
   "id": "<stable digest>",
   "selection": {
     "schema": "once.test_selection.v1",
-    "policy": { "mode": "affected", "safety": "conservative", "evidence": "declared_graph" },
+    "policy": { "mode": "affected", "safety": "conservative", "evidence": "declared_graph_and_package_ownership" },
     "changed_paths": ["src/lib.src"],
     "unmatched_paths": [],
     "tests": [{ "id": "tests/unit", "kind": "test_suite", "reasons": ["changed dependency `lib` input `src/lib.src`"] }]
@@ -836,7 +892,7 @@ Opt-in tool exposed only when the Model Context Protocol server starts with `onc
 
 Build a target by running its generic `build` capability.
 
-This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once build <target> --format json`, including dependency traversal, target actions, cache policy, and output groups. The result includes the exit status, standard error, and standard output parsed as structured data when possible. A failed build is returned as normal tool content with `success: false` so agents can inspect diagnostics.
+This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once build <target> --format json`, including dependency traversal, target actions, cache policy, and output groups. Because cache identity follows declared content rather than workspace history, a first build in a new workspace can reuse an equivalent action produced elsewhere. The result includes the exit status, command diagnostics under `stderr`, and bounded declared action logs under `captured_stdout` and `captured_stderr`. A captured field is null when the target did not declare that log. A failed build is returned as normal tool content with `success: false` so agents can inspect diagnostics.
 
 **Input schema**
 
@@ -876,9 +932,9 @@ This tool is available only when the server starts with `once mcp --allow-run`. 
 
 ## `once_validate_actions`
 
-Run scripted graph actions in an isolated validation workspace.
+Run scripted graph actions in a private validation sandbox.
 
-Runs the same declared action analysis used by the graph, bypasses the action cache, checks isolated and project workspace changes, and returns structured input and output repairs. The matching command-line operation is `once query validate-actions <target> --capability <name>`. This tool requires `once mcp --allow-run` because it executes commands. Reads that leave no observable filesystem evidence remain a documented limitation of this validation mode.
+Runs the same declared action analysis used by the graph, bypasses the action cache, inventories private and real-workspace filesystem changes, and returns structured input and output repairs. The matching command-line operation is `once query validate-actions <target> --capability <name>`. This tool requires `once mcp --allow-run` because it executes commands. Successful reads that leave no filesystem evidence remain a documented limitation of symlink-only validation.
 
 **Input schema**
 
@@ -917,7 +973,7 @@ Runs the same declared action analysis used by the graph, bypasses the action ca
 
 Run a target by executing its generic `run` capability.
 
-This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once run <target> --format json`, including prerequisite build outputs declared by the target's `run` capability. Set `visible` to request a visible interface when the target kind supports one. Uncacheable actions run again instead of replaying an action-cache hit. The result includes the exit status, standard error, and standard output parsed as structured data when possible.
+This tool is available only when the server starts with `once mcp --allow-run`. It behaves like `once run <target> --format json`, including prerequisite build outputs declared by the target's `run` capability. Set `visible` to request a visible interface when the target kind supports one. Uncacheable actions run again instead of replaying an action-cache hit. The result includes command diagnostics under `stderr` and up to 64 kibibytes of each declared `stdout.log` or `stderr.log` output under `captured_stdout` and `captured_stderr`, so an agent can verify ordinary command output without a separate filesystem read. A captured field is null when the target did not declare that log.
 
 **Input schema**
 
@@ -1116,7 +1172,7 @@ Requests that the process stop and updates the session status as the request is 
 
 Validate the complete workspace graph before execution.
 
-Loads every manifest and target kind schema, then checks target attributes, duplicate target ids, missing dependencies, dependency provider compatibility, source patterns, and dependency cycles. Returns stable diagnostics with target and attribute scope plus suggested repairs. Call this after materializing a starter or applying edits and before build, run, or test. The matching command-line operation is `once query validate-workspace`.
+Loads every manifest and target kind schema, then checks target attributes, target-valued attribute references, duplicate target identifiers, missing dependencies, dependency visibility, dependency provider compatibility, source patterns, and dependency cycles. Returns stable diagnostics with target and attribute scope plus suggested repairs. Call this after materializing a starter or applying edits and before build, run, or test. The matching command-line operation is `once query validate-workspace`.
 
 **Input schema**
 
@@ -1188,7 +1244,7 @@ Schema-only validation: checks that the target declares a known target kind, eve
 
 Apply a batch of `create` / `update` / `delete` operations to one `once.toml` atomically.
 
-Reads the manifest at `<workspace>/<package>/once.toml`, creating it if needed, and applies the operations only if every operation succeeds. Returns `{ applied: true, path: <manifest path> }` on success or `{ applied: false, diagnostics: [...] }` with the structured diagnostic shape used by `once_validate_target`. A failed batch leaves the original file unchanged.
+Reads the manifest at `<workspace>/<package>/once.toml` and applies the operations only if every operation succeeds. Returns `{ applied: true, changed: <bool>, path: <manifest path> }` on success. `changed` is false when the requested state already exists, in which case no manifest is written. Returns `{ applied: false, diagnostics: [...] }` with the structured diagnostic shape used by `once_validate_target` when the edit is invalid. A failed batch leaves the original file unchanged.
 
 **Input schema**
 
@@ -1220,6 +1276,7 @@ Reads the manifest at `<workspace>/<package>/once.toml`, creating it if needed, 
 ```json
 {
   "applied": true,
+  "changed": true,
   "path": "packages/core/once.toml"
 }
 ```

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -76,6 +76,13 @@ discovery.
 Attributes can be configurable unless their schema sets
 `configurable = False`. Non-configurable attributes reject `select`
 during validation before the implementation runs.
+Set `implemented = False` on compatibility attributes that should remain
+discoverable but are not available yet. Validation returns
+`unimplemented_attr` with an attribute-scoped repair before analysis starts.
+Values declared with the `target` type use the same package-relative target
+syntax as dependency references. Complete-workspace validation confirms that
+each referenced target exists and returns an attribute-scoped repair when it
+does not.
 
 ## Dependency Resolver Contract
 
@@ -89,6 +96,8 @@ The resolver receives a restricted context:
 - `ctx["label"]`: package, name, and stable target identifier.
 - `ctx["attr"]`: typed owner attributes. `ctx["attrs"]` is an equivalent
   spelling for resolver compatibility.
+- `ctx["configuration"]`: normalized target operating system, architecture,
+  and ordered selection tokens.
 - `ctx["srcs"]`: declared build source patterns.
 - `ctx["files"]`: resolver input files decoded as text, keyed by path relative
   to the owner package. Non-empty `resolver_inputs` patterns define this map.
@@ -135,14 +144,15 @@ def _resolve(ctx):
 ```
 
 Each target record accepts only `name`, `kind`, `deps`, `dependencies`, `srcs`,
-and `attrs`. Dependency references use the same syntax as a manifest, including
-`./name` for a target in the owner package. A bare root name that matches an
-emitted target is also package-local. When `roots` is omitted, every emitted
-target becomes an owner dependency. Resolver-owned and synthetic attributes
-must be declared in their target kind schemas, including internal bookkeeping
-attributes. A resolver attribute cannot replace a value declared by the owner
-target. Expansion stops at 100,000 workspace targets so a recursive resolver
-cannot grow the graph without bound.
+`visibility`, and `attrs`. Dependency references and exact visibility entries
+use the same syntax as a manifest, including `./name` for a target in the owner
+package. A bare root name that matches an emitted target is also package-local.
+When `roots` is omitted, every emitted target becomes an owner dependency.
+Resolver-owned and synthetic attributes must be declared in their target kind
+schemas, including internal bookkeeping attributes. A resolver attribute
+cannot replace a value declared by the owner target. Expansion stops at
+100,000 workspace targets so a recursive resolver cannot grow the graph
+without bound.
 
 Ordinary builds consume locked metadata and already materialized sources. A
 separate explicit update workflow should invoke the native package manager when
@@ -245,8 +255,14 @@ once query schema apple_library --format json
 }
 ```
 
-Agents should use `use_when` to pick the closest starter, then fetch its
-file bundle:
+Agents should use `use_when` to pick the closest starter, then materialize it
+without copying file payloads through model context:
+
+```sh
+once edit materialize-example apple_library apple-library-minimal
+```
+
+Fetch the file bundle only when the caller needs to inspect or adapt it:
 
 ```sh
 once query example apple_library apple-library-minimal --format json
@@ -268,7 +284,10 @@ once query example apple_library apple-library-minimal --format json
 
 [Model Context Protocol](https://modelcontextprotocol.io/) callers use
 `once_list_target_kinds` and `once_query_schema` for discovery, then
-`once_query_example` to fetch the file bundle for the chosen starter.
+`once_materialize_example` for direct setup or `once_query_example` to inspect
+the file bundle. Repository contributors can run
+`mise run examples:verify-portable` to materialize and execute the portable
+starter set.
 
 ## External Rule Assimilation
 

--- a/docs/reference/prelude/go_binary.md
+++ b/docs/reference/prelude/go_binary.md
@@ -43,3 +43,10 @@ header and transitive native metadata.
 
 Only `exe` and `pie` can run. Other build modes remain buildable outputs.
 `once run` writes its log and result marker under `.once/out/<target>/run/`.
+
+## Starter
+
+The `go-binary-minimal` starter contains one executable and no external
+dependencies. Discover its descriptor through `once query schema go_binary`,
+then create it with `once edit materialize-example go_binary
+go-binary-minimal`.

--- a/docs/reference/prelude/index.md
+++ b/docs/reference/prelude/index.md
@@ -9,6 +9,18 @@ Use [`once query schema`](/reference/cli/query/schema) to inspect the same
 contract from the command line. See [Ecosystems](/guide/graph/ecosystems) for
 help choosing between typed target kinds and scripted automation.
 
+Each schema reports whether an attribute is required, configurable, and
+implemented. An attribute marked as not implemented remains discoverable for
+compatibility, but validation rejects it with a focused repair before
+analysis. Tool requirements list the executable alternatives Once can use, so
+an agent can discover missing setup without reading prose documentation.
+
+Every target kind includes at least one materializable starter. Repository
+contributors can run `mise run examples:verify-portable` to materialize and
+execute the portable starter set against the release command-line interface.
+Platform-specific starters remain covered by their dedicated toolchain setup
+and action tests.
+
 ## Apple target kinds
 
 - [`apple_library`](/reference/prelude/apple_library): Swift,

--- a/docs/reference/prelude/jest_test.md
+++ b/docs/reference/prelude/jest_test.md
@@ -4,8 +4,8 @@ JavaScript and TypeScript tests run with Jest.
 
 ## Start Here
 
-Install Jest in the package with the project's JavaScript package manager.
-For example:
+Install Jest in the package with the project's JavaScript package manager, or
+make the `jest` command available on the executable search path. For example:
 
 ```sh
 npm install --save-dev jest
@@ -34,10 +34,14 @@ batching, and exact unit commands.
 
 ## Description
 
-`jest_test` invokes the package-local Jest entry point with structured output,
-records stable file and full-name identifiers, and writes normalized Once
-results. Exact execution selects the discovered file and an anchored test name
-pattern.
+`jest_test` prefers the package-local Jest entry point, then falls back to the
+installed `jest` command. It uses structured output, records stable file and
+full-name identifiers, and writes normalized Once results. Exact execution
+selects the discovered file and an anchored test name pattern.
+
+The target kind declares Node.js and Jest as tool requirements. A
+workspace-relative `runner` is treated as an input, while an installed runner
+is identified as part of the toolchain.
 
 Automatic batching uses one batch per test file by default. Set `batching` to
 `case` for individual cases, or `target` for one target batch. A complete run
@@ -51,7 +55,7 @@ results when those inputs have not changed.
 | Attribute | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `node` | string | no | `node` | Node.js executable name, absolute path, or workspace-relative path |
-| `runner` | string | no | `node_modules/jest/bin/jest.js` | Package-relative Jest entry point |
+| `runner` | string | no | automatic | Package-relative Jest entry point or installed command. Once prefers `node_modules/jest/bin/jest.js`, then searches for `jest` |
 | `config` | list&lt;string&gt; | no | package and lock files | Dependency and runner configuration inputs |
 | `dependencies` | list&lt;string&gt; | no | `node_modules/**/*` | Installed runner and package files required during execution |
 | `data` | list&lt;string&gt; | no | `[]` | Setup, transform, snapshot, and runtime inputs |

--- a/docs/reference/prelude/pytest_test.md
+++ b/docs/reference/prelude/pytest_test.md
@@ -5,10 +5,11 @@ Python tests run with pytest.
 ## Start Here
 
 The selected `python` interpreter must be able to import pytest. When the
-attribute is omitted, Once first uses `.venv/bin/python` or the Windows virtual
-environment equivalent when present, then tries `python3` and `python` on the
-executable search path. You can also set an absolute or workspace-relative
-path explicitly. A common direct installation is:
+attribute is omitted, Once first uses the workspace virtual environment. It
+then finds the installed pytest command and uses the interpreter named by that
+command or a neighboring Python interpreter. You can also set an absolute or
+workspace-relative interpreter path explicitly. A common direct installation
+is:
 
 ```sh
 python3 -m pip install pytest
@@ -40,6 +41,10 @@ batching, and exact unit commands.
 `pytest_test` invokes pytest through the selected Python interpreter, records
 stable node identifiers, and writes normalized Once results. A complete run
 discovers cases for exact interactive execution and automatic scheduling.
+
+The target kind declares both Python and pytest as tool requirements. This
+lets schema discovery and toolchain setup explain the complete runtime
+requirement even when pytest is installed outside the workspace.
 
 Automatic batching uses one batch per test file by default. Set `batching` to
 `case` for one batch per discovered case, or `target` to keep one batch for the

--- a/docs/reference/prelude/rspec_test.md
+++ b/docs/reference/prelude/rspec_test.md
@@ -4,10 +4,9 @@
 
 ## Start Here
 
-The selected `ruby` interpreter must be able to load `rspec/core`. Use the
-Ruby environment already managed by the project. The interpreter may be a
-name on the executable search path, an absolute path, or a workspace-relative
-path. A common direct installation is:
+Once resolves the Ruby interpreter and the Ruby Specification runner as
+separate tools. Each may be a name on the executable search path, an absolute
+path, or a workspace-relative path. A common direct installation is:
 
 ```sh
 gem install rspec
@@ -37,10 +36,14 @@ batching, and exact unit commands.
 
 ## Description
 
-`rspec_test` invokes the Ruby Specification core runner with its structured
-formatter, converts examples into stable target-qualified identifiers, and
-writes normalized Once results. Exact execution passes the native example
-identifier back to the runner.
+`rspec_test` invokes the selected Ruby Specification command with its
+structured formatter, converts examples into stable target-qualified
+identifiers, and writes normalized Once results. Exact execution passes the
+native example identifier back to the runner.
+
+The target kind declares Ruby and Ruby Specification as tool requirements.
+The runner does not need to be loadable by an unrelated system Ruby
+installation.
 
 Automatic batching uses one batch per specification file by default. Set
 `batching` to `case` for individual examples, or `target` for one target batch.
@@ -50,7 +53,8 @@ A complete discovery run is required before smaller batches are planned.
 
 | Attribute | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `ruby` | string | no | `ruby` | Ruby interpreter name, absolute path, or workspace-relative path that can load the Ruby Specification library |
+| `ruby` | string | no | `ruby` | Ruby interpreter name, absolute path, or workspace-relative path |
+| `runner` | string | no | `rspec` | Ruby Specification runner name, absolute path, or workspace-relative path |
 | `config` | list&lt;string&gt; | no | `Gemfile`, `Gemfile.lock` | Dependency and runner configuration inputs |
 | `data` | list&lt;string&gt; | no | `[]` | Runtime data and support inputs |
 | `args` | list&lt;string&gt; | no | `[]` | Additional runner arguments |

--- a/docs/reference/prelude/rust_binary.md
+++ b/docs/reference/prelude/rust_binary.md
@@ -81,17 +81,14 @@ The target emits `rust_binary`.
 
 ```toml
 [[target]]
-name = "hello"
+name = "Hello"
 kind = "rust_binary"
-deps = ["cargo_dependencies"]
 srcs = ["src/**/*.rs"]
 
 [target.attrs]
 crate_name = "hello"
 edition = "2021"
-
-[target.attrs.rustc_env]
-CARGO_MANIFEST_DIR = "apps/hello"
-CARGO_PKG_NAME = "hello"
-CARGO_PKG_VERSION = "0.0.0"
 ```
+
+Discover the complete `rust-binary-minimal` starter through `once query schema
+rust_binary`.

--- a/docs/reference/prelude/vitest_test.md
+++ b/docs/reference/prelude/vitest_test.md
@@ -4,8 +4,9 @@ JavaScript and TypeScript tests run with Vitest.
 
 ## Start Here
 
-Install Vitest in the package with the project's JavaScript package manager.
-For example:
+Install Vitest in the package with the project's JavaScript package manager,
+or make the `vitest` command available on the executable search path. For
+example:
 
 ```sh
 npm install --save-dev vitest
@@ -34,10 +35,14 @@ batching, and exact unit commands.
 
 ## Description
 
-`vitest_test` invokes the package-local Vitest entry point with its structured
-reporter, records stable file and full-name identifiers, and writes normalized
-Once results. Exact execution selects the discovered file and an anchored test
-name pattern.
+`vitest_test` prefers the package-local Vitest entry point, then falls back to
+the installed `vitest` command. It uses Vitest's structured reporter, records
+stable file and full-name identifiers, and writes normalized Once results.
+Exact execution selects the discovered file and an anchored test name pattern.
+
+The target kind declares Node.js and Vitest as tool requirements. A
+workspace-relative `runner` is treated as an input, while an installed runner
+is identified as part of the toolchain.
 
 Automatic batching uses one batch per test file by default. Set `batching` to
 `case` for individual cases, or `target` for one target batch. A complete run
@@ -51,7 +56,7 @@ test results when those inputs have not changed.
 | Attribute | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `node` | string | no | `node` | Node.js executable name, absolute path, or workspace-relative path |
-| `runner` | string | no | `node_modules/vitest/vitest.mjs` | Package-relative Vitest entry point |
+| `runner` | string | no | automatic | Package-relative Vitest entry point or installed command. Once prefers `node_modules/vitest/vitest.mjs`, then searches for `vitest` |
 | `config` | list&lt;string&gt; | no | package and lock files | Dependency and runner configuration inputs |
 | `dependencies` | list&lt;string&gt; | no | `node_modules/**/*` | Installed runner and package files required during execution |
 | `data` | list&lt;string&gt; | no | `[]` | Setup, transform, snapshot, and runtime inputs |

--- a/mise.toml
+++ b/mise.toml
@@ -168,3 +168,10 @@ rustup target add aarch64-linux-android
 mise run kotlin-native:install
 mise run swift:install-android-sdk
 '''
+
+[tasks."examples:verify-portable"]
+description = "Build the release binary, materialize the portable starter examples, and execute their primary capability."
+run = '''
+mise exec -- cargo build --release --package once-cli
+mise exec -- shellspec spec/starter_examples_spec.sh
+'''

--- a/spec/graph_edit_spec.sh
+++ b/spec/graph_edit_spec.sh
@@ -100,6 +100,32 @@ Describe 'once query example'
   End
 End
 
+Describe 'once edit materialize-example'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  It 'creates a valid starter without printing file contents'
+    When call "$ONCE_BIN" -C "$WORKSPACE" --format json edit materialize-example rust_library rust-library-minimal
+    The status should be success
+    The stdout should include '"materialized":true'
+    The stdout should include '"id":"crates/hello/hello"'
+    The stdout should include '"valid":true'
+    The stdout should not include 'pub fn'
+    The path "$WORKSPACE/crates/hello/once.toml" should be file
+    The path "$WORKSPACE/crates/hello/src/lib.rs" should be file
+  End
+
+  It 'keeps an identical retry idempotent'
+    "$ONCE_BIN" -C "$WORKSPACE" edit materialize-example rust_library rust-library-minimal >/dev/null
+
+    When call "$ONCE_BIN" -C "$WORKSPACE" --format json edit materialize-example rust_library rust-library-minimal
+    The status should be success
+    The stdout should include '"materialized":true'
+    The stdout should include '"created_files":[]'
+    The stdout should include '"unchanged_files":'
+  End
+End
+
 Describe 'workspace custom module CLI surface'
   BeforeEach 'setup_workspace'
   AfterEach 'cleanup_workspace'

--- a/spec/starter_examples_spec.sh
+++ b/spec/starter_examples_spec.sh
@@ -1,0 +1,80 @@
+#shellcheck shell=bash
+
+verify_starter_example() {
+  kind="$1"
+  slug="$2"
+  capability="$3"
+  root="$WORKSPACE/starters/$kind-$slug"
+  mkdir -p "$root"
+
+  "$ONCE_BIN" -C "$root" edit materialize-example "$kind" "$slug" >/dev/null || return
+  target_ids="$(
+    "$ONCE_BIN" -C "$root" --format json query targets |
+      jq -r --arg kind "$kind" '.[] | select(.kind == $kind) | .id'
+  )" || return
+  if [ -z "$target_ids" ]; then
+    echo "starter $kind $slug created no matching target" >&2
+    return 1
+  fi
+
+  while IFS= read -r target_id; do
+    [ -n "$target_id" ] || continue
+    "$ONCE_BIN" -C "$root" "$capability" "$target_id" --quiet || return
+  done <<EOF
+$target_ids
+EOF
+
+  printf 'verified %s %s with %s\n' "$kind" "$slug" "$capability"
+}
+
+verify_portable_starter_examples() {
+  while IFS='|' read -r kind slug capability; do
+    [ -n "$kind" ] || continue
+    verify_starter_example "$kind" "$slug" "$capability" || return
+  done <<'EOF'
+c_library|c-library-minimal|build
+elixir_library|elixir-library-minimal|build
+elixir_test|elixir-test-minimal|test
+go_binary|go-binary-minimal|build
+go_binary|go-comprehensive|build
+go_test|go-comprehensive|test
+jest_test|jest-test-minimal|test
+kotlin_jvm_binary|kotlin-jvm-binary-minimal|build
+kotlin_jvm_library|kotlin-jvm-library-minimal|build
+kotlin_jvm_test|kotlin-jvm-test-minimal|test
+minitest_test|minitest-test-minimal|test
+pytest_test|pytest-test-minimal|test
+rspec_test|rspec-test-minimal|test
+rust_binary|rust-binary-minimal|build
+rust_binary|rust-binary-with-crate|build
+rust_library|rust-library-minimal|build
+rust_proc_macro|rust-proc-macro-minimal|build
+rust_test|rust-test-minimal|build
+shellspec_test|shellspec-test-minimal|test
+vitest_test|vitest-test-minimal|test
+zig_binary|zig-binary-with-library|build
+zig_c_library|zig-c-library-with-c-provider|build
+zig_configure|zig-configure-library-minimal|build
+zig_configure_binary|zig-configure-binary-minimal|build
+zig_configure_test|zig-configure-test-minimal|build
+zig_dependencies|zig-binary-with-package|build
+zig_library|zig-library-minimal|build
+zig_shared_library|zig-shared-library-minimal|build
+zig_static_library|zig-static-library-minimal|build
+zig_test|zig-test-minimal|build
+EOF
+}
+
+Describe 'portable starter examples'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  It 'materializes and executes every portable starter'
+    When call verify_portable_starter_examples
+    The status should be success
+    The stdout should include 'verified c_library c-library-minimal with build'
+    The stdout should include 'verified pytest_test pytest-test-minimal with test'
+    The stdout should include 'verified rust_binary rust-binary-minimal with build'
+    The stdout should include 'verified zig_test zig-test-minimal with build'
+  End
+End

--- a/spec/test_capability_spec.sh
+++ b/spec/test_capability_spec.sh
@@ -100,6 +100,18 @@ TOML
   create_javascript_test_workspace() {
     runner_name="$1"
     runner_entry="$(realpath "$(command -v "$runner_name")")"
+    case "$runner_name" in
+      jest)
+        package_entry="jest/bin/jest.js"
+        ;;
+      vitest)
+        package_entry="vitest/vitest.mjs"
+        ;;
+    esac
+    node_modules_dir="$(dirname "$(dirname "$runner_entry")")"
+    if [ -f "$node_modules_dir/$package_entry" ]; then
+      runner_entry="$node_modules_dir/$package_entry"
+    fi
     cp -R "$REPO_ROOT/crates/once-frontend/prelude/examples/$runner_name-test-minimal/." "$WORKSPACE/"
     mkdir -p "$WORKSPACE/tools"
     ln -s "$(command -v node)" "$WORKSPACE/tools/node"

--- a/spec/zig_graph_spec.sh
+++ b/spec/zig_graph_spec.sh
@@ -15,7 +15,8 @@ if [ "${1:-}" = "--version" ]; then
   printf '%s\n' 'cc mock'
   exit 0
 fi
-printf 'cc %s\n' "$*" >> "$PWD/cc-argv.log"
+log_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+printf 'cc %s\n' "$*" >> "$log_root/cc-argv.log"
 out=''
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "-o" ]; then
@@ -37,7 +38,8 @@ if [ "${1:-}" = "--version" ]; then
   printf '%s\n' 'cxx mock'
   exit 0
 fi
-printf 'cxx %s\n' "$*" >> "$PWD/cc-argv.log"
+log_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+printf 'cxx %s\n' "$*" >> "$log_root/cc-argv.log"
 out=''
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "-o" ]; then
@@ -67,7 +69,8 @@ SH
 set -eu
 cmd="${1:-}"
 shift || true
-printf '%s %s\n' "$cmd" "$*" >> "$PWD/zig-argv.log"
+log_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+printf '%s %s\n' "$cmd" "$*" >> "$log_root/zig-argv.log"
 case "$cmd" in
   version)
     printf '%s\n' '0.15.1'
@@ -141,7 +144,8 @@ SH
     cat > "$WORKSPACE/bin/translate-c" <<'SH'
 #!/bin/sh
 set -eu
-printf '%s\n' "$*" >> "$PWD/translate-c-argv.log"
+log_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+printf '%s\n' "$*" >> "$log_root/translate-c-argv.log"
 out=''
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "-o" ]; then


### PR DESCRIPTION
## What changed

Once now exposes a closed setup loop for coding agents through the [Model Context Protocol](https://modelcontextprotocol.io/) and matching command-line operations. An agent can inspect an empty or configured workspace, discover a target kind and starter, materialize that starter transactionally, validate the complete graph, and build, run, or test the result without moving large file bundles through model context.

The graph contract now includes explicit workspace target configuration, generic configurable attributes, truthful implementation flags, target-valued attribute validation, dependency visibility, richer graph predicates, and package-aware affected-test selection. Analysis and execution failures return structured diagnostics with focused repairs and bounded captured output.

The built-in target kinds remove avoidable shell setup, add minimal Go and Rust starters, and resolve Python, Ruby Specification, Jest, and Vitest runners from either the workspace or installed toolchain. A new portable starter suite materializes and executes 30 representative examples.

## Why

A developer should be able to ask an agent to set up an ecosystem with Once without first teaching it Once-specific prose or asking it to author a build rule from scratch. The live contract needs to make workspace state, supported fields, starter choices, validation failures, and the next executable action discoverable in a small number of calls.

This makes the initial Once experience more accessible than workflows that require upfront Buck or Bazel rule knowledge, while preserving a typed, queryable, and structurally editable graph.

## Root cause

The previous agent surface exposed useful pieces but left gaps in the end-to-end authoring loop. It did not have a workspace-state query or a direct starter materialization operation, configuration was coupled to the host, visibility was absent, and compatibility attributes could appear supported while doing nothing.

Executable starter trials also exposed host assumptions in Elixir staging, project-local runner assumptions in dynamic-language tests, overly broad ecosystem discovery, and relative JavaScript runner probes that depended on the caller's working directory.

## Approach

The two commits are reviewable in dependency order:

- `feat(graph): make workspace setup agent-native`
- `docs(graph): document agent-native workflows`

The Rust layer remains ecosystem-neutral. It provides configuration, schema truthfulness, validation, editing, graph queries, diagnostics, and portable action primitives. Ecosystem behavior stays in target kinds, which invoke tools directly and declare inputs, outputs, setup, and identities explicitly.

Starter materialization is collision-safe and idempotent. It reports created and unchanged files, refuses partial writes on conflicts, validates the resulting workspace, and returns canonical targets with suggested next calls.

## Impact

Coding agents can take a blank directory to a working Go, Python, JavaScript, or Rust project in six or seven discoverable Once calls. Human users can reproduce the same workflow from the terminal.

Existing targets remain public by default, and workspace configuration still defaults to the host. Manifests that set previously inert compatibility attributes now receive an explicit validation diagnostic instead of silent acceptance.

Affected-test plans use declared graph inputs and package ownership before falling back conservatively. Build and test failures include enough bounded output to support a repair without a separate log-discovery round trip.

## Validation

- `mise exec -- cargo test --workspace`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo build --release --package once-cli`
- `mise exec -- shellspec`, 235 examples passed with 3 expected opt-in Microsandbox skips
- `mise exec -- shellspec spec/starter_examples_spec.sh`, 30 portable starters materialized and executed
- `git diff --check`
- Headless Claude built and ran Go, then materialized and passed Vitest using only Once tools
- Headless Codex materialized and passed pytest, then built and ran Rust using only Once tools
- Repeated the natural-language Rust discovery trial after its repair and confirmed that only Rust target kinds were returned
