### PR TITLE
feat(apple): support device-specific app thinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Added `apple_thinned_package` for producing ad-hoc signed, device-specific
+  application archives before uploading builds to size-analysis services such
+  as Sentry. Device application bundles now include the supported-platform
+  metadata required by Xcode's thinning tool.
+
 ### Breaking Changes
 
 - Script actions now live under `[[target]]` with `kind = "script"` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### Added
-
-- Added `apple_thinned_package` for producing ad-hoc signed, device-specific
-  application archives before uploading builds to size-analysis services such
-  as Sentry. Device application bundles now include the supported-platform
-  metadata required by Xcode's thinning tool.
-
 ### Breaking Changes
 
 - Script actions now live under `[[target]]` with `kind = "script"` and

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -3384,7 +3384,14 @@ apple_thinned_package = target_kind(
     docs = "Produces an ad-hoc signed, device-specific application archive for Apple application size analysis.",
     impl = _apple_thinned_package_impl,
     attrs = [
-        attr("device_model", "string", required = True, docs = "One Apple device model identifier, such as `iPhone17,1`", configurable = False),
+        attr(
+            "device_model",
+            "string",
+            required = True,
+            docs = "One Apple device model identifier, such as `iPhone17,1`",
+            configurable = False,
+            disallowed_values = ["", "all"],
+        ),
     ],
     deps = [
         dep("deps", ["apple_application"], "Exactly one device application to thin and package"),

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -3394,7 +3394,13 @@ apple_thinned_package = target_kind(
         ),
     ],
     deps = [
-        dep("deps", ["apple_application"], "Exactly one device application to thin and package"),
+        dep(
+            "deps",
+            ["apple_application"],
+            "Exactly one device application to thin and package",
+            min_count = 1,
+            max_count = 1,
+        ),
     ],
     providers = ["apple_thinned_package"],
     capabilities = [

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -243,6 +243,55 @@ def _resolve_codesign(xcode_developer_dir):
         "env": env,
     }
 
+def _resolve_apple_thinning_tools(xcode_developer_dir):
+    env = _developer_env(xcode_developer_dir)
+    xcrun = host_which("xcrun")
+    if xcode_developer_dir:
+        developer_dir = xcode_developer_dir
+        ipatool = developer_dir + "/usr/bin/ipatool"
+        xcodebuild = developer_dir + "/usr/bin/xcodebuild"
+    else:
+        ipatool = host_command([xcrun, "--find", "ipatool"], env = env).strip()
+        suffix = "/usr/bin/ipatool"
+        if not _ends_with(ipatool, suffix):
+            fail("unable to derive the Xcode developer directory from ipatool at " + ipatool)
+        developer_dir = ipatool[:len(ipatool) - len(suffix)]
+        xcodebuild = host_command([xcrun, "--find", "xcodebuild"], env = env).strip()
+    ruby = host_which("ruby")
+    zip = host_which("zip")
+    codesign = _resolve_codesign(developer_dir)
+    xcode_version = host_command([xcodebuild, "-version"], env = env).strip()
+    ruby_version = host_command([ruby, "--version"]).strip()
+    zip_version = host_command([zip, "-v"]).strip()
+    action_env = dict(env)
+    action_path = developer_dir + "/Toolchains/XcodeDefault.xctoolchain/usr/bin:/usr/bin:/bin"
+    action_env["PATH"] = action_path
+    action_env["LANG"] = "C"
+    action_env["LC_ALL"] = "C"
+    action_env["TZ"] = "UTC"
+    identity = "\x00".join([
+        "once.apple.thinning.v1",
+        developer_dir,
+        ipatool,
+        xcode_version,
+        ruby,
+        ruby_version,
+        zip,
+        zip_version,
+        codesign["codesign_path"],
+        action_path,
+    ])
+    return {
+        "ruby": ruby,
+        "ipatool": ipatool,
+        "zip": zip,
+        "codesign": codesign["codesign_path"],
+        "toolchain_dir": developer_dir + "/Toolchains/XcodeDefault.xctoolchain/usr",
+        "platforms_dir": developer_dir + "/Platforms",
+        "identity": identity,
+        "env": action_env,
+    }
+
 def _swift_testing_macros_plugin(swiftc_path):
     suffix = "/usr/bin/swiftc"
     if not _ends_with(swiftc_path, suffix):
@@ -1483,6 +1532,23 @@ def _render_plist(entries, bool_entries = {}, array_entries = {}):
     lines.append("")
     return "\n".join(lines)
 
+def _apple_supported_platform(sdk_name):
+    names = {
+        "macosx": "MacOSX",
+        "iphoneos": "iPhoneOS",
+        "iphonesimulator": "iPhoneSimulator",
+        "appletvos": "AppleTVOS",
+        "appletvsimulator": "AppleTVSimulator",
+        "watchos": "WatchOS",
+        "watchsimulator": "WatchSimulator",
+        "xros": "XROS",
+        "xrsimulator": "XRSimulator",
+    }
+    name = names.get(sdk_name)
+    if not name:
+        fail("no supported-platform property-list value for Apple SDK `" + sdk_name + "`")
+    return name
+
 def _collect_dep_compile_inputs(deps, build_dir):
     """Aggregate compile-visible inputs from dep providers.
 
@@ -1757,6 +1823,7 @@ def _apple_framework_impl(ctx):
 def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesign, identifier_prefix):
     embedded_paths = []
     embedded_stamps = []
+    embedded_files = []
     destination_sources = {}
     for bundle in _apple_collect_runtime_framework_bundles(deps):
         framework_path = bundle["path"]
@@ -1779,6 +1846,7 @@ def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesi
         embedded_stamp = declare_output(embedded_relative_path + "/_CodeSignature/CodeResources")
         if embedded_stamp not in embed_outputs:
             embed_outputs.append(embedded_stamp)
+        embedded_files.extend(embed_outputs)
         embedded_framework_path = ctx["build_dir"] + "/" + embedded_relative_path
         embedded_paths.append(embedded_framework_path)
         copy_path(
@@ -1800,6 +1868,7 @@ def _apple_embed_framework_bundles(ctx, deps, bundle_dir, frameworks_dir, codesi
     return {
         "paths": embedded_paths,
         "stamps": embedded_stamps,
+        "files": embedded_files,
     }
 
 def shell_quote_for_action(path):
@@ -1903,8 +1972,13 @@ def _apple_application_impl(ctx):
         )
         return {
             "label_id": ctx["label"]["id"],
+            "target_kind": "apple_application",
             "app_path": app_path,
             "bundle_id": bundle_id,
+            "platform": platform,
+            "sdk_variant": sdk_variant,
+            "xcode_developer_dir": xcode_developer_dir,
+            "product_name": product_name,
         }
 
     executable = declare_output(app_dir + "/" + product_name)
@@ -2018,7 +2092,10 @@ def _apple_application_impl(ctx):
             device_family_codes.append({"integer": 1})
         elif family == "ipad":
             device_family_codes.append({"integer": 2})
-    array_entries = {"UIDeviceFamily": device_family_codes}
+    array_entries = {
+        "CFBundleSupportedPlatforms": [_apple_supported_platform(swiftc["sdk_name"])],
+        "UIDeviceFamily": device_family_codes,
+    }
     write_path(info_plist, _render_plist(plist_entries, bool_entries, array_entries))
 
     codesign = _resolve_codesign(xcode_developer_dir)
@@ -2049,8 +2126,242 @@ def _apple_application_impl(ctx):
 
     return {
         "label_id": ctx["label"]["id"],
+        "target_kind": "apple_application",
         "app_path": app_path,
+        "app_files": [executable, info_plist, app_cs_stamp] + embedded_frameworks["files"],
         "bundle_id": bundle_id,
+        "platform": platform,
+        "sdk_variant": sdk_variant,
+        "xcode_developer_dir": xcode_developer_dir,
+        "product_name": product_name,
+    }
+
+def _apple_thinning_application(deps, label_id):
+    if len(deps) != 1:
+        fail(label_id + ": apple_thinned_package requires exactly one apple_application dependency")
+    application = deps[0]
+    if application.get("target_kind") != "apple_application" or not application.get("app_path"):
+        fail(label_id + ": dependency must provide an apple_application bundle")
+    if application.get("platform") != "ios":
+        fail(label_id + ": apple_thinned_package only supports applications with platform = \"ios\"")
+    if application.get("sdk_variant") != "device":
+        fail(label_id + ": apple_thinned_package requires an application with sdk_variant = \"device\"")
+    return application
+
+def _apple_thinning_adapter():
+    return '''require "fileutils"
+require "find"
+require "json"
+require "open3"
+
+ruby_arguments = [
+  :ipatool,
+  :codesign,
+  :zip,
+  :input,
+  :device,
+  :product,
+  :target,
+  :variants,
+  :report,
+  :packages,
+  :manifest,
+  :toolchain,
+  :platforms,
+]
+options = ruby_arguments.zip(ARGV).to_h
+
+def run_quietly(argv, failure, working_directory = nil, input = nil)
+  _stdout, _stderr, status = if working_directory && input
+    Open3.capture3(*argv, chdir: working_directory, stdin_data: input)
+  elsif working_directory
+    Open3.capture3(*argv, chdir: working_directory)
+  else
+    Open3.capture3(*argv)
+  end
+  raise failure unless status.success?
+end
+
+def safe_name(value)
+  value.gsub(/[^A-Za-z0-9._-]+/, "-").gsub(/^-+|-+$/, "")
+end
+
+begin
+  ipatool_argv = [
+    options.fetch(:ipatool),
+    options.fetch(:input),
+    "--create-thinned=#{options.fetch(:device)}",
+    "--validate-output",
+    "--validate-output-zero-variants",
+    "--toolchain=#{options.fetch(:toolchain)}",
+    "--platforms=#{options.fetch(:platforms)}",
+    "--json=#{options.fetch(:report)}",
+    "--output=#{options.fetch(:variants)}",
+    "--quiet",
+  ]
+  _stdout, _stderr, status = Open3.capture3(*ipatool_argv)
+  unless status.success?
+    alerts = if File.file?(options.fetch(:report))
+      JSON.parse(File.read(options.fetch(:report))).fetch("alerts", [])
+    else
+      []
+    end
+    descriptions = alerts.each_with_object([]) do |alert, values|
+      values << alert["description"] if alert["level"] == "ERROR" && alert["description"]
+    end
+    detail = descriptions.empty? ? "Xcode app thinning failed" : descriptions.join("\n")
+    raise detail
+  end
+
+  report = JSON.parse(File.read(options.fetch(:report)))
+  records = report.fetch("thinnedIPAs", []).select do |record|
+    Array(record["devices"]).include?(options.fetch(:device))
+  end
+  raise "Xcode produced no thinned application for #{options.fetch(:device)}" if records.empty?
+
+  records.sort_by! do |record|
+    [
+      Array(record["devices"]).join(","),
+      JSON.generate(Array(record["installTargets"])),
+      record.fetch("path"),
+    ]
+  end
+  FileUtils.mkdir_p(options.fetch(:packages))
+  fixed_time = Time.utc(1980, 1, 1)
+  packages = records.each_with_index.map do |record, index|
+    expanded = record.fetch("path")
+    applications = Dir.glob(File.join(expanded, "Payload", "*.app")).sort
+    raise "thinned output must contain exactly one application bundle" unless applications.length == 1
+
+    signables = []
+    Find.find(applications.first) do |path|
+      if File.directory?(path) && [".app", ".appex", ".framework", ".xpc"].include?(File.extname(path))
+        signables << path
+      elsif File.file?(path) && File.extname(path) == ".dylib"
+        signables << path
+      end
+    end
+    signables.uniq.sort_by { |path| [-path.count("/"), path] }.each do |path|
+      run_quietly(
+        [options.fetch(:codesign), "--force", "--sign", "-", "--timestamp=none", path],
+        "failed to sign #{File.basename(path)} after app thinning",
+      )
+    end
+
+    Find.find(expanded) do |path|
+      File.utime(fixed_time, fixed_time, path) unless File.symlink?(path)
+    end
+    suffix = records.length == 1 ? "" : "-#{index + 1}"
+    filename = "#{safe_name(options.fetch(:product))}-#{safe_name(options.fetch(:device))}#{suffix}.ipa"
+    package = File.join(options.fetch(:packages), filename)
+    package_absolute = File.expand_path(package)
+    archive_entries = []
+    Find.find(expanded) do |path|
+      next if path == expanded
+      if File.file?(path) || File.symlink?(path)
+        archive_entries << path.delete_prefix(expanded + "/")
+      end
+    end
+    archive_entries.sort!
+    run_quietly(
+      [
+        options.fetch(:zip),
+        "-X",
+        "-q",
+        "-y",
+        package_absolute,
+        "-@",
+      ],
+      "failed to package #{filename}",
+      expanded,
+      archive_entries.join("\n") + "\n",
+    )
+    install_targets = Array(record["installTargets"]).sort_by do |target|
+      [target["deviceModel"].to_s, target["operatingSystemVersion"].to_s]
+    end
+    {
+      "path" => package,
+      "devices" => Array(record["devices"]).sort,
+      "installTargets" => install_targets,
+    }
+  end
+
+  manifest = {
+    "schema" => "once.apple.thinned-package.v1",
+    "target" => options.fetch(:target),
+    "deviceModel" => options.fetch(:device),
+    "packages" => packages,
+  }
+  File.write(options.fetch(:manifest), JSON.pretty_generate(manifest) + "\n")
+rescue StandardError => error
+  warn error.message
+  exit 1
+end
+'''
+
+def _apple_thinned_package_impl(ctx):
+    device_model = (ctx["attr"].get("device_model") or "").strip()
+    if not device_model:
+        fail(ctx["label"]["id"] + ": attribute `device_model` must name an Apple device model, such as `iPhone17,1`")
+    if device_model == "all":
+        fail(ctx["label"]["id"] + ": attribute `device_model` must name one device model; declare one target per model")
+
+    application = _apple_thinning_application(ctx["deps"], ctx["label"]["id"])
+    product_name = application.get("product_name") or ctx["label"]["name"]
+    app_path = application["app_path"]
+    app_files = application.get("app_files") or [app_path]
+    xcode_developer_dir = application.get("xcode_developer_dir") or ""
+    tools = _resolve_apple_thinning_tools(xcode_developer_dir)
+
+    staged_app = declare_output("thinning-input/Payload/" + product_name + ".app")
+    adapter = declare_output("apple-thinning-package.rb")
+    packages = declare_output("ipas")
+    manifest = declare_output("thinned-packages.json")
+    scratch = ctx["scratch_dir"] + "/apple-thinning"
+    variants = scratch + "/variants"
+    report = scratch + "/ipatool-report.json"
+
+    copy_path(
+        app_path,
+        staged_app,
+        kind = "tree",
+        inputs = app_files,
+        toolchain_identity = "once.apple.thinning.input.v1",
+        identifier = "apple_thinned_package_stage:" + ctx["label"]["id"],
+    )
+    write_path(adapter, _apple_thinning_adapter())
+    run_action(
+        argv = [
+            tools["ruby"],
+            adapter,
+            tools["ipatool"],
+            tools["codesign"],
+            tools["zip"],
+            _parent_dir(_parent_dir(staged_app)),
+            device_model,
+            product_name,
+            ctx["label"]["id"],
+            variants,
+            report,
+            packages,
+            manifest,
+            tools["toolchain_dir"],
+            tools["platforms_dir"],
+        ],
+        inputs = [adapter, staged_app],
+        outputs = [packages, manifest],
+        clean_paths = [scratch, packages, manifest],
+        create_dirs = [scratch],
+        env = tools["env"],
+        toolchain_identity = tools["identity"] + "\x00device\x00" + device_model,
+        identifier = "apple_thinned_package:" + ctx["label"]["id"],
+    )
+    return {
+        "label_id": ctx["label"]["id"],
+        "target_kind": "apple_thinned_package",
+        "device_model": device_model,
+        "ipa_directory": packages,
+        "manifest": manifest,
     }
 
 def _apple_test_bundle_impl(ctx):
@@ -3065,6 +3376,42 @@ apple_application = target_kind(
             "native-mobile-shared-code-e2e",
             name = "Apple app with shared native code",
             use_when = "Use this when an Apple app should embed a Kotlin/Native framework and link a Rust static library.",
+        ),
+    ],
+)
+
+apple_thinned_package = target_kind(
+    docs = "Produces an ad-hoc signed, device-specific application archive for Apple application size analysis.",
+    impl = _apple_thinned_package_impl,
+    attrs = [
+        attr("device_model", "string", required = True, docs = "One Apple device model identifier, such as `iPhone17,1`", configurable = False),
+    ],
+    deps = [
+        dep("deps", ["apple_application"], "Exactly one device application to thin and package"),
+    ],
+    providers = ["apple_thinned_package"],
+    capabilities = [
+        capability("build", ["default", "ipas", "manifest"]),
+    ],
+    source_references = [
+        source_reference(
+            "Sentry",
+            "Apple application size analysis",
+            "https://docs.sentry.io/platforms/apple/guides/ios/size-analysis/#app-thinning",
+            "Confirm that device-specific application archives should be created before upload.",
+        ),
+        source_reference(
+            "Apple",
+            "Reducing your app's size",
+            "https://developer.apple.com/documentation/Xcode/reducing-your-app-s-size",
+            "Confirm Apple application thinning behavior and size-analysis guidance.",
+        ),
+    ],
+    examples = [
+        example(
+            "apple-thinned-package-minimal",
+            name = "Device-specific Apple size-analysis package",
+            use_when = "You want an application archive thinned for one device model before uploading it for size analysis.",
         ),
     ],
 )

--- a/crates/once-frontend/prelude/common.star
+++ b/crates/once-frontend/prelude/common.star
@@ -1,4 +1,4 @@
-def attr(name, ty, required = False, default = None, docs = "", configurable = True, implemented = True, allowed_values = []):
+def attr(name, ty, required = False, default = None, docs = "", configurable = True, implemented = True, allowed_values = [], disallowed_values = []):
     return {
         "name": name,
         "ty": ty,
@@ -8,6 +8,7 @@ def attr(name, ty, required = False, default = None, docs = "", configurable = T
         "configurable": configurable,
         "implemented": implemented,
         "allowed_values": allowed_values,
+        "disallowed_values": disallowed_values,
     }
 
 def dep(name, expected_providers, docs = ""):

--- a/crates/once-frontend/prelude/common.star
+++ b/crates/once-frontend/prelude/common.star
@@ -11,11 +11,13 @@ def attr(name, ty, required = False, default = None, docs = "", configurable = T
         "disallowed_values": disallowed_values,
     }
 
-def dep(name, expected_providers, docs = ""):
+def dep(name, expected_providers, docs = "", min_count = 0, max_count = None):
     return {
         "name": name,
         "expected_providers": expected_providers,
         "docs": docs,
+        "min_count": min_count,
+        "max_count": max_count,
     }
 
 def capability(name, output_groups, requires_outputs = []):

--- a/crates/once-frontend/prelude/examples/apple-thinned-package-minimal/apps/Hello/Sources/HelloApp.swift
+++ b/crates/once-frontend/prelude/examples/apple-thinned-package-minimal/apps/Hello/Sources/HelloApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct HelloApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello, world!")
+                .padding()
+        }
+    }
+}

--- a/crates/once-frontend/prelude/examples/apple-thinned-package-minimal/apps/Hello/once.toml
+++ b/crates/once-frontend/prelude/examples/apple-thinned-package-minimal/apps/Hello/once.toml
@@ -1,0 +1,19 @@
+[[target]]
+name = "Hello"
+kind = "apple_application"
+srcs = ["Sources/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+sdk_variant = "device"
+bundle_id = "dev.once.Hello"
+minimum_os = "17.0"
+families = ["iphone"]
+
+[[target]]
+name = "HelloThinned"
+kind = "apple_thinned_package"
+deps = ["./Hello"]
+
+[target.attrs]
+device_model = "iPhone17,1"

--- a/crates/once-frontend/prelude/index.star
+++ b/crates/once-frontend/prelude/index.star
@@ -45,6 +45,7 @@ PRELUDE_TARGET_KINDS = {
         "apple_library",
         "apple_framework",
         "apple_application",
+        "apple_thinned_package",
         "apple_test_bundle",
         "shellspec_test",
     ],

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -283,6 +283,9 @@ pub struct AttrSchema {
     /// Accepted string values. An empty list accepts every value of the type.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_values: Vec<String>,
+    /// Rejected string values. Surrounding whitespace is ignored during validation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disallowed_values: Vec<String>,
 }
 
 /// Dependency metadata exposed by a target kind schema.
@@ -873,10 +876,16 @@ fn attr_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<A
         configurable: field_bool(value, path, "configurable")?,
         implemented: field_bool(value, path, "implemented")?,
         allowed_values: field_string_list(value, path, "allowed_values")?,
+        disallowed_values: field_string_list(value, path, "disallowed_values")?,
     };
     if !schema.allowed_values.is_empty() && schema.ty != "string" && schema.ty != "target" {
         return Err(format!(
             "{path}.allowed_values is supported only for string and target attributes"
+        ));
+    }
+    if !schema.disallowed_values.is_empty() && schema.ty != "string" && schema.ty != "target" {
+        return Err(format!(
+            "{path}.disallowed_values is supported only for string and target attributes"
         ));
     }
     Ok(schema)
@@ -1102,6 +1111,7 @@ fn attr(
         configurable,
         implemented: true,
         allowed_values: Vec::new(),
+        disallowed_values: Vec::new(),
     }
 }
 
@@ -1214,12 +1224,48 @@ mod tests {
     }
 
     #[test]
+    fn parse_target_kind_schemas_exposes_disallowed_attribute_values() {
+        let source = source_with_common(
+            r#"demo = target_kind(
+    docs = "Demo kind",
+    attrs = [
+        attr("mode", "string", disallowed_values = ["", "all"]),
+    ],
+)"#,
+        );
+        let schemas = parse_target_kind_schemas("test.star", &source).unwrap();
+
+        assert_eq!(
+            schemas[0].attrs[0].disallowed_values,
+            vec![String::new(), "all".to_string()]
+        );
+    }
+
+    #[test]
     fn parse_target_kind_schemas_rejects_allowed_values_on_non_string_attributes() {
         let source = source_with_common(
             r#"demo = target_kind(
     docs = "Demo kind",
     attrs = [
         attr("count", "int", allowed_values = ["1", "2"]),
+    ],
+)"#,
+        );
+
+        let error = parse_target_kind_schemas("test.star", &source).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("supported only for string and target attributes"));
+    }
+
+    #[test]
+    fn parse_target_kind_schemas_rejects_disallowed_values_on_non_string_attributes() {
+        let source = source_with_common(
+            r#"demo = target_kind(
+    docs = "Demo kind",
+    attrs = [
+        attr("count", "int", disallowed_values = ["0"]),
     ],
 )"#,
         );

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -297,6 +297,12 @@ pub struct DepSchema {
     pub expected_providers: Vec<String>,
     /// Human-readable dependency description.
     pub docs: String,
+    /// Minimum number of dependencies accepted by this edge.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub min_count: usize,
+    /// Maximum number of dependencies accepted by this edge.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_count: Option<usize>,
 }
 
 pub fn load_graph_workspace(root: &Path) -> Result<Vec<GraphTarget>> {
@@ -892,11 +898,20 @@ fn attr_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<A
 }
 
 fn dep_schema_from_value(value: Value<'_>, path: &str) -> std::result::Result<DepSchema, String> {
-    Ok(DepSchema {
+    let schema = DepSchema {
         name: field_string(value, path, "name")?,
         expected_providers: field_string_list(value, path, "expected_providers")?,
         docs: field_string(value, path, "docs")?,
-    })
+        min_count: field_non_negative_usize(value, path, "min_count")?,
+        max_count: optional_field_non_negative_usize(value, path, "max_count")?,
+    };
+    if schema
+        .max_count
+        .is_some_and(|max_count| schema.min_count > max_count)
+    {
+        return Err(format!("{path}.min_count must not exceed {path}.max_count"));
+    }
+    Ok(schema)
 }
 
 fn capability_from_value(value: Value<'_>, path: &str) -> std::result::Result<Capability, String> {
@@ -1028,6 +1043,41 @@ fn field_bool(value: Value<'_>, path: &str, field: &str) -> std::result::Result<
     })
 }
 
+fn field_non_negative_usize(
+    value: Value<'_>,
+    path: &str,
+    field: &str,
+) -> std::result::Result<usize, String> {
+    let value = field_value(value, path, field)?;
+    let integer = value.unpack_i32().ok_or_else(|| {
+        format!(
+            "{path}.{field} should be a non-negative integer, got `{}`",
+            value.get_type()
+        )
+    })?;
+    usize::try_from(integer).map_err(|_| format!("{path}.{field} should be a non-negative integer"))
+}
+
+fn optional_field_non_negative_usize(
+    value: Value<'_>,
+    path: &str,
+    field: &str,
+) -> std::result::Result<Option<usize>, String> {
+    let value = field_value(value, path, field)?;
+    if value.is_none() {
+        return Ok(None);
+    }
+    let integer = value.unpack_i32().ok_or_else(|| {
+        format!(
+            "{path}.{field} should be a non-negative integer or None, got `{}`",
+            value.get_type()
+        )
+    })?;
+    usize::try_from(integer)
+        .map(Some)
+        .map_err(|_| format!("{path}.{field} should be a non-negative integer or None"))
+}
+
 fn field_list<'v>(
     value: Value<'v>,
     path: &str,
@@ -1060,6 +1110,11 @@ fn field_string_list(
 fn list<'v>(value: Value<'v>, path: &str) -> std::result::Result<&'v ListRef<'v>, String> {
     ListRef::from_value(value)
         .ok_or_else(|| format!("{path} should be a list, got `{}`", value.get_type()))
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 fn script_schema() -> TargetKindSchema {
@@ -1275,6 +1330,38 @@ mod tests {
         assert!(error
             .to_string()
             .contains("supported only for string and target attributes"));
+    }
+
+    #[test]
+    fn parse_target_kind_schemas_exposes_dependency_count_bounds() {
+        let source = source_with_common(
+            r#"demo = target_kind(
+    docs = "Demo kind",
+    deps = [
+        dep("deps", ["provider"], min_count = 1, max_count = 1),
+    ],
+)"#,
+        );
+        let schemas = parse_target_kind_schemas("test.star", &source).unwrap();
+
+        assert_eq!(schemas[0].deps[0].min_count, 1);
+        assert_eq!(schemas[0].deps[0].max_count, Some(1));
+    }
+
+    #[test]
+    fn parse_target_kind_schemas_rejects_invalid_dependency_count_bounds() {
+        let source = source_with_common(
+            r#"demo = target_kind(
+    docs = "Demo kind",
+    deps = [
+        dep("deps", ["provider"], min_count = 2, max_count = 1),
+    ],
+)"#,
+        );
+
+        let error = parse_target_kind_schemas("test.star", &source).unwrap_err();
+
+        assert!(error.to_string().contains("min_count must not exceed"));
     }
 
     #[test]

--- a/crates/once-frontend/src/manifest_editor.rs
+++ b/crates/once-frontend/src/manifest_editor.rs
@@ -654,6 +654,28 @@ kind = "apple_library"
     }
 
     #[test]
+    fn create_rejects_invalid_dependency_counts() {
+        for deps in [
+            Vec::new(),
+            vec!["./Hello".to_string(), "./OtherHello".to_string()],
+        ] {
+            let mut spec = TargetSpec {
+                name: "HelloThinned".to_string(),
+                kind: "apple_thinned_package".to_string(),
+                deps,
+                ..Default::default()
+            };
+            spec.attrs
+                .insert("device_model".to_string(), json!("iPhone17,1"));
+
+            let diagnostics = apply_operations("", &[EditOperation::Create { target: spec }])
+                .expect_err("invalid dependency count must fail");
+            assert_eq!(diagnostics[0].code, "dependency_count_mismatch");
+            assert_eq!(diagnostics[0].attribute.as_deref(), Some("deps"));
+        }
+    }
+
+    #[test]
     fn update_replaces_only_set_fields() {
         let src = r#"
 [[target]]

--- a/crates/once-frontend/src/manifest_editor.rs
+++ b/crates/once-frontend/src/manifest_editor.rs
@@ -205,13 +205,75 @@ fn update(
         .expect("find_target_index returned a valid index");
     let mut updated = table.clone();
     apply_update(&mut updated, set, target_name)?;
-    validate_spec(&target_spec_from_table(&updated), schemas)?;
+    validate_table(&updated, schemas)?;
     *table = updated;
     Ok(())
 }
 
 fn validate_spec(spec: &TargetSpec, schemas: &[TargetKindSchema]) -> Result<(), Vec<Diagnostic>> {
     let diagnostics = validate_target(spec, schemas);
+    if diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(diagnostics)
+    }
+}
+
+fn validate_table(table: &Table, schemas: &[TargetKindSchema]) -> Result<(), Vec<Diagnostic>> {
+    let spec = target_spec_from_table(table);
+    let mut diagnostics = validate_target(&spec, schemas);
+    let Some(schema) = schemas.iter().find(|schema| schema.kind == spec.kind) else {
+        return if diagnostics.is_empty() {
+            Ok(())
+        } else {
+            Err(diagnostics)
+        };
+    };
+
+    for edge in &schema.deps {
+        let (attribute, item) = if edge.name == "deps" {
+            ("deps".to_string(), table.get("deps"))
+        } else {
+            (
+                format!("dependencies.{}", edge.name),
+                table
+                    .get("dependencies")
+                    .and_then(Item::as_table)
+                    .and_then(|dependencies| dependencies.get(&edge.name)),
+            )
+        };
+        let Some(branches) = dependency_select_branches(item) else {
+            continue;
+        };
+
+        diagnostics.retain(|diagnostic| {
+            diagnostic.code != "dependency_count_mismatch"
+                || diagnostic.attribute.as_deref() != Some(attribute.as_str())
+        });
+        for dependencies in branches {
+            let mut branch_spec = spec.clone();
+            if edge.name == "deps" {
+                branch_spec.deps = dependencies;
+            } else {
+                branch_spec
+                    .dependencies
+                    .insert(edge.name.clone(), dependencies);
+            }
+            for diagnostic in
+                validate_target(&branch_spec, schemas)
+                    .into_iter()
+                    .filter(|diagnostic| {
+                        diagnostic.code == "dependency_count_mismatch"
+                            && diagnostic.attribute.as_deref() == Some(attribute.as_str())
+                    })
+            {
+                if !diagnostics.contains(&diagnostic) {
+                    diagnostics.push(diagnostic);
+                }
+            }
+        }
+    }
+
     if diagnostics.is_empty() {
         Ok(())
     } else {
@@ -357,6 +419,40 @@ fn string_vec_from_item(item: Option<&Item>) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn dependency_select_branches(item: Option<&Item>) -> Option<Vec<Vec<String>>> {
+    match item? {
+        Item::Table(table) if table.len() == 1 => {
+            let branches = table.get("select")?.as_table()?;
+            Some(
+                branches
+                    .iter()
+                    .map(|(_, item)| string_vec_from_item(Some(item)))
+                    .collect(),
+            )
+        }
+        Item::Value(Value::InlineTable(table)) if table.len() == 1 => {
+            let branches = table.get("select")?.as_inline_table()?;
+            Some(
+                branches
+                    .iter()
+                    .map(|(_, value)| {
+                        value
+                            .as_array()
+                            .map(|array| {
+                                array
+                                    .iter()
+                                    .filter_map(|value| value.as_str().map(ToString::to_string))
+                                    .collect()
+                            })
+                            .unwrap_or_default()
+                    })
+                    .collect(),
+            )
+        }
+        _ => None,
+    }
 }
 
 fn attrs_from_item(item: Option<&Item>) -> JsonMap<String, JsonValue> {
@@ -700,6 +796,67 @@ platform = "ios"
         assert!(out.contains("deps = [\"./Other\"]"));
         assert!(out.contains("srcs = [\"Sources/**/*.swift\"]"));
         assert!(out.contains("platform = \"ios\""));
+    }
+
+    #[test]
+    fn update_preserves_dependency_select_counts() {
+        let src = r#"
+[[target]]
+name = "HelloThinned"
+kind = "apple_thinned_package"
+
+[target.deps.select]
+macos = ["./Hello"]
+default = ["./Portable"]
+
+[target.attrs]
+device_model = "iPhone17,1"
+"#;
+        let out = apply_operations(
+            src,
+            &[EditOperation::Update {
+                target_name: "HelloThinned".to_string(),
+                set: TargetUpdate {
+                    visibility: Some(vec!["public".to_string()]),
+                    ..Default::default()
+                },
+            }],
+        )
+        .expect("update target with selected dependencies");
+
+        assert!(out.contains("[target.deps.select]"));
+        assert!(out.contains("macos = [\"./Hello\"]"));
+        assert!(out.contains("visibility = [\"public\"]"));
+    }
+
+    #[test]
+    fn update_rejects_invalid_dependency_select_branch_counts() {
+        let src = r#"
+[[target]]
+name = "HelloThinned"
+kind = "apple_thinned_package"
+
+[target.deps.select]
+macos = ["./Hello"]
+default = ["./Portable", "./OtherPortable"]
+
+[target.attrs]
+device_model = "iPhone17,1"
+"#;
+        let diagnostics = apply_operations(
+            src,
+            &[EditOperation::Update {
+                target_name: "HelloThinned".to_string(),
+                set: TargetUpdate {
+                    visibility: Some(vec!["public".to_string()]),
+                    ..Default::default()
+                },
+            }],
+        )
+        .expect_err("invalid dependency select branch must fail");
+
+        assert_eq!(diagnostics[0].code, "dependency_count_mismatch");
+        assert_eq!(diagnostics[0].attribute.as_deref(), Some("deps"));
     }
 
     #[test]

--- a/crates/once-frontend/src/manifest_editor.rs
+++ b/crates/once-frontend/src/manifest_editor.rs
@@ -636,6 +636,24 @@ kind = "apple_library"
     }
 
     #[test]
+    fn create_rejects_disallowed_attribute_values() {
+        for value in ["", "all"] {
+            let mut spec = TargetSpec {
+                name: "HelloThinned".to_string(),
+                kind: "apple_thinned_package".to_string(),
+                deps: vec!["./Hello".to_string()],
+                ..Default::default()
+            };
+            spec.attrs.insert("device_model".to_string(), json!(value));
+
+            let diagnostics = apply_operations("", &[EditOperation::Create { target: spec }])
+                .expect_err("disallowed device model must fail");
+            assert_eq!(diagnostics[0].code, "attr_value_disallowed");
+            assert_eq!(diagnostics[0].attribute.as_deref(), Some("device_model"));
+        }
+    }
+
+    #[test]
     fn update_replaces_only_set_fields() {
         let src = r#"
 [[target]]
@@ -740,6 +758,37 @@ platform = "ios"
         .expect_err("removing required platform must fail");
         assert_eq!(diagnostics[0].code, "missing_required_attr");
         assert_eq!(diagnostics[0].attribute.as_deref(), Some("platform"));
+    }
+
+    #[test]
+    fn update_rejects_disallowed_attribute_values() {
+        let src = r#"
+[[target]]
+name = "HelloThinned"
+kind = "apple_thinned_package"
+deps = ["./Hello"]
+
+[target.attrs]
+device_model = "iPhone17,1"
+"#;
+        let diagnostics = apply_operations(
+            src,
+            &[EditOperation::Update {
+                target_name: "HelloThinned".to_string(),
+                set: TargetUpdate {
+                    attrs: Some(JsonMap::from_iter([(
+                        "device_model".to_string(),
+                        json!("all"),
+                    )])),
+                    ..Default::default()
+                },
+            }],
+        )
+        .expect_err("disallowed device model must fail");
+
+        assert_eq!(diagnostics[0].code, "attr_value_disallowed");
+        assert_eq!(diagnostics[0].target.as_deref(), Some("HelloThinned"));
+        assert_eq!(diagnostics[0].attribute.as_deref(), Some("device_model"));
     }
 
     #[test]

--- a/crates/once-frontend/src/module_contract.rs
+++ b/crates/once-frontend/src/module_contract.rs
@@ -190,6 +190,7 @@ pub fn module_authoring_contract() -> ModuleAuthoringContract {
         schema_invariants: vec![
             "Supported attribute types are string, bool, int, float, list<string>, map<string,string>, target, and select values for configurable attributes.",
             "Set allowed_values on string or target attributes when validation must reject values outside a fixed set before analysis.",
+            "Set disallowed_values on string or target attributes when validation must reject a small reserved set before analysis. Surrounding whitespace is ignored when comparing values.",
             "Set implemented = False only for discoverable compatibility attributes that validation must reject until the target kind gives them behavior.",
             "attr.default is optional schema documentation and must be a string; it does not insert a runtime value. Implementations must use ctx[\"attr\"].get(...) when an optional attribute needs a fallback.",
             "Set configurable = False when analysis or output identity cannot safely vary through select.",

--- a/crates/once-frontend/src/module_contract.rs
+++ b/crates/once-frontend/src/module_contract.rs
@@ -195,6 +195,7 @@ pub fn module_authoring_contract() -> ModuleAuthoringContract {
             "attr.default is optional schema documentation and must be a string; it does not insert a runtime value. Implementations must use ctx[\"attr\"].get(...) when an optional attribute needs a fallback.",
             "Set configurable = False when analysis or output identity cannot safely vary through select.",
             "Dependency declarations name provider records accepted from ctx[\"deps\"] and ctx[\"deps_by_role\"], and implementations should consume provider fields instead of dependency target kind names.",
+            "Set dep.min_count and dep.max_count when validation must reject a dependency role with too few or too many targets before analysis.",
             "An implementation must return a JSON-shaped provider record whose fields satisfy the target kind's declared provider contract.",
             "Resolver-owned attributes and synthetic target attributes must be declared in their target kind schemas.",
             "Modules are trusted analysis code. Host commands must be deterministic, must not mutate workspace sources or the build output tree, and may keep resolver scratch state only under .once/tmp. Fetching and build work belong in explicit workflows and actions.",

--- a/crates/once-frontend/src/target_validator.rs
+++ b/crates/once-frontend/src/target_validator.rs
@@ -37,6 +37,7 @@ pub fn validate_target(target: &TargetSpec, schemas: &[TargetKindSchema]) -> Vec
     };
 
     validate_dependency_roles(target, schema, &mut diagnostics);
+    validate_dependency_counts(target, schema, &mut diagnostics);
     validate_required_attrs(target, schema, &mut diagnostics);
 
     for (attr_name, attr_value) in &target.attrs {
@@ -125,6 +126,60 @@ fn validate_dependency_roles(
                 .with_repair(suggest_known_dependency_roles(schema)),
             );
         }
+    }
+}
+
+fn validate_dependency_counts(
+    target: &TargetSpec,
+    schema: &TargetKindSchema,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for edge in &schema.deps {
+        let (attribute, count) = if edge.name == "deps" {
+            ("deps".to_string(), target.deps.len())
+        } else {
+            (
+                format!("dependencies.{}", edge.name),
+                target.dependencies.get(&edge.name).map_or(0, Vec::len),
+            )
+        };
+        if count >= edge.min_count && edge.max_count.is_none_or(|maximum| count <= maximum) {
+            continue;
+        }
+        let expected = dependency_count_expectation(edge.min_count, edge.max_count);
+        diagnostics.push(
+            Diagnostic::new(
+                "dependency_count_mismatch",
+                format!(
+                    "dependency role `{}` must contain {expected}; got {count}",
+                    edge.name
+                ),
+            )
+            .with_target(target.name.as_str())
+            .with_attribute(&attribute)
+            .with_repair(format!("Set `target.{attribute}` to contain {expected}")),
+        );
+    }
+}
+
+fn dependency_count_expectation(minimum: usize, maximum: Option<usize>) -> String {
+    match maximum {
+        Some(maximum) if minimum == maximum => {
+            format!("exactly {minimum} {}", dependency_unit(minimum))
+        }
+        Some(maximum) if minimum == 0 => {
+            format!("at most {maximum} {}", dependency_unit(maximum))
+        }
+        Some(maximum) => format!("between {minimum} and {maximum} dependencies"),
+        None => format!("at least {minimum} {}", dependency_unit(minimum)),
+    }
+}
+
+fn dependency_unit(count: usize) -> &'static str {
+    if count == 1 {
+        "dependency"
+    } else {
+        "dependencies"
     }
 }
 
@@ -561,6 +616,32 @@ mod tests {
         );
         assert!(diagnostic.repairs[0].contains("proc_macro_deps"));
         assert!(diagnostic.repairs[0].contains("link_deps"));
+    }
+
+    #[test]
+    fn dependency_count_reports_structured_diagnostic() {
+        let schemas = vec![schema_named("apple_thinned_package")];
+        for deps in [
+            Vec::new(),
+            vec!["./App".to_string(), "./OtherApp".to_string()],
+        ] {
+            let mut target = target("AppThinned", "apple_thinned_package");
+            target.deps = deps;
+            target
+                .attrs
+                .insert("device_model".to_string(), json!("iPhone17,1"));
+
+            let diagnostics = validate_target(&target, &schemas);
+            let diagnostic = diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.code == "dependency_count_mismatch")
+                .expect("dependency count diagnostic");
+
+            assert_eq!(diagnostic.target.as_deref(), Some("AppThinned"));
+            assert_eq!(diagnostic.attribute.as_deref(), Some("deps"));
+            assert!(diagnostic.message.contains("exactly 1 dependency"));
+            assert!(diagnostic.repairs[0].contains("target.deps"));
+        }
     }
 
     #[test]

--- a/crates/once-frontend/src/target_validator.rs
+++ b/crates/once-frontend/src/target_validator.rs
@@ -254,37 +254,73 @@ fn validate_attr_value(
         diagnostics.push(type_mismatch(target, attr_name, &attr_schema.ty, &detail));
         return;
     }
-    if attr_schema.allowed_values.is_empty() {
-        return;
-    }
     let Some(value) = value.as_str() else {
         return;
     };
-    if attr_schema
-        .allowed_values
-        .iter()
-        .any(|allowed| allowed == value)
+    if !attr_schema.allowed_values.is_empty()
+        && !attr_schema
+            .allowed_values
+            .iter()
+            .any(|allowed| allowed == value)
     {
+        let location = select_branch
+            .map(|branch| format!(" in select branch `{branch}`"))
+            .unwrap_or_default();
+        diagnostics.push(
+            Diagnostic::new(
+                "attr_value_not_allowed",
+                format!(
+                    "attribute `{attr_name}`{location} must be one of: {}; got `{value}`",
+                    attr_schema.allowed_values.join(", ")
+                ),
+            )
+            .with_target(target.name.as_str())
+            .with_attribute(attr_name)
+            .with_repair(format!(
+                "Set `target.attrs.{attr_name}` to one of: {}",
+                attr_schema.allowed_values.join(", ")
+            )),
+        );
         return;
     }
-    let location = select_branch
-        .map(|branch| format!(" in select branch `{branch}`"))
-        .unwrap_or_default();
-    diagnostics.push(
-        Diagnostic::new(
-            "attr_value_not_allowed",
-            format!(
-                "attribute `{attr_name}`{location} must be one of: {}; got `{value}`",
-                attr_schema.allowed_values.join(", ")
-            ),
-        )
-        .with_target(target.name.as_str())
-        .with_attribute(attr_name)
-        .with_repair(format!(
-            "Set `target.attrs.{attr_name}` to one of: {}",
-            attr_schema.allowed_values.join(", ")
-        )),
-    );
+    if attr_schema
+        .disallowed_values
+        .iter()
+        .any(|disallowed| disallowed == value.trim())
+    {
+        let location = select_branch
+            .map(|branch| format!(" in select branch `{branch}`"))
+            .unwrap_or_default();
+        diagnostics.push(
+            Diagnostic::new(
+                "attr_value_disallowed",
+                format!(
+                    "attribute `{attr_name}`{location} must not be {}; got `{value}`",
+                    describe_disallowed_values(&attr_schema.disallowed_values)
+                ),
+            )
+            .with_target(target.name.as_str())
+            .with_attribute(attr_name)
+            .with_repair(format!(
+                "Set `target.attrs.{attr_name}` to a value other than {}",
+                describe_disallowed_values(&attr_schema.disallowed_values)
+            )),
+        );
+    }
+}
+
+fn describe_disallowed_values(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| {
+            if value.is_empty() {
+                "empty".to_string()
+            } else {
+                format!("`{value}`")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" or ")
 }
 
 fn type_mismatch(target: &TargetSpec, attr_name: &str, ty: &str, err: &str) -> Diagnostic {
@@ -637,6 +673,28 @@ mod tests {
         assert_eq!(diagnostic.attribute.as_deref(), Some("platform"));
         assert!(diagnostic.message.contains("ios, android"));
         assert!(diagnostic.repairs[0].contains("target.attrs.platform"));
+    }
+
+    #[test]
+    fn disallowed_string_value_reports_structured_diagnostic() {
+        let schemas = vec![schema_named("apple_thinned_package")];
+        for value in ["", "  ", "all", " all "] {
+            let mut target = target("AppThinned", "apple_thinned_package");
+            target
+                .attrs
+                .insert("device_model".to_string(), json!(value));
+
+            let diagnostics = validate_target(&target, &schemas);
+            let diagnostic = diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.code == "attr_value_disallowed")
+                .expect("disallowed-value diagnostic");
+
+            assert_eq!(diagnostic.target.as_deref(), Some("AppThinned"));
+            assert_eq!(diagnostic.attribute.as_deref(), Some("device_model"));
+            assert!(diagnostic.message.contains("empty or `all`"));
+            assert!(diagnostic.repairs[0].contains("target.attrs.device_model"));
+        }
     }
 
     #[test]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1368,6 +1368,23 @@ fn apple_application_exposes_build_and_run() {
 }
 
 #[test]
+fn apple_thinned_package_schema_exposes_device_model_and_example() {
+    let schema =
+        built_in_target_kind_schema("apple_thinned_package").expect("thinned package schema");
+
+    assert!(schema
+        .attrs
+        .iter()
+        .any(|attr| attr.name == "device_model" && attr.required && !attr.configurable));
+    assert_eq!(schema.deps.len(), 1);
+    assert_eq!(schema.deps[0].expected_providers, vec!["apple_application"]);
+    assert!(schema
+        .examples
+        .iter()
+        .any(|example| example.slug == "apple-thinned-package-minimal"));
+}
+
+#[test]
 fn android_binary_exposes_build_and_run() {
     let schema = built_in_target_kind_schema("android_binary").expect("android_binary schema");
     let run = schema
@@ -5929,6 +5946,173 @@ result = repr(provider["app_path"])
         "{:?}",
         codesign.outputs
     );
+    let plist = action_by_identifier(&store, "write_path:.once/out/app/App.app/Info.plist");
+    let Some(DeclaredActionOperation::WriteFile { bytes, .. }) = &plist.operation else {
+        panic!("expected generated application property list");
+    };
+    let plist = String::from_utf8(bytes.clone()).unwrap();
+    assert!(plist.contains("<key>CFBundleSupportedPlatforms</key>"));
+    assert!(plist.contains("<string>iPhoneSimulator</string>"));
+}
+
+#[cfg(unix)]
+#[test]
+fn prelude_apple_thinned_package_stages_and_packages_one_device_application() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    if name == "ruby":
+        return "/usr/bin/ruby"
+    if name == "zip":
+        return "/usr/bin/zip"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None, merge_stderr = None):
+    if argv == ["/usr/bin/xcrun", "--find", "ipatool"]:
+        return "/Applications/TestXcode.app/Contents/Developer/usr/bin/ipatool\n"
+    if argv == ["/usr/bin/xcrun", "--find", "xcodebuild"]:
+        return "/Applications/TestXcode.app/Contents/Developer/usr/bin/xcodebuild\n"
+    if argv == ["/usr/bin/xcrun", "--find", "codesign"]:
+        return "/usr/bin/codesign\n"
+    if argv == ["/Applications/TestXcode.app/Contents/Developer/usr/bin/xcodebuild", "-version"]:
+        return "Xcode 26.0\nBuild version 17A1\n"
+    if argv == ["/usr/bin/ruby", "--version"]:
+        return "ruby 2.6.10\n"
+    if argv == ["/usr/bin/zip", "-v"]:
+        return "Zip 3.0\n"
+    fail("unexpected host_command: " + str(argv))
+
+ctx = {{
+    "label": {{
+        "package": "packages",
+        "name": "AppThinned",
+        "id": "packages/AppThinned",
+    }},
+    "attr": {{"device_model": "iPhone17,1"}},
+    "deps": [{{
+        "label_id": "apps/App",
+        "target_kind": "apple_application",
+        "app_path": ".once/out/apps/App/App.app",
+        "app_files": [
+            ".once/out/apps/App/App.app/App",
+            ".once/out/apps/App/App.app/Info.plist",
+            ".once/out/apps/App/App.app/_CodeSignature/CodeResources",
+        ],
+        "platform": "ios",
+        "sdk_variant": "device",
+        "xcode_developer_dir": "",
+        "product_name": "App",
+    }}],
+    "srcs": [],
+    "build_dir": ".once/out/packages/AppThinned",
+    "scratch_dir": ".once/tmp/analysis/packages/AppThinned",
+    "capability": "build",
+}}
+provider = _apple_thinned_package_impl(ctx)
+result = repr(provider)
+"#
+    );
+    let store = AnalysisStore::new(
+        workspace.path().to_path_buf(),
+        "packages".to_string(),
+        ".once/out/packages/AppThinned".to_string(),
+    );
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    let out = out.unwrap();
+    assert!(out.contains("\"device_model\": \"iPhone17,1\""), "{out}");
+    assert!(out.contains("\"ipa_directory\""), "{out}");
+    let stage = action_by_identifier(&store, "apple_thinned_package_stage:packages/AppThinned");
+    assert_eq!(
+        stage.operation,
+        Some(DeclaredActionOperation::CopyPath {
+            sources: vec![".once/out/apps/App/App.app".to_string()],
+            destination: ".once/out/packages/AppThinned/thinning-input/Payload/App.app".to_string(),
+            mode: DeclaredCopyPathMode::Tree,
+        })
+    );
+    assert_eq!(
+        stage.inputs,
+        vec![
+            ".once/out/apps/App/App.app/App",
+            ".once/out/apps/App/App.app/Info.plist",
+            ".once/out/apps/App/App.app/_CodeSignature/CodeResources",
+        ]
+    );
+    let adapter = action_by_identifier(
+        &store,
+        "write_path:.once/out/packages/AppThinned/apple-thinning-package.rb",
+    );
+    let Some(DeclaredActionOperation::WriteFile { bytes, .. }) = &adapter.operation else {
+        panic!("expected generated thinning adapter");
+    };
+    let adapter = String::from_utf8(bytes.clone()).unwrap();
+    assert!(adapter.contains("--create-thinned=#{options.fetch(:device)}"));
+    assert!(adapter.contains("--validate-output-zero-variants"));
+    assert!(adapter.contains("Open3.capture3(*ipatool_argv)"));
+    assert!(adapter.contains("archive_entries.sort!"));
+    assert!(adapter.contains("stdin_data: input"));
+    assert!(adapter.contains("\"-X\""));
+    assert!(!adapter.contains("puts _stdout"));
+
+    let package = action_by_identifier(&store, "apple_thinned_package:packages/AppThinned");
+    assert_eq!(package.argv[0], "/usr/bin/ruby");
+    assert!(package.argv.iter().any(|arg| arg == "iPhone17,1"));
+    assert!(package.argv.iter().any(|arg| {
+        arg == "/Applications/TestXcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr"
+    }));
+    assert!(package
+        .argv
+        .iter()
+        .any(|arg| { arg == "/Applications/TestXcode.app/Contents/Developer/Platforms" }));
+    assert!(package
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("/ipas")));
+    assert!(package
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("/thinned-packages.json")));
+    assert_eq!(package.env.get("TZ").map(String::as_str), Some("UTC"));
+    assert_eq!(package.env.get("LC_ALL").map(String::as_str), Some("C"));
+    assert_eq!(
+        package.env.get("PATH").map(String::as_str),
+        Some(
+            "/Applications/TestXcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:/usr/bin:/bin"
+        )
+    );
+    let identity = package.toolchain_identity.as_deref().unwrap();
+    assert!(identity.contains("Xcode 26.0"));
+    assert!(identity.contains("\u{0}device\u{0}iPhone17,1"));
+}
+
+#[test]
+fn prelude_apple_thinned_package_rejects_non_device_applications() {
+    let error = eval_prelude_function(
+        "_apple_thinning_application",
+        r#"([{
+            "target_kind": "apple_application",
+            "app_path": ".once/out/App.app",
+            "platform": "ios",
+            "sdk_variant": "simulator",
+        }], "AppThinned")"#,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("sdk_variant = \\\"device\\\""), "{error}");
+}
+
+#[test]
+fn prelude_apple_thinned_package_rejects_multiple_applications() {
+    let error = eval_prelude_function("_apple_thinning_application", r#"([{}, {}], "AppThinned")"#)
+        .unwrap_err();
+
+    assert!(error.contains("requires exactly one"), "{error}");
 }
 
 #[cfg(unix)]
@@ -6785,6 +6969,7 @@ fn target_kind_has_impl_returns_true_for_all_apple_bundle_kinds() {
     // analysis.
     assert!(target_kind_has_impl("apple_framework").unwrap());
     assert!(target_kind_has_impl("apple_application").unwrap());
+    assert!(target_kind_has_impl("apple_thinned_package").unwrap());
     assert!(target_kind_has_impl("apple_test_bundle").unwrap());
 }
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1372,10 +1372,14 @@ fn apple_thinned_package_schema_exposes_device_model_and_example() {
     let schema =
         built_in_target_kind_schema("apple_thinned_package").expect("thinned package schema");
 
-    assert!(schema
+    let device_model = schema
         .attrs
         .iter()
-        .any(|attr| attr.name == "device_model" && attr.required && !attr.configurable));
+        .find(|attr| attr.name == "device_model")
+        .expect("device model attribute");
+    assert!(device_model.required);
+    assert!(!device_model.configurable);
+    assert_eq!(device_model.disallowed_values, vec!["", "all"]);
     assert_eq!(schema.deps.len(), 1);
     assert_eq!(schema.deps[0].expected_providers, vec!["apple_application"]);
     assert!(schema
@@ -5956,6 +5960,58 @@ result = repr(provider["app_path"])
 }
 
 #[cfg(unix)]
+fn assert_apple_thinning_adapter(store: &AnalysisStore) {
+    let adapter = action_by_identifier(
+        store,
+        "write_path:.once/out/packages/AppThinned/apple-thinning-package.rb",
+    );
+    let Some(DeclaredActionOperation::WriteFile { bytes, .. }) = &adapter.operation else {
+        panic!("expected generated thinning adapter");
+    };
+    let adapter = String::from_utf8(bytes.clone()).unwrap();
+    assert!(adapter.contains("--create-thinned=#{options.fetch(:device)}"));
+    assert!(adapter.contains("--validate-output-zero-variants"));
+    assert!(adapter.contains("Open3.capture3(*ipatool_argv)"));
+    assert!(adapter.contains("archive_entries.sort!"));
+    assert!(adapter.contains("stdin_data: input"));
+    assert!(adapter.contains("\"-X\""));
+    assert!(!adapter.contains("puts _stdout"));
+}
+
+#[cfg(unix)]
+fn assert_apple_thinning_package_action(store: &AnalysisStore) {
+    let package = action_by_identifier(store, "apple_thinned_package:packages/AppThinned");
+    assert_eq!(package.argv[0], "/usr/bin/ruby");
+    assert!(package.argv.iter().any(|arg| arg == "iPhone17,1"));
+    assert!(package.argv.iter().any(|arg| {
+        arg == "/Applications/TestXcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr"
+    }));
+    assert!(package
+        .argv
+        .iter()
+        .any(|arg| { arg == "/Applications/TestXcode.app/Contents/Developer/Platforms" }));
+    assert!(package
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("/ipas")));
+    assert!(package
+        .outputs
+        .iter()
+        .any(|output| output.ends_with("/thinned-packages.json")));
+    assert_eq!(package.env.get("TZ").map(String::as_str), Some("UTC"));
+    assert_eq!(package.env.get("LC_ALL").map(String::as_str), Some("C"));
+    assert_eq!(
+        package.env.get("PATH").map(String::as_str),
+        Some(
+            "/Applications/TestXcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:/usr/bin:/bin"
+        )
+    );
+    let identity = package.toolchain_identity.as_deref().unwrap();
+    assert!(identity.contains("Xcode 26.0"));
+    assert!(identity.contains("\u{0}device\u{0}iPhone17,1"));
+}
+
+#[cfg(unix)]
 #[test]
 fn prelude_apple_thinned_package_stages_and_packages_one_device_application() {
     let prelude = all_prelude_source();
@@ -6044,51 +6100,8 @@ result = repr(provider)
             ".once/out/apps/App/App.app/_CodeSignature/CodeResources",
         ]
     );
-    let adapter = action_by_identifier(
-        &store,
-        "write_path:.once/out/packages/AppThinned/apple-thinning-package.rb",
-    );
-    let Some(DeclaredActionOperation::WriteFile { bytes, .. }) = &adapter.operation else {
-        panic!("expected generated thinning adapter");
-    };
-    let adapter = String::from_utf8(bytes.clone()).unwrap();
-    assert!(adapter.contains("--create-thinned=#{options.fetch(:device)}"));
-    assert!(adapter.contains("--validate-output-zero-variants"));
-    assert!(adapter.contains("Open3.capture3(*ipatool_argv)"));
-    assert!(adapter.contains("archive_entries.sort!"));
-    assert!(adapter.contains("stdin_data: input"));
-    assert!(adapter.contains("\"-X\""));
-    assert!(!adapter.contains("puts _stdout"));
-
-    let package = action_by_identifier(&store, "apple_thinned_package:packages/AppThinned");
-    assert_eq!(package.argv[0], "/usr/bin/ruby");
-    assert!(package.argv.iter().any(|arg| arg == "iPhone17,1"));
-    assert!(package.argv.iter().any(|arg| {
-        arg == "/Applications/TestXcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr"
-    }));
-    assert!(package
-        .argv
-        .iter()
-        .any(|arg| { arg == "/Applications/TestXcode.app/Contents/Developer/Platforms" }));
-    assert!(package
-        .outputs
-        .iter()
-        .any(|output| output.ends_with("/ipas")));
-    assert!(package
-        .outputs
-        .iter()
-        .any(|output| output.ends_with("/thinned-packages.json")));
-    assert_eq!(package.env.get("TZ").map(String::as_str), Some("UTC"));
-    assert_eq!(package.env.get("LC_ALL").map(String::as_str), Some("C"));
-    assert_eq!(
-        package.env.get("PATH").map(String::as_str),
-        Some(
-            "/Applications/TestXcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:/usr/bin:/bin"
-        )
-    );
-    let identity = package.toolchain_identity.as_deref().unwrap();
-    assert!(identity.contains("Xcode 26.0"));
-    assert!(identity.contains("\u{0}device\u{0}iPhone17,1"));
+    assert_apple_thinning_adapter(&store);
+    assert_apple_thinning_package_action(&store);
 }
 
 #[test]

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -1382,6 +1382,8 @@ fn apple_thinned_package_schema_exposes_device_model_and_example() {
     assert_eq!(device_model.disallowed_values, vec!["", "all"]);
     assert_eq!(schema.deps.len(), 1);
     assert_eq!(schema.deps[0].expected_providers, vec!["apple_application"]);
+    assert_eq!(schema.deps[0].min_count, 1);
+    assert_eq!(schema.deps[0].max_count, Some(1));
     assert!(schema
         .examples
         .iter()

--- a/fixtures/apple_thinned_package/apps/ios/Sources/App/App.swift
+++ b/fixtures/apple_thinned_package/apps/ios/Sources/App/App.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct App: SwiftUI.App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello")
+        }
+    }
+}

--- a/fixtures/apple_thinned_package/apps/ios/once.toml
+++ b/fixtures/apple_thinned_package/apps/ios/once.toml
@@ -1,0 +1,19 @@
+[[target]]
+name = "App"
+kind = "apple_application"
+srcs = ["Sources/App/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+sdk_variant = "device"
+bundle_id = "dev.once.App"
+minimum_os = "17.0"
+families = ["iphone"]
+
+[[target]]
+name = "AppThinned"
+kind = "apple_thinned_package"
+deps = ["./App"]
+
+[target.attrs]
+device_model = "iPhone17,1"

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -42,6 +42,10 @@ Describe 'apple graph'
     cp -R "$REPO_ROOT/fixtures/apple_application_swiftui/." "$WORKSPACE/"
   }
 
+  copy_apple_thinned_package_fixture() {
+    cp -R "$REPO_ROOT/fixtures/apple_thinned_package/." "$WORKSPACE/"
+  }
+
   copy_apple_graph_fixture() {
     cp -R "$REPO_ROOT/fixtures/apple_graph/." "$WORKSPACE/"
   }
@@ -680,6 +684,26 @@ EOF
 
       When call verify_unchanged_framework_signature
       The status should be success
+    End
+  End
+
+  Describe 'apple_thinned_package end-to-end'
+    It 'creates a signed device-specific archive and stable manifest'
+      Skip if 'apple toolchain unavailable on this host' apple_toolchain_unavailable
+      copy_apple_thinned_package_fixture
+
+      verify_thinned_package() {
+        once --format json build apps/ios/AppThinned >/dev/null &&
+          unzip -q "$WORKSPACE/.once/out/apps/ios/AppThinned/ipas/App-iPhone17-1.ipa" -d "$WORKSPACE/extracted" &&
+          codesign --verify --deep --strict "$WORKSPACE/extracted/Payload/App.app" &&
+          grep -q '"schema": "once.apple.thinned-package.v1"' "$WORKSPACE/.once/out/apps/ios/AppThinned/thinned-packages.json" &&
+          grep -q '"deviceModel": "iPhone17,1"' "$WORKSPACE/.once/out/apps/ios/AppThinned/thinned-packages.json"
+      }
+
+      When call verify_thinned_package
+      The status should be success
+      The path "$WORKSPACE/.once/out/apps/ios/AppThinned/ipas/App-iPhone17-1.ipa" should be file
+      The path "$WORKSPACE/.once/out/apps/ios/AppThinned/thinned-packages.json" should be file
     End
   End
 

--- a/web/priv/changelog/2026-07-27-apple-app-thinning.md
+++ b/web/priv/changelog/2026-07-27-apple-app-thinning.md
@@ -1,0 +1,14 @@
+---
+title: Device-specific Apple app size analysis
+date: 2026-07-27
+---
+
+Once can now produce ad-hoc signed app archives for one Apple device model at a
+time with `apple_thinned_package`. Keeping each model in its own target makes
+the variants independently cacheable and ready for size-analysis services such
+as Sentry without the noise of a universal build.
+
+The target validates device builds, uses Xcode's thinning tool, re-signs
+embedded bundles, and writes a deterministic archive plus a stable manifest.
+Existing `apple_application` bundles now include the supported-platform
+metadata that Xcode requires for thinning.

--- a/web/priv/docs/guide/graph/apple.md
+++ b/web/priv/docs/guide/graph/apple.md
@@ -108,6 +108,56 @@ need to be brought to the foreground.
 macOS applications use the host application launcher. Launching directly on
 an iPhone or iPad is not supported yet.
 
+## Create a Device-Specific Size-Analysis Archive
+
+Size-analysis services can report confusing results when they receive a
+universal application. Sentry, for example, does not thin an uploaded
+application and [recommends thinning it before
+upload](https://docs.sentry.io/platforms/apple/guides/ios/size-analysis/#app-thinning).
+
+Add a device application and a package target for the device model you want to
+measure:
+
+```toml
+[[target]]
+name = "HelloDevice"
+kind = "apple_application"
+srcs = ["Sources/HelloApp/**/*.swift"]
+deps = ["./AppCore"]
+
+[target.attrs]
+platform = "ios"
+sdk_variant = "device"
+bundle_id = "dev.once.Hello"
+minimum_os = "17.0"
+families = ["iphone"]
+
+[[target]]
+name = "HelloSizeAnalysis"
+kind = "apple_thinned_package"
+deps = ["./HelloDevice"]
+
+[target.attrs]
+device_model = "iPhone17,1"
+```
+
+Build the device-specific archive:
+
+```sh
+once build apps/Hello/HelloSizeAnalysis
+```
+
+The target writes one or more archives with the `.ipa` extension and a stable
+manifest that maps them to the requested device model. Declare another
+`apple_thinned_package` target for each additional model so builds and cache
+entries stay independent.
+
+These archives use ad-hoc signing and are intended for size analysis. They do
+not replace distribution signing or provisioning for physical-device
+installation. See the
+[`apple_thinned_package` reference](/reference/prelude/apple_thinned_package)
+for the exact outputs and validation rules.
+
 ## Add a Test Target
 
 Add a test target to the same `apps/Hello/once.toml`:
@@ -179,6 +229,7 @@ Use the target kind reference for the contract that matches the artifact:
 - [`apple_library`](/reference/prelude/apple_library)
 - [`apple_framework`](/reference/prelude/apple_framework)
 - [`apple_application`](/reference/prelude/apple_application)
+- [`apple_thinned_package`](/reference/prelude/apple_thinned_package)
 - [`apple_test_bundle`](/reference/prelude/apple_test_bundle)
 - [`swift_macro`](/reference/prelude/swift_macro)
 

--- a/web/priv/docs/reference/manifest.md
+++ b/web/priv/docs/reference/manifest.md
@@ -203,6 +203,9 @@ attribute. Validation rejects `select` on a non-configurable attribute and
 rejects an unavailable compatibility attribute marked `implemented = false`.
 Schemas can also report `allowed_values` for string attributes. Validation
 rejects other values with the target, attribute, and accepted replacements.
+Schemas can report `disallowed_values` when only a small reserved set should
+be rejected. Validation ignores surrounding whitespace for those comparisons
+and reports an attribute-scoped replacement before analysis.
 Generic target kinds use the tokens returned by `once query workspace`.
 Ecosystem target kinds can add their own tokens and restrictions.
 

--- a/web/priv/docs/reference/manifest.md
+++ b/web/priv/docs/reference/manifest.md
@@ -142,6 +142,9 @@ Validation checks each role against its matching schema entry. Analysis keeps
 `deps` in declared order and exposes the other roles separately, so a target
 kind can distinguish compiler plug-ins, runtime-only dependencies, native
 links, and other semantics without hardcoding them in Once.
+Target kinds can also set minimum and maximum counts for each role. Validation
+reports an attribute-scoped repair before an edit can commit too few or too
+many dependencies.
 
 ## Target Identifiers
 

--- a/web/priv/docs/reference/modules/index.md
+++ b/web/priv/docs/reference/modules/index.md
@@ -86,6 +86,10 @@ does not.
 Use `allowed_values = ["first", "second"]` on a `string` or `target` attribute
 when the schema accepts a fixed set. Validation reports an attribute-scoped
 repair before analysis when a manifest supplies another value.
+Use `disallowed_values = ["", "reserved"]` when the schema accepts arbitrary
+strings except for a small reserved set. Validation ignores surrounding
+whitespace when comparing these values and reports an attribute-scoped repair
+before analysis.
 
 ## Dependency Resolver Contract
 

--- a/web/priv/docs/reference/modules/index.md
+++ b/web/priv/docs/reference/modules/index.md
@@ -90,6 +90,10 @@ Use `disallowed_values = ["", "reserved"]` when the schema accepts arbitrary
 strings except for a small reserved set. Validation ignores surrounding
 whitespace when comparing these values and reports an attribute-scoped repair
 before analysis.
+Use `min_count` and `max_count` on `dep(...)` when a dependency role requires
+a bounded number of targets. For example,
+`dep("deps", ["application"], min_count = 1, max_count = 1)` requires exactly
+one default dependency and reports an attribute-scoped repair before analysis.
 
 ## Dependency Resolver Contract
 

--- a/web/priv/docs/reference/prelude/apple_thinned_package.md
+++ b/web/priv/docs/reference/prelude/apple_thinned_package.md
@@ -1,0 +1,91 @@
+# `apple_thinned_package`
+
+Device-specific Apple application archive.
+
+## Description
+
+Produces an application archive thinned for one Apple device model. The target
+accepts one device build from `apple_application`, runs Xcode's thinning tool,
+re-signs the resulting bundle with an ad-hoc signature, and packages it in an
+archive with the `.ipa` extension.
+
+This target is intended for services such as
+[Sentry application size analysis](https://docs.sentry.io/platforms/apple/guides/ios/size-analysis/#app-thinning),
+which expects the application to be thinned before upload. One target produces
+variants for one device model so each model has an independent cache key.
+
+## Attributes
+
+| Attribute | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `device_model` | string | yes |  | One Apple device model identifier, such as `iPhone17,1` (not configurable) |
+
+## Dependency Edges
+
+| Edge | Accepts | Description |
+| --- | --- | --- |
+| `deps` | `apple_application` | Exactly one device application to thin and package |
+
+The application must set `platform = "ios"` and `sdk_variant = "device"`.
+Simulator and desktop applications fail during graph analysis.
+
+## Providers
+
+The target emits `apple_thinned_package`.
+
+## Capabilities
+
+| Capability | Output groups | Requires |
+| --- | --- | --- |
+| `build` | `default`, `ipas`, `manifest` |  |
+
+## Outputs
+
+| Output | Location |
+| --- | --- |
+| Device-specific archives | `.once/out/<target>/ipas/<product>-<device_model>.ipa` |
+| Package manifest | `.once/out/<target>/thinned-packages.json` |
+
+The manifest uses the `once.apple.thinned-package.v1` schema. It records the
+requested device model, every generated archive, and the installation targets
+reported by Xcode without retaining Xcode's host-specific temporary paths.
+
+## Example
+
+```toml
+[[target]]
+name = "HelloDevice"
+kind = "apple_application"
+srcs = ["Sources/**/*.swift"]
+
+[target.attrs]
+platform = "ios"
+sdk_variant = "device"
+bundle_id = "dev.once.Hello"
+minimum_os = "17.0"
+
+[[target]]
+name = "HelloSizeAnalysis"
+kind = "apple_thinned_package"
+deps = ["./HelloDevice"]
+
+[target.attrs]
+device_model = "iPhone17,1"
+```
+
+Build the archive with:
+
+```sh
+once build apps/Hello/HelloSizeAnalysis
+```
+
+## Limitations
+
+The output is ad-hoc signed for size analysis. It is not a distribution-signed
+archive and cannot replace the provisioning and signing flow used to install
+an application on physical devices or submit it to an application store.
+
+Xcode exposes thinning through `ipatool`, an internal interface that may change
+between Xcode releases. Once validates that the requested model produced a
+variant, includes the Xcode build version in the action cache identity, and
+fails without emitting a universal archive when thinning produces no match.

--- a/web/priv/docs/reference/prelude/apple_thinned_package.md
+++ b/web/priv/docs/reference/prelude/apple_thinned_package.md
@@ -18,7 +18,7 @@ variants for one device model so each model has an independent cache key.
 
 | Attribute | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `device_model` | string | yes |  | One Apple device model identifier, such as `iPhone17,1` (not configurable) |
+| `device_model` | string | yes |  | One non-empty Apple device model identifier, such as `iPhone17,1`; `all` is reserved (not configurable) |
 
 ## Dependency Edges
 

--- a/web/priv/docs/reference/prelude/apple_thinned_package.md
+++ b/web/priv/docs/reference/prelude/apple_thinned_package.md
@@ -43,8 +43,14 @@ The target emits `apple_thinned_package`.
 
 | Output | Location |
 | --- | --- |
-| Device-specific archives | `.once/out/<target>/ipas/<product>-<device_model>.ipa` |
+| Device-specific archives | `.once/out/<target>/ipas/*.ipa` |
 | Package manifest | `.once/out/<target>/thinned-packages.json` |
+
+Archive names contain the product and device model. Runs of characters outside
+English letters, numbers, `.`, `_`, and `-` become one `-`, and leading or
+trailing hyphens are removed. For example, `iPhone17,1` becomes `iPhone17-1`.
+When Xcode returns multiple records, every archive receives a one-based suffix
+such as `-1` or `-2`.
 
 The manifest uses the `once.apple.thinned-package.v1` schema. It records the
 requested device model, every generated archive, and the installation targets

--- a/web/priv/docs/reference/prelude/index.md
+++ b/web/priv/docs/reference/prelude/index.md
@@ -49,6 +49,8 @@ required analyzer is not built in.
   Apple framework bundle
 - [`apple_application`](/reference/prelude/apple_application): Apple
   application bundle
+- [`apple_thinned_package`](/reference/prelude/apple_thinned_package):
+  device-specific archive for application size analysis
 - [`apple_test_bundle`](/reference/prelude/apple_test_bundle): XCTest
   bundle assembled for an external runner
 


### PR DESCRIPTION
## What changed

This adds `apple_thinned_package`, a dedicated target kind that creates an ad-hoc signed application archive for one Apple device model. It stages an `apple_application` bundle, asks Xcode to produce the requested thinned variant, re-signs nested bundles, creates a deterministic archive with the `.ipa` extension, and emits a stable package manifest.

Apple application bundles now include the supported-platform property required by Xcode's thinning tool. The change also adds a runnable starter, end-to-end fixture, target-kind reference, Apple graph guide, and a web application changelog entry.

## Why

[Sentry application size analysis](https://docs.sentry.io/platforms/apple/guides/ios/size-analysis/#app-thinning) does not thin uploaded applications. Uploading a universal build can therefore make size results confusing. Once should be able to produce the device-specific artifact before upload.

## Root cause

`apple_application` previously stopped at an ad-hoc signed application bundle. There was no target that modeled device-specific packaging, and the generated property list omitted the supported-platform entry required by Xcode's thinning tool.

## Approach

Thinning is a separate target rather than an option on `apple_application`. One device model per target gives each variant an independent action and cache key while keeping the application build reusable.

The target validates that it receives exactly one device application, uses Xcode's internal thinning interface, rejects a missing variant, re-signs the result, and packages a sorted file list with fixed timestamps. Xcode build identity, the device model, and packaging tool versions participate in cache identity. Raw Xcode reports remain in scratch space so host-specific paths do not enter the public manifest.

## Impact

Existing application declarations require no migration. Generated application property lists gain supported-platform metadata. Projects that need size analysis can add one `apple_thinned_package` target per device model.

The resulting archives use ad-hoc signing and are intended for analysis. They do not replace distribution signing or provisioning for physical-device installation.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-frontend -- --nocapture`
- `mise exec -- cargo build --release -p once-cli`
- `mise exec -- shellspec spec/apple_spec.sh --example 'creates a signed device-specific archive and stable manifest'`
- `mise exec -- mix precommit` from the web application directory, with 48 tests passing.
- The locally served `/changelog` page returned a successful response and rendered the new entry.
- Two clean Xcode 26.6 builds under different package paths produced byte-identical archives with fixed timestamps.
- The unpacked thinned application passed strict deep `codesign` verification.
