### PR TITLE
feat(graph): support native Cargo projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,6 +3463,7 @@ dependencies = [
  "jsonwebtoken",
  "microsandbox",
  "once-cas",
+ "once-host-tree",
  "reqwest 0.13.4",
  "sea-orm",
  "sea-orm-migration",
@@ -3486,6 +3487,7 @@ dependencies = [
  "base64",
  "glob",
  "include_dir",
+ "once-host-tree",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3495,6 +3497,14 @@ dependencies = [
  "toml",
  "toml_edit",
  "walkdir",
+]
+
+[[package]]
+name = "once-host-tree"
+version = "0.0.0"
+dependencies = [
+ "sha2 0.11.0",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "anyhow",
  "base64",
  "blake3",
+ "fd-lock",
  "futures",
  "jsonwebtoken",
  "microsandbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/once-core",
     "crates/once-cas",
     "crates/once-frontend",
+    "crates/once-host-tree",
 ]
 
 [workspace.package]
@@ -20,6 +21,7 @@ once = { version = "0.0.0", path = "crates/once" }
 once-core = { version = "0.0.0", path = "crates/once-core", default-features = false }
 once-cas = { version = "0.0.0", path = "crates/once-cas" }
 once-frontend = { version = "0.0.0", path = "crates/once-frontend" }
+once-host-tree = { version = "0.0.0", path = "crates/once-host-tree" }
 
 anyhow = "1"
 bazel-remote-apis = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ base64 = "0.22"
 blake3 = "1"
 clap = { version = "4", features = ["derive"] }
 console = "0.16"
+fd-lock = "4"
 futures = "0.3"
 glob = "0.3"
 hex = "0.4"

--- a/crates/once-cli/once.toml
+++ b/crates/once-cli/once.toml
@@ -3,6 +3,7 @@ name = "once"
 kind = "rust_binary"
 deps = [
   "crates/once-cas/once_cas",
+  "crates/once-host-tree/once_host_tree",
   "crates/once-core/once_core",
   "crates/once-frontend/once_frontend",
   "cargo_dependencies",

--- a/crates/once-cli/src/cli/query.rs
+++ b/crates/once-cli/src/cli/query.rs
@@ -116,6 +116,9 @@ pub enum QueryCmd {
     TestResults {
         /// Target id, such as `tests/unit`.
         target: String,
+        /// Return the normalized status and totals without case-level records.
+        #[arg(long)]
+        summary_only: bool,
     },
 
     /// List stable test units discovered in a target's normalized results.

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -1183,6 +1183,7 @@ async fn run_uncached_action(
         | Action::CopyPath { .. }
         | Action::LinkPath { .. }
         | Action::MaterializeHostFile { .. }
+        | Action::MaterializeHostTree { .. }
         | Action::PreparePath { .. }
         | Action::WriteTreeDigest { .. }
         | Action::WriteArchive { .. } => once_core::run_uncached(action, workspace, cache, false)
@@ -1584,6 +1585,25 @@ fn operation_to_action(operation: DeclaredActionOperation, input_digest: Digest)
                 source,
                 source_sha256,
                 destination: workspace_path(&destination, "materialize_host_file destination")?,
+                input_digest: Some(input_digest),
+            }
+        }
+        DeclaredActionOperation::MaterializeHostTree {
+            source,
+            source_sha256,
+            destination,
+        } => {
+            let source = std::path::PathBuf::from(source);
+            if !source.is_absolute() {
+                anyhow::bail!(
+                    "invalid materialize_host_tree source `{}`: expected an absolute path",
+                    source.display()
+                );
+            }
+            Action::MaterializeHostTree {
+                source,
+                source_sha256,
+                destination: workspace_path(&destination, "materialize_host_tree destination")?,
                 input_digest: Some(input_digest),
             }
         }

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -1505,6 +1505,35 @@ mod tests {
     }
 
     #[test]
+    fn summarized_test_run_results_tolerate_partial_result() {
+        // A non-null but partial result (missing `runner`/`artifacts`) must not
+        // fail the whole report; absent fields become null.
+        let mut value = json!({
+            "runs": [
+                {
+                    "target": "tests/unit",
+                    "results": {
+                        "schema": "once.test_results.v1",
+                        "target": "tests/unit",
+                        "status": "errored",
+                        "summary": { "total": 0, "passed": 0, "failed": 0, "skipped": 0, "flaky": 0 }
+                    }
+                }
+            ]
+        });
+
+        summarize_test_run_results(&mut value).unwrap();
+
+        assert_eq!(
+            value["runs"][0]["results"]["schema"],
+            "once.test_results_summary.v1"
+        );
+        assert_eq!(value["runs"][0]["results"]["status"], "errored");
+        assert!(value["runs"][0]["results"]["runner"].is_null());
+        assert!(value["runs"][0]["results"]["artifacts"].is_null());
+    }
+
+    #[test]
     fn capped_reader_reads_normal_lines() {
         let data = b"first\nsecond\n";
         let mut reader = std::io::BufReader::new(&data[..]);

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -493,7 +493,16 @@ impl Server {
             .get("target")
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow::anyhow!("missing `target` argument"))?;
-        crate::commands::query::test_results_value(&self.workspace, target_id)
+        let summary_only = args
+            .get("summary_only")
+            .map(|value| value.as_bool().context("`summary_only` must be a boolean"))
+            .transpose()?
+            .unwrap_or(false);
+        let value = crate::commands::query::test_results_value(&self.workspace, target_id)?;
+        if summary_only {
+            return crate::commands::query::test_results_summary_value(&value);
+        }
+        Ok(value)
     }
 
     fn tool_query_test_manifest(&self, args: &Value) -> Result<Value> {
@@ -553,6 +562,7 @@ impl Server {
         let plan = run_test_plan_args(&self.workspace, &args)?;
         let workspace = self.workspace.clone();
         let workers = args.jobs;
+        let summary_only = args.summary_only;
         let resource_limits = self.resource_limits.clone();
         run_async_result(async move {
             let report = crate::commands::test_schedule::execute(
@@ -564,7 +574,11 @@ impl Server {
                 resource_limits,
             )
             .await?;
-            Ok(serde_json::to_value(report)?)
+            let mut value = serde_json::to_value(report)?;
+            if summary_only {
+                summarize_test_run_results(&mut value)?;
+            }
+            Ok(value)
         })
     }
 
@@ -714,6 +728,23 @@ fn run_test_plan_args(
         .collect::<Vec<_>>();
     validate_test_targets(workspace, &targets)?;
     Ok(plan)
+}
+
+fn summarize_test_run_results(value: &mut Value) -> Result<()> {
+    let runs = value
+        .get_mut("runs")
+        .and_then(Value::as_array_mut)
+        .context("test run report is missing `runs`")?;
+    for run in runs {
+        let Some(results) = run.get_mut("results") else {
+            continue;
+        };
+        if results.is_null() {
+            continue;
+        }
+        *results = crate::commands::query::test_results_summary_value(results)?;
+    }
+    Ok(())
 }
 
 fn validate_test_targets(workspace: &std::path::Path, targets: &[String]) -> Result<()> {
@@ -1037,6 +1068,8 @@ struct RunTestsArgs {
     jobs: Option<usize>,
     #[serde(default)]
     test_unit: Option<String>,
+    #[serde(default)]
+    summary_only: bool,
 }
 
 #[derive(Deserialize)]
@@ -1431,6 +1464,44 @@ mod tests {
 
     fn server(workspace: PathBuf) -> Server {
         Server::new(workspace, false)
+    }
+
+    #[test]
+    fn summarized_test_run_results_keep_totals_without_cases() {
+        let mut value = json!({
+            "runs": [
+                {
+                    "target": "tests/unit",
+                    "results": {
+                        "schema": "once.test_results.v1",
+                        "target": "tests/unit",
+                        "runner": { "type": "rust_libtest", "metadata": {} },
+                        "status": "passed",
+                        "summary": {
+                            "total": 2,
+                            "passed": 1,
+                            "failed": 0,
+                            "skipped": 1,
+                            "flaky": 0
+                        },
+                        "cases": [
+                            { "name": "passes", "status": "passed" },
+                            { "name": "skips", "status": "skipped" }
+                        ],
+                        "artifacts": { "logs": [], "native_results": [] }
+                    }
+                }
+            ]
+        });
+
+        summarize_test_run_results(&mut value).unwrap();
+
+        assert_eq!(
+            value["runs"][0]["results"]["schema"],
+            "once.test_results_summary.v1"
+        );
+        assert_eq!(value["runs"][0]["results"]["summary"]["total"], 2);
+        assert!(value["runs"][0]["results"].get("cases").is_none());
     }
 
     #[test]

--- a/crates/once-cli/src/commands/mcp/tools.rs
+++ b/crates/once-cli/src/commands/mcp/tools.rs
@@ -232,7 +232,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_preview_native_project",
             description: "Preview the seed target and complete typed graph derived by one detected native project.",
-            long_description: "Runs the selected native project's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `package` when the native project has one match. The matching command-line operation is `once query native-project <name> [--package <path>] --format json`.",
+            long_description: "Runs the selected native project's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `package` when the native project has one match. Expanded dependency graphs can be very large. For a loaded project, prefer `once_query_workspace`, filtered `once_query_targets`, `once_query_tests`, and `once_get_target` when the complete graph is not needed. The matching command-line operation is `once query native-project <name> [--package <path>] --format json`.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -277,7 +277,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                 "type": "object",
                 "properties": {}
             }),
-            example_return: "{\n  \"language\": \"Starlark\",\n  \"registration\": \"[modules]\\npaths = [\\\"modules/*.star\\\"]\\n\",\n  \"schema_invariants\": [\"attr.default is optional schema documentation and must be a string...\"],\n  \"context_fields\": [\n    { \"signature\": \"ctx[\\\"attr\\\"]\", \"purpose\": \"Typed target attributes.\" }\n  ],\n  \"action_primitives\": [\n    { \"signature\": \"write_path(path, content)\", \"purpose\": \"Declare a portable file-writing action.\" },\n    { \"signature\": \"materialize_host_file(source, destination)\", \"purpose\": \"Snapshot a content-verified absolute host toolchain file into a workspace output.\" }\n  ],\n  \"starter\": \"def _generated_text_impl(ctx): ...\",\n  \"lint_starter\": \"def _scripted_lint_impl(ctx): ...\",\n  \"lint_target_starter\": \"[[target]]\\nname = \\\"lint\\\"\\nkind = \\\"scripted_lint\\\"\\n...\",\n  \"lint_adapter_starter\": \"import argparse\\nimport json\\n...\",\n  \"normalized_lint_result_example\": {\n    \"schema\": \"once.lint_results.v1\",\n    \"status\": \"completed\"\n  },\n  \"test_starter\": \"def _scripted_test_impl(ctx): ...\"\n}",
+            example_return: "{\n  \"language\": \"Starlark\",\n  \"registration\": \"[modules]\\npaths = [\\\"modules/*.star\\\"]\\n\",\n  \"schema_invariants\": [\"attr.default is optional schema documentation and must be a string...\"],\n  \"context_fields\": [\n    { \"signature\": \"ctx[\\\"attr\\\"]\", \"purpose\": \"Typed target attributes.\" }\n  ],\n  \"action_primitives\": [\n    { \"signature\": \"write_path(path, content)\", \"purpose\": \"Declare a portable file-writing action.\" },\n    { \"signature\": \"materialize_host_file(source, destination)\", \"purpose\": \"Snapshot a content-verified absolute host toolchain file into a workspace output.\" },\n    { \"signature\": \"materialize_host_tree(source, destination)\", \"purpose\": \"Snapshot a content-verified absolute host directory into a workspace output.\" }\n  ],\n  \"starter\": \"def _generated_text_impl(ctx): ...\",\n  \"lint_starter\": \"def _scripted_lint_impl(ctx): ...\",\n  \"lint_target_starter\": \"[[target]]\\nname = \\\"lint\\\"\\nkind = \\\"scripted_lint\\\"\\n...\",\n  \"lint_adapter_starter\": \"import argparse\\nimport json\\n...\",\n  \"normalized_lint_result_example\": {\n    \"schema\": \"once.lint_results.v1\",\n    \"status\": \"completed\"\n  },\n  \"test_starter\": \"def _scripted_test_impl(ctx): ...\"\n}",
         },
         ToolDefinition {
             name: "once_fetch_external_source",
@@ -387,7 +387,7 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_run_tests",
             description: "Run test targets by id, or run tests affected by changed workspace paths.",
-            long_description: "Creates the same immutable plan as `once_query_test_plan`, then pulls stable batches from a shared local queue. Batches with longer historical uncached durations are queued first, and idle workers dynamically take the next batch. Explicit `target` or `targets` produce an exact plan; otherwise `changed_paths` drive conservative graph selection. With exactly one target, `test_unit` runs a stable unit returned by `once_query_test_manifest` when the target kind declares filtering support. `jobs` caps workers without changing plan or batch identity. The result's `plan` is the work that just executed. Its `next_plan` is recomputed after complete runs refresh discovery, so use that field to assess file or case batching for the next run. The result also includes actual schedule attempts and normalized test results. Failed tests are returned as normal tool content with `success: false` rather than a tool protocol error, so agents can inspect failures and iterate. The matching command-line operations are `once test --changed-path <path> --jobs <count> --format json` and `once test <target> --test-unit <unit> --format json`.",
+            long_description: "Creates the same immutable plan as `once_query_test_plan`, then pulls stable batches from a shared local queue. Batches with longer historical uncached durations are queued first, and idle workers dynamically take the next batch. Explicit `target` or `targets` produce an exact plan; otherwise `changed_paths` drive conservative graph selection. With exactly one target, `test_unit` runs a stable unit returned by `once_query_test_manifest` when the target kind declares filtering support. `jobs` caps workers without changing plan or batch identity. Set `summary_only` for compact normalized totals without case-level records. The result's `plan` is the work that just executed. Its `next_plan` is recomputed after complete runs refresh discovery, so use that field to assess file or case batching for the next run. The result also includes actual schedule attempts and normalized test results. Failed tests are returned as normal tool content with `success: false` rather than a tool protocol error, so agents can inspect failures and iterate. The matching command-line operations are `once test --changed-path <path> --jobs <count> --format json` and `once test <target> --test-unit <unit> --format json`.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -414,6 +414,10 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
                     "test_unit": {
                         "type": "string",
                         "description": "Run one stable unit identifier returned by once_query_test_manifest. Requires exactly one explicit target."
+                    },
+                    "summary_only": {
+                        "type": "boolean",
+                        "description": "Replace case-level normalized results with compact once.test_results_summary.v1 totals."
                     }
                 }
             }),
@@ -422,13 +426,17 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
         ToolDefinition {
             name: "once_query_test_results",
             description: "Read normalized once.test_results.v1 results for a target.",
-            long_description: "Reads the normalized result file produced by the target's `test` capability. This is the stable agent-facing interface for pass or fail summaries, case-level failures, attempts, and artifacts. Callers do not need to parse a runner's command output.",
+            long_description: "Reads the normalized result file produced by the target's `test` capability. This is the stable agent-facing interface for pass or fail summaries, case-level failures, attempts, and artifacts. Set `summary_only` when exact totals are sufficient and a large case array would waste model context. The matching command-line operation is `once query test-results <target> --summary-only --format json`. Callers do not need to parse a runner's command output.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "target": {
                         "type": "string",
                         "description": "Canonical target id, such as `tests/unit`."
+                    },
+                    "summary_only": {
+                        "type": "boolean",
+                        "description": "Return once.test_results_summary.v1 status, totals, runner, and artifacts without case-level records."
                     }
                 },
                 "required": ["target"]

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -1175,20 +1175,19 @@ pub(crate) fn test_results_summary_value(value: &serde_json::Value) -> Result<se
     let object = value
         .as_object()
         .context("normalized test results must be an object")?;
-    let required = |name: &str| {
-        object
-            .get(name)
-            .cloned()
-            .with_context(|| format!("normalized test results are missing `{name}`"))
-    };
+    // Tolerate results objects that are non-null but partial (for example an
+    // errored or minimally-populated run). Missing fields become `null` rather
+    // than failing the whole report, which would otherwise make `summary_only`
+    // error on runs that the full (non-summary) view returns fine.
+    let field = |name: &str| object.get(name).cloned().unwrap_or(serde_json::Value::Null);
     Ok(serde_json::json!({
         "schema": "once.test_results_summary.v1",
-        "source_schema": required("schema")?,
-        "target": required("target")?,
-        "runner": required("runner")?,
-        "status": required("status")?,
-        "summary": required("summary")?,
-        "artifacts": required("artifacts")?,
+        "source_schema": field("schema"),
+        "target": field("target"),
+        "runner": field("runner"),
+        "status": field("status"),
+        "summary": field("summary"),
+        "artifacts": field("artifacts"),
     }))
 }
 

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -839,8 +839,16 @@ pub(crate) fn validate_test_unit(
     Ok(())
 }
 
