### PR TITLE
perf(frontend): bound native project discovery

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Test with Once
         run: target/debug/once test web/tests
         env:
-          ONCE_CACHE_PROVIDER: ${{ steps.once-cache-auth.outcome == 'success' && 'tuist' || 'local' }}
+          ONCE_CACHE_PROVIDER: local
 
   release:
     name: release

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -91,10 +91,9 @@ jobs:
         env:
           ONCE_CACHE_PROVIDER: ${{ steps.once-cache-auth.outcome == 'success' && 'tuist' || 'local' }}
 
-      - name: Test with Once
-        run: target/debug/once test web/tests
-        env:
-          ONCE_CACHE_PROVIDER: local
+      - name: Test
+        working-directory: web
+        run: mise exec -- mix test
 
   release:
     name: release

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -87,12 +87,6 @@ struct ModuleDiagnostic {
     repairs: Vec<&'static str>,
 }
 
-#[derive(Debug, Serialize)]
-struct NativeProjectCatalog {
-    native_projects: Vec<once_frontend::NativeProjectSchema>,
-    matches: Vec<once_frontend::NativeProjectMatch>,
-}
-
 pub async fn targets(workspace: &Path, output: Output, kind: Option<&str>) -> Result<()> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
     let records = target_records(graph, kind);
@@ -507,11 +501,8 @@ pub(crate) fn native_projects_value(workspace: &Path) -> Result<serde_json::Valu
     Ok(serde_json::to_value(native_project_catalog(workspace)?)?)
 }
 
