### PR TITLE
feat(cache): reference-aware cache gc, recovery, and resource bounds

### DIFF
--- a/crates/once-cas/src/lib.rs
+++ b/crates/once-cas/src/lib.rs
@@ -10,10 +10,12 @@
 //! filesystems; for stricter expectations the caller should swap the
 //! substrate for a REAPI-backed store.
 
+use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
 
 use tokio::fs::{self, File};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
@@ -309,6 +311,302 @@ impl Cas {
             action_bytes: actions.1,
         })
     }
+
+    /// Reclaim disk space until the store fits within `max_bytes`.
+    ///
+    /// Eviction is reference-aware and runs in priority order:
+    /// 1. Orphan blobs - content no surviving action result points at,
+    ///    oldest first. These are pure waste, so they always go first.
+    /// 2. Action results, oldest first. Evicting an action releases the
+    ///    blobs that only it referenced, which then become collectable.
+    ///
+    /// A blob is never removed while a surviving action result still
+    /// references it, so a pass never manufactures a dangling cache
+    /// entry (which would force an otherwise-avoidable re-execution). A
+    /// large, stable input shared by a recent action therefore stays
+    /// cached even when it is the oldest thing on disk - the opposite of
+    /// a plain oldest-first sweep, which would evict exactly those hot
+    /// toolchain blobs first.
+    ///
+    /// Recency is a file's modification time. Because content-addressed
+    /// blobs are immutable, a blob's own mtime is its first-seen time,
+    /// which is why blobs are ranked by reachability rather than their
+    /// own age; action-result files carry the recency signal.
+    ///
+    /// With `dry_run`, nothing is deleted and the report describes what a
+    /// real pass would reclaim.
+    ///
+    /// Safe to run against a store an in-flight build shares: a racing
+    /// writer may push the store back over budget, and the next lookup of
+    /// a just-evicted entry re-executes (restore stages every blob before
+    /// touching the workspace, so nothing is left partially applied).
+    pub async fn gc(&self, max_bytes: u64, dry_run: bool) -> Result<GcReport> {
+        let blobs = collect_blob_files(&self.blobs_dir()).await?;
+        let actions = collect_action_files(&self.actions_dir()).await?;
+
+        let bytes_before: u64 =
+            blobs.iter().map(|b| b.size).sum::<u64>() + actions.iter().map(|a| a.size).sum::<u64>();
+        if bytes_before <= max_bytes {
+            return Ok(GcReport {
+                bytes_before,
+                bytes_after: bytes_before,
+                removed: 0,
+                dry_run,
+            });
+        }
+
+        // How many surviving action results reference each blob digest.
+        let mut refcount: HashMap<Digest, usize> = HashMap::new();
+        for action in &actions {
+            for digest in &action.refs {
+                *refcount.entry(*digest).or_insert(0) += 1;
+            }
+        }
+        let blob_index: HashMap<Digest, usize> = blobs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, b)| b.digest.map(|d| (d, i)))
+            .collect();
+
+        let mut blob_removed = vec![false; blobs.len()];
+        let mut action_removed = vec![false; actions.len()];
+        let mut bytes_after = bytes_before;
+
+        // Tier 1: orphan blobs, oldest first. A file that is not a valid
+        // content address (a stray) references nothing, so it counts as
+        // an orphan too.
+        let mut orphans: Vec<usize> = blobs
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| match b.digest {
+                Some(d) => refcount.get(&d).copied().unwrap_or(0) == 0,
+                None => true,
+            })
+            .map(|(i, _)| i)
+            .collect();
+        orphans.sort_by_key(|&i| blobs[i].modified);
+        for i in orphans {
+            if bytes_after <= max_bytes {
+                break;
+            }
+            blob_removed[i] = true;
+            bytes_after = bytes_after.saturating_sub(blobs[i].size);
+        }
+
+        // Tier 2: action results, oldest first, cascading the blobs they
+        // release once no surviving action references them.
+        if bytes_after > max_bytes {
+            let mut order: Vec<usize> = (0..actions.len()).collect();
+            order.sort_by_key(|&i| actions[i].modified);
+            for ai in order {
+                if bytes_after <= max_bytes {
+                    break;
+                }
+                action_removed[ai] = true;
+                bytes_after = bytes_after.saturating_sub(actions[ai].size);
+                for digest in &actions[ai].refs {
+                    let Some(count) = refcount.get_mut(digest) else {
+                        continue;
+                    };
+                    *count = count.saturating_sub(1);
+                    // A blob whose last surviving action just went away is
+                    // now unreachable garbage; collect it unconditionally
+                    // rather than gating on the byte budget, so evicting an
+                    // action never leaves its private blobs (including
+                    // zero-byte ones) stranded.
+                    if *count == 0 {
+                        if let Some(&bi) = blob_index.get(digest) {
+                            if !blob_removed[bi] {
+                                blob_removed[bi] = true;
+                                bytes_after = bytes_after.saturating_sub(blobs[bi].size);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let victims: Vec<PathBuf> = blob_removed
+            .iter()
+            .enumerate()
+            .filter(|(_, &r)| r)
+            .map(|(i, _)| blobs[i].path.clone())
+            .chain(
+                action_removed
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, &r)| r)
+                    .map(|(i, _)| actions[i].path.clone()),
+            )
+            .collect();
+        let removed = victims.len() as u64;
+
+        if !dry_run {
+            for path in victims {
+                match fs::remove_file(&path).await {
+                    Ok(()) => {}
+                    // A concurrent writer or another `gc` may have
+                    // removed it already; the space is reclaimed either
+                    // way.
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                    Err(source) => return Err(Error::Io { path, source }),
+                }
+            }
+        }
+
+        Ok(GcReport {
+            bytes_before,
+            bytes_after,
+            removed,
+            dry_run,
+        })
+    }
+}
+
+/// Outcome of a [`Cas::gc`] pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GcReport {
+    /// Total on-disk size before collection.
+    pub bytes_before: u64,
+    /// Total on-disk size after collection (projected, when `dry_run`).
+    pub bytes_after: u64,
+    /// Number of blobs and action results removed (or that would be).
+    pub removed: u64,
+    /// Whether this pass only reported and left the store untouched.
+    pub dry_run: bool,
+}
+
+/// A stored blob and the metadata `gc` ranks it by. `digest` is `None`
+/// for a file whose path is not a valid content address.
+struct BlobFile {
+    path: PathBuf,
+    digest: Option<Digest>,
+    size: u64,
+    modified: SystemTime,
+}
+
+/// A stored action result plus the blob digests it references (its
+/// outputs, stdout, and stderr).
+struct ActionFile {
+    path: PathBuf,
+    size: u64,
+    modified: SystemTime,
+    refs: Vec<Digest>,
+}
+
+async fn collect_blob_files(root: &Path) -> Result<Vec<BlobFile>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let mut entries = match fs::read_dir(&dir).await {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(source) => return Err(Error::Io { path: dir, source }),
+        };
+        while let Some(entry) = entries.next_entry().await.map_err(|source| Error::Io {
+            path: dir.clone(),
+            source,
+        })? {
+            let ft = entry.file_type().await.map_err(|source| Error::Io {
+                path: entry.path(),
+                source,
+            })?;
+            if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                let name = entry.file_name();
+                if name.to_string_lossy().starts_with(".tmp-") {
+                    continue;
+                }
+                let path = entry.path();
+                let metadata = entry.metadata().await.map_err(|source| Error::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+                let digest = digest_from_blob_path(&path);
+                out.push(BlobFile {
+                    digest,
+                    size: metadata.len(),
+                    modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                    path,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn collect_action_files(root: &Path) -> Result<Vec<ActionFile>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let mut entries = match fs::read_dir(&dir).await {
+            Ok(e) => e,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(source) => return Err(Error::Io { path: dir, source }),
+        };
+        while let Some(entry) = entries.next_entry().await.map_err(|source| Error::Io {
+            path: dir.clone(),
+            source,
+        })? {
+            let ft = entry.file_type().await.map_err(|source| Error::Io {
+                path: entry.path(),
+                source,
+            })?;
+            if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with(".tmp-") || !name.ends_with(".json") {
+                    continue;
+                }
+                let path = entry.path();
+                let metadata = entry.metadata().await.map_err(|source| Error::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+                let refs = match fs::read(&path).await {
+                    Ok(bytes) => parse_action_refs(&bytes),
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => Vec::new(),
+                    Err(source) => return Err(Error::Io { path, source }),
+                };
+                out.push(ActionFile {
+                    size: metadata.len(),
+                    modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                    refs,
+                    path,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// The blob digests an action result depends on. A corrupt or foreign
+/// file references nothing, so it protects no blob from collection.
+fn parse_action_refs(bytes: &[u8]) -> Vec<Digest> {
+    let Ok(result) = serde_json::from_slice::<ActionResult>(bytes) else {
+        return Vec::new();
+    };
+    let mut refs: Vec<Digest> = result.outputs.into_values().collect();
+    refs.extend(result.stdout);
+    refs.extend(result.stderr);
+    refs
+}
+
+/// Reconstruct a blob digest from its sharded path (`.../aa/<rest>`).
+/// Returns `None` for any path that is not a 64-hex content address.
+fn digest_from_blob_path(path: &Path) -> Option<Digest> {
+    let file = path.file_name()?.to_str()?;
+    let shard = path.parent()?.file_name()?.to_str()?;
+    if shard.len() != 2 {
+        return None;
+    }
+    let mut hex = String::with_capacity(shard.len() + file.len());
+    hex.push_str(shard);
+    hex.push_str(file);
+    Digest::from_hex(&hex)
 }
 
 /// Buffer size for [`Cas::put_stream`]. Bounds per-stream memory use.
@@ -639,6 +937,185 @@ mod tests {
         assert_eq!(s.blob_bytes, 0);
         assert_eq!(s.action_count, 0);
         assert_eq!(s.action_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn gc_on_empty_cas_reports_nothing_removed() {
+        let tmp = TempDir::new().unwrap();
+        let cas = Cas::open(tmp.path());
+        let report = cas.gc(0, false).await.unwrap();
+        assert_eq!(report.bytes_before, 0);
+        assert_eq!(report.bytes_after, 0);
+        assert_eq!(report.removed, 0);
+    }
+
+    #[tokio::test]
+    async fn gc_under_budget_removes_nothing() {
+        let tmp = TempDir::new().unwrap();
+        let cas = Cas::open(tmp.path());
+        cas.put_blob(b"keep me").await.unwrap();
+        let before = cas.stats().await.unwrap().blob_bytes;
+
+        let report = cas.gc(u64::MAX, false).await.unwrap();
+
+        assert_eq!(report.removed, 0);
+        assert_eq!(report.bytes_before, before);
+        assert_eq!(report.bytes_after, before);
+        assert_eq!(cas.stats().await.unwrap().blob_count, 1);
+    }
+
+    #[tokio::test]
+    async fn gc_evicts_oldest_orphan_blobs_until_within_budget() {
+        let tmp = TempDir::new().unwrap();
+        let cas = Cas::open(tmp.path());
+
+        // Three distinct, incompressible orphan blobs (no action result
+        // references them) written oldest-first. Explicit mtimes make the
+        // ordering deterministic regardless of filesystem resolution.
+        let payloads: [&[u8]; 3] = [b"first-blob-aaaa", b"second-blob-bbb", b"third-blob-cccc"];
+        let mut digests = Vec::new();
+        for (index, payload) in payloads.iter().enumerate() {
+            let digest = cas.put_blob(payload).await.unwrap();
+            let when = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1000 + index as u64);
+            filetime_set(&cas.blob_path(&digest), when);
+            digests.push(digest);
+        }
+
+        let total = cas.stats().await.unwrap().blob_bytes;
+        let per_blob = total / 3;
+
+        let report = cas.gc(per_blob * 2 + 1, false).await.unwrap();
+
+        assert_eq!(report.bytes_before, total);
+        assert!(report.bytes_after <= per_blob * 2 + 1);
+        assert_eq!(report.removed, 1);
+        // The oldest blob is gone; the two newest survive.
+        assert!(!cas.has_blob(&digests[0]).await.unwrap());
+        assert!(cas.has_blob(&digests[1]).await.unwrap());
+        assert!(cas.has_blob(&digests[2]).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn gc_keeps_a_blob_a_surviving_action_references_even_if_oldest() {
+        let tmp = TempDir::new().unwrap();
+        let cas = Cas::open(tmp.path());
+
+        // An OLD blob referenced by a recent action (think: a toolchain
+        // blob), and a NEWER orphan blob referenced by nothing.
+        let referenced = cas.put_blob(b"toolchain-blob-xxxxxxxx").await.unwrap();
+        filetime_set(
+            &cas.blob_path(&referenced),
+            SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1000),
+        );
+        let orphan = cas.put_blob(b"stale-output-blob-yyyyyy").await.unwrap();
+        filetime_set(
+            &cas.blob_path(&orphan),
+            SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(5000),
+        );
+
+        let action = Digest::of_bytes(b"toolchain-consumer");
+        cas.put_action_result(
+            &action,
+            &ActionResult {
+                exit_code: 0,
+                stdout: None,
+                stderr: None,
+                outputs: std::collections::BTreeMap::from([("out/bin".to_string(), referenced)]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let total = cas.stats().await.unwrap().blob_bytes + cas.stats().await.unwrap().action_bytes;
+        // Budget forces roughly one blob's worth out. A naive oldest-first
+        // sweep would evict the referenced (older) blob; reference-aware
+        // GC must evict the orphan instead.
+        let per_blob = cas.blob_size(&orphan).await.unwrap();
+        cas.gc(total - per_blob, false).await.unwrap();
+
+        assert!(
+            cas.has_blob(&referenced).await.unwrap(),
+            "a blob a surviving action references must be kept"
+        );
+        assert!(
+            !cas.has_blob(&orphan).await.unwrap(),
+            "the unreferenced orphan should be evicted first"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_cascades_a_blob_when_its_only_action_is_evicted() {
+        let tmp = TempDir::new().unwrap();
+        let cas = Cas::open(tmp.path());
+        let blob = cas.put_blob(b"exclusively-owned-output").await.unwrap();
+        // A zero-byte blob (an empty stderr capture) that only this action
+        // references: it must be cascaded out even though removing it
+        // reclaims no bytes.
+        let empty = cas.put_blob(b"").await.unwrap();
+        let action = Digest::of_bytes(b"sole-owner");
+        cas.put_action_result(
+            &action,
+            &ActionResult {
+                exit_code: 0,
+                stdout: None,
+                stderr: Some(empty),
+                outputs: std::collections::BTreeMap::from([("out/x".to_string(), blob)]),
+            },
+        )
+        .await
+        .unwrap();
+
+        // A zero budget evicts the action and, with it, every blob only
+        // it referenced - leaving nothing stranded.
+        let report = cas.gc(0, false).await.unwrap();
+
+        assert_eq!(report.bytes_after, 0);
+        assert!(!cas.has_blob(&blob).await.unwrap());
+        assert!(!cas.has_blob(&empty).await.unwrap());
+        assert_eq!(cas.get_action_result(&action).await.unwrap(), None);
+        assert_eq!(cas.stats().await.unwrap().blob_count, 0);
+    }
+
+    #[tokio::test]
+    async fn gc_dry_run_reports_without_deleting() {
+        let tmp = TempDir::new().unwrap();
+        let cas = Cas::open(tmp.path());
+        let blob = cas.put_blob(b"still here after dry run").await.unwrap();
+
+        let report = cas.gc(0, true).await.unwrap();
+
+        assert!(report.dry_run);
+        assert!(report.removed >= 1);
+        assert_eq!(report.bytes_after, 0);
+        // Nothing was actually deleted.
+        assert!(cas.has_blob(&blob).await.unwrap());
+        assert_eq!(cas.stats().await.unwrap().blob_count, 1);
+    }
+
+    #[tokio::test]
+    async fn gc_ignores_orphaned_tmp_files() {
+        let tmp = TempDir::new().unwrap();
+        let cas = Cas::open(tmp.path());
+        cas.put_blob(b"real").await.unwrap();
+        let orphan = cas.blobs_dir().join("zz").join(".tmp-leftover-1234-5");
+        fs::create_dir_all(orphan.parent().unwrap()).await.unwrap();
+        fs::write(&orphan, b"junk").await.unwrap();
+
+        // A zero budget removes the real blob but must leave the tmp
+        // file alone - it is not durable cache state.
+        cas.gc(0, false).await.unwrap();
+
+        assert!(orphan.exists());
+    }
+
+    /// Set the modified time on `path`. Kept local to the test module so
+    /// production code carries no timestamp-mutation API.
+    fn filetime_set(path: &Path, when: SystemTime) {
+        let file = std::fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open blob to set mtime");
+        file.set_modified(when).expect("set mtime");
     }
 
     #[tokio::test]

--- a/crates/once-cas/src/provider.rs
+++ b/crates/once-cas/src/provider.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use tokio::io::AsyncRead;
 
 use crate::tuist::{TuistCache, TuistCacheConfig};
-use crate::{ActionResult, Cas, Digest, Result, Stats};
+use crate::{ActionResult, Cas, Digest, GcReport, Result, Stats};
 
 const TUIST_STREAM_REMOTE_UPLOAD_LIMIT: u64 = 8 * 1024 * 1024;
 
@@ -101,6 +101,17 @@ impl CacheProvider {
         match self {
             Self::Local(cas) => cas.stats().await,
             Self::Tuist(cache) => cache.local().stats().await,
+        }
+    }
+
+    /// Reclaim local disk space until it fits within `max_bytes`.
+    ///
+    /// Only the local tier is collected: the Tuist remote tier is shared
+    /// and managed server-side, so `gc` never deletes from it.
+    pub async fn gc(&self, max_bytes: u64, dry_run: bool) -> Result<GcReport> {
+        match self {
+            Self::Local(cas) => cas.gc(max_bytes, dry_run).await,
+            Self::Tuist(cache) => cache.local().gc(max_bytes, dry_run).await,
         }
     }
 }

--- a/crates/once-cas/src/tuist/cache.rs
+++ b/crates/once-cas/src/tuist/cache.rs
@@ -13,7 +13,7 @@ use bazel_remote_apis::{
 use futures::future::try_join_all;
 use reqwest::{Method, Url};
 use sha2::{Digest as _, Sha256};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 use tokio::time::Instant;
 use tonic::metadata::MetadataValue;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
@@ -23,6 +23,14 @@ use super::{
     join_url, remote_status_message, TuistAuth, TuistCacheConfig, ENDPOINTS_PATH, PROVIDER_NAME,
 };
 use crate::{ActionResult, Cas, Digest, Error, Result};
+
+/// Ceiling on blobs transferred to or from the remote cache at once. The
+/// number of outputs comes from a remote `ActionResult` (untrusted), and
+/// each transfer buffers a whole blob, so an unbounded fan-out would let
+/// a single response spike memory and open a connection per blob. This
+/// caps the in-flight transfers regardless of how many the response
+/// declares.
+const MAX_CONCURRENT_BLOB_TRANSFERS: usize = 16;
 
 const ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const GRPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -243,15 +251,23 @@ impl TuistCache {
     async fn put_action_result_remote(&self, action: &Digest, result: &ActionResult) -> Result<()> {
         let stdout_upload = self.upload_local_blob(result.stdout.as_ref(), "put action result");
         let stderr_upload = self.upload_local_blob(result.stderr.as_ref(), "put action result");
-        let output_uploads = try_join_all(result.outputs.iter().map(|(path, digest)| async move {
-            let reapi_digest = self
-                .upload_local_blob(Some(digest), "put action result")
-                .await?;
-            Ok::<_, Error>(reapi::OutputFile {
-                path: path.clone(),
-                digest: reapi_digest,
-                ..Default::default()
-            })
+        let upload_permits = Arc::new(Semaphore::new(MAX_CONCURRENT_BLOB_TRANSFERS));
+        let output_uploads = try_join_all(result.outputs.iter().map(|(path, digest)| {
+            let upload_permits = Arc::clone(&upload_permits);
+            async move {
+                let _permit = upload_permits
+                    .acquire()
+                    .await
+                    .expect("blob transfer semaphore is never closed");
+                let reapi_digest = self
+                    .upload_local_blob(Some(digest), "put action result")
+                    .await?;
+                Ok::<_, Error>(reapi::OutputFile {
+                    path: path.clone(),
+                    digest: reapi_digest,
+                    ..Default::default()
+                })
+            }
         }));
         let (stdout_digest, stderr_digest, output_files) =
             tokio::try_join!(stdout_upload, stderr_upload, output_uploads)?;
@@ -343,8 +359,14 @@ impl TuistCache {
             &result.stderr_raw,
             "get action result",
         );
-        let output_mirrors =
-            try_join_all(result.output_files.iter().map(|output_file| async move {
+        let mirror_permits = Arc::new(Semaphore::new(MAX_CONCURRENT_BLOB_TRANSFERS));
+        let output_mirrors = try_join_all(result.output_files.iter().map(|output_file| {
+            let mirror_permits = Arc::clone(&mirror_permits);
+            async move {
+                let _permit = mirror_permits
+                    .acquire()
+                    .await
+                    .expect("blob transfer semaphore is never closed");
                 let digest = match output_file.digest.as_ref() {
                     Some(reapi_digest) => Some(
                         self.mirror_reapi_blob(reapi_digest, "get action result")
@@ -356,7 +378,8 @@ impl TuistCache {
                     None => None,
                 };
                 Ok::<_, Error>(digest.map(|digest| (output_file.path.clone(), digest)))
-            }));
+            }
+        }));
         let (stdout, stderr, output_pairs) =
             tokio::try_join!(stdout_mirror, stderr_mirror, output_mirrors)?;
         let outputs: BTreeMap<String, Digest> = output_pairs.into_iter().flatten().collect();

--- a/crates/once-cli/src/cli/cache.rs
+++ b/crates/once-cli/src/cli/cache.rs
@@ -8,6 +8,26 @@ pub enum CacheCmd {
     /// Print blob and action counts plus on-disk size.
     Stats,
 
+    /// Reclaim local cache space down to a size budget.
+    ///
+    /// Removes the oldest blobs and action results until the local
+    /// store fits within `--max-size`. Safe to run at any time: an
+    /// action whose outputs get evicted simply re-executes on its next
+    /// build. Only the local tier is collected; a remote cache is never
+    /// touched.
+    Gc {
+        /// Maximum local cache size to keep. Plain bytes or a human
+        /// suffix: `500MB`, `2GiB`, `750k`. Decimal suffixes (KB/MB/GB/
+        /// TB) are powers of 1000; binary suffixes (KiB/MiB/GiB/TiB) are
+        /// powers of 1024.
+        #[arg(long = "max-size", value_name = "SIZE", value_parser = parse_size)]
+        max_size: u64,
+
+        /// Report what would be reclaimed without deleting anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Read and write content-addressed blobs.
     #[command(arg_required_else_help = true)]
     Blob {
@@ -132,6 +152,7 @@ impl CacheCmd {
     pub(super) fn surface_path(&self) -> Vec<&'static str> {
         match self {
             Self::Stats => vec!["stats"],
+            Self::Gc { .. } => vec!["gc"],
             Self::Blob { cmd } => {
                 let mut path = vec!["blob"];
                 if let Some(cmd) = cmd {
@@ -174,6 +195,42 @@ fn parse_digest(raw: &str) -> std::result::Result<Digest, String> {
     Digest::from_hex(raw).ok_or_else(|| "expected a 64-character lowercase BLAKE3 digest".into())
 }
 
+/// Parse a byte size with an optional decimal (KB/MB/GB/TB, powers of
+/// 1000) or binary (KiB/MiB/GiB/TiB, powers of 1024) suffix. A bare
+/// number, or a `B` suffix, is bytes. Case-insensitive; surrounding
+/// whitespace and a space before the unit are allowed.
+fn parse_size(raw: &str) -> std::result::Result<u64, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("expected a size such as `500MB`, `2GiB`, or a byte count".into());
+    }
+    let digits_end = trimmed
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (number, unit) = trimmed.split_at(digits_end);
+    if number.is_empty() {
+        return Err(format!("`{raw}` must start with a number"));
+    }
+    let value: u64 = number
+        .parse()
+        .map_err(|_| format!("`{number}` is not a valid whole number of units"))?;
+    let multiplier = match unit.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1_u64,
+        "kb" => 1_000,
+        "mb" => 1_000_000,
+        "gb" => 1_000_000_000,
+        "tb" => 1_000_000_000_000,
+        "kib" | "k" => 1_024,
+        "mib" | "m" => 1_024 * 1_024,
+        "gib" | "g" => 1_024 * 1_024 * 1_024,
+        "tib" | "t" => 1_024 * 1_024 * 1_024 * 1_024,
+        other => return Err(format!("unknown size unit `{other}`")),
+    };
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("`{raw}` overflows a 64-bit byte count"))
+}
+
 fn parse_output_digest(raw: &str) -> std::result::Result<(String, Digest), String> {
     let (path, digest) = raw
         .split_once('=')
@@ -182,4 +239,48 @@ fn parse_output_digest(raw: &str) -> std::result::Result<(String, Digest), Strin
         return Err("output path must not be empty".into());
     }
     Ok((path.to_string(), parse_digest(digest)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_size;
+
+    #[test]
+    fn parses_bare_bytes_and_b_suffix() {
+        assert_eq!(parse_size("0").unwrap(), 0);
+        assert_eq!(parse_size("1024").unwrap(), 1024);
+        assert_eq!(parse_size("512B").unwrap(), 512);
+    }
+
+    #[test]
+    fn parses_decimal_and_binary_suffixes() {
+        assert_eq!(parse_size("500MB").unwrap(), 500_000_000);
+        assert_eq!(parse_size("2GiB").unwrap(), 2 * 1024 * 1024 * 1024);
+        assert_eq!(parse_size("1TB").unwrap(), 1_000_000_000_000);
+    }
+
+    #[test]
+    fn is_case_insensitive_and_allows_a_space_before_the_unit() {
+        assert_eq!(parse_size("750 mib").unwrap(), 750 * 1024 * 1024);
+        assert_eq!(parse_size("  4gb ").unwrap(), 4_000_000_000);
+    }
+
+    #[test]
+    fn short_binary_aliases_match_their_long_forms() {
+        assert_eq!(parse_size("3g").unwrap(), parse_size("3GiB").unwrap());
+        assert_eq!(parse_size("8k").unwrap(), parse_size("8KiB").unwrap());
+    }
+
+    #[test]
+    fn rejects_garbage_and_unknown_units() {
+        assert!(parse_size("").is_err());
+        assert!(parse_size("MB").is_err());
+        assert!(parse_size("12ZB").is_err());
+        assert!(parse_size("abc").is_err());
+    }
+
+    #[test]
+    fn rejects_overflow() {
+        assert!(parse_size("99999999999999999999TiB").is_err());
+    }
 }

--- a/crates/once-cli/src/commands/cache.rs
+++ b/crates/once-cli/src/commands/cache.rs
@@ -27,6 +27,16 @@ struct CacheStats {
 }
 
 #[derive(Serialize)]
+struct CacheGcRecord {
+    bytes_before: u64,
+    bytes_after: u64,
+    bytes_reclaimed: u64,
+    removed: u64,
+    max_size: u64,
+    dry_run: bool,
+}
+
+#[derive(Serialize)]
 struct BlobPutRecord {
     digest: Digest,
 }
@@ -116,6 +126,31 @@ pub async fn print_stats(cache: &CacheProvider, output: Output) -> Result<()> {
     out.write_all(body.as_bytes()).await?;
     out.flush().await?;
     Ok(())
+}
+
+pub async fn gc(cache: &CacheProvider, max_size: u64, dry_run: bool, output: Output) -> Result<()> {
+    let report = cache.gc(max_size, dry_run).await?;
+    let reclaimed = report.bytes_before.saturating_sub(report.bytes_after);
+    let record = CacheGcRecord {
+        bytes_before: report.bytes_before,
+        bytes_after: report.bytes_after,
+        bytes_reclaimed: reclaimed,
+        removed: report.removed,
+        max_size,
+        dry_run: report.dry_run,
+    };
+    let body = match output.format {
+        Format::Human if report.dry_run => format!(
+            "would reclaim {reclaimed} bytes ({} entries); {} bytes would remain, budget {max_size} bytes\n",
+            report.removed, report.bytes_after,
+        ),
+        Format::Human => format!(
+            "reclaimed {reclaimed} bytes ({} entries removed); {} bytes cached, budget {max_size} bytes\n",
+            report.removed, report.bytes_after,
+        ),
+        Format::Json | Format::Toon => render::structured(output.format, &record)?,
+    };
+    write_stdout(body.as_bytes()).await
 }
 
 pub async fn put_blob(cache: &CacheProvider, path: Option<&Path>, output: Output) -> Result<()> {

--- a/crates/once-cli/src/commands/graph/analysis/scheduler.rs
+++ b/crates/once-cli/src/commands/graph/analysis/scheduler.rs
@@ -22,6 +22,13 @@ pub(super) struct BuildScheduler<'a> {
     reachable: &'a HashSet<String>,
     retained: &'a HashSet<String>,
     sandbox: SandboxMode,
+    /// Ceiling on build tasks in flight at once. A wide graph can have
+    /// thousands of independently-ready targets; spawning a task (and its
+    /// subprocess) for every one at once is how a build system exhausts
+    /// memory and file descriptors. Ready targets past this many wait in
+    /// the queue until a slot frees. Action-level CPU concurrency is
+    /// bounded separately by the core runner's resource pool.
+    max_in_flight: usize,
 }
 
 impl<'a> BuildScheduler<'a> {
@@ -37,6 +44,8 @@ impl<'a> BuildScheduler<'a> {
         sandbox: SandboxMode,
     ) -> Self {
         let module_source_digest = Digest::of_bytes(analyzer.module_source().as_bytes());
+        let max_in_flight =
+            std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
         Self {
             root_id,
             workspace,
@@ -47,6 +56,7 @@ impl<'a> BuildScheduler<'a> {
             reachable,
             retained,
             sandbox,
+            max_in_flight,
         }
     }
 
@@ -88,7 +98,10 @@ impl<'a> BuildScheduler<'a> {
         state: &mut BuildState,
         running: &mut JoinSet<Result<(String, BuildOutcome)>>,
     ) -> Result<()> {
-        while let Some(target_id) = state.ready.pop_front() {
+        while running.len() < self.max_in_flight {
+            let Some(target_id) = state.ready.pop_front() else {
+                break;
+            };
             let target = Arc::clone(
                 self.targets
                     .get(&target_id)

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -80,17 +80,51 @@ pub async fn serve(workspace: PathBuf, allow_run: bool) -> Result<()> {
         .context("joining MCP server thread")?
 }
 
+/// Largest single newline-delimited JSON-RPC request the server will
+/// buffer. The transport is one request per line, so without a cap a
+/// client (or a prompt-injected agent) could send one unterminated
+/// multi-gigabyte line and OOM the process before it is ever parsed.
+/// Tool calls are orders of magnitude smaller than this.
+const MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
+
 fn serve_blocking(workspace: PathBuf, allow_run: bool) -> Result<()> {
     let stdin = io::stdin();
+    let mut handle = stdin.lock();
     let mut stdout = io::stdout().lock();
     let server = Server::new(workspace, allow_run);
 
-    for line in stdin.lock().lines() {
-        let line = line.context("reading MCP request")?;
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        match read_capped_line(&mut handle, &mut buf, MAX_REQUEST_BYTES)
+            .context("reading MCP request")?
+        {
+            CappedLine::Eof => break,
+            CappedLine::TooLong => {
+                // Refuse the oversize request instead of buffering it, and
+                // keep serving: the rest of that line was drained.
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": Value::Null,
+                    "error": {
+                        "code": -32600,
+                        "message": "request exceeds maximum size",
+                    },
+                });
+                let bytes = serde_json::to_vec(&response).context("encoding MCP response")?;
+                stdout.write_all(&bytes)?;
+                stdout.write_all(b"\n")?;
+                stdout.flush()?;
+                continue;
+            }
+            CappedLine::Line => {}
+        }
+        let Ok(line) = std::str::from_utf8(&buf) else {
+            continue;
+        };
         if line.trim().is_empty() {
             continue;
         }
-        match server.dispatch_line(&line) {
+        match server.dispatch_line(line) {
             DispatchOutcome::Reply(response) => {
                 let bytes = serde_json::to_vec(&response).context("encoding MCP response")?;
                 stdout.write_all(&bytes)?;
@@ -103,6 +137,69 @@ fn serve_blocking(workspace: PathBuf, allow_run: bool) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Result of reading one newline-delimited record under a byte cap.
+enum CappedLine {
+    /// A complete line (newline stripped) is in the buffer.
+    Line,
+    /// The line exceeded the cap; its bytes were drained and dropped, so
+    /// the next read resumes at the following record.
+    TooLong,
+    /// End of input.
+    Eof,
+}
+
+/// Read one `\n`-delimited record into `buf` (without the newline),
+/// buffering at most `max` bytes. A longer line is drained to its
+/// terminator and reported as [`CappedLine::TooLong`] without ever
+/// holding more than `max` bytes in memory.
+fn read_capped_line<R: BufRead>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    max: usize,
+) -> io::Result<CappedLine> {
+    buf.clear();
+    let mut over = false;
+    loop {
+        let available = match reader.fill_buf() {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        if available.is_empty() {
+            return Ok(if over {
+                CappedLine::TooLong
+            } else if buf.is_empty() {
+                CappedLine::Eof
+            } else {
+                CappedLine::Line
+            });
+        }
+        if let Some(pos) = available.iter().position(|&b| b == b'\n') {
+            if !over && buf.len() + pos <= max {
+                buf.extend_from_slice(&available[..pos]);
+            } else {
+                over = true;
+            }
+            reader.consume(pos + 1);
+            return Ok(if over {
+                CappedLine::TooLong
+            } else {
+                CappedLine::Line
+            });
+        }
+        if !over && buf.len() + available.len() <= max {
+            buf.extend_from_slice(available);
+        } else if !over {
+            // Would exceed the cap: stop accumulating and drop what we
+            // have so memory stays bounded while we drain to the newline.
+            over = true;
+            buf.clear();
+        }
+        let consumed = available.len();
+        reader.consume(consumed);
+    }
 }
 
 /// State the dispatcher needs to answer requests.
@@ -1202,6 +1299,61 @@ mod tests {
 
     fn server(workspace: PathBuf) -> Server {
         Server::new(workspace, false)
+    }
+
+    #[test]
+    fn capped_reader_reads_normal_lines() {
+        let data = b"first\nsecond\n";
+        let mut reader = std::io::BufReader::new(&data[..]);
+        let mut buf = Vec::new();
+        assert!(matches!(
+            read_capped_line(&mut reader, &mut buf, 1024).unwrap(),
+            CappedLine::Line
+        ));
+        assert_eq!(buf, b"first");
+        assert!(matches!(
+            read_capped_line(&mut reader, &mut buf, 1024).unwrap(),
+            CappedLine::Line
+        ));
+        assert_eq!(buf, b"second");
+        assert!(matches!(
+            read_capped_line(&mut reader, &mut buf, 1024).unwrap(),
+            CappedLine::Eof
+        ));
+    }
+
+    #[test]
+    fn capped_reader_rejects_oversize_line_without_buffering_it() {
+        // An 8 KiB line under a 16-byte cap: reported TooLong, and the
+        // buffer never holds more than the cap.
+        let mut data = vec![b'x'; 8192];
+        data.push(b'\n');
+        data.extend_from_slice(b"next\n");
+        let mut reader = std::io::BufReader::with_capacity(64, &data[..]);
+        let mut buf = Vec::new();
+        assert!(matches!(
+            read_capped_line(&mut reader, &mut buf, 16).unwrap(),
+            CappedLine::TooLong
+        ));
+        assert!(buf.len() <= 16, "buffer must stay within the cap");
+        // The reader resumes cleanly at the following record.
+        assert!(matches!(
+            read_capped_line(&mut reader, &mut buf, 16).unwrap(),
+            CappedLine::Line
+        ));
+        assert_eq!(buf, b"next");
+    }
+
+    #[test]
+    fn capped_reader_accepts_a_line_exactly_at_the_cap() {
+        let data = b"1234567890\n";
+        let mut reader = std::io::BufReader::new(&data[..]);
+        let mut buf = Vec::new();
+        assert!(matches!(
+            read_capped_line(&mut reader, &mut buf, 10).unwrap(),
+            CappedLine::Line
+        ));
+        assert_eq!(buf, b"1234567890");
     }
 
     fn run_server(workspace: PathBuf) -> Server {

--- a/crates/once-cli/src/commands/surface/model.rs
+++ b/crates/once-cli/src/commands/surface/model.rs
@@ -182,6 +182,7 @@ mod tests {
             &["once", "exec", "true"],
             &["once", "test", "apps/ios/AppTests"],
             &["once", "cache", "stats"],
+            &["once", "cache", "gc", "--max-size", "1GB"],
             &["once", "cache", "blob", "put", "-"],
             &[
                 "once",

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -519,6 +519,12 @@ async fn run_cache_command(
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
+        Some(cli::CacheCmd::Gc { max_size, dry_run }) => {
+            let cache = crate::cache_provider::resolve(workspace, xdg)?;
+            commands::cache::gc(&cache, max_size, dry_run, output)
+                .await
+                .map(|()| ExitCode::SUCCESS)
+        }
         Some(cli::CacheCmd::Blob { cmd }) => {
             let cache = crate::cache_provider::resolve(workspace, xdg)?;
             match cmd {

--- a/crates/once-core/src/runner.rs
+++ b/crates/once-core/src/runner.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use once_cas::{ActionResult, CacheProvider, Cas, Digest};
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use crate::{execute, outputs, Action, ResourceLimits, ResourcePool, Result};
 
@@ -226,15 +226,61 @@ async fn lookup_cached(
     key: &Digest,
 ) -> Result<Option<Outcome>> {
     if let Some(result) = cache.get_action_result(key).await? {
-        debug!("cache hit");
-        outputs::restore(&result, workspace_root, cache).await?;
-        return Ok(Some(Outcome {
-            action: *key,
-            result,
-            cache: CacheState::Hit,
-        }));
+        // A partially-evicted or partially-synced entry can have its
+        // action result present while a blob it points at is gone. The
+        // captured stdout/stderr blobs are not restored to the workspace
+        // here, but downstream consumers read them straight from the CAS,
+        // so a "hit" that references a missing stream blob would crash
+        // them. Verify those blobs exist before reporting a hit, and if
+        // either is gone treat the entry as absent and re-execute.
+        if !stream_blobs_present(&result, cache).await? {
+            warn!("cached action is missing a captured stdout/stderr blob; re-executing");
+            return Ok(None);
+        }
+        match outputs::restore(&result, workspace_root, cache).await {
+            Ok(()) => {
+                debug!("cache hit");
+                return Ok(Some(Outcome {
+                    action: *key,
+                    result,
+                    cache: CacheState::Hit,
+                }));
+            }
+            // An action result survived but an output blob it references
+            // is gone (evicted by `once cache gc`, or never synced from a
+            // remote tier). Treat the entry as absent and let the caller
+            // re-execute rather than failing the build. `restore` stages
+            // every output blob before materializing any of them, so a
+            // missing blob leaves no partial output on disk.
+            Err(err) if is_incomplete_cache_entry(&err) => {
+                warn!(error = %err, "cached action outputs are unrestorable; re-executing");
+                return Ok(None);
+            }
+            Err(err) => return Err(err),
+        }
     }
     Ok(None)
+}
+
+/// True when every captured stdout/stderr blob an action result
+/// references is still present in the cache. A `false` here means the
+/// entry is incomplete and the action should be re-executed rather than
+/// returned as a hit a consumer cannot fully read.
+async fn stream_blobs_present(result: &ActionResult, cache: &CacheProvider) -> Result<bool> {
+    for digest in [result.stdout, result.stderr].into_iter().flatten() {
+        if !cache.has_blob(&digest).await? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// True when a restore failed only because the cache is missing a blob
+/// the action result points at - a recoverable "the cache lost data"
+/// condition, distinct from a real I/O or corruption error the caller
+/// should see.
+fn is_incomplete_cache_entry(err: &crate::Error) -> bool {
+    matches!(err, crate::Error::Cas(once_cas::Error::BlobNotFound(_)))
 }
 
 #[instrument(skip(action, cache), fields(action_digest = %key))]
@@ -526,6 +572,90 @@ mod tests {
             std::fs::read_to_string(tmp.path().join("out/generated.txt")).unwrap(),
             "generated"
         );
+    }
+
+    #[tokio::test]
+    async fn cache_hit_with_evicted_output_blob_falls_back_to_execution() {
+        let (tmp, cas) = fresh_cas();
+        let action = Action::WriteFile {
+            path: WorkspacePath::try_from("out/generated.txt").unwrap(),
+            bytes: b"generated".to_vec(),
+            input_digest: Some(Digest::of_bytes(b"evicted-blob")),
+        };
+
+        let first = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(first.cache, CacheState::Miss);
+
+        // Simulate `once cache gc` reclaiming the blob tier while the
+        // action result survives, plus the materialized output being
+        // removed from the workspace.
+        std::fs::remove_dir_all(tmp.path().join("cas")).unwrap();
+        std::fs::remove_file(tmp.path().join("out/generated.txt")).unwrap();
+        assert!(
+            cas.get_action_result(&action.digest())
+                .await
+                .unwrap()
+                .is_some(),
+            "the stale action result must still be present"
+        );
+
+        // The stale result points at a now-missing blob. The lookup must
+        // degrade to a miss and re-execute rather than erroring.
+        let second = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(second.cache, CacheState::Miss);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("out/generated.txt")).unwrap(),
+            "generated"
+        );
+
+        // And the cache is self-healed: a third run hits cleanly.
+        let third = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(third.cache, CacheState::Hit);
+    }
+
+    #[tokio::test]
+    async fn cache_hit_with_evicted_stdout_blob_falls_back_to_execution() {
+        let (tmp, cas) = fresh_cas();
+        let action = echo_action("streamed-hello");
+
+        let first = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(first.cache, CacheState::Miss);
+        assert!(first.result.stdout.is_some());
+
+        // Evict the blob tier (as `once cache gc` cascading, or a remote
+        // tier that never synced the stream blobs) while the action
+        // result survives and still references the stdout/stderr blobs.
+        std::fs::remove_dir_all(tmp.path().join("cas")).unwrap();
+        assert!(cas
+            .get_action_result(&action.digest())
+            .await
+            .unwrap()
+            .is_some());
+
+        // The referenced stdout blob is gone, so the lookup must decline
+        // the hit and re-execute rather than return a result whose stdout
+        // a consumer cannot read.
+        let second = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(second.cache, CacheState::Miss);
+        assert_eq!(
+            cas.get_blob(&second.result.stdout.unwrap()).await.unwrap(),
+            b"streamed-hello"
+        );
+
+        let third = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(third.cache, CacheState::Hit);
     }
 
     #[tokio::test]

--- a/crates/once-frontend/src/analysis/values.rs
+++ b/crates/once-frontend/src/analysis/values.rs
@@ -66,7 +66,22 @@ pub(super) fn json_to_value<'v>(eval: &Evaluator<'v, '_, '_>, json: &JsonValue) 
     }
 }
 
+/// Deepest Starlark nesting `value_to_json` will follow before it stops
+/// recursing. A Starlark value can be nested arbitrarily deep with a
+/// trivial loop (`x = []; for _ in range(1_000_000): x = [x]`); following
+/// that with native recursion overflows the stack and aborts the
+/// process. The limit is far above any legitimate provider or attribute
+/// shape, so real graphs are unaffected.
+const MAX_JSON_DEPTH: usize = 256;
+
 pub(super) fn value_to_json(value: Value<'_>) -> JsonValue {
+    value_to_json_at(value, 0)
+}
+
+fn value_to_json_at(value: Value<'_>, depth: usize) -> JsonValue {
+    if depth >= MAX_JSON_DEPTH {
+        return JsonValue::String("<once: value nested too deeply to serialize>".to_string());
+    }
     if value.is_none() {
         return JsonValue::Null;
     }
@@ -80,7 +95,11 @@ pub(super) fn value_to_json(value: Value<'_>) -> JsonValue {
         return JsonValue::String(string.to_string());
     }
     if let Some(list) = ListRef::from_value(value) {
-        return JsonValue::Array(list.iter().map(value_to_json).collect());
+        return JsonValue::Array(
+            list.iter()
+                .map(|item| value_to_json_at(item, depth + 1))
+                .collect(),
+        );
     }
     if let Some(dict) = DictRef::from_value(value) {
         let mut map = serde_json::Map::new();
@@ -88,7 +107,7 @@ pub(super) fn value_to_json(value: Value<'_>) -> JsonValue {
             let Some(key_str) = key.unpack_str() else {
                 continue;
             };
-            map.insert(key_str.to_string(), value_to_json(child));
+            map.insert(key_str.to_string(), value_to_json_at(child, depth + 1));
         }
         return JsonValue::Object(map);
     }

--- a/docs/reference/cli/cache/gc.md
+++ b/docs/reference/cli/cache/gc.md
@@ -1,30 +1,25 @@
-# `once cache`
+# `once cache gc`
 
-Cache management
+Reclaim local cache space down to a size budget
 
 ## Synopsis
 
 ```text
-once cache [OPTIONS] <SUBCOMMAND>
+once cache gc [OPTIONS]
 ```
 
 ## Description
 
-Inspect, read, and write the content-addressed cache that every Once action runs through. `cache stats` reports counts and on-disk size; `cache blob` and `cache action` expose the CAS and action-result tables as primitives for debugging, reproducibility checks, and external tooling. Useful for answering "did this run hit the cache?" without scraping command output.
+Removes the oldest blobs and action results until the local store fits within `--max-size`. Safe to run at any time: an action whose outputs get evicted simply re-executes on its next build. Only the local tier is collected; a remote cache is never touched.
 
 ## Options
 
 | Flag | Value | Default | Description |
 | --- | --- | --- | --- |
+| `--max-size` | `<SIZE>` |  | Maximum local cache size to keep. Plain bytes or a human suffix: `500MB`, `2GiB`, `750k`. Decimal suffixes (KB/MB/GB/ TB) are powers of 1000; binary suffixes (KiB/MiB/GiB/TiB) are powers of 1024 |
+| `--dry-run` | (flag) | `false` | Report what would be reclaimed without deleting anything |
 | `-C, --directory` | `<DIR>` |  | Project root. Defaults to the current directory; the cache lives under `<project>/.once/`. Mirrors `make -C` |
 | `--format` | `<FORMAT>` | `human` | Output format for Once's structured data (`cache stats`, `run`/`exec` trailers). Defaults to a human-readable rendering; pass `json` or `toon` to get machine-parseable output for scripting and for agent consumers |
 | `-v, --verbose` | (flag) | `0` | Increase log verbosity. Repeat for more (-v: info, -vv: debug, -vvv: trace). Overridden by `RUST_LOG` |
 | `-q, --quiet` | (flag) | `false` | Suppress human-mode success and progress trailers. Errors and the structured envelope of `--format json`/`toon` still print. Mirrors the `-q` flag of common build tools |
 | `--list` | (flag) | `false` | Print the command surface at the current command depth |
-
-## Subcommands
-
-- [`once cache stats`](/reference/cli/cache/stats)
-- [`once cache gc`](/reference/cli/cache/gc)
-- [`once cache blob`](/reference/cli/cache/blob)
-- [`once cache action`](/reference/cli/cache/action)

--- a/spec/cache_gc_spec.sh
+++ b/spec/cache_gc_spec.sh
@@ -1,0 +1,53 @@
+#shellcheck shell=bash
+# End-to-end specs for `once cache gc`.
+
+Describe 'once cache gc'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  It 'is a no-op on an empty workspace'
+    When call once cache gc --max-size 1GB
+    The status should be success
+    The stdout should include '0 entries removed'
+  End
+
+  It 'leaves the cache intact when it already fits the budget'
+    once exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'printf hello' >/dev/null 2>&1
+    When call once cache gc --max-size 1GiB
+    The status should be success
+    The stdout should include 'reclaimed 0 bytes'
+  End
+
+  It 'reclaims the whole store under a zero budget'
+    once exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'printf hello' >/dev/null 2>&1
+    once cache gc --max-size 0 >/dev/null 2>&1
+    # After a full reclaim the store reports zero blobs and actions.
+    When call once cache stats
+    The status should be success
+    The stdout should include 'blobs:   0'
+    The stdout should include 'actions: 0'
+  End
+
+  It 'previews reclaimable space with --dry-run without deleting'
+    once exec -e PATH=/usr/bin:/bin -- /bin/sh -c 'printf hello' >/dev/null 2>&1
+    once cache gc --max-size 0 --dry-run >/dev/null 2>&1
+    # The store is untouched: blobs and the action are still present.
+    When call once cache stats
+    The status should be success
+    The stdout should not include 'blobs:   0'
+  End
+
+  It 'rejects a malformed size'
+    When call once cache gc --max-size not-a-size
+    The status should not equal 0
+    The stderr should include 'max-size'
+  End
+
+  It 'emits a structured record under --format json'
+    When call "$ONCE_BIN" --format json -C "$WORKSPACE" cache gc --max-size 500MB
+    The status should be success
+    The stdout should include '"bytes_reclaimed":'
+    The stdout should include '"removed":'
+    The stdout should include '"max_size":500000000'
+  End
+End


### PR DESCRIPTION
## What changed

Two focused commits that make the local cache safer to keep bounded and close several unbounded resource paths.

**Cache garbage collection and recovery (`feat(cache)`)**
- Add `once cache gc --max-size <SIZE> [--dry-run]`. It reclaims the local content-addressed store down to a byte budget. `SIZE` accepts a raw byte count or a human suffix (`500MB`, `2GiB`, `750k`; decimal suffixes are powers of 1000, binary suffixes powers of 1024). `--dry-run` reports what a pass would reclaim without deleting anything.
- Eviction is reference-aware: orphan blobs (content no surviving action result points at) go first, then action results oldest-first, cascading the blobs each one exclusively owned. A blob a surviving action still references is never evicted.
- Cache hits now tolerate a partially-populated store. If an action result survives but a blob it references is gone, the lookup re-executes the action instead of failing the build. This covers both declared output blobs and the captured stdout/stderr blobs that downstream consumers read straight from the store.

**Resource bounds to prevent out-of-memory failures (`fix`)**
- Model Context Protocol (a JSON-RPC protocol coding agents use to drive the tool, see https://modelcontextprotocol.io) server: cap the size of a single newline-delimited request. An oversize request is refused and the server keeps serving instead of buffering an unbounded line.
- Build scheduler: cap in-flight build tasks at the host parallelism so a wide graph no longer spawns a task and subprocess for every ready target at once. Action-level concurrency is still bounded separately by the core runner's resource pool.
- Starlark-to-JSON conversion: add a recursion-depth guard so a value nested arbitrarily deep (trivial to construct in Starlark) can no longer overflow the native stack and abort the process.
- Remote cache: bound the concurrent blob transfers driven by a remote action result, so an untrusted response cannot fan out one in-memory buffer per declared output.

## Why

`once cache gc` closes a long-standing gap for a local-first cache: without it the store grows without bound, the same problem that dogged other build systems for years. Making cache hits recover from a partially-populated store is what makes garbage collection safe to run at any time, including while a build shares the store.

The resource-bound fixes come from a deliberate sweep for unbounded memory, file-descriptor, and stack growth. The goal is that a large or hostile input degrades gracefully rather than triggering an out-of-memory kill, which is a recurring failure mode for build systems at scale.

## Root cause

- The action cache previously treated a missing referenced blob on a hit as a hard error, so an evicted or unsynced blob could fail an otherwise fine build.
- Several paths scaled with untrusted or unbounded input without a ceiling: a single request line, the number of independently-ready graph targets, Starlark nesting depth, and the number of outputs in a remote action result.

## Approach

Garbage collection is reference-aware rather than a flat oldest-first sweep, because a plain sweep would evict exactly the hot, stable toolchain blobs that are the oldest entries on disk. Ordering by reachability keeps those while still reclaiming true waste first. A blob whose last surviving action is evicted is unreachable, so it is cascaded out unconditionally rather than gated on the remaining budget, which avoids stranding zero-byte entries.

For the bounds, the fixes are non-arbitrary caps and guards rather than hard size limits that could break legitimate large builds. The larger streaming refactors that some other findings need (streaming output capture, a bounded decompressor) are intentionally left out of this change so they can land carefully on their own.

## Impact

- New `once cache gc` subcommand; no change to existing commands or on-disk formats. Reference documentation is regenerated to include it.
- Builds are more robust: a partially-evicted or partially-synced cache re-executes instead of erroring, and a build self-heals its cache on the next run.
- Large graphs, large or malformed requests, deeply nested Starlark, and large remote responses no longer have an unbounded path to out-of-memory or stack-overflow.

## Validation

- `cargo build --workspace` and `cargo clippy --workspace --all-targets` are clean.
- `cargo test --workspace` passes, including new unit tests for reference-aware eviction, dry-run, cache recovery from an evicted output blob and from an evicted stdout blob, the capped request reader, and the human size parser.
- Shellspec end-to-end suites pass: `spec/cache_gc_spec.sh` (new), plus `cache_stats`, `mcp`, and `cli_surface`.
- Manual end-to-end check: populate the cache, `gc --max-size 0` reclaims it, `stats` confirms an empty store, and a subsequent build succeeds as a graceful miss.