-pub async fn test_results(workspace: &Path, output: Output, target_id: &str) -> Result<()> {
-    let value = test_results_value(workspace, target_id)?;
+pub async fn test_results(
+    workspace: &Path,
+    output: Output,
+    target_id: &str,
+    summary_only: bool,
+) -> Result<()> {
+    let mut value = test_results_value(workspace, target_id)?;
+    if summary_only {
+        value = test_results_summary_value(&value)?;
+    }
     write_body(output, || render_test_results_human(&value), &value).await
 }
 
@@ -1161,6 +1169,27 @@ pub(crate) async fn evidence_records(
 
 pub(crate) fn test_results_value(workspace: &Path, target_id: &str) -> Result<serde_json::Value> {
     test_results_value_at(workspace, target_id, None, &[])
+}
+
+pub(crate) fn test_results_summary_value(value: &serde_json::Value) -> Result<serde_json::Value> {
+    let object = value
+        .as_object()
+        .context("normalized test results must be an object")?;
+    let required = |name: &str| {
+        object
+            .get(name)
+            .cloned()
+            .with_context(|| format!("normalized test results are missing `{name}`"))
+    };
+    Ok(serde_json::json!({
+        "schema": "once.test_results_summary.v1",
+        "source_schema": required("schema")?,
+        "target": required("target")?,
+        "runner": required("runner")?,
+        "status": required("status")?,
+        "summary": required("summary")?,
+        "artifacts": required("artifacts")?,
+    }))
 }
 
 pub(crate) fn test_results_value_at(
@@ -1801,6 +1830,36 @@ mod tests {
             tools: Vec::new(),
             diagnostics: Vec::new(),
         }
+    }
+
+    #[test]
+    fn test_results_summary_omits_case_records() {
+        let value = serde_json::json!({
+            "schema": "once.test_results.v1",
+            "target": "tests/unit",
+            "runner": { "type": "rust_libtest", "metadata": {} },
+            "status": "passed",
+            "summary": {
+                "total": 2,
+                "passed": 1,
+                "failed": 0,
+                "skipped": 1,
+                "flaky": 0
+            },
+            "cases": [
+                { "name": "passes", "status": "passed" },
+                { "name": "skips", "status": "skipped" }
+            ],
+            "artifacts": { "logs": ["test.log"], "native_results": [] }
+        });
+
+        let summary = test_results_summary_value(&value).unwrap();
+
+        assert_eq!(summary["schema"], "once.test_results_summary.v1");
+        assert_eq!(summary["source_schema"], "once.test_results.v1");
+        assert_eq!(summary["summary"]["passed"], 1);
+        assert_eq!(summary["summary"]["skipped"], 1);
+        assert!(summary.get("cases").is_none());
     }
 
     #[test]

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -440,11 +440,12 @@ async fn run_query_command(
             target,
             test_unit,
         }) => run_test_plan_query(workspace, output, &changed_paths, target, test_unit).await,
-        Some(cli::QueryCmd::TestResults { target }) => {
-            commands::query::test_results(workspace, output, &target)
-                .await
-                .map(|()| ExitCode::SUCCESS)
-        }
+        Some(cli::QueryCmd::TestResults {
+            target,
+            summary_only,
+        }) => commands::query::test_results(workspace, output, &target, summary_only)
+            .await
+            .map(|()| ExitCode::SUCCESS),
         Some(cli::QueryCmd::TestManifest { target }) => {
             commands::query::test_manifest(workspace, output, &target)
                 .await

--- a/crates/once-core/Cargo.toml
+++ b/crates/once-core/Cargo.toml
@@ -12,6 +12,7 @@ remote-microsandbox = ["dep:microsandbox"]
 
 [dependencies]
 once-cas.workspace = true
+once-host-tree.workspace = true
 
 anyhow.workspace = true
 base64.workspace = true

--- a/crates/once-core/Cargo.toml
+++ b/crates/once-core/Cargo.toml
@@ -16,6 +16,7 @@ once-cas.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 blake3.workspace = true
+fd-lock.workspace = true
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/once-core/once.toml
+++ b/crates/once-core/once.toml
@@ -3,6 +3,7 @@ name = "once_core"
 kind = "rust_library"
 deps = [
   "crates/once-cas/once_cas",
+  "crates/once-host-tree/once_host_tree",
   "cargo_dependencies",
 ]
 srcs = ["src/**/*.rs"]

--- a/crates/once-core/src/action.rs
+++ b/crates/once-core/src/action.rs
@@ -175,6 +175,13 @@ pub enum Action {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         input_digest: Option<Digest>,
     },
+    MaterializeHostTree {
+        source: PathBuf,
+        source_sha256: String,
+        destination: WorkspacePath,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        input_digest: Option<Digest>,
+    },
     PreparePath {
         path: WorkspacePath,
         mode: PreparePathMode,
@@ -276,6 +283,7 @@ impl Action {
             | Action::CopyPath { .. }
             | Action::LinkPath { .. }
             | Action::MaterializeHostFile { .. }
+            | Action::MaterializeHostTree { .. }
             | Action::PreparePath { .. }
             | Action::WriteTreeDigest { .. }
             | Action::WriteArchive { .. } => &DEFAULT_RESOURCE_REQUEST,
@@ -289,6 +297,7 @@ impl Action {
             | Action::CopyPath { input_digest, .. }
             | Action::LinkPath { input_digest, .. }
             | Action::MaterializeHostFile { input_digest, .. }
+            | Action::MaterializeHostTree { input_digest, .. }
             | Action::PreparePath { input_digest, .. }
             | Action::WriteTreeDigest { input_digest, .. }
             | Action::WriteArchive { input_digest, .. } => *input_digest,

--- a/crates/once-core/src/directory_blob.rs
+++ b/crates/once-core/src/directory_blob.rs
@@ -12,6 +12,8 @@ use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+use once_cas::Digest;
+
 use crate::path::WorkspacePath;
 use crate::{Error, OutputSymlinkMode, Result};
 
@@ -85,6 +87,35 @@ impl DirectoryEntryContent {
 
 pub(crate) fn is_directory_blob(bytes: &[u8]) -> bool {
     bytes.starts_with(DIRECTORY_BLOB_MAGIC) || bytes.starts_with(DIRECTORY_BLOB_V1_MAGIC)
+}
+
+pub(crate) fn digest_directory_blob(
+    root: &Path,
+    symlink_mode: OutputSymlinkMode,
+) -> std::io::Result<Digest> {
+    let mut writer = DigestWriter::default();
+    write_directory_blob(root, symlink_mode, &mut writer)?;
+    Ok(writer.finish())
+}
+
+#[derive(Default)]
+struct DigestWriter(blake3::Hasher);
+
+impl DigestWriter {
+    fn finish(self) -> Digest {
+        Digest::from_bytes(*self.0.finalize().as_bytes())
+    }
+}
+
+impl Write for DigestWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.update(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/once-core/src/execute.rs
+++ b/crates/once-core/src/execute.rs
@@ -666,6 +666,11 @@ async fn materialize_host_tree(
     let destination_label = destination.as_str().to_string();
     let expected = source_sha256.to_string();
     tokio::task::spawn_blocking(move || {
+        // Copying a tree into itself (destination equal to, nested under, or an
+        // ancestor of the source) would remove the verified source before
+        // recreating it or recurse the fresh destination into itself, silently
+        // destroying workspace data. Reject the overlap before touching disk.
+        reject_overlapping_host_tree_paths(&source, &destination_path)?;
         let actual = once_host_tree::host_tree_sha256_hex(&source).map_err(|source_error| {
             Error::FileAction {
                 action: "hash_host_tree",
@@ -686,7 +691,27 @@ async fn materialize_host_tree(
                 path: destination_label,
                 source: source_error,
             }
-        })
+        })?;
+        // The hash above and this copy are independent traversals of the
+        // source. If the source changed in between, the destination we just
+        // captured no longer matches `expected`; re-hash the copied snapshot
+        // and reject it rather than caching bytes under a stale digest.
+        let copied =
+            once_host_tree::host_tree_sha256_hex(&destination_path).map_err(|source_error| {
+                Error::FileAction {
+                    action: "verify_host_tree",
+                    path: destination_path.display().to_string(),
+                    source: source_error,
+                }
+            })?;
+        if copied != expected {
+            return Err(Error::HostFileDigestMismatch {
+                path: destination_path.display().to_string(),
+                expected,
+                actual: copied,
+            });
+        }
+        Ok(())
     })
     .await
     .map_err(|source_error| Error::FileAction {
@@ -694,6 +719,51 @@ async fn materialize_host_tree(
         path: destination.as_str().to_string(),
         source: std::io::Error::other(source_error.to_string()),
     })?
+}
+
+/// Reject a host-tree copy whose source and destination overlap: equal paths,
+/// a destination nested under the source, or a source nested under the
+/// destination. Symlinks in the existing prefixes are resolved so the check
+/// cannot be bypassed by linking one side into the other.
+fn reject_overlapping_host_tree_paths(source: &Path, destination: &Path) -> Result<()> {
+    let source_c = source
+        .canonicalize()
+        .unwrap_or_else(|_| source.to_path_buf());
+    let dest_c = canonicalize_existing_prefix(destination);
+    if dest_c == source_c || dest_c.starts_with(&source_c) || source_c.starts_with(&dest_c) {
+        return Err(Error::InvalidHostFile {
+            reason: format!(
+                "materialize_host_tree destination `{}` overlaps source `{}`",
+                destination.display(),
+                source.display()
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Canonicalize the longest existing prefix of `path` (resolving any symlinks
+/// there) and re-append the not-yet-created remainder lexically, so a
+/// destination that does not exist on disk can still be compared safely.
+fn canonicalize_existing_prefix(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        if let Ok(canonical) = current.canonicalize() {
+            let mut resolved = canonical;
+            for part in suffix.iter().rev() {
+                resolved.push(part);
+            }
+            return resolved;
+        }
+        match (current.parent(), current.file_name()) {
+            (Some(parent), Some(name)) => {
+                suffix.push(name.to_os_string());
+                current = parent.to_path_buf();
+            }
+            _ => return path.to_path_buf(),
+        }
+    }
 }
 
 async fn copy_tree(

--- a/crates/once-core/src/execute.rs
+++ b/crates/once-core/src/execute.rs
@@ -95,6 +95,16 @@ async fn execute_portable_action(
             capture_file_action_outputs(std::slice::from_ref(destination), workspace_root, cache)
                 .await
         }
+        Action::MaterializeHostTree {
+            source,
+            source_sha256,
+            destination,
+            ..
+        } => {
+            materialize_host_tree(source, source_sha256, destination, workspace_root).await?;
+            capture_file_action_outputs(std::slice::from_ref(destination), workspace_root, cache)
+                .await
+        }
         Action::PreparePath { path, mode, .. } => match mode {
             PreparePathMode::Remove => {
                 remove_path(path, workspace_root).await?;
@@ -635,6 +645,55 @@ async fn materialize_host_file(
     write_file(destination, &bytes, workspace_root).await
 }
 
+async fn materialize_host_tree(
+    source: &Path,
+    source_sha256: &str,
+    destination: &WorkspacePath,
+    workspace_root: &Path,
+) -> Result<()> {
+    if !source.is_absolute() {
+        return Err(Error::InvalidHostFile {
+            reason: format!("source `{}` must be absolute", source.display()),
+        });
+    }
+    if !source.is_dir() {
+        return Err(Error::InvalidHostFile {
+            reason: format!("source `{}` must be a directory", source.display()),
+        });
+    }
+    let source = source.to_path_buf();
+    let destination_path = destination.resolve(workspace_root);
+    let destination_label = destination.as_str().to_string();
+    let expected = source_sha256.to_string();
+    tokio::task::spawn_blocking(move || {
+        let actual = host_tree_sha256_hex(&source).map_err(|source_error| Error::FileAction {
+            action: "hash_host_tree",
+            path: source.display().to_string(),
+            source: source_error,
+        })?;
+        if actual != expected {
+            return Err(Error::HostFileDigestMismatch {
+                path: source.display().to_string(),
+                expected,
+                actual,
+            });
+        }
+        copy_sandbox_output_blocking(&source, &destination_path).map_err(|source_error| {
+            Error::FileAction {
+                action: "materialize_host_tree",
+                path: destination_label,
+                source: source_error,
+            }
+        })
+    })
+    .await
+    .map_err(|source_error| Error::FileAction {
+        action: "materialize_host_tree",
+        path: destination.as_str().to_string(),
+        source: std::io::Error::other(source_error.to_string()),
+    })?
+}
+
 async fn copy_tree(
     sources: &[WorkspacePath],
     destination: &WorkspacePath,
@@ -1001,6 +1060,65 @@ fn file_sha256_hex(path: &Path) -> std::io::Result<String> {
         hasher.update(&buf[..read]);
     }
     Ok(hex_lower(&hasher.finalize()))
+}
+
+pub(crate) fn host_tree_sha256_hex(root: &Path) -> std::io::Result<String> {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"once.host_tree.v1\0");
+    hash_host_tree_directory(root, root, &mut hasher)?;
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+fn hash_host_tree_directory(
+    root: &Path,
+    directory: &Path,
+    hasher: &mut sha2::Sha256,
+) -> std::io::Result<()> {
+    let mut children = std::fs::read_dir(directory)?.collect::<std::io::Result<Vec<_>>>()?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let path = child.path();
+        let metadata = std::fs::symlink_metadata(&path)?;
+        let relative = path
+            .strip_prefix(root)
+            .map_err(std::io::Error::other)?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let kind = if metadata.file_type().is_symlink() {
+            b'l'
+        } else if metadata.is_dir() {
+            b'd'
+        } else if metadata.is_file() {
+            b'f'
+        } else {
+            continue;
+        };
+        hasher.update([kind]);
+        hasher.update(relative.as_bytes());
+        hasher.update([0]);
+        hasher.update(host_file_mode(&metadata).to_le_bytes());
+        if metadata.file_type().is_symlink() {
+            hasher.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
+        } else if metadata.is_file() {
+            hasher.update(file_sha256_hex(&path)?.as_bytes());
+        }
+        hasher.update([0]);
+        if metadata.is_dir() {
+            hash_host_tree_directory(root, &path, hasher)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn host_file_mode(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode()
+}
+
+#[cfg(not(unix))]
+fn host_file_mode(_metadata: &std::fs::Metadata) -> u32 {
+    0
 }
 
 fn hex_lower(bytes: &[u8]) -> String {

--- a/crates/once-core/src/execute.rs
+++ b/crates/once-core/src/execute.rs
@@ -666,10 +666,12 @@ async fn materialize_host_tree(
     let destination_label = destination.as_str().to_string();
     let expected = source_sha256.to_string();
     tokio::task::spawn_blocking(move || {
-        let actual = host_tree_sha256_hex(&source).map_err(|source_error| Error::FileAction {
-            action: "hash_host_tree",
-            path: source.display().to_string(),
-            source: source_error,
+        let actual = once_host_tree::host_tree_sha256_hex(&source).map_err(|source_error| {
+            Error::FileAction {
+                action: "hash_host_tree",
+                path: source.display().to_string(),
+                source: source_error,
+            }
         })?;
         if actual != expected {
             return Err(Error::HostFileDigestMismatch {
@@ -1060,65 +1062,6 @@ fn file_sha256_hex(path: &Path) -> std::io::Result<String> {
         hasher.update(&buf[..read]);
     }
     Ok(hex_lower(&hasher.finalize()))
-}
-
-pub(crate) fn host_tree_sha256_hex(root: &Path) -> std::io::Result<String> {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(b"once.host_tree.v1\0");
-    hash_host_tree_directory(root, root, &mut hasher)?;
-    Ok(hex_lower(&hasher.finalize()))
-}
-
-fn hash_host_tree_directory(
-    root: &Path,
-    directory: &Path,
-    hasher: &mut sha2::Sha256,
-) -> std::io::Result<()> {
-    let mut children = std::fs::read_dir(directory)?.collect::<std::io::Result<Vec<_>>>()?;
-    children.sort_by_key(std::fs::DirEntry::file_name);
-    for child in children {
-        let path = child.path();
-        let metadata = std::fs::symlink_metadata(&path)?;
-        let relative = path
-            .strip_prefix(root)
-            .map_err(std::io::Error::other)?
-            .to_string_lossy()
-            .replace('\\', "/");
-        let kind = if metadata.file_type().is_symlink() {
-            b'l'
-        } else if metadata.is_dir() {
-            b'd'
-        } else if metadata.is_file() {
-            b'f'
-        } else {
-            continue;
-        };
-        hasher.update([kind]);
-        hasher.update(relative.as_bytes());
-        hasher.update([0]);
-        hasher.update(host_file_mode(&metadata).to_le_bytes());
-        if metadata.file_type().is_symlink() {
-            hasher.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
-        } else if metadata.is_file() {
-            hasher.update(file_sha256_hex(&path)?.as_bytes());
-        }
-        hasher.update([0]);
-        if metadata.is_dir() {
-            hash_host_tree_directory(root, &path, hasher)?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn host_file_mode(metadata: &std::fs::Metadata) -> u32 {
-    use std::os::unix::fs::PermissionsExt;
-    metadata.permissions().mode()
-}
-
-#[cfg(not(unix))]
-fn host_file_mode(_metadata: &std::fs::Metadata) -> u32 {
-    0
 }
 
 fn hex_lower(bytes: &[u8]) -> String {

--- a/crates/once-core/src/input_digest.rs
+++ b/crates/once-core/src/input_digest.rs
@@ -8,12 +8,11 @@
 //! domain prefix that collides across two plugins. This builder is the
 //! one canonical implementation.
 
-use std::io::Write;
 use std::path::Path;
 
 use once_cas::Digest;
 
-use crate::directory_blob::write_directory_blob;
+use crate::directory_blob::digest_directory_blob;
 use crate::OutputSymlinkMode;
 
 #[derive(Debug)]
@@ -79,9 +78,7 @@ impl InputDigestBuilder {
             bytes.extend_from_slice(target.to_string_lossy().as_bytes());
             Digest::of_bytes(&bytes)
         } else if metadata.is_dir() {
-            let mut writer = DigestWriter::default();
-            write_directory_blob(&abs, OutputSymlinkMode::Preserve, &mut writer)?;
-            writer.finish()
+            digest_directory_blob(&abs, OutputSymlinkMode::Preserve)?
         } else {
             let file = std::fs::File::open(&abs)?;
             Digest::of_reader(std::io::BufReader::new(file))?
@@ -92,26 +89,6 @@ impl InputDigestBuilder {
     /// Finalise the buffer into a [`Digest`].
     pub fn finish(self) -> Digest {
         Digest::of_bytes(&self.buf)
-    }
-}
-
-#[derive(Default)]
-struct DigestWriter(blake3::Hasher);
-
-impl DigestWriter {
-    fn finish(self) -> Digest {
-        Digest::from_bytes(*self.0.finalize().as_bytes())
-    }
-}
-
-impl Write for DigestWriter {
-    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-        self.0.update(bytes);
-        Ok(bytes.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
     }
 }
 

--- a/crates/once-core/src/outputs.rs
+++ b/crates/once-core/src/outputs.rs
@@ -1,13 +1,16 @@
 use std::collections::{BTreeMap, VecDeque};
+use std::fs::OpenOptions;
 use std::io::{BufWriter, Cursor, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use fd_lock::RwLock;
 use once_cas::{ActionResult, CacheProvider, Digest};
 use tokio::task::JoinSet;
 
 use crate::directory_blob::{
-    is_directory_blob, restore_directory_blob_from_reader, write_directory_blob,
+    digest_directory_blob, is_directory_blob, restore_directory_blob_from_reader,
+    write_directory_blob,
 };
 use crate::file_blob::{
     digest_file_blob, file_blob_header, restore_file_blob_from_reader, FILE_BLOB_MAGIC,
@@ -30,12 +33,51 @@ pub(crate) async fn restore(
     }
     let staging = StagingDir::create(workspace_root)?;
     let prefetched = prefetch_output_blobs(&outputs, cache, staging.path()).await?;
+    let mut lock = output_restore_lock(workspace_root)?;
+    let _guard = lock.write().map_err(|source| Error::RestoreOutput {
+        path: output_restore_lock_path(workspace_root)
+            .display()
+            .to_string(),
+        source,
+    })?;
     for output in prefetched {
-        let PrefetchedOutput { rel, blob_path, .. } = output;
+        let PrefetchedOutput {
+            rel,
+            digest,
+            blob_path,
+            ..
+        } = output;
         let abs = workspace_root.join(&rel);
+        if existing_output_matches_digest(&abs, digest) {
+            continue;
+        }
         restore_prefetched_output(&rel, &abs, &blob_path)?;
     }
     Ok(())
+}
+
+fn output_restore_lock(workspace_root: &Path) -> Result<RwLock<std::fs::File>> {
+    let path = output_restore_lock_path(workspace_root);
+    let parent = path.parent().expect("output restore lock has a parent");
+    std::fs::create_dir_all(parent).map_err(|source| Error::RestoreOutput {
+        path: parent.display().to_string(),
+        source,
+    })?;
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|source| Error::RestoreOutput {
+            path: path.display().to_string(),
+            source,
+        })?;
+    Ok(RwLock::new(file))
+}
+
+fn output_restore_lock_path(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".once/locks/output-restore.lock")
 }
 
 fn restore_prefetched_output(rel: &str, abs: &Path, blob_path: &Path) -> Result<()> {
@@ -115,22 +157,26 @@ fn spawn_output_validation(
 ) {
     let absolute = workspace_root.join(&path);
     tasks.spawn_blocking(move || {
-        let matches = existing_file_matches_digest(&absolute, digest);
+        let matches = existing_output_matches_digest(&absolute, digest);
         (path, digest, matches)
     });
 }
 
-fn existing_file_matches_digest(path: &Path, expected: Digest) -> bool {
+fn existing_output_matches_digest(path: &Path, expected: Digest) -> bool {
     let Ok(metadata) = std::fs::metadata(path) else {
         return false;
     };
-    if !metadata.is_file() {
-        return false;
+    if metadata.is_dir() {
+        return digest_directory_blob(path, OutputSymlinkMode::Preserve)
+            .is_ok_and(|digest| digest == expected);
     }
-    if digest_file_blob(path, &metadata).is_ok_and(|digest| digest == expected) {
+    if metadata.is_file()
+        && digest_file_blob(path, &metadata).is_ok_and(|digest| digest == expected)
+    {
         return true;
     }
-    std::fs::read(path).is_ok_and(|bytes| Digest::of_bytes(&bytes) == expected)
+    metadata.is_file()
+        && std::fs::read(path).is_ok_and(|bytes| Digest::of_bytes(&bytes) == expected)
 }
 
 async fn prefetch_output_blobs(
@@ -192,6 +238,7 @@ fn spawn_prefetch(
         Ok(PrefetchedOutput {
             index,
             rel,
+            digest,
             blob_path,
         })
     });
@@ -200,6 +247,7 @@ fn spawn_prefetch(
 struct PrefetchedOutput {
     index: usize,
     rel: String,
+    digest: Digest,
     blob_path: PathBuf,
 }
 
@@ -416,6 +464,38 @@ mod tests {
         let output_path = workspace.join("out/data.txt");
         std::fs::write(&output_path, b"payload").unwrap();
         let output = WorkspacePath::try_from("out/data.txt").unwrap();
+        let outputs = capture(
+            std::slice::from_ref(&output),
+            &workspace,
+            &cache,
+            OutputSymlinkMode::default(),
+        )
+        .await
+        .unwrap();
+        let result = ActionResult {
+            exit_code: 0,
+            stdout: None,
+            stderr: None,
+            outputs,
+        };
+        let modified = std::fs::metadata(&output_path).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        restore(&result, &workspace, &cache).await.unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&output_path).unwrap().modified().unwrap(),
+            modified
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_does_not_rewrite_an_unchanged_directory_output() {
+        let (_tmp, workspace, cache) = workspace_and_cache();
+        let output_path = workspace.join("out/tree/data.txt");
+        std::fs::create_dir_all(output_path.parent().unwrap()).unwrap();
+        std::fs::write(&output_path, b"payload").unwrap();
+        let output = WorkspacePath::try_from("out/tree").unwrap();
         let outputs = capture(
             std::slice::from_ref(&output),
             &workspace,

--- a/crates/once-core/src/outputs.rs
+++ b/crates/once-core/src/outputs.rs
@@ -177,9 +177,7 @@ fn existing_output_matches_digest(path: &Path, expected: Digest) -> bool {
         // the usual way match on the first hash.
         return [OutputSymlinkMode::default(), OutputSymlinkMode::Preserve]
             .into_iter()
-            .any(|mode| {
-                digest_directory_blob(path, mode).is_ok_and(|digest| digest == expected)
-            });
+            .any(|mode| digest_directory_blob(path, mode).is_ok_and(|digest| digest == expected));
     }
     if metadata.is_file()
         && digest_file_blob(path, &metadata).is_ok_and(|digest| digest == expected)

--- a/crates/once-core/src/outputs.rs
+++ b/crates/once-core/src/outputs.rs
@@ -167,8 +167,19 @@ fn existing_output_matches_digest(path: &Path, expected: Digest) -> bool {
         return false;
     };
     if metadata.is_dir() {
-        return digest_directory_blob(path, OutputSymlinkMode::Preserve)
-            .is_ok_and(|digest| digest == expected);
+        // The capture symlink mode is not carried in the cached
+        // `ActionResult`, so we cannot know which mode produced `expected`.
+        // The two modes only differ for directories containing symlinks that
+        // point outside the tree; for everything else they hash identically.
+        // Accept a match under either mode so the "already on disk, skip
+        // restore" optimization is not silently defeated for such outputs.
+        // The default mode is tried first, so unchanged directories captured
+        // the usual way match on the first hash.
+        return [OutputSymlinkMode::default(), OutputSymlinkMode::Preserve]
+            .into_iter()
+            .any(|mode| {
+                digest_directory_blob(path, mode).is_ok_and(|digest| digest == expected)
+            });
     }
     if metadata.is_file()
         && digest_file_blob(path, &metadata).is_ok_and(|digest| digest == expected)
@@ -517,6 +528,47 @@ mod tests {
 
         assert_eq!(
             std::fs::metadata(&output_path).unwrap().modified().unwrap(),
+            modified
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn restore_does_not_rewrite_an_unchanged_directory_output_with_external_symlink() {
+        let (tmp, workspace, cache) = workspace_and_cache();
+        let external = tmp.path().join("external.txt");
+        std::fs::write(&external, b"external payload").unwrap();
+        let tree = workspace.join("out/tree");
+        std::fs::create_dir_all(&tree).unwrap();
+        std::fs::write(tree.join("data.txt"), b"payload").unwrap();
+        std::os::unix::fs::symlink(&external, tree.join("link")).unwrap();
+
+        let output = WorkspacePath::try_from("out/tree").unwrap();
+        // Captured with the default mode, which materializes the external
+        // symlink's contents into the directory blob.
+        let outputs = capture(
+            std::slice::from_ref(&output),
+            &workspace,
+            &cache,
+            OutputSymlinkMode::default(),
+        )
+        .await
+        .unwrap();
+        let result = ActionResult {
+            exit_code: 0,
+            stdout: None,
+            stderr: None,
+            outputs,
+        };
+        let modified = std::fs::metadata(&tree).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        restore(&result, &workspace, &cache).await.unwrap();
+
+        // The on-disk tree already matches the cached digest, so restore must
+        // recognize it as unchanged rather than re-materializing it.
+        assert_eq!(
+            std::fs::metadata(&tree).unwrap().modified().unwrap(),
             modified
         );
     }

--- a/crates/once-core/src/runner.rs
+++ b/crates/once-core/src/runner.rs
@@ -996,6 +996,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn materialize_host_tree_rejects_destination_nested_under_source() {
+        let (tmp, cas) = fresh_cas();
+        // Source is a workspace directory and the destination resolves beneath
+        // it, so copying would recurse the fresh destination into itself.
+        let source = tmp.path().join("out");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("keep.rs"), "keep\n").unwrap();
+        let action = Action::MaterializeHostTree {
+            source,
+            source_sha256: "unused".to_string(),
+            destination: WorkspacePath::try_from("out/nested").unwrap(),
+            input_digest: Some(Digest::of_bytes(b"overlap-host-tree")),
+        };
+
+        let error = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidHostFile { .. }));
+        // The source data must be untouched.
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("out/keep.rs")).unwrap(),
+            "keep\n"
+        );
+    }
+
+    #[tokio::test]
     async fn copy_tree_action_replaces_destination_and_restores_from_cache() {
         let (tmp, cas) = fresh_cas();
         std::fs::create_dir_all(tmp.path().join("src/a")).unwrap();

--- a/crates/once-core/src/runner.rs
+++ b/crates/once-core/src/runner.rs
@@ -935,7 +935,7 @@ mod tests {
         std::fs::write(&executable, "#!/bin/sh\n").unwrap();
         std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
         symlink("src/lib.rs", source.join("linked.rs")).unwrap();
-        let source_sha256 = crate::execute::host_tree_sha256_hex(&source).unwrap();
+        let source_sha256 = once_host_tree::host_tree_sha256_hex(&source).unwrap();
         let action = Action::MaterializeHostTree {
             source: source.clone(),
             source_sha256,
@@ -980,7 +980,7 @@ mod tests {
         let source = tmp.path().join("crate");
         std::fs::create_dir_all(&source).unwrap();
         std::fs::write(source.join("source.rs"), "before\n").unwrap();
-        let source_sha256 = crate::execute::host_tree_sha256_hex(&source).unwrap();
+        let source_sha256 = once_host_tree::host_tree_sha256_hex(&source).unwrap();
         std::fs::write(source.join("source.rs"), "after\n").unwrap();
         let action = Action::MaterializeHostTree {
             source,

--- a/crates/once-core/src/runner.rs
+++ b/crates/once-core/src/runner.rs
@@ -921,6 +921,80 @@ mod tests {
         assert!(matches!(error, Error::HostFileDigestMismatch { .. }));
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn materialize_host_tree_preserves_modes_and_symlinks_and_replays_from_cache() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let (tmp, cas) = fresh_cas();
+        let host = TempDir::new().unwrap();
+        let source = host.path().join("crate");
+        std::fs::create_dir_all(source.join("src")).unwrap();
+        std::fs::write(source.join("src/lib.rs"), "pub fn value() {}\n").unwrap();
+        let executable = source.join("build-helper");
+        std::fs::write(&executable, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+        symlink("src/lib.rs", source.join("linked.rs")).unwrap();
+        let source_sha256 = crate::execute::host_tree_sha256_hex(&source).unwrap();
+        let action = Action::MaterializeHostTree {
+            source: source.clone(),
+            source_sha256,
+            destination: WorkspacePath::try_from("out/crate").unwrap(),
+            input_digest: Some(Digest::of_bytes(b"host-tree")),
+        };
+
+        let first = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(first.cache, CacheState::Miss);
+        assert_eq!(
+            std::fs::metadata(tmp.path().join("out/crate/build-helper"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert!(
+            std::fs::symlink_metadata(tmp.path().join("out/crate/linked.rs"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+
+        std::fs::remove_dir_all(source).unwrap();
+        std::fs::remove_dir_all(tmp.path().join("out/crate")).unwrap();
+        let second = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap();
+        assert_eq!(second.cache, CacheState::Hit);
+        assert_eq!(
+            std::fs::read_link(tmp.path().join("out/crate/linked.rs")).unwrap(),
+            std::path::PathBuf::from("src/lib.rs")
+        );
+    }
+
+    #[tokio::test]
+    async fn materialize_host_tree_rejects_content_changed_after_analysis() {
+        let (tmp, cas) = fresh_cas();
+        let source = tmp.path().join("crate");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("source.rs"), "before\n").unwrap();
+        let source_sha256 = crate::execute::host_tree_sha256_hex(&source).unwrap();
+        std::fs::write(source.join("source.rs"), "after\n").unwrap();
+        let action = Action::MaterializeHostTree {
+            source,
+            source_sha256,
+            destination: WorkspacePath::try_from("out/crate").unwrap(),
+            input_digest: Some(Digest::of_bytes(b"changed-host-tree")),
+        };
+
+        let error = run(&action, tmp.path(), &cas, RunOpts::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::HostFileDigestMismatch { .. }));
+    }
+
     #[tokio::test]
     async fn copy_tree_action_replaces_destination_and_restores_from_cache() {
         let (tmp, cas) = fresh_cas();

--- a/crates/once-frontend/Cargo.toml
+++ b/crates/once-frontend/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 base64.workspace = true
 glob.workspace = true
 include_dir = "0.7"
+once-host-tree.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/once-frontend/once.toml
+++ b/crates/once-frontend/once.toml
@@ -1,7 +1,10 @@
 [[target]]
 name = "once_frontend"
 kind = "rust_library"
-deps = ["cargo_dependencies"]
+deps = [
+  "crates/once-host-tree/once_host_tree",
+  "cargo_dependencies",
+]
 srcs = ["src/**/*.rs", "prelude/**/*.star", "prelude/examples/**"]
 
 [target.attrs]

--- a/crates/once-frontend/prelude/common.star
+++ b/crates/once-frontend/prelude/common.star
@@ -67,6 +67,9 @@ def native_project(target_kind, markers, name = None, target_name = None, docs =
         "requires_tools": requires_tools,
     }
 
+def _native_project_generated_dirs():
+    return ["_build", "deps", "target", "third_party", "vendor"]
+
 def target_kind(kind = None, docs = "", attrs = [], deps = [], providers = [], capabilities = [], examples = [], impl = None, resolver = None, tools = [], source_references = []):
     return {
         "_once_target_kind": True,

--- a/crates/once-frontend/prelude/elixir.star
+++ b/crates/once-frontend/prelude/elixir.star
@@ -3306,7 +3306,7 @@ mix = native_project(
     docs = "Recognizes a native Mix project from mix.exs.",
     markers = ["mix.exs"],
     inputs = ["mix.lock", ".formatter.exs", "config/**/*.exs"],
-    exclude = ["deps", "_build"],
+    exclude = _native_project_generated_dirs(),
     requires_tools = ["elixir"],
 )
 

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -2610,7 +2610,7 @@ def _cargo_package_id_set(packages):
 
 def _cargo_workspace_member_ids(metadata, packages = []):
     members = metadata.get("workspace_members")
-    if members != None:
+    if members:
         return {package_id: True for package_id in members}
     return _cargo_package_id_set([
         package

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -99,14 +99,26 @@ def _rust_crate_name(ctx):
 def _rust_crate_root(ctx, default_root):
     return _package_relative(ctx, _rust_attr(ctx, "crate_root", default_root))
 
-def _rust_sources(ctx, crate_root):
+def _rust_materialized_cargo_sources(ctx):
+    host_root = _rust_attr(ctx, "_cargo_source_root", "")
+    output_root = _rust_attr(ctx, "_cargo_materialized_source_root", "")
+    if not host_root or not output_root:
+        return []
+    materialize_host_tree(host_root, output_root)
+    return [output_root]
+
+def _rust_sources(ctx, crate_root, materialized_sources = []):
+    if materialized_sources:
+        return _unique(materialized_sources)
     resolved = ctx["attr"].get("_resolved_sources")
     srcs = _filter_by_extensions(resolved if resolved != None else glob(ctx["srcs"]), [".rs"])
     if crate_root not in srcs:
         srcs.append(crate_root)
     return _unique(srcs)
 
-def _rust_source_inputs(ctx):
+def _rust_source_inputs(ctx, materialized_sources = []):
+    if materialized_sources:
+        return _unique(materialized_sources)
     resolved = ctx["attr"].get("_resolved_source_inputs")
     if resolved != None:
         return resolved
@@ -1084,7 +1096,7 @@ def _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports):
     ])
     return "\n".join(lines)
 
-def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps, feature_flags):
+def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_args, dep_inputs, deps, metadata_deps, feature_flags, source_inputs, build_script_inputs):
     build_script = _rust_attr(ctx, "build_script", "")
     if not build_script:
         return (None, [], {}, None)
@@ -1132,7 +1144,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     run_script = _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports)
     run_action(
         argv = [host_which("sh"), "-c", run_script],
-        inputs = _unique([runner] + metadata_inputs + _rust_source_inputs(ctx) + _rust_build_script_inputs(ctx) + _rust_extra_inputs(ctx)),
+        inputs = _unique([runner] + metadata_inputs + source_inputs + build_script_inputs + _rust_extra_inputs(ctx)),
         outputs = [out_dir, stdout],
         env = run_env,
         toolchain_identity = identity + "\x00build-script-run",
@@ -1442,7 +1454,7 @@ def _rust_output_name(ctx, crate_type):
     crate_name = _rust_crate_name(ctx)
     target = _rust_effective_target(ctx, crate_type)
     if crate_type == "bin":
-        return crate_name + _rust_output_extension(crate_type, target)
+        return _rust_attr(ctx, "_binary_output_name", crate_name) + _rust_output_extension(crate_type, target)
     if crate_type == "rlib" or crate_type == "staticlib" or crate_type == "cdylib" or crate_type == "dylib" or crate_type == "proc-macro":
         prefix = "" if "windows" in (target or host_os()) and crate_type != "rlib" else "lib"
         return prefix + crate_name + _rust_extra_filename(ctx, crate_type) + _rust_output_extension(crate_type, target)
@@ -1472,7 +1484,10 @@ def _rust_compile(ctx, crate_type, default_root, output_name, test = False, prov
     crate_name = _rust_crate_name(ctx)
     edition = _rust_attr(ctx, "edition", "2021")
     crate_root = _rust_crate_root(ctx, default_root)
-    srcs = _rust_sources(ctx, crate_root)
+    materialized_sources = _rust_materialized_cargo_sources(ctx)
+    source_inputs = _rust_source_inputs(ctx, materialized_sources)
+    build_script_inputs = materialized_sources if materialized_sources else _rust_build_script_inputs(ctx)
+    srcs = _rust_sources(ctx, crate_root, materialized_sources)
     output = declare_output(_rust_declared_output(ctx, _rust_compile_output_name(ctx, crate_type, output_name)))
     aliases = _rust_aliases(ctx)
     deps = _rust_resolved_deps(ctx)
@@ -1485,7 +1500,7 @@ def _rust_compile(ctx, crate_type, default_root, output_name, test = False, prov
     build_dep_args.extend(build_dep_search_args)
     build_dep_inputs = _unique(_rust_dep_inputs(build_deps) + build_dep_search_inputs)
     feature_flags = _rust_feature_flags(ctx)
-    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps, feature_flags)
+    build_out_dir, build_inputs, build_env, build_stdout = _rust_build_script(ctx, rustc, identity, target, host_triple, edition, build_dep_args, build_dep_inputs, build_deps, deps + build_deps, feature_flags, source_inputs, build_script_inputs)
     compile_env = build_env if build_env else _rust_compile_action_env(ctx, target, host_triple)
     _rust_add_windows_rustc_runtime_path(compile_env, rustc, host_triple)
     _rust_add_windows_proc_macro_path(compile_env, deps)
@@ -1544,7 +1559,7 @@ def _rust_compile(ctx, crate_type, default_root, output_name, test = False, prov
         own_android_native_libraries.append({"abi": android_abi, "path": output})
     own_native_archives = [output] if crate_type == "staticlib" else []
     own_build_script_outputs = [build_stdout] if build_stdout else []
-    own_build_script_inputs = _rust_build_script_inputs(ctx) if build_stdout else []
+    own_build_script_inputs = build_script_inputs if build_stdout else []
     provider = {
         "label_id": ctx["label"]["id"],
         "target_kind": provider_kind,
@@ -1905,13 +1920,13 @@ fn parse_statuses(text: &str) -> BTreeMap<String, String> {
             continue;
         }
         let rest = &line[5..];
-        for (suffix, status) in [
-            (" ... ok", "passed"),
-            (" ... FAILED", "failed"),
-            (" ... ignored", "skipped"),
-        ] {
-            if let Some(name) = rest.strip_suffix(suffix) {
-                out.insert(name.to_string(), status.to_string());
+        if let Some(name) = rest.strip_suffix(" ... ok") {
+            out.insert(name.to_string(), "passed".to_string());
+        } else if let Some(name) = rest.strip_suffix(" ... FAILED") {
+            out.insert(name.to_string(), "failed".to_string());
+        } else if let Some((name, detail)) = rest.split_once(" ... ignored") {
+            if detail.is_empty() || detail.starts_with(", ") {
+                out.insert(name.to_string(), "skipped".to_string());
             }
         }
     }
@@ -2078,9 +2093,9 @@ def _cargo_feature_args(ctx):
         args.extend(["--features", ",".join(features)])
     return args
 
-def _cargo_resolved_metadata(ctx):
+def _cargo_resolved_metadata(ctx, default_vendor_dir = "third_party/rust/vendor", materialize_sources = False):
     manifest = _package_relative(ctx, _rust_attr(ctx, "manifest", "Cargo.toml"))
-    vendor_dir = _trim_trailing_slash(_rust_attr(ctx, "vendor_dir", "third_party/rust/vendor"))
+    vendor_dir = _trim_trailing_slash(_rust_attr(ctx, "vendor_dir", default_vendor_dir))
     target = _rust_target(ctx)
     metadata_file = _rust_attr(ctx, "metadata_file", "")
     host_metadata_file = _rust_attr(ctx, "host_metadata_file", "")
@@ -2113,7 +2128,7 @@ def _cargo_resolved_metadata(ctx):
         "label": ctx["label"],
         "attrs": resolver_attrs,
     }
-    resolution = _cargo_metadata_resolution(resolver_ctx, metadata, host_metadata)
+    resolution = _cargo_metadata_resolution(resolver_ctx, metadata, host_metadata, materialize_sources)
     return {
         "metadata": metadata,
         "specs": resolution["specs"],
@@ -2142,15 +2157,11 @@ def _cargo_resolver_target_specs(ctx, specs):
 def _cargo_workspace_dependency_names(metadata, id_to_target_name):
     packages = metadata.get("packages") or []
     nodes = _cargo_resolve_nodes(metadata)
-    workspace_package_ids = _cargo_package_id_set([
-        package
-        for package in packages
-        if package.get("source") == None
-    ])
+    workspace_package_ids = _cargo_workspace_member_ids(metadata, packages)
     dependencies = {}
     aliases = {}
     for package in packages:
-        if package.get("source") != None:
+        if not workspace_package_ids.get(package.get("id")):
             continue
         node = nodes.get(package.get("id")) or {}
         external_deps = [
@@ -2422,10 +2433,10 @@ def _cargo_source_suffix(source):
             out.append("_")
     return "".join(out)
 
-def _cargo_duplicate_counts(packages):
+def _cargo_duplicate_counts(packages, workspace_member_ids = {}):
     counts = {}
     for package in packages:
-        if package.get("source") == None:
+        if workspace_member_ids.get(package.get("id")):
             continue
         key = _cargo_key([package["name"], package["version"]])
         counts[key] = counts.get(key, 0) + 1
@@ -2491,8 +2502,8 @@ def _cargo_package_is_proc_macro(package):
 def _cargo_host_variant_name(package, duplicate_counts, target = ""):
     return _cargo_target_name(package, duplicate_counts, target) + "-host"
 
-def _cargo_host_dependency_ids(packages, nodes, host_nodes = None):
-    package_by_id, _ = _cargo_package_indexes(packages, _cargo_duplicate_counts(packages))
+def _cargo_host_dependency_ids(packages, nodes, host_nodes = None, workspace_member_ids = {}):
+    package_by_id, _ = _cargo_package_indexes(packages, _cargo_duplicate_counts(packages, workspace_member_ids), workspace_member_ids)
     if host_nodes == None:
         host_nodes = nodes
     needed = {}
@@ -2501,7 +2512,7 @@ def _cargo_host_dependency_ids(packages, nodes, host_nodes = None):
         package_id = package.get("id")
         if not package_id:
             continue
-        if package.get("source") == None:
+        if workspace_member_ids.get(package_id):
             if _cargo_build_script_target(package) != None:
                 node = nodes.get(package_id) or {}
                 for dep in node.get("deps") or []:
@@ -2509,7 +2520,7 @@ def _cargo_host_dependency_ids(packages, nodes, host_nodes = None):
                         continue
                     dep_id = dep.get("pkg")
                     dep_package = package_by_id.get(dep_id)
-                    if dep_package != None and dep_package.get("source") != None:
+                    if dep_package != None and not workspace_member_ids.get(dep_id):
                         stack.append(dep_id)
             continue
         if _cargo_package_is_proc_macro(package):
@@ -2520,7 +2531,7 @@ def _cargo_host_dependency_ids(packages, nodes, host_nodes = None):
                 if _cargo_dep_is_build(dep):
                     dep_id = dep.get("pkg")
                     dep_package = package_by_id.get(dep_id)
-                    if dep_package != None and dep_package.get("source") != None:
+                    if dep_package != None and not workspace_member_ids.get(dep_id):
                         stack.append(dep_id)
     for _ in range(len(packages) + 1):
         if len(stack) == 0:
@@ -2529,7 +2540,7 @@ def _cargo_host_dependency_ids(packages, nodes, host_nodes = None):
         stack = []
         for package_id in current:
             package = package_by_id.get(package_id)
-            if package == None or package.get("source") == None or package_id in needed:
+            if package == None or workspace_member_ids.get(package_id) or package_id in needed:
                 continue
             needed[package_id] = True
             node = host_nodes.get(package_id) or nodes.get(package_id) or {}
@@ -2539,16 +2550,16 @@ def _cargo_host_dependency_ids(packages, nodes, host_nodes = None):
                     continue
                 dep_id = dep.get("pkg")
                 dep_package = package_by_id.get(dep_id)
-                if dep_package != None and dep_package.get("source") != None and dep_id not in needed:
+                if dep_package != None and not workspace_member_ids.get(dep_id) and dep_id not in needed:
                     stack.append(dep_id)
     return needed
 
-def _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids, target = ""):
+def _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids, target = "", workspace_member_ids = {}):
     target_names = {}
     host_names = {}
     for package in packages:
         package_id = package.get("id")
-        if package.get("source") == None or not package_id:
+        if workspace_member_ids.get(package_id) or not package_id:
             continue
         target_name = _cargo_target_name(package, duplicate_counts, target)
         target_names[package_id] = target_name
@@ -2558,7 +2569,7 @@ def _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids,
             host_names[package_id] = _cargo_host_variant_name(package, duplicate_counts, target)
     return (target_names, host_names)
 
-def _cargo_package_indexes(packages, duplicate_counts):
+def _cargo_package_indexes(packages, duplicate_counts, workspace_member_ids = {}):
     by_id = {}
     id_to_target_name = {}
     for package in packages:
@@ -2566,7 +2577,7 @@ def _cargo_package_indexes(packages, duplicate_counts):
         if not package_id:
             continue
         by_id[package_id] = package
-        if package.get("source") != None:
+        if not workspace_member_ids.get(package_id):
             id_to_target_name[package_id] = _cargo_target_name(package, duplicate_counts)
     return (by_id, id_to_target_name)
 
@@ -2597,6 +2608,16 @@ def _cargo_package_id_set(packages):
             ids[package_id] = True
     return ids
 
+def _cargo_workspace_member_ids(metadata, packages = []):
+    members = metadata.get("workspace_members")
+    if members != None:
+        return {package_id: True for package_id in members}
+    return _cargo_package_id_set([
+        package
+        for package in packages
+        if package.get("source") == None
+    ])
+
 def _cargo_dep_is_runtime(dep):
     saw_kind = False
     for kind in dep.get("dep_kinds") or []:
@@ -2611,13 +2632,20 @@ def _cargo_dep_is_build(dep):
             return True
     return False
 
-def _cargo_metadata_dep_refs(node, id_to_target_name, include_runtime, include_build, fail_missing = False):
+def _cargo_dep_is_dev(dep):
+    for kind in dep.get("dep_kinds") or []:
+        if kind.get("kind") == "dev":
+            return True
+    return False
+
+def _cargo_metadata_dep_refs(node, id_to_target_name, include_runtime, include_build, fail_missing = False, include_dev = False):
     deps = []
     aliases = {}
     for dep in node.get("deps") or []:
         runtime = include_runtime and _cargo_dep_is_runtime(dep)
         build = include_build and _cargo_dep_is_build(dep)
-        if not runtime and not build:
+        dev = include_dev and _cargo_dep_is_dev(dep)
+        if not runtime and not build and not dev:
             continue
         dep_id = dep.get("pkg")
         target_name = id_to_target_name.get(dep_id)
@@ -2631,8 +2659,8 @@ def _cargo_metadata_dep_refs(node, id_to_target_name, include_runtime, include_b
             aliases[target_name] = local_name
     return (_unique(deps), aliases)
 
-def _cargo_metadata_deps(node, id_to_target_name, include_build, fail_missing = False):
-    return _cargo_metadata_dep_refs(node, id_to_target_name, True, include_build, fail_missing)
+def _cargo_metadata_deps(node, id_to_target_name, include_build, fail_missing = False, include_dev = False):
+    return _cargo_metadata_dep_refs(node, id_to_target_name, True, include_build, fail_missing, include_dev)
 
 def _cargo_metadata_build_deps(node, id_to_target_name, fail_missing = False):
     return _cargo_metadata_dep_refs(node, id_to_target_name, False, True, fail_missing)
@@ -2661,7 +2689,7 @@ def _cargo_package_field(package, key):
     return value
 
 def _cargo_rustc_env(package, target, source_root):
-    crate_name = target.get("name") or package["name"].replace("-", "_")
+    crate_name = _cargo_crate_name(package, target)
     version = package["version"]
     components = _cargo_version_components(version)
     env = {
@@ -2682,15 +2710,17 @@ def _cargo_rustc_env(package, target, source_root):
         "CARGO_PKG_VERSION_PATCH": components["patch"],
         "CARGO_PKG_VERSION_PRE": components["pre"],
     }
+    if "bin" in (target.get("kind") or []) or "example" in (target.get("kind") or []):
+        env["CARGO_BIN_NAME"] = target.get("name") or package["name"]
     links = package.get("links")
     if links != None:
         env["CARGO_MANIFEST_LINKS"] = links
     return env
 
-def _cargo_metadata_attrs(package, target, node, source_root, crate_root, aliases):
+def _cargo_metadata_attrs(package, target, node, source_root, crate_root, aliases, host_source_root = ""):
     attrs = {
         "package_name": package["name"],
-        "crate_name": target.get("name") or package["name"].replace("-", "_"),
+        "crate_name": _cargo_crate_name(package, target),
         "version": package["version"],
         "crate_root": crate_root,
         "edition": target.get("edition") or package.get("edition") or "2021",
@@ -2701,6 +2731,9 @@ def _cargo_metadata_attrs(package, target, node, source_root, crate_root, aliase
     }
     if aliases:
         attrs["crate_aliases"] = aliases
+    if host_source_root:
+        attrs["_cargo_source_root"] = host_source_root
+        attrs["_cargo_materialized_source_root"] = source_root
     build_script = _cargo_build_script_target(package)
     if build_script != None:
         attrs["build_script"] = source_root + "/" + _cargo_source_rel(package, build_script)
@@ -2714,20 +2747,20 @@ def _cargo_merge_aliases(left, right):
         out[key] = value
     return out
 
-def _cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, aliases, rust_target, host_tool = False):
-    attrs = _cargo_metadata_attrs(package, target, node, source_root, crate_root, aliases)
+def _cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, aliases, rust_target, host_tool = False, host_source_root = ""):
+    attrs = _cargo_metadata_attrs(package, target, node, source_root, crate_root, aliases, host_source_root)
     if rust_target:
         attrs["target"] = rust_target
     checksum = package.get("checksum")
     if checksum != None:
         attrs["checksum"] = checksum
-    if attrs.get("build_script"):
+    if attrs.get("build_script") and not host_source_root:
         attrs["_build_script_inputs"] = [source_root + "/**"]
     spec = {
         "name": name,
         "kind": kind,
         "deps": deps,
-        "srcs": _cargo_package_source_globs(source_root),
+        "srcs": [] if host_source_root else _cargo_package_source_globs(source_root),
         "attrs": attrs,
         "host_tool": host_tool,
     }
@@ -2735,21 +2768,30 @@ def _cargo_metadata_target_spec(package, target, node, source_root, crate_root, 
         spec["build_deps"] = build_deps
     return spec
 
-def _cargo_metadata_resolution(ctx, metadata, host_metadata = None):
+def _cargo_materialized_source_root(ctx, target_name):
+    package = (ctx.get("label") or {}).get("package") or ""
+    target_id = package + "/" + target_name if package else target_name
+    return ".once/out/" + target_id + "/source"
+
+def _cargo_metadata_resolution(ctx, metadata, host_metadata = None, materialize_sources = False):
     target_packages = metadata.get("packages") or []
     host_packages = host_metadata.get("packages") if host_metadata != None else []
     packages = _cargo_merge_packages(target_packages, host_packages)
+    workspace_member_ids = _cargo_workspace_member_ids(metadata, target_packages)
+    if host_metadata != None:
+        for package_id in _cargo_workspace_member_ids(host_metadata, host_packages).keys():
+            workspace_member_ids[package_id] = True
     target_package_ids = _cargo_package_id_set(target_packages)
-    duplicate_counts = _cargo_duplicate_counts(packages)
+    duplicate_counts = _cargo_duplicate_counts(packages, workspace_member_ids)
     nodes = _cargo_resolve_nodes(metadata)
     host_nodes = _cargo_resolve_nodes(host_metadata) if host_metadata != None else nodes
-    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes, host_nodes)
+    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes, host_nodes, workspace_member_ids)
     vendor_dir = _trim_trailing_slash(ctx["attrs"].get("vendor_dir") or "vendor")
     rust_target = ctx["attrs"].get("target") or ""
-    id_to_target_name, id_to_host_name = _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids, rust_target)
+    id_to_target_name, id_to_host_name = _cargo_dependency_name_maps(packages, duplicate_counts, host_dependency_ids, rust_target, workspace_member_ids)
     targets = []
     for package in packages:
-        if package.get("source") == None:
+        if workspace_member_ids.get(package.get("id")):
             continue
         target = _cargo_library_target(package)
         if target == None:
@@ -2757,7 +2799,8 @@ def _cargo_metadata_resolution(ctx, metadata, host_metadata = None):
         package_id = package.get("id")
         name = id_to_target_name.get(package_id) or _cargo_target_name(package, duplicate_counts, rust_target)
         kind = _cargo_kind_for_target(target)
-        source_root = _cargo_vendor_source_root(ctx, vendor_dir, package, _cargo_target_name(package, duplicate_counts))
+        host_source_root = _cargo_package_root(package) if materialize_sources else ""
+        source_root = _cargo_materialized_source_root(ctx, name) if materialize_sources else _cargo_vendor_source_root(ctx, vendor_dir, package, _cargo_target_name(package, duplicate_counts))
         rel_root = _cargo_source_rel(package, target)
         crate_root = source_root + "/" + rel_root
         node = nodes.get(package_id) or {}
@@ -2767,19 +2810,20 @@ def _cargo_metadata_resolution(ctx, metadata, host_metadata = None):
         if kind == "rust_proc_macro":
             deps, aliases = _cargo_metadata_deps(host_node, id_to_host_name, False, True)
             build_deps, build_aliases = _cargo_metadata_build_deps(host_node, id_to_host_name, True) if has_build_script else ([], {})
-            targets.append(_cargo_metadata_target_spec(package, target, host_node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), ""))
+            targets.append(_cargo_metadata_target_spec(package, target, host_node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), "", host_source_root = host_source_root))
             continue
 
         if target_package_ids.get(package_id):
             deps, aliases = _cargo_metadata_deps(node, id_to_target_name, False, True)
             build_deps, build_aliases = _cargo_metadata_build_deps(node, id_to_host_name, True) if has_build_script else ([], {})
-            targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), rust_target))
+            targets.append(_cargo_metadata_target_spec(package, target, node, source_root, crate_root, name, kind, deps, build_deps, _cargo_merge_aliases(aliases, build_aliases), rust_target, host_source_root = host_source_root))
 
         host_name = id_to_host_name.get(package_id)
         if host_name:
+            host_materialized_source_root = _cargo_materialized_source_root(ctx, host_name) if materialize_sources else source_root
             host_deps, host_aliases = _cargo_metadata_deps(host_node, id_to_host_name, False, True)
             host_build_deps, host_build_aliases = _cargo_metadata_build_deps(host_node, id_to_host_name, True) if has_build_script else ([], {})
-            targets.append(_cargo_metadata_target_spec(package, target, host_node, source_root, crate_root, host_name, kind, host_deps, host_build_deps, _cargo_merge_aliases(host_aliases, host_build_aliases), "", host_tool = True))
+            targets.append(_cargo_metadata_target_spec(package, target, host_node, host_materialized_source_root, host_materialized_source_root + "/" + rel_root, host_name, kind, host_deps, host_build_deps, _cargo_merge_aliases(host_aliases, host_build_aliases), "", host_tool = True, host_source_root = host_source_root))
     workspace_deps, workspace_dep_aliases = _cargo_workspace_dependency_names(metadata, id_to_target_name)
     return {
         "specs": targets,
@@ -2837,13 +2881,23 @@ def _cargo_workspace_source_root(ctx, package):
 def _cargo_workspace_name(value):
     return "cargo_" + value.replace("-", "_").replace(".", "_")
 
+def _cargo_crate_name(package, target):
+    return (target.get("name") or package["name"]).replace("-", "_")
+
 def _cargo_workspace_library_names(packages):
     names = {}
     for package in packages:
-        target = _cargo_library_target(package)
+        target = _cargo_workspace_library_target(package)
         if target != None:
             names[package["id"]] = _cargo_workspace_name(package["name"])
     return names
+
+def _cargo_workspace_library_target(package):
+    for target in package.get("targets") or []:
+        kind = _cargo_workspace_target_kind(target)
+        if kind == "library" or kind == "proc_macro":
+            return target
+    return None
 
 def _cargo_workspace_target_name(package, target, kind, library_names):
     if kind == "library" or kind == "proc_macro":
@@ -2865,15 +2919,38 @@ def _cargo_workspace_target_kind(target):
         return "proc_macro"
     if "test" in kinds or "bench" in kinds:
         return "test"
+    if "lib" in kinds or any([crate_type in ["lib", "rlib", "staticlib", "cdylib", "dylib"] for crate_type in crate_types]):
+        return "library"
     if "bin" in kinds or "example" in kinds:
         return "binary"
-    if "lib" in kinds or "rlib" in crate_types or "lib" in crate_types:
-        return "library"
     return ""
+
+def _cargo_workspace_crate_types(target, kind):
+    if kind != "library":
+        return []
+    crate_types = []
+    for crate_type in target.get("crate_types") or []:
+        normalized = "rlib" if crate_type == "lib" else crate_type
+        if normalized in ["rlib", "staticlib", "cdylib", "dylib"] and normalized not in crate_types:
+            crate_types.append(normalized)
+    if not crate_types:
+        crate_types.append("rlib")
+    if "rlib" in crate_types:
+        crate_types = ["rlib"] + [crate_type for crate_type in crate_types if crate_type != "rlib"]
+    return crate_types
+
+def _cargo_workspace_target_enabled(target, node):
+    enabled = {}
+    for feature in node.get("features") or []:
+        enabled[feature] = True
+    for feature in target.get("required-features") or []:
+        if not enabled.get(feature):
+            return False
+    return True
 
 def _cargo_workspace_attrs(package, target, node, source_root, aliases):
     attrs = {
-        "crate_name": target.get("name") or package["name"].replace("-", "_"),
+        "crate_name": _cargo_crate_name(package, target),
         "crate_root": source_root + "/" + _cargo_source_rel(package, target),
         "edition": target.get("edition") or package.get("edition") or "2021",
         "features": node.get("features") or [],
@@ -2882,6 +2959,8 @@ def _cargo_workspace_attrs(package, target, node, source_root, aliases):
     }
     if aliases:
         attrs["crate_aliases"] = aliases
+    if "bin" in (target.get("kind") or []) or "example" in (target.get("kind") or []):
+        attrs["_binary_output_name"] = target.get("name") or package["name"]
     build_script = _cargo_build_script_target(package)
     if build_script != None:
         attrs["build_script"] = source_root + "/" + _cargo_source_rel(package, build_script)
@@ -2895,8 +2974,8 @@ def _cargo_workspace_dep_maps(metadata, external_names, local_names):
         target_names[package_id] = name
     return target_names
 
-def _cargo_workspace_target_spec(package, target, node, kind, source_root, target_names, build_target_names, local_library):
-    deps, aliases = _cargo_metadata_deps(node, target_names, False, True)
+def _cargo_workspace_target_spec(package, target, node, kind, source_root, target_names, build_target_names, local_library, rust_target = ""):
+    deps, aliases = _cargo_metadata_deps(node, target_names, False, True, kind == "test")
     build_deps, build_aliases = _cargo_metadata_build_deps(node, build_target_names, True)
     name = _cargo_workspace_target_name(
         package,
@@ -2908,7 +2987,7 @@ def _cargo_workspace_target_spec(package, target, node, kind, source_root, targe
         local_ref = "./" + local_library
         if local_ref not in deps:
             deps.append(local_ref)
-        library = _cargo_library_target(package)
+        library = _cargo_workspace_library_target(package)
         if library != None:
             aliases[local_library] = library.get("name") or package["name"].replace("-", "_")
     attrs = _cargo_workspace_attrs(
@@ -2918,6 +2997,8 @@ def _cargo_workspace_target_spec(package, target, node, kind, source_root, targe
         source_root,
         _cargo_merge_aliases(aliases, build_aliases),
     )
+    if rust_target and kind != "proc_macro":
+        attrs["target"] = rust_target
     target_kind = {
         "library": "rust_library",
         "proc_macro": "rust_proc_macro",
@@ -2935,25 +3016,45 @@ def _cargo_workspace_target_spec(package, target, node, kind, source_root, targe
         spec["dependencies"] = {"build_deps": build_deps}
     return spec
 
+def _cargo_workspace_target_specs(package, target, node, kind, source_root, target_names, build_target_names, local_library, rust_target = ""):
+    crate_types = _cargo_workspace_crate_types(target, kind)
+    if not crate_types:
+        return [_cargo_workspace_target_spec(package, target, node, kind, source_root, target_names, build_target_names, local_library, rust_target)]
+    specs = []
+    for index, crate_type in enumerate(crate_types):
+        spec = _cargo_workspace_target_spec(package, target, node, kind, source_root, target_names, build_target_names, local_library, rust_target)
+        spec["attrs"]["crate_type"] = crate_type
+        if index > 0:
+            spec["name"] += "_" + crate_type.replace("-", "_")
+        specs.append(spec)
+    return specs
+
 def _cargo_workspace_resolver(ctx):
     _cargo_require_resolver_file(ctx, "manifest", "Cargo.toml")
     _cargo_require_resolver_file(ctx, "lockfile", "Cargo.lock")
-    resolved = _cargo_resolved_metadata(ctx)
+    vendor_dir = _rust_attr(ctx, "vendor_dir", "")
+    resolved = _cargo_resolved_metadata(ctx, vendor_dir, not vendor_dir)
     metadata = resolved["metadata"]
     packages = metadata.get("packages") or []
+    workspace_member_ids = _cargo_workspace_member_ids(metadata, packages)
     workspace_packages = [
         package
         for package in packages
-        if package.get("source") == None
+        if workspace_member_ids.get(package.get("id"))
     ]
-    duplicate_counts = _cargo_duplicate_counts(packages)
+    default_member_ids = {
+        package_id: True
+        for package_id in (metadata.get("workspace_default_members") or metadata.get("workspace_members") or workspace_member_ids.keys())
+    }
+    duplicate_counts = _cargo_duplicate_counts(packages, workspace_member_ids)
     nodes = _cargo_resolve_nodes(metadata)
-    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes)
+    host_dependency_ids = _cargo_host_dependency_ids(packages, nodes, workspace_member_ids = workspace_member_ids)
     external_names, host_external_names = _cargo_dependency_name_maps(
         packages,
         duplicate_counts,
         host_dependency_ids,
         _rust_target(ctx),
+        workspace_member_ids,
     )
     library_names = _cargo_workspace_library_names(workspace_packages)
     target_names = _cargo_workspace_dep_maps(metadata, external_names, library_names)
@@ -2968,11 +3069,13 @@ def _cargo_workspace_resolver(ctx):
         node = nodes.get(package.get("id")) or {}
         local_library = library_names.get(package.get("id")) or ""
         for target in package.get("targets") or []:
+            if not _cargo_workspace_target_enabled(target, node):
+                continue
             kind = _cargo_workspace_target_kind(target)
             if not kind:
                 continue
             names = host_target_names if kind == "proc_macro" else target_names
-            spec = _cargo_workspace_target_spec(
+            specs = _cargo_workspace_target_specs(
                 package,
                 target,
                 node,
@@ -2981,10 +3084,11 @@ def _cargo_workspace_resolver(ctx):
                 names,
                 host_target_names,
                 local_library,
+                _rust_target(ctx),
             )
-            targets.append(spec)
-            if kind != "test":
-                roots.append(spec["name"])
+            targets.extend(specs)
+            if kind != "test" and default_member_ids.get(package.get("id")):
+                roots.extend([spec["name"] for spec in specs])
 
             if kind != "test" and target.get("test"):
                 test_spec = _cargo_workspace_target_spec(
@@ -2996,8 +3100,9 @@ def _cargo_workspace_resolver(ctx):
                     target_names,
                     host_target_names,
                     local_library if kind != "library" else "",
+                    _rust_target(ctx),
                 )
-                test_spec["name"] = spec["name"] + "_unit_tests"
+                test_spec["name"] = specs[0]["name"] + "_unit_tests"
                 targets.append(test_spec)
 
     return {
@@ -3041,6 +3146,9 @@ _RUST_COMMON_ATTRS = [
     attr("named_deps", "map<string, string>", default = "{}", docs = "Buck-compatible alias map from local extern crate name to dependency label or crate name.", configurable = False),
     attr("cargo_package", "string", docs = "Cargo package name used to select direct external deps from a cargo_dependencies dependency set. Defaults to CARGO_PKG_NAME when present.", configurable = False),
     attr("build_script", "string", docs = "Package-relative Cargo build script path. Once compiles and runs it before rustc, consumes common cargo:rustc-* stdout directives, and passes direct dependency links metadata as DEP_* env vars.", configurable = False),
+    attr("_binary_output_name", "string", docs = "Resolver-owned executable name before the platform extension.", configurable = False),
+    attr("_cargo_source_root", "string", docs = "Resolver-owned absolute Cargo source directory materialized through a declared host-tree action.", configurable = False),
+    attr("_cargo_materialized_source_root", "string", docs = "Resolver-owned Once output directory for one materialized Cargo package.", configurable = False),
     attr("default_deps", "string", docs = "Reserved Buck-compatible default dependency mode.", configurable = False),
     attr("doc_deps", "list<string>", default = "[]", docs = "Reserved for Rust documentation-only dependencies.", configurable = False, implemented = False),
     attr("doc_env", "map<string, string>", default = "{}", docs = "Reserved for Rust documentation action environments.", configurable = False, implemented = False),
@@ -3099,7 +3207,7 @@ cargo_workspace = target_kind(
         attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative text globs supplied to native project resolution. Defaults to srcs when empty.", configurable = False),
         attr("metadata_file", "string", docs = "Optional checked-in JavaScript Object Notation output from cargo metadata.", configurable = False),
         attr("host_metadata_file", "string", docs = "Optional checked-in host Cargo metadata snapshot.", configurable = False),
-        attr("vendor_dir", "string", default = "vendor", docs = "Package-relative directory containing vendored crate sources.", configurable = False),
+        attr("vendor_dir", "string", docs = "Optional package-relative directory containing pre-vendored crate sources. When omitted, Once snapshots locked sources from Cargo's local cache into target outputs.", configurable = False),
         attr("features", "list<string>", default = "[]", docs = "Cargo features passed to `cargo metadata --features`.", configurable = True),
         attr("all_features", "bool", default = "false", docs = "Pass `--all-features` to Cargo metadata.", configurable = True),
         attr("no_default_features", "bool", default = "false", docs = "Pass `--no-default-features` to Cargo metadata.", configurable = True),
@@ -3127,7 +3235,7 @@ cargo = native_project(
     markers = ["Cargo.toml"],
     target_name = "cargo",
     inputs = ["Cargo.lock", "**/Cargo.toml", ".cargo/config", ".cargo/config.toml"],
-    exclude = ["target", "vendor", "third_party"],
+    exclude = _native_project_generated_dirs(),
     on_match = "stop",
     requires_tools = ["cargo", "rustc"],
 )

--- a/crates/once-frontend/src/analysis/globals.rs
+++ b/crates/once-frontend/src/analysis/globals.rs
@@ -468,6 +468,58 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
         Ok(NoneType)
     }
 
+    /// Snapshot an absolute host directory into a workspace-relative output.
+    /// The source tree digest is captured during analysis and verified again
+    /// on execution, so cache identity follows files, modes, and symlinks.
+    fn materialize_host_tree(source: &str, destination: &str) -> anyhow::Result<NoneType> {
+        if !analysis_active() {
+            return Ok(NoneType);
+        }
+        let source_path = Path::new(source);
+        if !source_path.is_absolute() {
+            return Err(anyhow!(
+                "materialize_host_tree source must be absolute, got `{source}`"
+            ));
+        }
+        if !source_path.is_dir() {
+            return Err(anyhow!(
+                "materialize_host_tree source is not a directory: `{source}`"
+            ));
+        }
+        let source_sha256 = host_tree_sha256_hex(source_path)
+            .with_context(|| format!("hashing host directory `{source}`"))?;
+        let action = DeclaredAction {
+            operation: Some(DeclaredActionOperation::MaterializeHostTree {
+                source: source.to_string(),
+                source_sha256,
+                destination: destination.to_string(),
+            }),
+            argv: Vec::new(),
+            arg_files: Vec::new(),
+            inputs: Vec::new(),
+            outputs: vec![destination.to_string()],
+            stdout: None,
+            stderr: None,
+            clean_paths: Vec::new(),
+            create_dirs: Vec::new(),
+            cwd: None,
+            env: BTreeMap::new(),
+            sandbox: None,
+            success_exit_codes: vec![0],
+            cacheable: true,
+            inherit_parent_env: false,
+            depends_on_prior_actions: true,
+            toolchain_identity: None,
+            identifier: Some(format!("materialize_host_tree:{destination}")),
+        };
+        with_store_mut(|store| {
+            if let Some(store) = store {
+                store.actions.push(action);
+            }
+        });
+        Ok(NoneType)
+    }
+
     /// Link one workspace path to another without copying or caching
     /// the linked contents. Downstream actions still hash the linked
     /// tree when they declare it as an input.
@@ -1228,6 +1280,71 @@ fn file_sha256_hex(path: &Path) -> Result<String> {
         hasher.update(&buf[..read]);
     }
     Ok(hex_lower(&hasher.finalize()))
+}
+
+fn host_tree_sha256_hex(root: &Path) -> Result<String> {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"once.host_tree.v1\0");
+    hash_host_tree_directory(root, root, &mut hasher)?;
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+fn hash_host_tree_directory(
+    root: &Path,
+    directory: &Path,
+    hasher: &mut sha2::Sha256,
+) -> Result<()> {
+    let mut children = std::fs::read_dir(directory)?.collect::<std::io::Result<Vec<_>>>()?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let path = child.path();
+        let metadata = std::fs::symlink_metadata(&path)?;
+        let relative = path
+            .strip_prefix(root)
+            .with_context(|| {
+                format!(
+                    "making `{}` relative to `{}`",
+                    path.display(),
+                    root.display()
+                )
+            })?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let kind = if metadata.file_type().is_symlink() {
+            b'l'
+        } else if metadata.is_dir() {
+            b'd'
+        } else if metadata.is_file() {
+            b'f'
+        } else {
+            continue;
+        };
+        hasher.update([kind]);
+        hasher.update(relative.as_bytes());
+        hasher.update([0]);
+        hasher.update(host_file_mode(&metadata).to_le_bytes());
+        if metadata.file_type().is_symlink() {
+            hasher.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
+        } else if metadata.is_file() {
+            hasher.update(file_sha256_hex(&path)?.as_bytes());
+        }
+        hasher.update([0]);
+        if metadata.is_dir() {
+            hash_host_tree_directory(root, &path, hasher)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn host_file_mode(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode()
+}
+
+#[cfg(not(unix))]
+fn host_file_mode(_metadata: &std::fs::Metadata) -> u32 {
+    0
 }
 
 fn hex_lower(bytes: &[u8]) -> String {

--- a/crates/once-frontend/src/analysis/globals.rs
+++ b/crates/once-frontend/src/analysis/globals.rs
@@ -486,7 +486,7 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
                 "materialize_host_tree source is not a directory: `{source}`"
             ));
         }
-        let source_sha256 = host_tree_sha256_hex(source_path)
+        let source_sha256 = once_host_tree::host_tree_sha256_hex(source_path)
             .with_context(|| format!("hashing host directory `{source}`"))?;
         let action = DeclaredAction {
             operation: Some(DeclaredActionOperation::MaterializeHostTree {
@@ -1280,71 +1280,6 @@ fn file_sha256_hex(path: &Path) -> Result<String> {
         hasher.update(&buf[..read]);
     }
     Ok(hex_lower(&hasher.finalize()))
-}
-
-fn host_tree_sha256_hex(root: &Path) -> Result<String> {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(b"once.host_tree.v1\0");
-    hash_host_tree_directory(root, root, &mut hasher)?;
-    Ok(hex_lower(&hasher.finalize()))
-}
-
-fn hash_host_tree_directory(
-    root: &Path,
-    directory: &Path,
-    hasher: &mut sha2::Sha256,
-) -> Result<()> {
-    let mut children = std::fs::read_dir(directory)?.collect::<std::io::Result<Vec<_>>>()?;
-    children.sort_by_key(std::fs::DirEntry::file_name);
-    for child in children {
-        let path = child.path();
-        let metadata = std::fs::symlink_metadata(&path)?;
-        let relative = path
-            .strip_prefix(root)
-            .with_context(|| {
-                format!(
-                    "making `{}` relative to `{}`",
-                    path.display(),
-                    root.display()
-                )
-            })?
-            .to_string_lossy()
-            .replace('\\', "/");
-        let kind = if metadata.file_type().is_symlink() {
-            b'l'
-        } else if metadata.is_dir() {
-            b'd'
-        } else if metadata.is_file() {
-            b'f'
-        } else {
-            continue;
-        };
-        hasher.update([kind]);
-        hasher.update(relative.as_bytes());
-        hasher.update([0]);
-        hasher.update(host_file_mode(&metadata).to_le_bytes());
-        if metadata.file_type().is_symlink() {
-            hasher.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
-        } else if metadata.is_file() {
-            hasher.update(file_sha256_hex(&path)?.as_bytes());
-        }
-        hasher.update([0]);
-        if metadata.is_dir() {
-            hash_host_tree_directory(root, &path, hasher)?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn host_file_mode(metadata: &std::fs::Metadata) -> u32 {
-    use std::os::unix::fs::PermissionsExt;
-    metadata.permissions().mode()
-}
-
-#[cfg(not(unix))]
-fn host_file_mode(_metadata: &std::fs::Metadata) -> u32 {
-    0
 }
 
 fn hex_lower(bytes: &[u8]) -> String {

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -32,6 +32,11 @@ pub enum DeclaredActionOperation {
         source_sha256: String,
         destination: String,
     },
+    MaterializeHostTree {
+        source: String,
+        source_sha256: String,
+        destination: String,
+    },
     PreparePath {
         path: String,
         mode: DeclaredPreparePathMode,

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -916,6 +916,28 @@ fn materialize_host_file_records_a_content_addressed_operation() {
 }
 
 #[test]
+fn materialize_host_tree_records_a_content_addressed_operation() {
+    let tmp = TempDir::new().unwrap();
+    let source = tmp.path().join("toolchain");
+    std::fs::create_dir_all(source.join("bin")).unwrap();
+    std::fs::write(source.join("bin/tool"), b"toolchain").unwrap();
+    let store = store_for(tmp.path(), "p");
+    let source_literal = serde_json::to_string(source.to_str().unwrap()).unwrap();
+    let script = format!("materialize_host_tree({source_literal}, \".once/out/p/toolchain\")");
+    let (store, ()) = with_active_store(store, || run(&script).unwrap());
+
+    assert_eq!(store.actions.len(), 1);
+    assert!(matches!(
+        store.actions[0].operation,
+        Some(DeclaredActionOperation::MaterializeHostTree {
+            ref source_sha256,
+            ref destination,
+            ..
+        }) if source_sha256.len() == 64 && destination == ".once/out/p/toolchain"
+    ));
+}
+
+#[test]
 fn run_action_records_command_setup_paths() {
     let tmp = TempDir::new().unwrap();
     let store = store_for(tmp.path(), "p");

--- a/crates/once-frontend/src/module_contract.rs
+++ b/crates/once-frontend/src/module_contract.rs
@@ -318,6 +318,10 @@ pub fn module_authoring_contract() -> ModuleAuthoringContract {
                 "Snapshot a content-verified absolute host toolchain file into a workspace output.",
             ),
             entry(
+                "materialize_host_tree(source, destination)",
+                "Snapshot a content-verified absolute host directory into one workspace directory output while preserving file modes and symbolic links.",
+            ),
+            entry(
                 "link_path(source, destination, identifier = None)",
                 "Declare an uncached relative workspace link from an existing source without copying or caching the linked contents.",
             ),
@@ -617,6 +621,10 @@ mod tests {
             .action_primitives
             .iter()
             .any(|entry| entry.signature.starts_with("materialize_host_file(")));
+        assert!(contract
+            .action_primitives
+            .iter()
+            .any(|entry| entry.signature.starts_with("materialize_host_tree(")));
         assert!(contract
             .schema_invariants
             .iter()

--- a/crates/once-frontend/src/native_project.rs
+++ b/crates/once-frontend/src/native_project.rs
@@ -494,4 +494,28 @@ mod tests {
             .iter()
             .any(|matched| matched.native_project == "cargo" && matched.package == "rust/member"));
     }
+
+    #[test]
+    fn built_in_native_projects_ignore_generated_dependency_trees() {
+        let temporary = tempfile::tempdir().unwrap();
+        std::fs::write(temporary.path().join("mix.exs"), "raise \"not executed\"\n").unwrap();
+        std::fs::create_dir_all(temporary.path().join("deps/native")).unwrap();
+        std::fs::write(
+            temporary.path().join("deps/native/Cargo.toml"),
+            "[package]\nname = \"native\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(temporary.path().join("target/tool")).unwrap();
+        std::fs::write(
+            temporary.path().join("target/tool/mix.exs"),
+            "raise \"not executed\"\n",
+        )
+        .unwrap();
+
+        let matches = detect_native_projects(temporary.path()).unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].native_project, "mix");
+        assert!(matches[0].package.is_empty());
+    }
 }

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -164,6 +164,38 @@ fn every_impl_backed_target_kind_has_a_schema_example() {
 
 #[cfg(unix)]
 #[test]
+fn cargo_native_project_loads_without_a_once_manifest() {
+    let schemas = built_in_target_kind_schemas_result().expect("built-in target kind schemas load");
+    let schema = schemas
+        .iter()
+        .find(|schema| schema.kind == "cargo_workspace")
+        .expect("cargo_workspace schema");
+    let bundle = load_target_kind_example(schema, "cargo-workspace-native-project")
+        .expect("Cargo native project example materializes");
+    let tmp = TempDir::new().expect("tempdir");
+    materialize(tmp.path(), &bundle);
+    fs::remove_file(tmp.path().join("once.toml")).expect("remove explicit Once manifest");
+
+    let graph = once_frontend::load_graph_workspace(tmp.path())
+        .expect("Cargo native project graph loads without once.toml");
+    let kinds_by_id = graph
+        .iter()
+        .map(|target| (target.label.id.as_str(), target.kind.as_str()))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(kinds_by_id.get("cargo"), Some(&"cargo_workspace"));
+    assert_eq!(
+        kinds_by_id.get("cargo_once_native_project_example"),
+        Some(&"rust_library")
+    );
+    assert_eq!(
+        kinds_by_id.get("cargo_once_native_project_example_unit_tests"),
+        Some(&"rust_test")
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn mix_native_project_lints_in_the_development_environment() {
     let schemas = built_in_target_kind_schemas_result().expect("built-in target kind schemas load");
     let schema = schemas

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -8430,6 +8430,297 @@ fn prelude_cargo_workspace_edges_reject_missing_providers() {
 }
 
 #[test]
+fn prelude_cargo_normalizes_hyphenated_crate_names() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+package = {{
+    "name": "demo-tool",
+    "version": "1.0.0",
+}}
+target = {{
+    "name": "demo-tool",
+    "kind": ["bin"],
+}}
+env = _cargo_rustc_env(package, target, ".")
+example_env = _cargo_rustc_env(package, {{
+    "name": "demo-example",
+    "kind": ["example"],
+}}, ".")
+result = repr([
+    _cargo_crate_name(package, target),
+    env["CARGO_CRATE_NAME"],
+    env["CARGO_BIN_NAME"],
+    example_env["CARGO_BIN_NAME"],
+])
+"#
+    );
+
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        "[\"demo_tool\", \"demo_tool\", \"demo-tool\", \"demo-example\"]"
+    );
+}
+
+#[test]
+fn prelude_cargo_native_workspace_materializes_cached_sources() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+root_id = "path+file:///workspace#root@0.1.0"
+dependency_id = "registry+https://registry.example/index#demo@1.0.0"
+metadata = {{
+    "workspace_members": [root_id],
+    "packages": [
+        {{
+            "id": root_id,
+            "name": "root",
+            "version": "0.1.0",
+            "source": None,
+            "manifest_path": "/workspace/Cargo.toml",
+            "targets": [],
+        }},
+        {{
+            "id": dependency_id,
+            "name": "demo",
+            "version": "1.0.0",
+            "source": "registry+https://registry.example/index",
+            "manifest_path": "/cargo/cache/demo-1.0.0/Cargo.toml",
+            "targets": [{{
+                "name": "demo",
+                "kind": ["lib"],
+                "crate_types": ["lib"],
+                "src_path": "/cargo/cache/demo-1.0.0/src/lib.rs",
+                "edition": "2021",
+            }}],
+        }},
+    ],
+    "resolve": {{"nodes": [
+        {{"id": root_id, "features": [], "deps": []}},
+        {{"id": dependency_id, "features": [], "deps": []}},
+    ]}},
+}}
+resolution = _cargo_metadata_resolution({{
+    "label": {{"package": "pkg", "name": "cargo", "id": "pkg/cargo"}},
+    "attrs": {{}},
+}}, metadata, None, True)
+target = resolution["specs"][0]
+result = repr([
+    target["srcs"],
+    target["attrs"]["_cargo_source_root"],
+    target["attrs"]["_cargo_materialized_source_root"],
+    target["attrs"]["crate_root"],
+])
+"#
+    );
+
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[[], "/cargo/cache/demo-1.0.0", ".once/out/pkg/demo-1.0.0/source", ".once/out/pkg/demo-1.0.0/source/src/lib.rs"]"#
+    );
+}
+
+#[test]
+fn prelude_rust_materializes_resolver_owned_host_source_tree() {
+    let workspace = TempDir::new().unwrap();
+    let host_root = workspace.path().join("cargo-cache/demo-1.0.0");
+    std::fs::create_dir_all(host_root.join("src")).unwrap();
+    std::fs::write(
+        host_root.join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(host_root.join("src/lib.rs"), "pub fn demo() {}\n").unwrap();
+    let host_root = host_root.to_string_lossy();
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def _rustc_toolchain(target):
+    return ("rustc", "rustc-test", "test-host-triple")
+
+ctx = {{
+    "label": {{"package": "pkg", "name": "demo", "id": "pkg/demo"}},
+    "attr": {{
+        "crate_name": "demo",
+        "crate_root": ".once/out/pkg/demo/source/src/lib.rs",
+        "_cargo_source_root": {host_root:?},
+        "_cargo_materialized_source_root": ".once/out/pkg/demo/source",
+    }},
+    "deps": [],
+    "srcs": [],
+}}
+_rust_compile(ctx, "rlib", "src/lib.rs", "libdemo.rlib")
+result = repr("ok")
+"#
+    );
+    let store = store_for(workspace.path(), "pkg/demo");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(out.unwrap(), "\"ok\"");
+    assert!(matches!(
+        store.actions[0].operation,
+        Some(DeclaredActionOperation::MaterializeHostTree {
+            ref source,
+            ref destination,
+            ..
+        }) if source.ends_with("cargo-cache/demo-1.0.0")
+            && destination == ".once/out/pkg/demo/source"
+    ));
+    let rustc = action_by_identifier(&store, "pkg/demo:rustc");
+    assert!(
+        rustc
+            .inputs
+            .iter()
+            .any(|input| input == ".once/out/pkg/demo/source"),
+        "{:?}",
+        rustc.inputs
+    );
+}
+
+#[test]
+fn prelude_cargo_skips_targets_with_disabled_required_features() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+target = {{"required-features": ["standalone", "windows"]}}
+result = repr([
+    _cargo_workspace_target_enabled(target, {{"features": ["standalone"]}}),
+    _cargo_workspace_target_enabled(target, {{"features": ["standalone", "windows"]}}),
+])
+"#
+    );
+
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        "[False, True]"
+    );
+}
+
+#[test]
+fn prelude_cargo_emits_each_declared_library_crate_type() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+package = {{
+    "id": "demo-id",
+    "name": "demo",
+    "version": "1.0.0",
+    "targets": [],
+}}
+target = {{
+    "name": "demo",
+    "kind": ["lib"],
+    "crate_types": ["staticlib", "rlib", "cdylib"],
+    "src_path": "/workspace/src/lib.rs",
+    "edition": "2021",
+}}
+specs = _cargo_workspace_target_specs(
+    package,
+    target,
+    {{"features": [], "deps": []}},
+    "library",
+    ".",
+    {{}},
+    {{}},
+    "cargo_demo",
+    "aarch64-unknown-linux-gnu",
+)
+result = repr([
+    [[spec["name"], spec["attrs"]["crate_type"], spec["attrs"]["target"]] for spec in specs],
+    _cargo_workspace_target_kind({{
+        "kind": ["example"],
+        "crate_types": ["staticlib"],
+    }}),
+])
+"#
+    );
+
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[[["cargo_demo", "rlib", "aarch64-unknown-linux-gnu"], ["cargo_demo_staticlib", "staticlib", "aarch64-unknown-linux-gnu"], ["cargo_demo_cdylib", "cdylib", "aarch64-unknown-linux-gnu"]], "library"]"#
+    );
+}
+
+#[test]
+fn prelude_cargo_treats_nonmember_path_packages_as_dependencies() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+root_id = "path+file:///workspace#root@0.1.0"
+path_id = "path+file:///shared#shared@1.0.0"
+metadata = {{
+    "workspace_members": [root_id],
+    "packages": [
+        {{
+            "id": root_id,
+            "name": "root",
+            "version": "0.1.0",
+            "source": None,
+            "manifest_path": "/workspace/Cargo.toml",
+            "targets": [],
+        }},
+        {{
+            "id": path_id,
+            "name": "shared",
+            "version": "1.0.0",
+            "source": None,
+            "manifest_path": "/shared/Cargo.toml",
+            "targets": [{{
+                "name": "shared",
+                "kind": ["lib"],
+                "crate_types": ["lib"],
+                "src_path": "/shared/src/lib.rs",
+                "edition": "2021",
+            }}],
+        }},
+    ],
+    "resolve": {{"nodes": [
+        {{"id": root_id, "features": [], "deps": []}},
+        {{"id": path_id, "features": [], "deps": []}},
+    ]}},
+}}
+resolution = _cargo_metadata_resolution({{
+    "label": {{"package": "", "name": "cargo", "id": "cargo"}},
+    "attrs": {{}},
+}}, metadata, None, True)
+result = repr([
+    len(resolution["specs"]),
+    resolution["specs"][0]["name"],
+    resolution["specs"][0]["attrs"]["_cargo_source_root"],
+])
+"#
+    );
+
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[1, "shared-1.0.0", "/shared"]"#
+    );
+}
+
+#[test]
+fn prelude_cargo_test_targets_include_development_dependencies() {
+    let prelude = all_prelude_source();
+    let source = format!(
+        r#"{prelude}
+node = {{"deps": [
+    {{"name": "runtime", "pkg": "runtime-id", "dep_kinds": [{{"kind": None}}]}},
+    {{"name": "test_support", "pkg": "dev-id", "dep_kinds": [{{"kind": "dev"}}]}},
+]}}
+names = {{"runtime-id": "runtime-target", "dev-id": "dev-target"}}
+library_deps, _library_aliases = _cargo_metadata_deps(node, names, False, True)
+test_deps, test_aliases = _cargo_metadata_deps(node, names, False, True, True)
+result = repr([library_deps, test_deps, test_aliases])
+"#
+    );
+
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["./runtime-target"], ["./runtime-target", "./dev-target"], {"runtime-target": "runtime", "dev-target": "test_support"}]"#
+    );
+}
+
+#[test]
 fn prelude_cargo_ignores_unused_build_dependencies_without_a_build_script() {
     let prelude = all_prelude_source();
     let source = format!(

--- a/crates/once-host-tree/Cargo.toml
+++ b/crates/once-host-tree/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "once-host-tree"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+sha2.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/once-host-tree/once.toml
+++ b/crates/once-host-tree/once.toml
@@ -1,0 +1,15 @@
+[[target]]
+name = "once_host_tree"
+kind = "rust_library"
+deps = ["cargo_dependencies"]
+srcs = ["src/**/*.rs"]
+
+[target.attrs]
+crate_name = "once_host_tree"
+crate_root = "src/lib.rs"
+edition = "2021"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once-host-tree"
+CARGO_PKG_NAME = "once-host-tree"
+CARGO_PKG_VERSION = "0.0.0"

--- a/crates/once-host-tree/src/lib.rs
+++ b/crates/once-host-tree/src/lib.rs
@@ -10,6 +10,13 @@
 //! The digest is stable and order-independent: directory entries are visited
 //! sorted by file name, and each entry contributes its kind, workspace-relative
 //! path, mode, and either its symlink target or its file content hash.
+//!
+//! Symlinks contribute only their target text, not the contents behind them.
+//! That is sound for links that stay inside the tree, but a link whose target
+//! resolves outside the tree would let external contents change without moving
+//! the digest, while output capture materializes those same external contents.
+//! To keep the digest an honest cache key, a symlink proven to point outside
+//! the tree is rejected rather than silently under-hashed.
 
 use std::path::Path;
 
@@ -19,15 +26,18 @@ use sha2::Digest as _;
 ///
 /// Entries that are neither files, directories, nor symlinks (sockets, fifos,
 /// device nodes) are skipped so the digest depends only on portable content.
+/// Fails if a symlink resolves to a target outside `root`.
 pub fn host_tree_sha256_hex(root: &Path) -> std::io::Result<String> {
+    let root_canonical = root.canonicalize()?;
     let mut hasher = sha2::Sha256::new();
     hasher.update(b"once.host_tree.v1\0");
-    hash_host_tree_directory(root, root, &mut hasher)?;
+    hash_host_tree_directory(root, &root_canonical, root, &mut hasher)?;
     Ok(hex_lower(&hasher.finalize()))
 }
 
 fn hash_host_tree_directory(
     root: &Path,
+    root_canonical: &Path,
     directory: &Path,
     hasher: &mut sha2::Sha256,
 ) -> std::io::Result<()> {
@@ -55,16 +65,48 @@ fn hash_host_tree_directory(
         hasher.update([0]);
         hasher.update(host_file_mode(&metadata).to_le_bytes());
         if metadata.file_type().is_symlink() {
-            hasher.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
+            let target = std::fs::read_link(&path)?;
+            if symlink_target_escapes(root_canonical, &path, &target) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "host tree `{}` contains symlink `{}` pointing outside the tree; \
+                         external symlink targets are not supported because their contents \
+                         cannot be tracked in the tree digest",
+                        root.display(),
+                        path.display()
+                    ),
+                ));
+            }
+            hasher.update(target.to_string_lossy().as_bytes());
         } else if metadata.is_file() {
             hasher.update(file_sha256_hex(&path)?.as_bytes());
         }
         hasher.update([0]);
         if metadata.is_dir() {
-            hash_host_tree_directory(root, &path, hasher)?;
+            hash_host_tree_directory(root, root_canonical, &path, hasher)?;
         }
     }
     Ok(())
+}
+
+/// Whether `target` (as read from the symlink at `symlink_path`) provably
+/// resolves outside `root_canonical`. A target that cannot be resolved (a
+/// dangling link) is treated as inside: it carries no external contents to
+/// track, so hashing its link text alone stays sound.
+fn symlink_target_escapes(root_canonical: &Path, symlink_path: &Path, target: &Path) -> bool {
+    let resolved = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        match symlink_path.parent() {
+            Some(parent) => parent.join(target),
+            None => target.to_path_buf(),
+        }
+    };
+    match resolved.canonicalize() {
+        Ok(canonical) => !canonical.starts_with(root_canonical),
+        Err(_) => false,
+    }
 }
 
 fn file_sha256_hex(path: &Path) -> std::io::Result<String> {
@@ -132,6 +174,42 @@ mod tests {
         let second = host_tree_sha256_hex(tmp.path()).unwrap();
         assert_eq!(first, second);
         assert_eq!(first.len(), 64);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn internal_symlink_is_hashed_by_target_text() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("real.txt"), b"payload").unwrap();
+        std::os::unix::fs::symlink("real.txt", tmp.path().join("link.txt")).unwrap();
+        // A link that stays inside the tree is accepted and stable.
+        let first = host_tree_sha256_hex(tmp.path()).unwrap();
+        let second = host_tree_sha256_hex(tmp.path()).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_symlink_is_rejected() {
+        let outside = tempfile::TempDir::new().unwrap();
+        let external = outside.path().join("secret.txt");
+        std::fs::write(&external, b"external payload").unwrap();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::os::unix::fs::symlink(&external, tmp.path().join("link.txt")).unwrap();
+
+        let err = host_tree_sha256_hex(tmp.path()).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_is_accepted() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::os::unix::fs::symlink("does-not-exist", tmp.path().join("link.txt")).unwrap();
+        // Unresolvable links carry no external contents, so hashing the link
+        // text alone stays sound and must not error.
+        assert_eq!(host_tree_sha256_hex(tmp.path()).unwrap().len(), 64);
     }
 
     #[test]

--- a/crates/once-host-tree/src/lib.rs
+++ b/crates/once-host-tree/src/lib.rs
@@ -1,0 +1,149 @@
+//! Canonical content hash for a host directory tree.
+//!
+//! `materialize_host_tree` records this digest at analysis time and
+//! re-verifies it at execution time. The two happen in different crates, so
+//! the hashing must live in one place: any drift between an analysis-side and
+//! an execution-side implementation would make every `materialize_host_tree`
+//! build fail with a spurious digest mismatch even when nothing on disk
+//! changed. Keep this the single source of truth.
+//!
+//! The digest is stable and order-independent: directory entries are visited
+//! sorted by file name, and each entry contributes its kind, workspace-relative
+//! path, mode, and either its symlink target or its file content hash.
+
+use std::path::Path;
+
+use sha2::Digest as _;
+
+/// Hash the directory rooted at `root` into a lowercase hex digest.
+///
+/// Entries that are neither files, directories, nor symlinks (sockets, fifos,
+/// device nodes) are skipped so the digest depends only on portable content.
+pub fn host_tree_sha256_hex(root: &Path) -> std::io::Result<String> {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"once.host_tree.v1\0");
+    hash_host_tree_directory(root, root, &mut hasher)?;
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+fn hash_host_tree_directory(
+    root: &Path,
+    directory: &Path,
+    hasher: &mut sha2::Sha256,
+) -> std::io::Result<()> {
+    let mut children = std::fs::read_dir(directory)?.collect::<std::io::Result<Vec<_>>>()?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let path = child.path();
+        let metadata = std::fs::symlink_metadata(&path)?;
+        let relative = path
+            .strip_prefix(root)
+            .map_err(std::io::Error::other)?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let kind = if metadata.file_type().is_symlink() {
+            b'l'
+        } else if metadata.is_dir() {
+            b'd'
+        } else if metadata.is_file() {
+            b'f'
+        } else {
+            continue;
+        };
+        hasher.update([kind]);
+        hasher.update(relative.as_bytes());
+        hasher.update([0]);
+        hasher.update(host_file_mode(&metadata).to_le_bytes());
+        if metadata.file_type().is_symlink() {
+            hasher.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
+        } else if metadata.is_file() {
+            hasher.update(file_sha256_hex(&path)?.as_bytes());
+        }
+        hasher.update([0]);
+        if metadata.is_dir() {
+            hash_host_tree_directory(root, &path, hasher)?;
+        }
+    }
+    Ok(())
+}
+
+fn file_sha256_hex(path: &Path) -> std::io::Result<String> {
+    use std::io::Read;
+
+    let file = std::fs::File::open(path)?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut hasher = sha2::Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+#[cfg(unix)]
+fn host_file_mode(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode()
+}
+
+#[cfg(not(unix))]
+fn host_file_mode(_metadata: &std::fs::Metadata) -> u32 {
+    0
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_directory_hashes_to_the_version_prefix_only() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // sha256("once.host_tree.v1\0")
+        assert_eq!(
+            host_tree_sha256_hex(tmp.path()).unwrap(),
+            {
+                let mut hasher = sha2::Sha256::new();
+                hasher.update(b"once.host_tree.v1\0");
+                hex_lower(&hasher.finalize())
+            }
+        );
+    }
+
+    #[test]
+    fn digest_is_stable_and_order_independent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("sub")).unwrap();
+        std::fs::write(tmp.path().join("b.txt"), b"b").unwrap();
+        std::fs::write(tmp.path().join("a.txt"), b"a").unwrap();
+        std::fs::write(tmp.path().join("sub/c.txt"), b"c").unwrap();
+
+        let first = host_tree_sha256_hex(tmp.path()).unwrap();
+        let second = host_tree_sha256_hex(tmp.path()).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+    }
+
+    #[test]
+    fn content_change_changes_the_digest() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), b"a").unwrap();
+        let before = host_tree_sha256_hex(tmp.path()).unwrap();
+        std::fs::write(tmp.path().join("a.txt"), b"changed").unwrap();
+        let after = host_tree_sha256_hex(tmp.path()).unwrap();
+        assert_ne!(before, after);
+    }
+}

--- a/crates/once-host-tree/src/lib.rs
+++ b/crates/once-host-tree/src/lib.rs
@@ -113,14 +113,11 @@ mod tests {
     fn empty_directory_hashes_to_the_version_prefix_only() {
         let tmp = tempfile::TempDir::new().unwrap();
         // sha256("once.host_tree.v1\0")
-        assert_eq!(
-            host_tree_sha256_hex(tmp.path()).unwrap(),
-            {
-                let mut hasher = sha2::Sha256::new();
-                hasher.update(b"once.host_tree.v1\0");
-                hex_lower(&hasher.finalize())
-            }
-        );
+        assert_eq!(host_tree_sha256_hex(tmp.path()).unwrap(), {
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(b"once.host_tree.v1\0");
+            hex_lower(&hasher.finalize())
+        });
     }
 
     #[test]

--- a/crates/once/once.toml
+++ b/crates/once/once.toml
@@ -3,6 +3,7 @@ name = "once"
 kind = "rust_library"
 deps = [
   "crates/once-cas/once_cas",
+  "crates/once-host-tree/once_host_tree",
   "crates/once-core/once_core",
   "crates/once-frontend/once_frontend",
   "cargo_dependencies",

--- a/mise/tasks/release/write-rust-release-manifests.sh
+++ b/mise/tasks/release/write-rust-release-manifests.sh
@@ -32,6 +32,7 @@ done
 manifest_files=(
   once.toml
   crates/once-cas/once.toml
+  crates/once-host-tree/once.toml
   crates/once-core/once.toml
   crates/once-frontend/once.toml
   crates/once/once.toml
@@ -126,6 +127,29 @@ CARGO_PKG_VERSION = "${version}"
 # once release generated targets end
 EOF
 
+cat >>crates/once-host-tree/once.toml <<EOF
+# once release generated targets start
+[[target]]
+name = "once_host_tree_${suffix}"
+kind = "rust_library"
+deps = ["${dependency_target}"]
+srcs = ["src/**/*.rs"]
+
+[target.attrs]
+crate_name = "once_host_tree"
+crate_root = "src/lib.rs"
+edition = "2021"
+target = "${target}"
+rustc_flags = ${release_flags}
+cargo_package = "once-host-tree"
+
+[target.attrs.rustc_env]
+CARGO_MANIFEST_DIR = "crates/once-host-tree"
+CARGO_PKG_NAME = "once-host-tree"
+CARGO_PKG_VERSION = "${version}"
+# once release generated targets end
+EOF
+
 cat >>crates/once-core/once.toml <<EOF
 # once release generated targets start
 [[target]]
@@ -133,6 +157,7 @@ name = "once_core_${suffix}"
 kind = "rust_library"
 deps = [
   "crates/once-cas/once_cas_${suffix}",
+  "crates/once-host-tree/once_host_tree_${suffix}",
   "${dependency_target}",
 ]
 srcs = ["src/**/*.rs"]
@@ -158,7 +183,10 @@ cat >>crates/once-frontend/once.toml <<EOF
 [[target]]
 name = "once_frontend_${suffix}"
 kind = "rust_library"
-deps = ["${dependency_target}"]
+deps = [
+  "crates/once-host-tree/once_host_tree_${suffix}",
+  "${dependency_target}",
+]
 srcs = ["src/**/*.rs", "prelude/**/*.star", "prelude/examples/**"]
 
 [target.attrs]
@@ -183,6 +211,7 @@ name = "once_cdylib_${suffix}"
 kind = "rust_library"
 deps = [
   "crates/once-cas/once_cas_${suffix}",
+  "crates/once-host-tree/once_host_tree_${suffix}",
   "crates/once-core/once_core_${suffix}",
   "crates/once-frontend/once_frontend_${suffix}",
   "${dependency_target}",
@@ -208,6 +237,7 @@ name = "once_staticlib_${suffix}"
 kind = "rust_library"
 deps = [
   "crates/once-cas/once_cas_${suffix}",
+  "crates/once-host-tree/once_host_tree_${suffix}",
   "crates/once-core/once_core_${suffix}",
   "crates/once-frontend/once_frontend_${suffix}",
   "${dependency_target}",
@@ -237,6 +267,7 @@ name = "once_cli_${suffix}"
 kind = "rust_binary"
 deps = [
   "crates/once-cas/once_cas_${suffix}",
+  "crates/once-host-tree/once_host_tree_${suffix}",
   "crates/once-core/once_core_${suffix}",
   "crates/once-frontend/once_frontend_${suffix}",
   "${dependency_target}",

--- a/rfcs/0007-native-project-discovery.md
+++ b/rfcs/0007-native-project-discovery.md
@@ -191,7 +191,13 @@ procedural macros, build scripts, and external packages.
 
 `on_match = "stop"` lets a workspace root own its members. Cargo remains
 authoritative for membership, features, resolved versions, build scripts, and
-target metadata.
+target metadata. Targets gated by unselected required features are omitted,
+test targets include development dependencies, and Cargo target names are
+normalized to valid Rust crate identifiers. Locked external sources are
+snapshotted from Cargo's local cache into target-owned outputs, without assuming
+that the project owns a `vendor` directory. Cargo's explicit workspace member
+set distinguishes first-party packages from local path dependencies, and
+multi-output libraries emit one target per declared Rust library crate type.
 
 ### Future Ecosystems
 

--- a/spec/test_capability_spec.sh
+++ b/spec/test_capability_spec.sh
@@ -917,4 +917,17 @@ KOTLIN
     The stdout should include 'spec/cli_surface_spec.sh::lists commands'
     The stdout should include 'spec/graph_query_spec.sh::lists declared targets'
   End
+
+  It 'queries summarized shellspec test results without case records'
+    create_shellspec_test_workspace
+    once --format json test cli_e2e >/dev/null
+
+    When call once --format json query test-results cli_e2e --summary-only
+    The status should be success
+    The stdout should include '"schema":"once.test_results_summary.v1"'
+    The stdout should include '"source_schema":"once.test_results.v1"'
+    The stdout should include '"target":"cli_e2e"'
+    The stdout should include '"status":"passed"'
+    The stdout should not include 'spec/cli_surface_spec.sh::lists commands'
+  End
 End

--- a/web/priv/changelog/2026-07-29-native-cargo-project-graphs.md
+++ b/web/priv/changelog/2026-07-29-native-cargo-project-graphs.md
@@ -1,0 +1,24 @@
+---
+title: Native Cargo project graphs
+date: 2026-07-29
+---
+
+Once can now read an existing `Cargo.toml` and turn it into a typed, cacheable
+build graph. Rust developers can build, run, and test a workspace without first
+translating it into `once.toml`.
+
+Native discovery understands Cargo workspaces and the locked dependency closure
+from `Cargo.lock`, including registry, Git, and path packages. Each workspace
+member and locked dependency compiles as its own action, so unchanged work can
+be restored independently from a local or remote cache. Procedural macros and
+build scripts are modeled as their own targets so they rebuild only when their
+own inputs change.
+
+Once keeps `Cargo.toml` and `Cargo.lock` authoritative and uses the Rust
+toolchain selected by the project's configuration. Test targets report their
+results through the same normalized shape as the other ecosystems, so scheduled
+runs, change-scoped selection, and summaries work the same way.
+
+Start by running `once query native-project cargo`, inspect the derived targets
+with `once query targets`, then use `once build`, `once run`, and `once test`
+with the target identifiers Once reports.

--- a/web/priv/docs/guide/graph/ecosystems.md
+++ b/web/priv/docs/guide/graph/ecosystems.md
@@ -83,8 +83,9 @@ query-before-build workflow, current limitations, and follow-up steps:
   binaries, Android Kotlin sources, and Kotlin/Native Apple frameworks.
 - [Go](/guide/graph/go) covers package archives, executables, tests, cgo,
   cross-compilation, and locked vendored modules.
-- [Rust](/guide/graph/rust) covers libraries, binaries, tests, procedural
-  macros, Cargo dependencies, and native mobile outputs.
+- [Rust](/guide/graph/rust) starts from an existing `Cargo.toml`, then covers
+  optional manifest adoption, libraries, binaries, tests, procedural macros,
+  Cargo dependencies, and native mobile outputs.
 - [React Native](/guide/graph/react-native) covers New Architecture
   dependencies, native modules, JavaScript bundles, Apple and Android
   applications, and Fast Refresh.

--- a/web/priv/docs/guide/graph/index.md
+++ b/web/priv/docs/guide/graph/index.md
@@ -168,11 +168,17 @@ Initialize the seed when the native project selection should be reviewed and sto
 
 ```sh
 once edit init-native-project mix
+once edit init-native-project cargo
 ```
 
 Initialization writes only the seed target to `once.toml`. The native project
 description and lockfile remain authoritative for dependencies, products,
 tests, and releases. Repeating an identical initialization makes no change.
+
+The native seed can remain the only target, or it can live beside explicit
+targets for exceptional build boundaries. Keep manifest data in `once.toml`
+and introduce a project Starlark module only when reusable behavior is missing
+from the built-in target kinds.
 
 An explicit Once target for the same target kind takes precedence in its
 package. Unrelated targets do not hide a native project in the same package or

--- a/web/priv/docs/guide/graph/rust.md
+++ b/web/priv/docs/guide/graph/rust.md
@@ -5,62 +5,223 @@ next: false
 
 # Rust
 
-Once can build Rust libraries, binaries, tests, procedural macros, and native
-mobile libraries. This guide starts with one local library, a binary that uses
-it, and a test for the same code. Cargo dependency resolution comes after that
-first working graph.
+Once can read an existing `Cargo.toml`, derive a typed build graph, and cache
+each workspace package and locked dependency separately. You can build, run,
+and test the project without first translating it into `once.toml`.
 
-## Prerequisites
+## Start With an Existing Cargo Project
 
-Install the repository's pinned Rust toolchain through mise:
+### Check the Toolchain
+
+Once invokes `rustc` and `cargo` from the selected toolchain. Confirm that the
+versions expected by the project are available:
+
+```sh
+rustc --version
+cargo --version
+```
+
+If the repository uses [mise](https://mise.jdx.dev/) to pin them, install and
+activate that configuration first:
 
 ```sh
 mise install
 mise exec -- rustc --version
+mise exec -- cargo --version
 ```
 
 Host binaries and tests also need the platform linker selected by the Rust
-compiler. Cross-compiled and mobile outputs require the linker and target
+compiler. Cross-compiled and mobile outputs require the linker and Rust target
 support for their destination platform.
 
-## Use `Cargo.toml` Directly
+### Materialize Locked Dependencies
 
-A locked Cargo project can derive its first-party and external Once targets
-without a hand-written `once.toml`:
+Once does not download dependencies or change `Cargo.lock`. If the project has
+a current lockfile, populate Cargo's local source cache from its exact
+resolution:
 
 ```sh
-cargo generate-lockfile
+cargo fetch --locked
+```
+
+Run `cargo generate-lockfile` once when the lockfile needs to be created or
+deliberately updated. Review that change before continuing. Once requires a
+concrete lockfile when a project declares external dependencies. Library
+maintainers who do not commit `Cargo.lock` can generate one locally, but
+repeatable builds on another machine require the same resolution.
+
+### Preview the Derived Graph
+
+From the directory that contains the root `Cargo.toml`, inspect the match and
+the first-party targets:
+
+```sh
 once query native-projects
-once query native-project cargo
-once query targets
+once query targets --kind rust_binary
+once query targets --kind rust_library
+once query targets --kind rust_test
+```
+
+No `once.toml` is required, and these commands do not write one. If a
+repository contains several independent Cargo projects, select one explicitly:
+
+```sh
+once query native-project cargo --package tools/linter
 ```
 
 The `cargo_workspace` seed runs locked, offline Cargo metadata. It emits
 first-party libraries, binaries, procedural macros, unit and integration test
 targets, build-script edges, and locked external packages.
 
-Build or test a generated target by the identifier returned from
-`once query targets`. For example:
+The complete preview includes locked external packages, so it can be large.
+Request it only when you need to inspect the full expansion:
+
+```sh
+once query native-project cargo
+```
+
+The identifiers printed by `once query targets` are the source of truth.
+Generated first-party identifiers carry their package and Cargo target role.
+For a package named `hello` with a binary also named `hello`, discovery
+normally derives `cargo_hello_bin_hello` and
+`cargo_hello_bin_hello_unit_tests`.
+
+Cargo workspaces use their shallowest matching `Cargo.toml`, so member
+manifests do not create duplicate native project seeds. Cargo remains
+authoritative for workspace membership, default members, features, target
+metadata, and resolved versions. Local path packages outside the workspace
+remain dependency targets instead of becoming first-party workspace members.
+
+Once snapshots external package trees from Cargo's local cache into target
+outputs. It preserves files, executable modes, and symbolic links without
+copying sources into the repository. It does not reuse or modify a repository's
+`vendor` directory.
+
+An explicit `vendor_dir` remains available for repositories that already
+manage pre-vendored Cargo sources. Graph loading never acquires sources or
+changes `Cargo.lock`.
+
+Targets gated by Cargo `required-features` appear only when every required
+feature is selected. Generated test targets include the package's development
+dependencies, and hyphenated Cargo target names are normalized for the Rust
+compiler automatically. Multi-output libraries expose each declared Rust
+library crate type as a separate generated target.
+
+### Build, Run, and Test
+
+Use a generated identifier through the same commands as every other Once
+graph:
 
 ```sh
 once build cargo_hello_bin_hello
+once run cargo_hello_bin_hello
 once test cargo_hello_bin_hello_unit_tests
 ```
 
-Cargo workspaces use their shallowest matching `Cargo.toml`, so member
-manifests do not create duplicate native project seeds. Cargo remains authoritative
-for workspace membership, features, target metadata, and resolved versions.
+Ask Once about a target before invoking it when its role is not obvious:
 
-Projects with external packages must materialize their locked sources into the
-native project's `vendor` directory and configure Cargo source replacement before
-building. Graph loading never acquires sources or changes `Cargo.lock`.
+```sh
+once query capabilities cargo_hello_bin_hello
+```
 
-Initialize the stable seed when the repository should record the native
-project selection:
+Outputs are materialized under `.once/out/<target>/`. The
+[`rust_binary` reference](/reference/prelude/rust_binary) and
+[`rust_test` reference](/reference/prelude/rust_test) list their executable,
+log, and test-result outputs.
+
+### Confirm Caching
+
+Run the same build twice without changing an input:
+
+```sh
+once build cargo_hello_bin_hello
+once build cargo_hello_bin_hello
+```
+
+The second invocation should restore unchanged actions from the configured
+cache. Changing one locked dependency invalidates that package and its
+consumers. Changing one workspace package invalidates that package and its
+dependants. Changing only a test file reruns the affected test without
+recompiling an unchanged library.
+
+Dependency fetching is outside the Once graph. Once caches compilation after
+Cargo's local cache contains the sources selected by `Cargo.lock`. Continue
+with [Caching](/guide/scripted/caching) to configure a shared remote cache.
+
+### Record the Project Selection
+
+Initialization is optional. Use it when the repository should make its native
+project selection explicit:
 
 ```sh
 once edit init-native-project cargo
 ```
+
+This writes only the `cargo_workspace` seed. The detailed targets remain
+derived from `Cargo.toml` and `Cargo.lock`, so they do not become duplicated
+configuration. Commit the seed when reviewers and continuous integration
+should see the selection.
+
+After initialization, the seed can select Cargo features or a compilation
+target without copying the generated package graph into the manifest:
+
+```toml
+[target.attrs]
+features = ["workspace-package/feature-name"]
+target = "aarch64-unknown-linux-gnu"
+```
+
+Use the [`cargo_workspace` reference](/reference/prelude/cargo_workspace) for
+the complete seed contract.
+
+### Workspaces and Troubleshooting
+
+- If graph loading reports a missing source, run `cargo fetch --locked` with
+  the same Cargo home and retry.
+- If a binary or example is absent, inspect its `required-features`, initialize
+  the seed, and select those features explicitly.
+- Use `once query native-project cargo --package <path>` when more than one
+  independent `Cargo.toml` matches the workspace.
+- Build scripts that invoke unsupported host tools fail as ordinary declared
+  actions. Add the required toolchain or move the exceptional operation into an
+  explicit target.
+- Cargo configuration files participate in graph resolution. Keep the
+  repository's source replacement and target configuration available when
+  loading the graph.
+
+## Choose How Much Configuration to Own
+
+Native discovery, manifests, and Starlark modules are composable layers. A
+project does not need to migrate away from `Cargo.toml` to gain more control.
+
+| Layer | Repository change | Use it when |
+| --- | --- | --- |
+| Native Cargo project | None | The graph derived from `Cargo.toml` already describes the build. |
+| Recorded native seed | One `cargo_workspace` target in `once.toml` | The repository should pin project selection, features, target configuration, caching, or execution infrastructure. |
+| Explicit typed targets | Additional targets in `once.toml` | A package needs a custom boundary, cross-language dependency, mobile artifact, or operation that Cargo metadata does not describe. |
+| Project Starlark module | A registered reusable target kind | Several targets need the same new behavior and an existing target kind cannot express it. |
+
+Start with native discovery and stop there when it is sufficient. Add an
+annotated script for a one-off repository task. Move data into `once.toml` when
+the task needs typed dependencies, inputs, outputs, or platform selection. Move
+behavior into a Starlark target kind only when the rule should be reusable.
+
+The initialized `cargo_workspace` seed can live beside additional explicit
+targets, so Cargo can continue to own its package graph while Once owns only
+the exceptional edges. Do not restate every generated Cargo package in
+`once.toml`.
+
+When a custom target kind is necessary, keep project-specific Cargo behavior
+inside that Starlark module and build it from generic action primitives. The
+shared Rust execution layer remains independent of Cargo and other build
+systems. The [Modules reference](/reference/modules/) covers target kind
+schemas, resolvers, actions, validation, and module registration.
+
+## Author a Graph When You Need More Control
+
+Hand-authored targets are useful for a standalone Rust library without Cargo,
+cross-language links, native mobile outputs, or a boundary that should be
+cached independently.
 
 ## Declare a Library, Binary, and Test
 
@@ -161,7 +322,12 @@ configuration. `data` files become declared run inputs, while `compile_data`
 files affect compilation. Keeping those roles separate makes cache behavior
 visible.
 
-## Add Cargo Dependencies
+## Keep Cargo Dependencies When Authoring Targets
+
+Skip this section when the native `cargo_workspace` graph is sufficient. That
+seed already imports the complete locked dependency graph. Use
+`cargo_dependencies` when hand-authored Rust targets should keep Cargo as the
+authority for third-party packages.
 
 Keep third-party requirements in `Cargo.toml` and exact versions in
 `Cargo.lock`. A root `cargo_dependencies` target lets Cargo resolve the
@@ -377,6 +543,7 @@ Use the target kind reference for each role:
 - [`rust_binary`](/reference/prelude/rust_binary)
 - [`rust_test`](/reference/prelude/rust_test)
 - [`rust_proc_macro`](/reference/prelude/rust_proc_macro)
+- [`cargo_workspace`](/reference/prelude/cargo_workspace)
 - [`cargo_dependencies`](/reference/prelude/cargo_dependencies)
 - [`rust_crate`](/reference/prelude/rust_crate)
 - [`rust_mobile_library`](/reference/prelude/rust_mobile_library)

--- a/web/priv/docs/reference/manifest.md
+++ b/web/priv/docs/reference/manifest.md
@@ -21,9 +21,10 @@ exclude = ["packages/experimental/once.toml"]
 ```
 
 `include` and `exclude` contain workspace-relative glob patterns. They match
-both `once.toml` manifests and native project markers such as `mix.exs`. An
-excluded path is always omitted. When `include` is empty, every discovered
-manifest and native project is included unless `exclude` removes it.
+both `once.toml` manifests and native project markers such as `Cargo.toml` and
+`mix.exs`. An excluded path is always omitted. When `include` is empty, every
+discovered manifest and native project is included unless `exclude` removes
+it.
 
 ## Root-only Tables
 

--- a/web/priv/docs/reference/mcp/tools.md
+++ b/web/priv/docs/reference/mcp/tools.md
@@ -326,7 +326,7 @@ Returns each enabled native project's name, documentation, marker files, additio
 
 Preview the seed target and complete typed graph derived by one detected native project.
 
-Runs the selected native project's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `package` when the native project has one match. The matching command-line operation is `once query native-project <name> [--package <path>] --format json`.
+Runs the selected native project's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `package` when the native project has one match. Expanded dependency graphs can be very large. For a loaded project, prefer `once_query_workspace`, filtered `once_query_targets`, `once_query_tests`, and `once_get_target` when the complete graph is not needed. The matching command-line operation is `once query native-project <name> [--package <path>] --format json`.
 
 **Input schema**
 
@@ -427,7 +427,8 @@ Use this when no discovered target kind covers an external rule or plugin. The r
   ],
   "action_primitives": [
     { "signature": "write_path(path, content)", "purpose": "Declare a portable file-writing action." },
-    { "signature": "materialize_host_file(source, destination)", "purpose": "Snapshot a content-verified absolute host toolchain file into a workspace output." }
+    { "signature": "materialize_host_file(source, destination)", "purpose": "Snapshot a content-verified absolute host toolchain file into a workspace output." },
+    { "signature": "materialize_host_tree(source, destination)", "purpose": "Snapshot a content-verified absolute host directory into a workspace output." }
   ],
   "starter": "def _generated_text_impl(ctx): ...",
   "lint_starter": "def _scripted_lint_impl(ctx): ...",
@@ -676,7 +677,7 @@ Returns the selection policy, normalized changed paths, unmatched paths, selecte
 
 Run test targets by id, or run tests affected by changed workspace paths.
 
-Creates the same immutable plan as `once_query_test_plan`, then pulls stable batches from a shared local queue. Batches with longer historical uncached durations are queued first, and idle workers dynamically take the next batch. Explicit `target` or `targets` produce an exact plan; otherwise `changed_paths` drive conservative graph selection. With exactly one target, `test_unit` runs a stable unit returned by `once_query_test_manifest` when the target kind declares filtering support. `jobs` caps workers without changing plan or batch identity. The result's `plan` is the work that just executed. Its `next_plan` is recomputed after complete runs refresh discovery, so use that field to assess file or case batching for the next run. The result also includes actual schedule attempts and normalized test results. Failed tests are returned as normal tool content with `success: false` rather than a tool protocol error, so agents can inspect failures and iterate. The matching command-line operations are `once test --changed-path <path> --jobs <count> --format json` and `once test <target> --test-unit <unit> --format json`.
+Creates the same immutable plan as `once_query_test_plan`, then pulls stable batches from a shared local queue. Batches with longer historical uncached durations are queued first, and idle workers dynamically take the next batch. Explicit `target` or `targets` produce an exact plan; otherwise `changed_paths` drive conservative graph selection. With exactly one target, `test_unit` runs a stable unit returned by `once_query_test_manifest` when the target kind declares filtering support. `jobs` caps workers without changing plan or batch identity. Set `summary_only` for compact normalized totals without case-level records. The result's `plan` is the work that just executed. Its `next_plan` is recomputed after complete runs refresh discovery, so use that field to assess file or case batching for the next run. The result also includes actual schedule attempts and normalized test results. Failed tests are returned as normal tool content with `success: false` rather than a tool protocol error, so agents can inspect failures and iterate. The matching command-line operations are `once test --changed-path <path> --jobs <count> --format json` and `once test <target> --test-unit <unit> --format json`.
 
 **Input schema**
 
@@ -695,6 +696,10 @@ Creates the same immutable plan as `once_query_test_plan`, then pulls stable bat
       "maximum": 256,
       "minimum": 1,
       "type": "integer"
+    },
+    "summary_only": {
+      "description": "Replace case-level normalized results with compact once.test_results_summary.v1 totals.",
+      "type": "boolean"
     },
     "target": {
       "description": "Single canonical target id to run, such as `tests/unit`.",
@@ -748,13 +753,17 @@ Creates the same immutable plan as `once_query_test_plan`, then pulls stable bat
 
 Read normalized once.test_results.v1 results for a target.
 
-Reads the normalized result file produced by the target's `test` capability. This is the stable agent-facing interface for pass or fail summaries, case-level failures, attempts, and artifacts. Callers do not need to parse a runner's command output.
+Reads the normalized result file produced by the target's `test` capability. This is the stable agent-facing interface for pass or fail summaries, case-level failures, attempts, and artifacts. Set `summary_only` when exact totals are sufficient and a large case array would waste model context. The matching command-line operation is `once query test-results <target> --summary-only --format json`. Callers do not need to parse a runner's command output.
 
 **Input schema**
 
 ```json
 {
   "properties": {
+    "summary_only": {
+      "description": "Return once.test_results_summary.v1 status, totals, runner, and artifacts without case-level records.",
+      "type": "boolean"
+    },
     "target": {
       "description": "Canonical target id, such as `tests/unit`.",
       "type": "string"

--- a/web/priv/docs/reference/modules/index.md
+++ b/web/priv/docs/reference/modules/index.md
@@ -556,6 +556,10 @@ separate update workflow.
   toolchain file into a workspace output. Analysis records its
   [256-bit Secure Hash Algorithm digest](https://csrc.nist.gov/pubs/fips/180-4/upd1/final),
   and execution verifies the digest before the output enters the cache.
+- `materialize_host_tree(source, destination)` snapshots one absolute host
+  directory into a workspace directory output. Analysis and execution verify
+  its content, file modes, and symbolic links before the output enters the
+  cache.
 - `link_path(source, destination)` declares an uncached, relative workspace
   link. The source must exist. Linked contents are not copied into the action
   cache, while downstream actions still hash them when they declare the link

--- a/web/priv/docs/reference/prelude/cargo_workspace.md
+++ b/web/priv/docs/reference/prelude/cargo_workspace.md
@@ -11,8 +11,17 @@ Locked external packages use the same fine-grained lowering as
 `cargo_dependencies`.
 
 Cargo remains authoritative for workspace membership, targets, features,
-renamed dependencies, build scripts, versions, and checksums. External package
-sources must already exist in the configured vendored source directory.
+renamed dependencies, build scripts, versions, and checksums. By default, Once
+snapshots locked external package trees from Cargo's local cache into each
+target's output. The repository stays unchanged. A pre-existing vendored source
+directory can be selected explicitly.
+Targets whose `required-features` are not selected are omitted, matching
+Cargo's target selection. Generated test targets include development
+dependencies. Cargo target names are normalized to valid Rust crate
+identifiers while binary names retain their manifest spelling. Multi-output
+libraries emit one target per declared Rust library crate type. Cargo's
+workspace member list determines which packages are first-party, so local path
+dependencies outside that list remain ordinary dependency targets.
 
 ## Attributes
 
@@ -23,7 +32,7 @@ sources must already exist in the configured vendored source directory.
 | `resolver_inputs` | list&lt;string&gt; | no | `srcs` | Text inputs available while deriving the graph |
 | `metadata_file` | string | no |  | Optional checked Cargo metadata snapshot |
 | `host_metadata_file` | string | no |  | Optional host metadata snapshot for cross-compilation |
-| `vendor_dir` | string | no | `vendor` | Package-relative vendored external sources |
+| `vendor_dir` | string | no | Once-managed | Optional package-relative pre-vendored external sources |
 | `features` | list&lt;string&gt; | no | `[]` | Selected Cargo features |
 | `all_features` | bool | no | `false` | Select every Cargo feature |
 | `no_default_features` | bool | no | `false` | Disable default Cargo features |
@@ -41,6 +50,15 @@ The target emits `cargo_workspace`.
 | `build` | none |
 
 ## Direct Use
+
+On a fresh clone, populate Cargo's local source cache from the lockfile:
+
+```sh
+cargo fetch --locked
+```
+
+Once never performs that network operation while loading or building the
+graph.
 
 Discover and preview the native project:
 
@@ -66,6 +84,12 @@ srcs = ["Cargo.toml"]
 [target.attrs]
 resolver_inputs = ["Cargo.toml", "Cargo.lock", "**/Cargo.toml", ".cargo/config", ".cargo/config.toml"]
 ```
+
+Keep this seed as the only Once target while Cargo metadata describes the
+complete build. Add explicit targets beside it for exceptional cross-language
+or packaging boundaries. Use a project Starlark module only when those
+exceptions share reusable behavior that the built-in target kinds cannot
+express.
 
 ## Sources
 

--- a/web/test/once_site_web/live/docs_live_test.exs
+++ b/web/test/once_site_web/live/docs_live_test.exs
@@ -20,6 +20,14 @@ defmodule OnceSiteWeb.DocsLiveTest do
     assert html =~ "data-prose"
   end
 
+  test "renders the native Cargo adoption path", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/docs/guide/graph/rust")
+
+    assert html =~ "Start With an Existing Cargo Project"
+    assert html =~ "Choose How Much Configuration to Own"
+    assert html =~ "once query targets --kind rust_binary"
+  end
+
   test "renders a hand-written reference page", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/docs/reference/prelude/apple_library")
 


### PR DESCRIPTION
## What changed

Once now recognizes a root `Cargo.toml` as a native project and derives a typed build graph without requiring `once.toml`.

- Added native Cargo workspace discovery, locked metadata resolution, workspace member targets, external package targets, build scripts, feature selection, binaries, libraries, and tests.
- Added generic host-tree materialization and race-safe restoration of cached directory outputs.
- Added compact test result summaries to the command-line and [Model Context Protocol](https://modelcontextprotocol.io/) surfaces so agents can read large test suites without receiving every case.
- Documented the incremental path from Cargo-only discovery to a recorded native seed, explicit typed targets, and reusable Starlark modules.

## Why

Rust projects should be able to adopt Once with their existing Cargo manifests. A repository can begin with no Once configuration, gain cached target-level builds and tests, and add explicit graph ownership only where it needs more control.

The implementation also needs to preserve Once's ecosystem-neutral architecture. Cargo-specific discovery and execution behavior belongs in Starlark target kinds, while the Rust implementation provides generic graph, action, materialization, validation, and cache primitives.

## Root cause

Native project discovery previously covered Mix but did not expose Cargo as a built-in native project. Cargo dependency sources also needed a portable way to enter the action graph without assuming a repository-managed vendor directory.

Kura's parallel tests exposed a separate cached-output race: concurrent actions could restore the same directory output simultaneously. Large normalized test results also exceeded agent response limits because the query always returned every case.

## Approach

The Cargo workspace target kind reads locked Cargo metadata and expands it into the existing Rust target kinds. External source trees are content-verified during analysis and execution through a generic host-tree action. The shared native-project loader remains unaware of Cargo, Mix, Rust, or Elixir.

Cached output restoration now validates directory digests, serializes the materialization section per workspace, and validates again after taking the lock. Compact test summaries preserve status, totals, runner information, and artifacts while omitting case arrays.

## Impact

Users can run Once directly from a Cargo workspace, query the generated targets, build binaries, and run normalized tests without creating `once.toml`. Existing hand-authored Rust targets and recorded Cargo seeds remain supported.

Projects can adopt configuration incrementally. Agent workflows can retrieve exact totals from large test suites without truncation.

## Validation

- `mise exec -- cargo test --workspace`
- `mise exec -- cargo test -p once-cli`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- Documentation tests: 6 passed
- Elixir web tests through Once: 52 passed
- Native Mix project without `once.toml`: passed
- Kura native Cargo build: passed
- Kura library tests: 343 passed, 1 skipped, 0 failed
- Kura binary tests: passed with 0 discovered cases
- Claude, restricted to Once's Model Context Protocol tools, detected the root `Cargo.toml`, confirmed that `once.toml` was absent, built Kura, ran both test targets, and retrieved complete compact summaries without truncation
- Local Rust documentation route returned HTTP status 200