-fn native_project_catalog(workspace: &Path) -> Result<NativeProjectCatalog> {
-    Ok(NativeProjectCatalog {
-        native_projects: once_frontend::native_project_schemas_for_workspace(workspace)?,
-        matches: once_frontend::detect_native_projects(workspace)?,
-    })
+fn native_project_catalog(workspace: &Path) -> Result<once_frontend::NativeProjectCatalog> {
+    once_frontend::discover_native_projects(workspace).map_err(Into::into)
 }
 
 pub async fn native_project(
@@ -1348,7 +1339,7 @@ fn render_target_kinds_human(target_kinds: &[TargetKindSummary]) -> String {
     out
 }
 
-fn render_native_projects_human(catalog: &NativeProjectCatalog) -> String {
+fn render_native_projects_human(catalog: &once_frontend::NativeProjectCatalog) -> String {
     if catalog.native_projects.is_empty() {
         return "native projects: none\n".to_string();
     }

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -56,8 +56,9 @@ pub use manifest_editor::{
 };
 pub use module_contract::{module_authoring_contract, ContractEntry, ModuleAuthoringContract};
 pub use native_project::{
-    detect_native_projects, native_project_schemas_for_workspace, native_project_seed_target,
-    preview_native_project, NativeProjectMatch, NativeProjectPreview, NativeProjectSchema,
+    detect_native_projects, discover_native_projects, native_project_schemas_for_workspace,
+    native_project_seed_target, preview_native_project, NativeProjectCatalog, NativeProjectMatch,
+    NativeProjectPreview, NativeProjectSchema,
 };
 pub use script::{parse_script_annotations, script_has_once_directives, ScriptAnnotations};
 pub use target::{AttrValue, Target};

--- a/crates/once-frontend/src/native_project.rs
+++ b/crates/once-frontend/src/native_project.rs
@@ -1,17 +1,17 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
+use crate::error::{Error, Result};
+use crate::graph::GraphTarget;
+use crate::target::{AttrValue, Target};
 use serde::Serialize;
 use starlark::environment::Module;
 use starlark::eval::Evaluator;
 use starlark::syntax::{AstModule, Dialect};
 use starlark::values::dict::DictRef;
 use starlark::values::list::ListRef;
-use walkdir::WalkDir;
 
-use crate::error::{Error, Result};
-use crate::graph::GraphTarget;
-use crate::target::{AttrValue, Target};
+mod discovery;
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct NativeProjectSchema {
@@ -43,16 +43,30 @@ pub struct NativeProjectPreview {
     pub targets: Vec<GraphTarget>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct NativeProjectCatalog {
+    pub native_projects: Vec<NativeProjectSchema>,
+    pub matches: Vec<NativeProjectMatch>,
+}
+
 pub fn native_project_schemas_for_workspace(root: &Path) -> Result<Vec<NativeProjectSchema>> {
+    let target_kinds = crate::graph::target_kind_schemas_for_workspace(root)?;
+    native_project_schemas_for_workspace_with_target_kinds(root, &target_kinds)
+}
+
+pub(crate) fn native_project_schemas_for_workspace_with_target_kinds(
+    root: &Path,
+    target_kinds: &[crate::graph::TargetKindSchema],
+) -> Result<Vec<NativeProjectSchema>> {
     let source = crate::modules::combined_module_source_for_workspace(root)?;
     let native_projects =
         parse_native_project_schemas(crate::modules::COMBINED_MODULE_PATH, &source)?;
-    let target_kinds = crate::graph::target_kind_schemas_for_workspace(root)?
-        .into_iter()
-        .map(|schema| schema.kind)
+    let target_kinds = target_kinds
+        .iter()
+        .map(|schema| schema.kind.as_str())
         .collect::<BTreeSet<_>>();
     for native_project in &native_projects {
-        if !target_kinds.contains(&native_project.target_kind) {
+        if !target_kinds.contains(native_project.target_kind.as_str()) {
             return Err(native_project_error(
                 &native_project.name,
                 format!(
@@ -65,44 +79,38 @@ pub fn native_project_schemas_for_workspace(root: &Path) -> Result<Vec<NativePro
     Ok(native_projects)
 }
 
+pub fn discover_native_projects(root: &Path) -> Result<NativeProjectCatalog> {
+    let target_kinds = crate::graph::target_kind_schemas_for_workspace(root)?;
+    let native_projects =
+        native_project_schemas_for_workspace_with_target_kinds(root, &target_kinds)?;
+    let boundary = crate::workspace::load_workspace_scan(root)?;
+    let (matches, _) =
+        discovery::detect_native_projects_with_schemas(root, &native_projects, &boundary)?;
+    Ok(NativeProjectCatalog {
+        native_projects,
+        matches,
+    })
+}
+
 pub fn detect_native_projects(root: &Path) -> Result<Vec<NativeProjectMatch>> {
-    let schemas = native_project_schemas_for_workspace(root)?;
-    let mut matches = Vec::new();
-    for schema in schemas {
-        let mut candidates = native_project_candidates(root, &schema)?;
-        candidates.sort();
-        for package_path in candidates {
-            let package = display_relative(root, &package_path);
-            let seed_target = crate::target_ref::target_id(&package, &schema.target_name);
-            matches.push(NativeProjectMatch {
-                native_project: schema.name.clone(),
-                package,
-                markers: schema.markers.clone(),
-                seed_target,
-            });
-        }
-    }
-    matches.sort_by(|left, right| {
-        left.package
-            .cmp(&right.package)
-            .then(left.native_project.cmp(&right.native_project))
-    });
-    Ok(matches)
+    Ok(discover_native_projects(root)?.matches)
 }
 
 pub(crate) fn synthesized_workspace_seeds(
     root: &Path,
+    schemas: &[NativeProjectSchema],
+    boundary: &crate::workspace::WorkspaceScan,
 ) -> Result<Vec<(NativeProjectMatch, Target)>> {
-    let schemas = native_project_schemas_for_workspace(root)?;
-    let schemas = schemas
-        .into_iter()
-        .map(|schema| (schema.name.clone(), schema))
+    let schema_by_name = schemas
+        .iter()
+        .map(|schema| (schema.name.as_str(), schema))
         .collect::<BTreeMap<_, _>>();
     let mut targets = Vec::new();
     let mut ids = BTreeMap::<String, String>::new();
-    for matched in detect_native_projects(root)? {
-        let schema = schemas
-            .get(&matched.native_project)
+    let (matches, _) = discovery::detect_native_projects_with_schemas(root, schemas, boundary)?;
+    for matched in matches {
+        let schema = schema_by_name
+            .get(matched.native_project.as_str())
             .ok_or_else(|| Error::Eval {
                 path: crate::modules::COMBINED_MODULE_PATH.to_string(),
                 message: format!(
@@ -130,14 +138,17 @@ pub(crate) fn synthesized_workspace_seeds(
 }
 
 pub fn native_project_seed_target(root: &Path, name: &str, package: &str) -> Result<Target> {
-    let schema = native_project_schemas_for_workspace(root)?
+    let catalog = discover_native_projects(root)?;
+    let schema = catalog
+        .native_projects
         .into_iter()
         .find(|schema| schema.name == name)
         .ok_or_else(|| Error::Eval {
             path: crate::modules::COMBINED_MODULE_PATH.to_string(),
             message: format!("unknown native project `{name}`"),
         })?;
-    let matched = detect_native_projects(root)?
+    let matched = catalog
+        .matches
         .into_iter()
         .any(|matched| matched.native_project == name && matched.package == package);
     if !matched {
@@ -157,14 +168,20 @@ pub fn preview_native_project(
     name: &str,
     package: &str,
 ) -> Result<NativeProjectPreview> {
-    let schema = native_project_schemas_for_workspace(root)?
+    let target_kinds = crate::graph::target_kind_schemas_for_workspace(root)?;
+    let native_projects =
+        native_project_schemas_for_workspace_with_target_kinds(root, &target_kinds)?;
+    let boundary = crate::workspace::load_workspace_scan(root)?;
+    let (matches, _) =
+        discovery::detect_native_projects_with_schemas(root, &native_projects, &boundary)?;
+    let schema = native_projects
         .into_iter()
         .find(|schema| schema.name == name)
         .ok_or_else(|| Error::Eval {
             path: crate::modules::COMBINED_MODULE_PATH.to_string(),
             message: format!("unknown native project `{name}`"),
         })?;
-    let matched = detect_native_projects(root)?
+    let selected_match = matches
         .into_iter()
         .find(|matched| matched.native_project == name && matched.package == package)
         .ok_or_else(|| Error::Eval {
@@ -175,15 +192,14 @@ pub fn preview_native_project(
             ),
         })?;
     let seed = seed_target(&schema, package);
-    let schemas = crate::graph::target_kind_schemas_for_workspace(root)?;
     let targets = crate::graph::load_graph_workspace_with_targets_and_schemas(
         root,
         vec![seed.clone()],
-        &schemas,
+        &target_kinds,
     )?;
     Ok(NativeProjectPreview {
         native_project: schema,
-        matched,
+        matched: selected_match,
         seed,
         targets,
     })
@@ -306,61 +322,6 @@ fn parse_native_project_schemas(path: &str, source: &str) -> Result<Vec<NativePr
             })
             .collect()
     })
-}
-
-fn native_project_candidates(root: &Path, schema: &NativeProjectSchema) -> Result<Vec<PathBuf>> {
-    let walker = WalkDir::new(root)
-        .max_depth(schema.max_depth)
-        .follow_links(false)
-        .into_iter()
-        .filter_entry(|entry| {
-            if entry.depth() == 0 {
-                return true;
-            }
-            let Some(name) = entry.file_name().to_str() else {
-                return false;
-            };
-            if name.starts_with('.') {
-                return false;
-            }
-            !entry.file_type().is_dir() || !schema.exclude.iter().any(|excluded| excluded == name)
-        });
-    let primary = &schema.markers[0];
-    let mut candidates = Vec::new();
-    for entry in walker {
-        let entry = entry.map_err(|source| Error::Walk {
-            root: root.display().to_string(),
-            source,
-        })?;
-        if !entry.file_type().is_file() || entry.file_name() != primary.as_str() {
-            continue;
-        }
-        let package = entry.path().parent().unwrap_or(root);
-        if schema
-            .markers
-            .iter()
-            .all(|marker| package.join(marker).is_file())
-        {
-            candidates.push(package.to_path_buf());
-        }
-    }
-    if schema.on_match == "stop" {
-        candidates.sort_by(|left, right| {
-            left.components()
-                .count()
-                .cmp(&right.components().count())
-                .then(left.cmp(right))
-        });
-        let mut roots = Vec::<PathBuf>::new();
-        for candidate in candidates {
-            if roots.iter().any(|root| candidate.starts_with(root)) {
-                continue;
-            }
-            roots.push(candidate);
-        }
-        return Ok(roots);
-    }
-    Ok(candidates)
 }
 
 fn validate_relative_literal(native_project: &str, field: &str, value: &str) -> Result<()> {
@@ -496,8 +457,12 @@ mod tests {
         assert_eq!(schemas[0].name, "demo");
         assert_eq!(schemas[0].target_kind, "demo_workspace");
 
-        let candidates = native_project_candidates(temporary.path(), &schemas[0]).unwrap();
-        assert_eq!(candidates, vec![temporary.path().to_path_buf()]);
+        let boundary = crate::workspace::load_workspace_scan(temporary.path()).unwrap();
+        let (matches, _) =
+            discovery::detect_native_projects_with_schemas(temporary.path(), &schemas, &boundary)
+                .unwrap();
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0].package.is_empty());
     }
 
     #[test]

--- a/crates/once-frontend/src/native_project/discovery.rs
+++ b/crates/once-frontend/src/native_project/discovery.rs
@@ -1,0 +1,405 @@
+use std::collections::BTreeMap;
+use std::path::{Component, Path};
+
+use walkdir::WalkDir;
+
+use crate::error::{Error, Result};
+
+use super::{display_relative, NativeProjectMatch, NativeProjectSchema};
+
+mod memory;
+
+use memory::{RetainedMatches, MAX_RETAINED_MATCH_BYTES};
+
+pub(super) fn detect_native_projects_with_schemas(
+    root: &Path,
+    schemas: &[NativeProjectSchema],
+    boundary: &crate::workspace::WorkspaceScan,
+) -> Result<(Vec<NativeProjectMatch>, usize)> {
+    detect_native_projects_with_limit(root, schemas, boundary, MAX_RETAINED_MATCH_BYTES)
+}
+
+fn detect_native_projects_with_limit(
+    root: &Path,
+    schemas: &[NativeProjectSchema],
+    boundary: &crate::workspace::WorkspaceScan,
+    retained_match_limit: usize,
+) -> Result<(Vec<NativeProjectMatch>, usize)> {
+    let Some(max_depth) = schemas.iter().map(|schema| schema.max_depth).max() else {
+        return Ok((Vec::new(), 0));
+    };
+    let walker = WalkDir::new(root)
+        .max_depth(max_depth)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|entry| {
+            if entry.depth() == 0 {
+                return true;
+            }
+            let Some(name) = entry.file_name().to_str() else {
+                return false;
+            };
+            if name.starts_with('.') {
+                return false;
+            }
+            if !entry.file_type().is_dir() {
+                return true;
+            }
+            let relative = display_relative(root, entry.path());
+            boundary.includes_native_project_dir(&relative, entry.depth())
+                && schemas.iter().any(|schema| {
+                    entry.depth() < schema.max_depth
+                        && !schema.exclude.iter().any(|excluded| excluded == name)
+                })
+        });
+    let mut scan = DiscoveryScan::new(root, schemas, boundary, retained_match_limit)?;
+    let mut visited_entries = 0;
+    for entry in walker {
+        let entry = entry.map_err(|source| Error::Walk {
+            root: root.display().to_string(),
+            source,
+        })?;
+        visited_entries += 1;
+        scan.visit(&entry)?;
+    }
+    let mut matches = scan.finish();
+    matches.sort_unstable_by(|left, right| {
+        left.package
+            .cmp(&right.package)
+            .then(left.native_project.cmp(&right.native_project))
+    });
+    Ok((matches, visited_entries))
+}
+
+struct DiscoveryScan<'a> {
+    root: &'a Path,
+    schemas: &'a [NativeProjectSchema],
+    boundary: &'a crate::workspace::WorkspaceScan,
+    stop_markers: BTreeMap<&'a str, Vec<usize>>,
+    descend_markers: BTreeMap<&'a str, Vec<usize>>,
+    stop_schema_count: usize,
+    retained: RetainedMatches,
+}
+
+impl<'a> DiscoveryScan<'a> {
+    fn new(
+        root: &'a Path,
+        schemas: &'a [NativeProjectSchema],
+        boundary: &'a crate::workspace::WorkspaceScan,
+        retained_match_limit: usize,
+    ) -> Result<Self> {
+        let mut stop_markers = BTreeMap::<&str, Vec<usize>>::new();
+        let mut descend_markers = BTreeMap::<&str, Vec<usize>>::new();
+        for (index, schema) in schemas.iter().enumerate() {
+            let markers = if schema.on_match == "stop" {
+                &mut stop_markers
+            } else {
+                &mut descend_markers
+            };
+            markers
+                .entry(schema.markers[0].as_str())
+                .or_default()
+                .push(index);
+        }
+        let stop_schema_count = stop_markers.values().map(Vec::len).sum();
+        Ok(Self {
+            root,
+            schemas,
+            boundary,
+            stop_markers,
+            descend_markers,
+            stop_schema_count,
+            retained: RetainedMatches::new(root, schemas.len(), retained_match_limit)?,
+        })
+    }
+
+    fn visit(&mut self, entry: &walkdir::DirEntry) -> Result<()> {
+        if entry.file_type().is_file() {
+            let Some(name) = entry.file_name().to_str() else {
+                return Ok(());
+            };
+            let Some(schema_indices) = self.descend_markers.get(name) else {
+                return Ok(());
+            };
+            let package = entry.path().parent().unwrap_or(self.root);
+            let package_name = display_relative(self.root, package);
+            return retain_marker_matches(
+                self.root,
+                self.schemas,
+                schema_indices,
+                self.boundary,
+                &mut self.retained,
+                package,
+                &package_name,
+                name,
+                entry.depth(),
+            );
+        }
+        if !entry.file_type().is_dir() {
+            return Ok(());
+        }
+        let package = entry.path();
+        let marker_depth = entry.depth().saturating_add(1);
+        let mut package_name = None;
+        if self
+            .retained
+            .all_stop_schemas_rooted(self.stop_schema_count)
+        {
+            return Ok(());
+        }
+        for (primary_marker, schema_indices) in &self.stop_markers {
+            if !schema_indices.iter().any(|index| {
+                marker_depth <= self.schemas[*index].max_depth
+                    && !package_has_excluded_component(
+                        self.root,
+                        package,
+                        &self.schemas[*index].exclude,
+                    )
+                    && !self.retained.stop_covers(*index, self.root, package)
+            }) {
+                continue;
+            }
+            if !is_primary_marker(&package.join(primary_marker)) {
+                continue;
+            }
+            let package_name =
+                package_name.get_or_insert_with(|| display_relative(self.root, package));
+            retain_marker_matches(
+                self.root,
+                self.schemas,
+                schema_indices,
+                self.boundary,
+                &mut self.retained,
+                package,
+                package_name,
+                primary_marker,
+                marker_depth,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> Vec<NativeProjectMatch> {
+        self.retained.finish()
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the shared marker check keeps stop and descend traversal behavior identical"
+)]
+fn retain_marker_matches(
+    root: &Path,
+    schemas: &[NativeProjectSchema],
+    schema_indices: &[usize],
+    boundary: &crate::workspace::WorkspaceScan,
+    retained: &mut RetainedMatches,
+    package: &Path,
+    package_name: &str,
+    primary_marker: &str,
+    marker_depth: usize,
+) -> Result<()> {
+    let manifest_path = package_child(package_name, crate::TOML_BUILD_FILE_NAME);
+    let marker_path = package_child(package_name, primary_marker);
+    for index in schema_indices {
+        let schema = &schemas[*index];
+        if marker_depth > schema.max_depth
+            || package_has_excluded_component(root, package, &schema.exclude)
+            || !boundary.includes_native_project(&manifest_path, &marker_path)
+            || !schema
+                .markers
+                .iter()
+                .skip(1)
+                .all(|marker| package.join(marker).is_file())
+        {
+            continue;
+        }
+        retained.insert(root, *index, schema, package_name)?;
+    }
+    Ok(())
+}
+
+fn package_child(package: &str, child: &str) -> String {
+    if package.is_empty() {
+        child.to_string()
+    } else {
+        format!("{package}/{child}")
+    }
+}
+
+fn is_primary_marker(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+}
+
+fn package_has_excluded_component(root: &Path, package: &Path, excluded: &[String]) -> bool {
+    package
+        .strip_prefix(root)
+        .unwrap_or(package)
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(name) => name.to_str(),
+            _ => None,
+        })
+        .any(|name| excluded.iter().any(|excluded| excluded == name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema(name: &str, marker: &str, exclude: &[&str]) -> NativeProjectSchema {
+        NativeProjectSchema {
+            name: name.to_string(),
+            docs: String::new(),
+            markers: vec![marker.to_string()],
+            target_name: name.to_string(),
+            target_kind: format!("{name}_workspace"),
+            inputs: Vec::new(),
+            exclude: exclude.iter().map(|value| (*value).to_string()).collect(),
+            on_match: "descend".to_string(),
+            max_depth: 16,
+            requires_tools: Vec::new(),
+        }
+    }
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn prunes_workspace_boundaries_before_descending() {
+        let temporary = tempfile::tempdir().unwrap();
+        write(
+            &temporary.path().join("once.toml"),
+            r#"[workspace]
+include = ["once.toml", "apps/*/once.toml"]
+exclude = ["apps/excluded/**"]
+"#,
+        );
+        write(&temporary.path().join("apps/keep/native.project"), "native");
+        write(
+            &temporary.path().join("apps/keep/secondary.project"),
+            "secondary",
+        );
+        for index in 0..200 {
+            write(
+                &temporary
+                    .path()
+                    .join(format!("unrelated/branch-{index}/native.project")),
+                "unrelated",
+            );
+            write(
+                &temporary
+                    .path()
+                    .join(format!("apps/excluded/branch-{index}/secondary.project")),
+                "excluded",
+            );
+        }
+        let schemas = vec![
+            schema("native", "native.project", &[]),
+            schema("secondary", "secondary.project", &[]),
+        ];
+        let boundary = crate::workspace::load_workspace_scan(temporary.path()).unwrap();
+
+        let (matches, visited_entries) =
+            detect_native_projects_with_schemas(temporary.path(), &schemas, &boundary).unwrap();
+
+        assert_eq!(
+            matches
+                .iter()
+                .map(|matched| (matched.native_project.as_str(), matched.package.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("native", "apps/keep"), ("secondary", "apps/keep")]
+        );
+        assert!(
+            visited_entries <= 8,
+            "bounded discovery visited {visited_entries} entries"
+        );
+    }
+
+    #[test]
+    fn preserves_schema_specific_exclusions() {
+        let temporary = tempfile::tempdir().unwrap();
+        write(&temporary.path().join("vendor/native.project"), "native");
+        write(
+            &temporary.path().join("vendor/secondary.project"),
+            "secondary",
+        );
+        let schemas = vec![
+            schema("native", "native.project", &["vendor"]),
+            schema("secondary", "secondary.project", &[]),
+        ];
+        let boundary = crate::workspace::load_workspace_scan(temporary.path()).unwrap();
+
+        let (matches, _) =
+            detect_native_projects_with_schemas(temporary.path(), &schemas, &boundary).unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].native_project, "secondary");
+        assert_eq!(matches[0].package, "vendor");
+    }
+
+    #[test]
+    fn stop_retains_only_the_shallowest_match_during_discovery() {
+        let temporary = tempfile::tempdir().unwrap();
+        write(&temporary.path().join("workspace/native.project"), "native");
+        for index in 0..200 {
+            write(
+                &temporary
+                    .path()
+                    .join(format!("workspace/package-{index}/native.project")),
+                "nested",
+            );
+        }
+        let mut native = schema("native", "native.project", &[]);
+        native.on_match = "stop".to_string();
+        native.max_depth = 4;
+        let schemas = vec![native];
+        let boundary = crate::workspace::load_workspace_scan(temporary.path()).unwrap();
+        let root_match_bytes = 4 * 1024;
+        assert!(std::mem::size_of::<NativeProjectMatch>() * 200 > root_match_bytes);
+
+        let (matches, _) = detect_native_projects_with_limit(
+            temporary.path(),
+            &schemas,
+            &boundary,
+            root_match_bytes,
+        )
+        .unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].package, "workspace");
+    }
+
+    #[test]
+    fn descend_fails_before_retained_matches_exceed_the_limit() {
+        let temporary = tempfile::tempdir().unwrap();
+        for index in 0..20 {
+            write(
+                &temporary
+                    .path()
+                    .join(format!("projects/project-{index}/native.project")),
+                "native",
+            );
+        }
+        let schemas = vec![schema("native", "native.project", &[])];
+        let boundary = crate::workspace::load_workspace_scan(temporary.path()).unwrap();
+        let one_match_limit = 256;
+
+        let error = detect_native_projects_with_limit(
+            temporary.path(),
+            &schemas,
+            &boundary,
+            one_match_limit,
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("native project discovery exceeded its"));
+        assert!(error.to_string().contains("retained-result limit"));
+    }
+}

--- a/crates/once-frontend/src/native_project/discovery/memory.rs
+++ b/crates/once-frontend/src/native_project/discovery/memory.rs
@@ -1,0 +1,283 @@
+use std::mem::size_of;
+use std::path::Path;
+
+use crate::error::{Error, Result};
+
+use super::super::{NativeProjectMatch, NativeProjectSchema};
+
+pub(super) const MAX_RETAINED_MATCH_BYTES: usize = 16 * 1024 * 1024;
+
+pub(super) struct RetainedMatches {
+    matches: Vec<NativeProjectMatch>,
+    stop_roots: Vec<Vec<String>>,
+    rooted_stop_schemas: usize,
+    retained_bytes: usize,
+    limit_bytes: usize,
+}
+
+impl RetainedMatches {
+    pub(super) fn new(root: &Path, schema_count: usize, limit_bytes: usize) -> Result<Self> {
+        let projected_schema_bytes = schema_count.saturating_mul(size_of::<Vec<String>>());
+        if projected_schema_bytes > limit_bytes {
+            return Err(discovery_memory_error(root, limit_bytes));
+        }
+        let mut stop_roots = Vec::new();
+        stop_roots
+            .try_reserve_exact(schema_count)
+            .map_err(|_| discovery_memory_error(root, limit_bytes))?;
+        stop_roots.resize_with(schema_count, Vec::new);
+        let retained_bytes = stop_roots
+            .capacity()
+            .saturating_mul(size_of::<Vec<String>>());
+        if retained_bytes > limit_bytes {
+            return Err(discovery_memory_error(root, limit_bytes));
+        }
+        Ok(Self {
+            matches: Vec::new(),
+            stop_roots,
+            rooted_stop_schemas: 0,
+            retained_bytes,
+            limit_bytes,
+        })
+    }
+
+    pub(super) fn insert(
+        &mut self,
+        root: &Path,
+        schema_index: usize,
+        schema: &NativeProjectSchema,
+        package: &str,
+    ) -> Result<()> {
+        if schema.on_match == "stop" {
+            if self.stop_roots[schema_index]
+                .iter()
+                .any(|root| package_is_within(package, root))
+            {
+                return Ok(());
+            }
+            let mut removed_bytes = 0usize;
+            self.stop_roots[schema_index].retain(|root| {
+                if package_is_within(root, package) {
+                    removed_bytes = removed_bytes.saturating_add(root.capacity());
+                    false
+                } else {
+                    true
+                }
+            });
+            self.matches.retain(|matched| {
+                if matched.native_project == schema.name
+                    && package_is_within(&matched.package, package)
+                {
+                    removed_bytes = removed_bytes.saturating_add(owned_match_bytes(matched));
+                    false
+                } else {
+                    true
+                }
+            });
+            self.retained_bytes = self.retained_bytes.saturating_sub(removed_bytes);
+        }
+
+        let stop_root_bytes = if schema.on_match == "stop" {
+            package.len()
+        } else {
+            0
+        };
+        let projected_bytes =
+            projected_owned_match_bytes(schema, package).saturating_add(stop_root_bytes);
+        if projected_bytes > self.limit_bytes.saturating_sub(self.retained_bytes) {
+            return Err(discovery_memory_error(root, self.limit_bytes));
+        }
+        let available_capacity_bytes = self
+            .limit_bytes
+            .saturating_sub(self.retained_bytes)
+            .saturating_sub(projected_bytes);
+        let mut capacity_bytes = reserve_one(
+            root,
+            &mut self.matches,
+            available_capacity_bytes,
+            self.limit_bytes,
+        )?;
+        if schema.on_match == "stop" {
+            capacity_bytes = capacity_bytes.saturating_add(reserve_one(
+                root,
+                &mut self.stop_roots[schema_index],
+                available_capacity_bytes.saturating_sub(capacity_bytes),
+                self.limit_bytes,
+            )?);
+        }
+        if projected_bytes.saturating_add(capacity_bytes)
+            > self.limit_bytes.saturating_sub(self.retained_bytes)
+        {
+            return Err(discovery_memory_error(root, self.limit_bytes));
+        }
+
+        let seed_target = crate::target_ref::target_id(package, &schema.target_name);
+        let matched = NativeProjectMatch {
+            native_project: schema.name.clone(),
+            package: package.to_string(),
+            markers: schema.markers.clone(),
+            seed_target,
+        };
+        let stop_root = (schema.on_match == "stop").then(|| package.to_string());
+        let owned_bytes = owned_match_bytes(&matched)
+            .saturating_add(stop_root.as_ref().map_or(0, String::capacity));
+        if owned_bytes.saturating_add(capacity_bytes)
+            > self.limit_bytes.saturating_sub(self.retained_bytes)
+        {
+            return Err(discovery_memory_error(root, self.limit_bytes));
+        }
+        self.retained_bytes = self
+            .retained_bytes
+            .saturating_add(owned_bytes)
+            .saturating_add(capacity_bytes);
+        self.matches.push(matched);
+        if let Some(stop_root) = stop_root {
+            if stop_root.is_empty() {
+                self.rooted_stop_schemas = self.rooted_stop_schemas.saturating_add(1);
+            }
+            self.stop_roots[schema_index].push(stop_root);
+        }
+        Ok(())
+    }
+
+    pub(super) fn all_stop_schemas_rooted(&self, stop_schema_count: usize) -> bool {
+        self.rooted_stop_schemas == stop_schema_count
+    }
+
+    pub(super) fn stop_covers(&self, schema_index: usize, root: &Path, package: &Path) -> bool {
+        let relative = package.strip_prefix(root).unwrap_or(package);
+        self.stop_roots[schema_index]
+            .iter()
+            .any(|stop_root| stop_root.is_empty() || relative.starts_with(Path::new(stop_root)))
+    }
+
+    pub(super) fn finish(self) -> Vec<NativeProjectMatch> {
+        self.matches
+    }
+}
+
+fn reserve_one<T>(
+    root: &Path,
+    values: &mut Vec<T>,
+    available_bytes: usize,
+    limit_bytes: usize,
+) -> Result<usize> {
+    if values.len() < values.capacity() {
+        return Ok(0);
+    }
+    let slot_bytes = size_of::<T>().max(1);
+    let maximum_growth = available_bytes / slot_bytes;
+    if maximum_growth == 0 {
+        return Err(discovery_memory_error(root, limit_bytes));
+    }
+    let growth = values.capacity().max(1).min(maximum_growth);
+    let previous_capacity = values.capacity();
+    values
+        .try_reserve_exact(growth)
+        .map_err(|_| discovery_memory_error(root, limit_bytes))?;
+    let allocated_bytes = values
+        .capacity()
+        .saturating_sub(previous_capacity)
+        .saturating_mul(slot_bytes);
+    if allocated_bytes > available_bytes {
+        return Err(discovery_memory_error(root, limit_bytes));
+    }
+    Ok(allocated_bytes)
+}
+
+fn projected_owned_match_bytes(schema: &NativeProjectSchema, package: &str) -> usize {
+    let seed_target_bytes = if package.is_empty() {
+        schema.target_name.len()
+    } else {
+        package
+            .len()
+            .saturating_add(1)
+            .saturating_add(schema.target_name.len())
+    };
+    schema
+        .markers
+        .iter()
+        .fold(0usize, |bytes, marker| bytes.saturating_add(marker.len()))
+        .saturating_add(schema.markers.len().saturating_mul(size_of::<String>()))
+        .saturating_add(schema.name.len())
+        .saturating_add(package.len())
+        .saturating_add(seed_target_bytes)
+}
+
+fn owned_match_bytes(matched: &NativeProjectMatch) -> usize {
+    matched
+        .markers
+        .iter()
+        .fold(0usize, |bytes, marker| {
+            bytes.saturating_add(marker.capacity())
+        })
+        .saturating_add(
+            matched
+                .markers
+                .capacity()
+                .saturating_mul(size_of::<String>()),
+        )
+        .saturating_add(matched.native_project.capacity())
+        .saturating_add(matched.package.capacity())
+        .saturating_add(matched.seed_target.capacity())
+}
+
+fn discovery_memory_error(root: &Path, limit_bytes: usize) -> Error {
+    Error::Eval {
+        path: root.display().to_string(),
+        message: format!(
+            "native project discovery exceeded its {limit_bytes} byte retained-result limit; narrow workspace includes or excludes, or use `on_match = \"stop\"` when nested projects belong to one workspace"
+        ),
+    }
+}
+
+fn package_is_within(package: &str, root: &str) -> bool {
+    package == root
+        || root.is_empty()
+        || package
+            .strip_prefix(root)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> NativeProjectSchema {
+        NativeProjectSchema {
+            name: "native".to_string(),
+            docs: String::new(),
+            markers: vec!["native.project".to_string()],
+            target_name: "native".to_string(),
+            target_kind: "native_workspace".to_string(),
+            inputs: Vec::new(),
+            exclude: Vec::new(),
+            on_match: "stop".to_string(),
+            max_depth: 16,
+            requires_tools: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn stop_releases_descendant_matches_if_a_parent_arrives_later() {
+        let temporary = tempfile::tempdir().unwrap();
+        let native = schema();
+        let mut retained =
+            RetainedMatches::new(temporary.path(), 1, MAX_RETAINED_MATCH_BYTES).unwrap();
+
+        retained
+            .insert(temporary.path(), 0, &native, "workspace/a")
+            .unwrap();
+        retained
+            .insert(temporary.path(), 0, &native, "workspace/b")
+            .unwrap();
+        let nested_bytes = retained.retained_bytes;
+        retained
+            .insert(temporary.path(), 0, &native, "workspace")
+            .unwrap();
+
+        assert_eq!(retained.matches.len(), 1);
+        assert_eq!(retained.matches[0].package, "workspace");
+        assert!(retained.retained_bytes < nested_bytes);
+    }
+}

--- a/crates/once-frontend/src/workspace.rs
+++ b/crates/once-frontend/src/workspace.rs
@@ -92,17 +92,20 @@ pub fn load_workspace(root: &Path) -> Result<Vec<Target>> {
             load_toml_with_configuration(&display, &src, root, &pkg, &scan.configuration)?;
         all.extend(targets);
     }
-    let resolver_kinds = crate::graph::target_kind_schemas_for_workspace(root)?
-        .into_iter()
+    let target_kind_schemas = crate::graph::target_kind_schemas_for_workspace(root)?;
+    let resolver_kinds = target_kind_schemas
+        .iter()
         .filter(|schema| schema.has_resolver)
-        .map(|schema| schema.kind)
+        .map(|schema| schema.kind.clone())
         .collect::<BTreeSet<_>>();
-    for (matched, target) in crate::native_project::synthesized_workspace_seeds(root)? {
-        let manifest_path = if target.package.is_empty() {
-            TOML_BUILD_FILE_NAME.to_string()
-        } else {
-            format!("{}/{}", target.package, TOML_BUILD_FILE_NAME)
-        };
+    let native_project_schemas =
+        crate::native_project::native_project_schemas_for_workspace_with_target_kinds(
+            root,
+            &target_kind_schemas,
+        )?;
+    for (matched, target) in
+        crate::native_project::synthesized_workspace_seeds(root, &native_project_schemas, &scan)?
+    {
         let marker_path = if matched.package.is_empty() {
             matched.markers[0].clone()
         } else {
@@ -115,7 +118,6 @@ pub fn load_workspace(root: &Path) -> Result<Vec<Target>> {
                 resolver_kinds.contains(&explicit.kind)
                     && target_covers_path(explicit, &marker_path)
             })
-            && scan.includes_native_project(&manifest_path, &marker_path)
         {
             all.push(target);
         }
@@ -154,7 +156,7 @@ fn resolver_input_patterns(target: &Target) -> Vec<String> {
 }
 
 #[derive(Debug, Default)]
-struct WorkspaceScan {
+pub(crate) struct WorkspaceScan {
     include: Vec<Pattern>,
     include_roots: Option<BTreeSet<String>>,
     exclude: Vec<Pattern>,
@@ -169,7 +171,7 @@ impl WorkspaceScan {
         self.include.is_empty() || self.include.iter().any(|pattern| pattern.matches(path))
     }
 
-    fn includes_native_project(&self, manifest_path: &str, marker_path: &str) -> bool {
+    pub(crate) fn includes_native_project(&self, manifest_path: &str, marker_path: &str) -> bool {
         if self
             .exclude
             .iter()
@@ -189,9 +191,20 @@ impl WorkspaceScan {
             .as_ref()
             .is_none_or(|roots| name.to_str().is_none_or(|name| roots.contains(name)))
     }
+
+    pub(crate) fn includes_native_project_dir(&self, path: &str, depth: usize) -> bool {
+        if depth == 1 && !self.includes_top_level_dir(OsStr::new(path)) {
+            return false;
+        }
+        let descendant = format!("{path}/__once_native_project_descendant__");
+        !self
+            .exclude
+            .iter()
+            .any(|pattern| pattern.matches(&descendant))
+    }
 }
 
-fn load_workspace_scan(root: &Path) -> Result<WorkspaceScan> {
+pub(crate) fn load_workspace_scan(root: &Path) -> Result<WorkspaceScan> {
     let path = root.join(TOML_BUILD_FILE_NAME);
     let src = match std::fs::read_to_string(&path) {
         Ok(src) => src,

--- a/web/priv/changelog/2026-07-29-faster-native-project-discovery.md
+++ b/web/priv/changelog/2026-07-29-faster-native-project-discovery.md
@@ -1,0 +1,16 @@
+---
+title: Faster native project discovery
+date: 2026-07-29
+---
+
+Once now discovers native Cargo, Mix, and future ecosystem projects with one
+shared filesystem pass. Workspace include and exclude patterns prune unrelated
+directories before Once enters them, reducing startup work in large
+repositories without changing the targets that discovery produces.
+
+Discovery also keeps its own memory usage predictable. Project kinds that own
+nested packages retain only their shallowest matching roots, while kinds that
+recognize every nested project have a 16 mebibyte retained-result limit. Once
+stops with guidance for narrowing the workspace if that limit is reached,
+instead of allowing the number of matching directories to cause unbounded
+memory growth.

--- a/web/priv/docs/reference/modules/index.md
+++ b/web/priv/docs/reference/modules/index.md
@@ -135,6 +135,11 @@ Detection reads file names only. It does not evaluate executable manifests or
 invoke native tools. Previewing or loading the graph runs the seed target's
 resolver through the normal trusted analysis boundary.
 
+Discovery retains at most 16 mebibytes of match records. Once stops with an
+error if a workspace produces more, rather than allowing repository size to
+drive unbounded memory growth. Narrow the workspace include or exclude patterns,
+or use `on_match = "stop"` when nested projects belong to one workspace.
+
 Native project discovery provides ephemeral seeds in packages that have no explicit Once
 targets. Explicit targets take precedence only in their own package, so an
 unrelated root target does not hide native projects elsewhere in a monorepo.


### PR DESCRIPTION
## What changed

Native project discovery now indexes every enabled project kind during one shared filesystem traversal. Workspace include and exclude patterns prune unrelated directories before traversal enters them, and the native-project query reuses the same loaded schemas and matches instead of repeating discovery work.

Discovery now retains only shallow roots for project kinds that own nested packages. Project kinds that recognize every nested project have a 16 mebibyte retained-result limit, fallible allocation growth, and an actionable error when the limit is reached. The module reference and website changelog document the behavior for users.

## Why

Native project discovery runs while Once loads the workspace, so its cost affects every graph-backed command. The previous implementation repeated a complete workspace walk for each project kind and allowed matching paths to determine retained memory without an explicit ceiling.

## Root cause

Discovery indexed one schema at a time, applied workspace boundaries after traversal, and accumulated every candidate path before reducing nested matches. Adding more project kinds multiplied filesystem work, while repositories with many matching manifests could grow frontend memory without a predictable bound.

## Approach

The new traversal indexes primary markers across all schemas, preserves each schema's depth and exclusion rules, and checks workspace boundaries before descending. Project kinds using `stop` are evaluated parent first so descendants can be skipped immediately. Project kinds using `descend` retain their complete result only within the fixed memory budget.

Retained strings and vector capacities are accounted explicitly. Growth uses fallible reservations, and final ordering is performed in place so sorting does not allocate another match-sized buffer.

## Impact

Existing manifests and target identifiers do not change. Large repositories perform less repeated discovery work, excluded trees are never indexed, and discovery-owned memory can no longer grow indefinitely with the number of matching directories. Workspaces that exceed the retained-result limit receive guidance to narrow their include or exclude patterns, or to use `on_match = "stop"` when nested projects belong to one workspace.

## Validation

- `mise exec -- cargo test --release -p once-frontend --lib`, with 229 passing tests.
- Focused discovery coverage verifies workspace pruning across 400 excluded markers, shallow-root retention across 200 nested projects, schema-specific exclusions, and graceful limit failures.
- `mise exec -- cargo clippy --release -p once-frontend -p once-cli --all-targets -- -D warnings` completed successfully.
- `mise exec -- cargo fmt --all -- --check` completed successfully.
- `git diff --check` completed successfully.
- `mise exec -- target/release/once query native-projects --format json` returned the expected root Cargo project and `web` Mix project.
