### PR TITLE
ci(infra): deploy Once on the shared Tuist workload cluster

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -83,8 +83,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: once-production" \
-            --vault once-k8s-production --output "$KUBECONFIG"
+          op document get "kubeconfig: tuist-production" \
+            --vault tuist-k8s-production --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
       - name: Verify cluster reachability
         run: |

--- a/infra/helm/once/templates/dns-issuer.yaml
+++ b/infra/helm/once/templates/dns-issuer.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.dnsIssuer.enabled }}
+# A namespaced ACME issuer that solves the DNS-01 challenge for buildonce.dev
+# through Cloudflare. The cluster's shared ClusterIssuer only has credentials
+# for the tuist.dev zone, so buildonce.dev needs its own issuer scoped to a
+# Cloudflare token that can edit the buildonce.dev zone.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.dnsIssuer.tokenSecretName }}
+  labels:
+    {{- include "once.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.storeRef.name }}
+    kind: {{ .Values.externalSecrets.storeRef.kind }}
+  target:
+    name: {{ .Values.dnsIssuer.tokenSecretName }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        api-token: "{{ `{{ .apiToken | trim }}` }}"
+  data:
+    - secretKey: apiToken
+      remoteRef:
+        key: {{ .Values.dnsIssuer.tokenRemoteRef | quote }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.ingress.issuer }}
+  labels:
+    {{- include "once.labels" . | nindent 4 }}
+spec:
+  acme:
+    server: {{ .Values.dnsIssuer.acmeServer | quote }}
+    email: {{ .Values.dnsIssuer.email | quote }}
+    privateKeySecretRef:
+      name: {{ .Values.ingress.issuer }}-account
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: {{ .Values.dnsIssuer.tokenSecretName }}
+              key: api-token
+{{- end }}

--- a/infra/helm/once/templates/dns-issuer.yaml
+++ b/infra/helm/once/templates/dns-issuer.yaml
@@ -3,6 +3,11 @@
 # through Cloudflare. The cluster's shared ClusterIssuer only has credentials
 # for the tuist.dev zone, so buildonce.dev needs its own issuer scoped to a
 # Cloudflare token that can edit the buildonce.dev zone.
+{{- if .Values.externalSecrets.enabled }}
+# The Cloudflare token is synced from 1Password only when external-secrets is
+# enabled, mirroring the app secret. Clusters that disable external-secrets are
+# expected to provide the token secret ({{ .Values.dnsIssuer.tokenSecretName }})
+# by other means.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -26,6 +31,7 @@ spec:
       remoteRef:
         key: {{ .Values.dnsIssuer.tokenRemoteRef | quote }}
 ---
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/infra/helm/once/templates/ingress.yaml
+++ b/infra/helm/once/templates/ingress.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     {{- include "once.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.ingress.issuer }}
+    cert-manager.io/issuer: {{ .Values.ingress.issuer | quote }}
+    {{- else }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | quote }}
+    {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 25m
 spec:
   ingressClassName: {{ .Values.ingress.className }}

--- a/infra/helm/once/tests/render-conditionals.sh
+++ b/infra/helm/once/tests/render-conditionals.sh
@@ -68,11 +68,23 @@ render \
   >"$tmpdir/external-secrets-enabled-pull-secret-enabled-no-name.yaml"
 expect_external_secret_count "$tmpdir/external-secrets-enabled-pull-secret-enabled-no-name.yaml" 1
 
-# The DNS-01 issuer renders its token ExternalSecret and a namespaced Issuer
-# independently of the app secrets, and disappears entirely when disabled.
-render --set dnsIssuer.enabled=true --set externalSecrets.enabled=false >"$tmpdir/dns-issuer-enabled.yaml"
-expect_external_secret_count "$tmpdir/dns-issuer-enabled.yaml" 1
-if ! grep -q '^kind: Issuer$' "$tmpdir/dns-issuer-enabled.yaml"; then
+# The namespaced Issuer renders whenever dnsIssuer.enabled, but its Cloudflare
+# token ExternalSecret is gated on externalSecrets.enabled like the rest of the
+# chart's secret syncing, so it stays installable on clusters without the
+# External Secrets CRD.
+render --set dnsIssuer.enabled=true --set externalSecrets.enabled=false >"$tmpdir/dns-issuer-no-es.yaml"
+expect_external_secret_count "$tmpdir/dns-issuer-no-es.yaml" 0
+if ! grep -q '^kind: Issuer$' "$tmpdir/dns-issuer-no-es.yaml"; then
+  echo "namespaced Issuer not rendered when dnsIssuer.enabled and externalSecrets disabled" >&2
+  exit 1
+fi
+
+render --set dnsIssuer.enabled=true --set externalSecrets.enabled=true >"$tmpdir/dns-issuer-with-es.yaml"
+if ! grep -q 'name: cloudflare-buildonce-token' "$tmpdir/dns-issuer-with-es.yaml"; then
+  echo "token ExternalSecret not rendered when dnsIssuer and externalSecrets enabled" >&2
+  exit 1
+fi
+if ! grep -q '^kind: Issuer$' "$tmpdir/dns-issuer-with-es.yaml"; then
   echo "namespaced Issuer not rendered when dnsIssuer.enabled=true" >&2
   exit 1
 fi

--- a/infra/helm/once/tests/render-conditionals.sh
+++ b/infra/helm/once/tests/render-conditionals.sh
@@ -34,29 +34,51 @@ if [[ -n "$rendered_manifest" ]]; then
 else
   render >"$tmpdir/default.yaml"
 fi
-grep -q '^[[:space:]]*imagePullSecrets:' "$tmpdir/default.yaml"
-
-render --set-string image.pullSecretName= >"$tmpdir/no-image-pull-secret.yaml"
-if grep -q '^[[:space:]]*imagePullSecrets:' "$tmpdir/no-image-pull-secret.yaml"; then
-  echo "imagePullSecrets rendered when image.pullSecretName was empty" >&2
+# The image is public, so the default values render no imagePullSecrets.
+if grep -q '^[[:space:]]*imagePullSecrets:' "$tmpdir/default.yaml"; then
+  echo "imagePullSecrets rendered with the default (empty) image.pullSecretName" >&2
   exit 1
 fi
 
-render --set externalSecrets.enabled=true --set externalSecrets.pullSecret.enabled=true >"$tmpdir/external-secrets-enabled-pull-secret-enabled.yaml"
+render --set-string image.pullSecretName=ghcr-pull >"$tmpdir/image-pull-secret.yaml"
+if ! grep -q '^[[:space:]]*imagePullSecrets:' "$tmpdir/image-pull-secret.yaml"; then
+  echo "imagePullSecrets not rendered when image.pullSecretName was set" >&2
+  exit 1
+fi
+
+# The DNS-01 issuer contributes its own ExternalSecret (for the Cloudflare
+# token); disable it here so the counts isolate the app/pull-secret matrix.
+render --set dnsIssuer.enabled=false --set externalSecrets.enabled=true --set externalSecrets.pullSecret.enabled=true --set-string image.pullSecretName=ghcr-pull >"$tmpdir/external-secrets-enabled-pull-secret-enabled.yaml"
 expect_external_secret_count "$tmpdir/external-secrets-enabled-pull-secret-enabled.yaml" 2
 
-render --set externalSecrets.enabled=true --set externalSecrets.pullSecret.enabled=false >"$tmpdir/external-secrets-enabled-pull-secret-disabled.yaml"
+render --set dnsIssuer.enabled=false --set externalSecrets.enabled=true --set externalSecrets.pullSecret.enabled=false >"$tmpdir/external-secrets-enabled-pull-secret-disabled.yaml"
 expect_external_secret_count "$tmpdir/external-secrets-enabled-pull-secret-disabled.yaml" 1
 
-render --set externalSecrets.enabled=false --set externalSecrets.pullSecret.enabled=true >"$tmpdir/external-secrets-disabled-pull-secret-enabled.yaml"
+render --set dnsIssuer.enabled=false --set externalSecrets.enabled=false --set externalSecrets.pullSecret.enabled=true >"$tmpdir/external-secrets-disabled-pull-secret-enabled.yaml"
 expect_external_secret_count "$tmpdir/external-secrets-disabled-pull-secret-enabled.yaml" 0
 
-render --set externalSecrets.enabled=false --set externalSecrets.pullSecret.enabled=false >"$tmpdir/external-secrets-disabled-pull-secret-disabled.yaml"
+render --set dnsIssuer.enabled=false --set externalSecrets.enabled=false --set externalSecrets.pullSecret.enabled=false >"$tmpdir/external-secrets-disabled-pull-secret-disabled.yaml"
 expect_external_secret_count "$tmpdir/external-secrets-disabled-pull-secret-disabled.yaml" 0
 
 render \
+  --set dnsIssuer.enabled=false \
   --set externalSecrets.enabled=true \
   --set externalSecrets.pullSecret.enabled=true \
   --set-string image.pullSecretName= \
   >"$tmpdir/external-secrets-enabled-pull-secret-enabled-no-name.yaml"
 expect_external_secret_count "$tmpdir/external-secrets-enabled-pull-secret-enabled-no-name.yaml" 1
+
+# The DNS-01 issuer renders its token ExternalSecret and a namespaced Issuer
+# independently of the app secrets, and disappears entirely when disabled.
+render --set dnsIssuer.enabled=true --set externalSecrets.enabled=false >"$tmpdir/dns-issuer-enabled.yaml"
+expect_external_secret_count "$tmpdir/dns-issuer-enabled.yaml" 1
+if ! grep -q '^kind: Issuer$' "$tmpdir/dns-issuer-enabled.yaml"; then
+  echo "namespaced Issuer not rendered when dnsIssuer.enabled=true" >&2
+  exit 1
+fi
+
+render --set dnsIssuer.enabled=false --set externalSecrets.enabled=false >"$tmpdir/dns-issuer-disabled.yaml"
+if grep -q '^kind: Issuer$' "$tmpdir/dns-issuer-disabled.yaml"; then
+  echo "namespaced Issuer rendered when dnsIssuer.enabled=false" >&2
+  exit 1
+fi

--- a/infra/helm/once/values.yaml
+++ b/infra/helm/once/values.yaml
@@ -18,7 +18,8 @@ image:
   repository: ghcr.io/tuist/once-web
   tag: ""
   pullPolicy: IfNotPresent
-  pullSecretName: ghcr-pull
+  # The image is published publicly on GHCR, so no pull secret is needed.
+  pullSecretName: ""
 
 # Single replica: the site is static and runs on a single-node cluster, so
 # horizontal scaling and HA are not achievable or needed right now.
@@ -51,7 +52,20 @@ service:
 
 ingress:
   className: nginx
-  clusterIssuer: letsencrypt-prod
+  # A namespaced Issuer (created by templates/dns-issuer.yaml) that can solve
+  # the DNS-01 challenge for buildonce.dev. When set, it takes precedence over
+  # clusterIssuer, which the shared cluster only scopes to the tuist.dev zone.
+  issuer: letsencrypt-buildonce
+  clusterIssuer: letsencrypt-cloudflare
+
+# Namespaced ACME issuer for buildonce.dev. Its Cloudflare token is synced from
+# 1Password into the namespace and grants edit access to the buildonce.dev zone.
+dnsIssuer:
+  enabled: true
+  email: ops@tuist.dev
+  acmeServer: https://acme-v02.api.letsencrypt.org/directory
+  tokenSecretName: cloudflare-buildonce-token
+  tokenRemoteRef: "cloudflare-buildonce-dns/credential"
 
 env: {}
 
@@ -81,8 +95,9 @@ externalSecrets:
   items:
     SECRET_KEY_BASE:
       remoteRef: "once-secret-key-base/password"
+  # The image is public, so no registry pull secret is synced.
   pullSecret:
-    enabled: true
+    enabled: false
     item: "once-ghcr-pull"
     field: "notesPlain"
 


### PR DESCRIPTION
## Motivation

After the docs migration merged, the web deploy pipeline was still targeting a standalone `once-production` Kubernetes cluster whose kubeconfig no longer exists in 1Password, so every deploy failed and buildonce.dev was not serving the new app. Rather than pay to keep a separate cluster alive for a single low-traffic site, we agreed to run Once as its own application on the existing Tuist production workload cluster, which has ample spare capacity.

## What changed

- **Deploy target**: `deploy-web.yml` now loads the kubeconfig from the `tuist-production` document in the `tuist-k8s-production` 1Password vault (the vault the cluster's external-secrets store already reads), keeping the `once-production` namespace and `once` release name.
- **Public image**: the GHCR image is published publicly, so the registry pull secret is removed (`image.pullSecretName: ""`, `externalSecrets.pullSecret.enabled: false`). One less secret to sync.
- **TLS for buildonce.dev**: the cluster's shared `letsencrypt-cloudflare` ClusterIssuer is scoped to the tuist.dev zone only, so it cannot solve the DNS-01 challenge for buildonce.dev. The chart now templates a namespaced ACME `Issuer` plus an `ExternalSecret` that syncs a Cloudflare token scoped to the buildonce.dev zone, and the ingress prefers that namespaced issuer when set.

## Approach and tradeoffs

The alternative was a `ClusterIssuer` with a second Cloudflare token, but a namespaced `Issuer` keeps the buildonce.dev credential contained to the `once-production` namespace and avoids granting a cluster-wide solver. The token and the app's `SECRET_KEY_BASE` are stored in the same `tuist-k8s-production` vault the cluster already trusts, so the whole deploy reproduces from the chart with no manual `--set` flags.

## Verification

- `helm lint` and `helm template` render the namespaced issuer annotation, both external-secrets, and the Issuer.
- Reconciled the live release to the chart with no overrides (`helm upgrade` revision 2): both ExternalSecrets report `SecretSynced`, the `letsencrypt-buildonce` Issuer and the `once-tls` certificate are `Ready`, and the pod is `1/1 Running`.
- DNS was cut over for buildonce.dev to the new load balancer. Public HTTPS now returns 200 for `/`, `/docs`, `/docs/guide/why`, `/changelog`, `/changelog/feed.xml`, and `/changelog/feed.atom` with a valid certificate.

## Follow-ups (not in this PR)

- `docs.buildonce.dev` is still bound to the old Cloudflare Workers custom domain and cannot be repointed with the DNS-scoped token; the Worker binding needs to be removed so the subdomain redirects to `/docs`.
- The two orphaned `once-production-*` Hetzner servers from the retired cluster can be decommissioned now that traffic is served from the Tuist cluster.