### PR TITLE
chore: address codebase review findings across correctness, memory, and structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "toon-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,18 @@ zstd = "0.13"
 tar = "0.4"
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+# `deny` rather than `forbid` so the C ABI layer can carve out a single
+# `#[allow(unsafe_code)]` on the one module that needs it. `forbid`
+# cannot be relaxed locally, which previously forced the `once` crate to
+# opt out of this whole table and silently lose every workspace lint.
+# The FFI boundary is the only sanctioned exemption; grep for
+# `allow(unsafe_code)` to audit it.
+unsafe_code = "deny"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
-# Pragmatic carve-outs from the pedantic group: documentation and
-# enum-variant naming aren't worth gating builds on yet.
+# Pragmatic carve-outs from the pedantic group: enum-variant naming and
+# per-call error/panic prose aren't worth gating builds on.
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"

--- a/crates/once-cas/src/digest.rs
+++ b/crates/once-cas/src/digest.rs
@@ -10,8 +10,13 @@ use serde::{Deserialize, Serialize, Serializer};
 pub struct Digest([u8; Self::LEN]);
 
 impl Digest {
+    /// Digest width in bytes.
     pub const LEN: usize = 32;
 
+    /// Hash a slice already held in memory.
+    ///
+    /// Prefer [`of_reader`](Self::of_reader) for anything file-sized so
+    /// the contents never need to be resident all at once.
     pub fn of_bytes(bytes: &[u8]) -> Self {
         Self(*blake3::hash(bytes).as_bytes())
     }
@@ -26,6 +31,10 @@ impl Digest {
         Ok(Self(*hasher.finalize().as_bytes()))
     }
 
+    /// Hash fixed prefix parts followed by a streaming reader.
+    ///
+    /// Used to bind a header (a format tag, a file mode) to a payload
+    /// without concatenating the two in memory first.
     pub fn of_parts_and_reader(parts: &[&[u8]], mut reader: impl Read) -> io::Result<Self> {
         let mut hasher = blake3::Hasher::new();
         for part in parts {
@@ -35,14 +44,19 @@ impl Digest {
         Ok(Self(*hasher.finalize().as_bytes()))
     }
 
+    /// Wrap raw digest bytes that were computed elsewhere.
+    ///
+    /// This does not hash: pass the digest itself, not the content.
     pub fn from_bytes(bytes: [u8; Self::LEN]) -> Self {
         Self(bytes)
     }
 
+    /// The raw digest bytes.
     pub fn as_bytes(&self) -> &[u8; Self::LEN] {
         &self.0
     }
 
+    /// Render as a 64-character lowercase hex string.
     pub fn to_hex(&self) -> String {
         hex::encode(self.0)
     }

--- a/crates/once-cas/src/error.rs
+++ b/crates/once-cas/src/error.rs
@@ -3,29 +3,45 @@ use std::path::PathBuf;
 
 use crate::Digest;
 
+/// Everything the store and its providers can fail with.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// A filesystem operation failed, carrying the path it was on.
     #[error("io error at {path}: {source}")]
     Io {
+        /// Path the failed operation targeted.
         path: PathBuf,
+        /// Underlying operating system error.
         #[source]
         source: io::Error,
     },
+    /// A stored action record could not be decoded, so the entry is
+    /// treated as a miss rather than trusted.
     #[error("corrupt action result at {0}: {1}")]
     Corrupt(PathBuf, serde_json::Error),
+    /// The requested blob is in neither the local store nor any
+    /// configured remote tier.
     #[error("blob not found: {0}")]
     BlobNotFound(Digest),
+    /// A provider was selected but its configuration is unusable.
     #[error("cache provider `{provider}` is misconfigured: {message}")]
     InvalidConfig {
+        /// Provider that rejected its configuration.
         provider: &'static str,
+        /// What was wrong with it.
         message: String,
     },
+    /// A remote tier returned an error for a specific operation.
     #[error("cache provider `{provider}` failed during `{operation}`: {message}")]
     Remote {
+        /// Provider that failed.
         provider: &'static str,
+        /// Operation being attempted, such as `get_blob`.
         operation: &'static str,
+        /// Message reported by the remote.
         message: String,
     },
 }
 
+/// Result alias for every fallible store operation.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/once-cas/src/lib.rs
+++ b/crates/once-cas/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //! Local content-addressed store and action-result cache.
 //!
 //! Blobs are addressed by their BLAKE3 digest; action results are keyed
@@ -60,6 +62,7 @@ impl Cas {
         Self { root: root.into() }
     }
 
+    /// Filesystem root this store reads and writes under.
     pub fn root(&self) -> &Path {
         &self.root
     }
@@ -108,6 +111,8 @@ impl Cas {
         }
     }
 
+    /// Write a blob's contents to `destination`, streaming rather than
+    /// buffering, and creating parent directories as needed.
     pub async fn copy_blob_to_file(&self, digest: &Digest, destination: &Path) -> Result<()> {
         let stored_path = self.blob_path(digest);
         if !fs::try_exists(&stored_path).await.unwrap_or(false) {
@@ -305,6 +310,9 @@ impl Cas {
             .map_err(|source| Error::Io { path, source })
     }
 
+    /// Record an action result durably: the write is flushed and its
+    /// parent directory synchronized before the call returns, so a crash
+    /// cannot leave a half-written entry behind.
     pub async fn put_action_result(&self, action: &Digest, result: &ActionResult) -> Result<()> {
         let path = self.action_path(action);
         let bytes = serde_json::to_vec(result).expect("ActionResult is serializable");
@@ -321,6 +329,7 @@ impl Cas {
         write_atomically(&path, &bytes).await
     }
 
+    /// Look up a cached action result. `None` is a miss.
     pub async fn get_action_result(&self, action: &Digest) -> Result<Option<ActionResult>> {
         let path = self.action_path(action);
         match fs::read(&path).await {
@@ -344,6 +353,7 @@ impl Cas {
         }
     }
 
+    /// Count blobs and action records by walking the store.
     pub async fn stats(&self) -> Result<Stats> {
         let blobs_dir = self.blobs_dir();
         let actions_dir = self.actions_dir();

--- a/crates/once-cas/src/model.rs
+++ b/crates/once-cas/src/model.rs
@@ -17,19 +17,29 @@ use crate::Digest;
 /// rather than materialising an empty blob.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActionResult {
+    /// Process exit code, or `-1` when the process was signalled.
     pub exit_code: i32,
+    /// Blob holding captured stdout, absent when it was not captured.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stdout: Option<Digest>,
+    /// Blob holding captured stderr, absent when it was not captured.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stderr: Option<Digest>,
+    /// Declared outputs the action produced, keyed by workspace-relative
+    /// path.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub outputs: BTreeMap<String, Digest>,
 }
 
+/// Size of a local store, as counted by a full walk.
 #[derive(Debug, Clone, Copy)]
 pub struct Stats {
+    /// Number of content blobs held.
     pub blob_count: u64,
+    /// Bytes those blobs occupy on disk, after compression.
     pub blob_bytes: u64,
+    /// Number of cached action results held.
     pub action_count: u64,
+    /// Bytes those action records occupy on disk.
     pub action_bytes: u64,
 }

--- a/crates/once-cas/src/provider.rs
+++ b/crates/once-cas/src/provider.rs
@@ -8,18 +8,32 @@ use crate::{ActionResult, Cas, Digest, GcReport, Result, Stats};
 
 const TUIST_STREAM_REMOTE_UPLOAD_LIMIT: u64 = 8 * 1024 * 1024;
 
+/// The cache a command talks to: a local store, optionally fronting a
+/// remote tier.
+///
+/// Every method dispatches to the selected tier, so callers do not branch
+/// on which provider is configured.
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum CacheProvider {
+    /// Filesystem-backed store with no remote tier.
     Local(Cas),
+    /// Local store fronting a Tuist remote tier, which is consulted on a
+    /// local miss and mirrored to on write.
     Tuist(TuistCache),
 }
 
 impl CacheProvider {
+    /// Open a purely local store rooted at `root`.
     pub fn open_local(root: impl Into<PathBuf>) -> Self {
         Self::Local(Cas::open(root))
     }
 
+    /// Open a local store backed by the Tuist remote tier.
+    ///
+    /// `auth_root` holds the credentials the remote tier authenticates
+    /// with; it is kept separate from the cache root so clearing the
+    /// cache never signs the user out.
     pub fn tuist(
         local_root: impl Into<PathBuf>,
         auth_root: impl AsRef<Path>,
@@ -32,6 +46,7 @@ impl CacheProvider {
         )?))
     }
 
+    /// Filesystem root of the local tier, remote tier or not.
     pub fn root(&self) -> &Path {
         match self {
             Self::Local(cas) => cas.root(),
@@ -39,6 +54,9 @@ impl CacheProvider {
         }
     }
 
+    /// Store a blob already held in memory and return its digest.
+    ///
+    /// Prefer [`put_stream`](Self::put_stream) for anything file-sized.
     pub async fn put_blob(&self, bytes: &[u8]) -> Result<Digest> {
         match self {
             Self::Local(cas) => cas.put_blob(bytes).await,
@@ -46,6 +64,11 @@ impl CacheProvider {
         }
     }
 
+    /// Store a blob by streaming it, without holding it all in memory.
+    ///
+    /// Only blobs below an internal size limit are mirrored to a remote
+    /// tier, so a huge stream stays local rather than stalling the write
+    /// on a slow upload.
     pub async fn put_stream<R: AsyncRead + Unpin>(&self, reader: R) -> Result<Digest> {
         match self {
             Self::Local(cas) => cas.put_stream(reader).await,
@@ -60,6 +83,12 @@ impl CacheProvider {
         }
     }
 
+    /// Read a whole blob into memory, consulting the remote tier on a
+    /// local miss.
+    ///
+    /// Use [`copy_blob_to_file`](Self::copy_blob_to_file) or
+    /// [`read_blob_limited`](Self::read_blob_limited) when the blob may
+    /// be large.
     pub async fn get_blob(&self, digest: &Digest) -> Result<Vec<u8>> {
         match self {
             Self::Local(cas) => cas.get_blob(digest).await,
@@ -67,6 +96,8 @@ impl CacheProvider {
         }
     }
 
+    /// Materialize a blob at `destination`, streaming it rather than
+    /// buffering it in memory.
     pub async fn copy_blob_to_file(&self, digest: &Digest, destination: &Path) -> Result<()> {
         match self {
             Self::Local(cas) => cas.copy_blob_to_file(digest, destination).await,
@@ -77,6 +108,12 @@ impl CacheProvider {
         }
     }
 
+    /// Read at most `limit` bytes of a blob, from the start or, when
+    /// `from_end` is set, from the tail.
+    ///
+    /// Returns the bytes and whether the blob was longer than `limit`.
+    /// Reading the tail is what a caller wants when surfacing the end of
+    /// a long log without paying for the whole thing.
     pub async fn read_blob_limited(
         &self,
         digest: &Digest,
@@ -134,6 +171,7 @@ impl CacheProvider {
         }
     }
 
+    /// Record the result of an action under its action digest.
     pub async fn put_action_result(&self, action: &Digest, result: &ActionResult) -> Result<()> {
         match self {
             Self::Local(cas) => cas.put_action_result(action, result).await,
@@ -141,6 +179,8 @@ impl CacheProvider {
         }
     }
 
+    /// Look up a cached action result. `None` is a miss; a stored record
+    /// that fails to decode is also treated as a miss.
     pub async fn get_action_result(&self, action: &Digest) -> Result<Option<ActionResult>> {
         match self {
             Self::Local(cas) => cas.get_action_result(action).await,
@@ -148,6 +188,7 @@ impl CacheProvider {
         }
     }
 
+    /// Drop a cached action result, returning whether one was present.
     pub async fn forget_action(&self, action: &Digest) -> Result<bool> {
         match self {
             Self::Local(cas) => cas.forget_action(action).await,
@@ -155,6 +196,7 @@ impl CacheProvider {
         }
     }
 
+    /// Count what the local tier currently holds.
     pub async fn stats(&self) -> Result<Stats> {
         match self {
             Self::Local(cas) => cas.stats().await,

--- a/crates/once-cas/src/tuist/auth.rs
+++ b/crates/once-cas/src/tuist/auth.rs
@@ -22,6 +22,7 @@ use crate::{Error, Result};
 
 /// Public OAuth client id for Once's built-in Tuist app. This is not a secret.
 pub const TUIST_APP_OAUTH_CLIENT_ID: &str = "b3298a92-3deb-4f5e-a526-b7ad324979b5";
+/// Environment variable that overrides [`TUIST_APP_OAUTH_CLIENT_ID`].
 pub const TUIST_OAUTH_CLIENT_ID_ENV: &str = "TUIST_OAUTH_CLIENT_ID";
 const TUIST_TOKEN_ENV: &str = "TUIST_TOKEN";
 
@@ -32,6 +33,11 @@ const OIDC_EXCHANGE_PATH: &str = "api/auth/oidc/token";
 const OIDC_TOKEN_REFRESH_WINDOW_SECONDS: u64 = 60;
 const CI_ENVIRONMENT_VARIABLES: &[&str] = &["GITHUB_RUN_ID", "CI", "BUILD_NUMBER"];
 
+/// Credential handling for the Tuist remote tier.
+///
+/// Resolves a token from the environment, a cached CI exchange, or stored
+/// credentials, in that order, so an explicitly supplied token always
+/// wins over whatever is on disk.
 #[derive(Debug, Clone)]
 pub struct TuistAuth {
     credentials_root: PathBuf,
@@ -40,14 +46,20 @@ pub struct TuistAuth {
     ci_exchange_lock: Arc<StdMutex<()>>,
 }
 
+/// What the user must be shown to complete an interactive login.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TuistAuthPrompt {
+    /// URL the user has to visit to authorize.
     pub authorize_url: String,
+    /// Loopback address the authorization is redirected back to.
     pub redirect_uri: String,
+    /// Whether a browser will be opened automatically after prompting.
     pub opens_browser: bool,
 }
 
 impl TuistAuth {
+    /// Bind credential handling to a storage root and server config.
+    /// Does no I/O.
     pub fn new(credentials_root: impl AsRef<Path>, config: &TuistCacheConfig) -> Self {
         Self {
             credentials_root: credentials_root.as_ref().to_path_buf(),
@@ -57,6 +69,7 @@ impl TuistAuth {
         }
     }
 
+    /// Resolve a bearer token, erroring when the user is not signed in.
     pub fn token(&self) -> Result<String> {
         self.token_with_env(env_token(TUIST_TOKEN_ENV))
     }
@@ -83,11 +96,14 @@ impl TuistAuth {
         }
     }
 
+    /// Run an interactive login, printing the prompt to the terminal.
     pub fn login(&self, open_browser_after_prompt: bool) -> Result<()> {
         let mut handler = |prompt| print_prompt(&prompt);
         self.login_with_handler(open_browser_after_prompt, &mut handler)
     }
 
+    /// Interactive login that hands the prompt to `handler` instead of
+    /// printing it, so a caller can render it its own way.
     pub fn login_with_handler(
         &self,
         open_browser_after_prompt: bool,
@@ -119,6 +135,7 @@ impl TuistAuth {
         )
     }
 
+    /// Discard stored credentials, returning whether any existed.
     pub fn logout(&self) -> Result<bool> {
         let key = self.storage_key();
         let storage = self.storage()?;

--- a/crates/once-cas/src/tuist/mod.rs
+++ b/crates/once-cas/src/tuist/mod.rs
@@ -11,12 +11,18 @@ pub use cache::TuistCache;
 const PROVIDER_NAME: &str = "tuist";
 const ENDPOINTS_PATH: &str = "api/cache/endpoints";
 
+/// How to reach a Tuist remote cache tier.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TuistCacheConfig {
+    /// Base URL of the Tuist server.
     pub url: String,
+    /// Account handle the cache belongs to, when scoped to one.
     pub account: Option<String>,
+    /// Project handle the cache belongs to, when scoped to one.
     pub project: Option<String>,
+    /// OAuth client id to authenticate with, overriding the built-in one.
     pub oauth_client_id: Option<String>,
+    /// Name reported in errors and logs for this provider instance.
     pub provider_name: String,
 }
 

--- a/crates/once-cli/Cargo.toml
+++ b/crates/once-cli/Cargo.toml
@@ -25,6 +25,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 toml.workspace = true
 toon-rust.workspace = true
 tokio.workspace = true

--- a/crates/once-cli/src/commands/cache.rs
+++ b/crates/once-cli/src/commands/cache.rs
@@ -426,6 +426,9 @@ fn hash_env_input(name: &str, value: &str) -> Digest {
 /// pool once per entry and serialise on the await; doing the work
 /// inline on one blocking thread is one dispatch total and lets the
 /// kernel page bytes through without async hops.
+///
+/// Entries stream into the hasher so peak memory stays at one buffered
+/// chunk rather than the size of the largest file in the tree.
 async fn hash_directory(root: &Path) -> Result<Digest> {
     let root = root.to_path_buf();
     tokio::task::spawn_blocking(move || -> Result<Digest> {
@@ -456,11 +459,13 @@ async fn hash_directory(root: &Path) -> Result<Digest> {
         let mut hasher = blake3::Hasher::new();
         hasher.update(b"once.hash.directory.v1\0");
         for (rel, abs) in entries {
-            let bytes = std::fs::read(&abs)
-                .with_context(|| format!("reading directory entry {}", abs.display()))?;
             hasher.update(rel.as_bytes());
             hasher.update(b"\0");
-            hasher.update(&bytes);
+            let file = std::fs::File::open(&abs)
+                .with_context(|| format!("reading directory entry {}", abs.display()))?;
+            hasher
+                .update_reader(std::io::BufReader::new(file))
+                .with_context(|| format!("reading directory entry {}", abs.display()))?;
             hasher.update(b"\0");
         }
         Ok(Digest::from_bytes(*hasher.finalize().as_bytes()))

--- a/crates/once-cli/src/commands/change_tracker/client.rs
+++ b/crates/once-cli/src/commands/change_tracker/client.rs
@@ -11,59 +11,130 @@ use tokio::time::sleep;
 use super::protocol::{Request, Response};
 use super::{ChangePosition, ChangeSnapshot};
 
+/// Read timeout for one barrier round trip.
+///
+/// Derived from the server's fence wait rather than set independently:
+/// the fence is the slow part, and a client that gave up first would
+/// report a bare timeout in place of the server's specific reason.
+fn response_timeout() -> Duration {
+    super::server::fence_timeout() + Duration::from_secs(3)
+}
+
+/// Take a barrier snapshot, starting the tracker daemon if it is not
+/// running yet.
+///
+/// Returns `None` when no snapshot could be obtained. Every cause is
+/// logged with its reason, because callers treat a missing snapshot as
+/// "fall back to full validation" and must not fail the build over it.
 pub(super) async fn snapshot(
     workspace: &Path,
     socket: &Path,
     outputs: &[String],
     since: Option<&ChangePosition>,
 ) -> Option<ChangeSnapshot> {
-    if let Some(snapshot) = request_snapshot(socket, outputs, since).await {
-        return Some(snapshot);
+    match request_snapshot(socket, outputs, since).await {
+        Ok(snapshot) => return Some(snapshot),
+        // Not being able to reach the socket is the expected first-run
+        // path, so it stays at trace level; everything else is a real
+        // surprise worth seeing at debug.
+        Err(error) if error.is_unreachable() => {
+            tracing::trace!(%error, "filesystem change tracker not running yet");
+        }
+        Err(error) => {
+            tracing::debug!(%error, "filesystem change tracker snapshot failed");
+        }
     }
     if let Err(error) = spawn_tracker(workspace, socket) {
         tracing::debug!(%error, "failed to start filesystem change tracker");
         return None;
     }
+    let mut last_error = None;
     for _ in 0..50 {
-        if let Some(snapshot) = request_snapshot(socket, outputs, since).await {
-            return Some(snapshot);
+        match request_snapshot(socket, outputs, since).await {
+            Ok(snapshot) => return Some(snapshot),
+            Err(error) => last_error = Some(error),
         }
         sleep(Duration::from_millis(10)).await;
     }
-    tracing::debug!("filesystem change tracker did not become ready");
+    if let Some(error) = last_error {
+        tracing::debug!(%error, "filesystem change tracker did not become ready");
+    } else {
+        tracing::debug!("filesystem change tracker did not become ready");
+    }
     None
+}
+
+/// Why a barrier request could not be answered.
+///
+/// Kept as a typed error rather than a bare `Option` so a failed
+/// snapshot reports its reason. The server already sends a precise
+/// message for a rejected barrier; collapsing that into `None` left
+/// callers and tests with no way to tell a cold socket apart from a
+/// fence timeout.
+#[derive(Debug, thiserror::Error)]
+pub(super) enum SnapshotError {
+    #[error("connecting to tracker socket {socket}: {source}")]
+    Connect {
+        socket: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("sending barrier request: {0}")]
+    Send(#[source] std::io::Error),
+    #[error("reading barrier response: {0}")]
+    Receive(#[source] std::io::Error),
+    #[error("tracker did not answer within {0:?}")]
+    ResponseTimeout(Duration),
+    #[error("decoding barrier response: {0}")]
+    Decode(#[source] serde_json::Error),
+    #[error("tracker rejected the barrier: {0}")]
+    Rejected(String),
+    #[error("tracker answered with neither a snapshot nor an error")]
+    Empty,
+}
+
+impl SnapshotError {
+    /// True when the tracker simply is not listening yet, which is the
+    /// normal state before the daemon has been spawned.
+    fn is_unreachable(&self) -> bool {
+        matches!(self, Self::Connect { .. })
+    }
 }
 
 pub(super) async fn request_snapshot(
     socket: &Path,
     outputs: &[String],
     since: Option<&ChangePosition>,
-) -> Option<ChangeSnapshot> {
-    let stream = UnixStream::connect(socket).await.ok()?;
+) -> std::result::Result<ChangeSnapshot, SnapshotError> {
+    let stream = UnixStream::connect(socket)
+        .await
+        .map_err(|source| SnapshotError::Connect {
+            socket: socket.to_path_buf(),
+            source,
+        })?;
     let (read, mut write) = stream.into_split();
-    let raw = serde_json::to_vec(&Request {
+    let mut raw = serde_json::to_vec(&Request {
         command: "barrier".to_string(),
         outputs: outputs.to_vec(),
         since: since.cloned(),
     })
-    .ok()?;
-    write.write_all(&raw).await.ok()?;
-    write.write_all(b"\n").await.ok()?;
-    write.shutdown().await.ok()?;
+    // The request is built from owned local data, so the only way
+    // serialisation fails is a bug in this function.
+    .expect("barrier request is serializable");
+    raw.push(b'\n');
+    write.write_all(&raw).await.map_err(SnapshotError::Send)?;
+    write.shutdown().await.map_err(SnapshotError::Send)?;
     let mut line = String::new();
-    tokio::time::timeout(
-        Duration::from_secs(3),
-        BufReader::new(read).read_line(&mut line),
-    )
-    .await
-    .ok()?
-    .ok()?;
-    let response = serde_json::from_str::<Response>(&line).ok()?;
+    let timeout = response_timeout();
+    tokio::time::timeout(timeout, BufReader::new(read).read_line(&mut line))
+        .await
+        .map_err(|_| SnapshotError::ResponseTimeout(timeout))?
+        .map_err(SnapshotError::Receive)?;
+    let response = serde_json::from_str::<Response>(&line).map_err(SnapshotError::Decode)?;
     if let Some(error) = response.error {
-        tracing::debug!(%error, "filesystem change tracker rejected snapshot");
-        return None;
+        return Err(SnapshotError::Rejected(error));
     }
-    response.snapshot
+    response.snapshot.ok_or(SnapshotError::Empty)
 }
 
 fn spawn_tracker(workspace: &Path, socket: &Path) -> std::io::Result<()> {

--- a/crates/once-cli/src/commands/change_tracker/server.rs
+++ b/crates/once-cli/src/commands/change_tracker/server.rs
@@ -17,6 +17,36 @@ use super::{ChangePosition, ChangeSnapshot};
 
 const MAX_JOURNAL_RECORDS: usize = 16_384;
 
+/// How long a barrier waits for the watcher to report its own fence file.
+///
+/// A barrier writes a sentinel into a watched directory and waits to be
+/// told about it. Because watch backends deliver events in order, seeing
+/// the sentinel proves every earlier event has already landed in the
+/// journal. That makes the wait bounded by the backend's coalescing
+/// latency, which on macOS `FSEvents` reaches several seconds when the
+/// machine is busy, so the budget is generous rather than tight: timing
+/// out costs a caller its incremental fast path, and the default used to
+/// be short enough to lose that path under load.
+const DEFAULT_FENCE_TIMEOUT: Duration = Duration::from_secs(9);
+
+/// How many fence sentinels one barrier will try before giving up. The
+/// budget above is split evenly across them.
+const FENCE_ATTEMPTS: u32 = 3;
+
+/// Override for [`DEFAULT_FENCE_TIMEOUT`], in whole seconds. Lets a
+/// heavily loaded or slow-filesystem host buy more headroom without a
+/// rebuild.
+const FENCE_TIMEOUT_ENV: &str = "ONCE_CHANGE_TRACKER_FENCE_TIMEOUT_SECS";
+
+/// Effective fence wait, honouring [`FENCE_TIMEOUT_ENV`].
+pub(super) fn fence_timeout() -> Duration {
+    std::env::var(FENCE_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map_or(DEFAULT_FENCE_TIMEOUT, Duration::from_secs)
+}
+
 struct ChangeRecord {
     generation: u64,
     paths: Option<BTreeSet<String>>,
@@ -36,7 +66,7 @@ struct TrackerState {
     journal: Mutex<ChangeJournal>,
     fences: Mutex<BTreeMap<String, oneshot::Sender<()>>>,
     source_watcher: Mutex<Option<RecommendedWatcher>>,
-    watched_outputs: Mutex<BTreeSet<PathBuf>>,
+    watched_outputs: Mutex<BTreeMap<PathBuf, OutputIdentity>>,
     root_fingerprint: Mutex<Digest>,
 }
 
@@ -51,7 +81,7 @@ pub(super) async fn serve(workspace: &Path, socket: &Path) -> Result<()> {
         journal: Mutex::new(ChangeJournal::default()),
         fences: Mutex::new(BTreeMap::new()),
         source_watcher: Mutex::new(None),
-        watched_outputs: Mutex::new(BTreeSet::new()),
+        watched_outputs: Mutex::new(BTreeMap::new()),
         root_fingerprint: Mutex::new(root_fingerprint),
     });
     let callback_state = Arc::clone(&state);
@@ -129,6 +159,35 @@ impl TrackerState {
         self.ensure_fence_watch()?;
         self.refresh_source_watcher()?;
         self.track_outputs(outputs)?;
+        let budget = fence_timeout();
+        let per_attempt = budget / FENCE_ATTEMPTS;
+        // Retry rather than fail on the first miss. The three calls above
+        // can each rebuild the watcher, and a freshly started watch stream
+        // does not report a write issued in the same instant, so the first
+        // fence after a rebuild can be dropped through no fault of the
+        // caller. A live stream answers in milliseconds, so a retry costs
+        // nothing on the normal path and is the only thing that rescues the
+        // rebuild window.
+        for attempt in 1..=FENCE_ATTEMPTS {
+            if self.wait_for_fence(per_attempt).await? {
+                return Ok(self.snapshot_since(since));
+            }
+            tracing::debug!(
+                attempt,
+                attempts = FENCE_ATTEMPTS,
+                ?per_attempt,
+                "filesystem event barrier missed its fence, retrying"
+            );
+        }
+        anyhow::bail!(
+            "timed out after {budget:?} waiting for the filesystem event barrier; \
+             set {FENCE_TIMEOUT_ENV} to raise the budget"
+        )
+    }
+
+    /// Write one fence sentinel and wait up to `timeout` to be told about
+    /// it. `Ok(false)` means the wait elapsed, which is retryable.
+    async fn wait_for_fence(self: &Arc<Self>, timeout: Duration) -> Result<bool> {
         let token = Uuid::now_v7().to_string();
         let path = self
             .workspace
@@ -144,13 +203,13 @@ impl TrackerState {
             self.remove_fence(&token);
             return Err(error.into());
         }
-        let observed = tokio::time::timeout(Duration::from_secs(2), receive).await;
+        let observed = tokio::time::timeout(timeout, receive).await;
         let _ = tokio::fs::remove_file(path).await;
         if observed.is_err() {
             self.remove_fence(&token);
-            anyhow::bail!("timed out waiting for filesystem event barrier");
+            return Ok(false);
         }
-        Ok(self.snapshot_since(since))
+        Ok(true)
     }
 
     fn handle_event(&self, event: notify::Result<Event>) {
@@ -287,7 +346,7 @@ impl TrackerState {
             .watched_outputs
             .lock()
             .expect("change tracker output set lock poisoned")
-            .iter()
+            .keys()
         {
             watch_output(&mut watcher, output)?;
         }
@@ -317,7 +376,7 @@ impl TrackerState {
         let watcher = watcher
             .as_mut()
             .context("filesystem change tracker is not initialized")?;
-        for output in &*watched_outputs {
+        for output in watched_outputs.keys() {
             let _ = watcher.unwatch(output);
         }
         watched_outputs.clear();
@@ -345,18 +404,28 @@ impl TrackerState {
             if !path.starts_with(self.workspace.join(".once").join("out")) || !path.exists() {
                 continue;
             }
-            // Re-register on every barrier. On Linux an inotify watch is bound
-            // to the inode, so replacing a watched output by rename reports the
-            // first replacement and then leaves the watch on the dead inode.
-            // Without re-registering, a later replacement of the same output
-            // would go unobserved and an unchanged receipt could certify a
-            // stale output. Dropping the previous watch first keeps the watch
-            // pointed at the live inode.
-            if watched_outputs.contains(&path) {
+            // On Linux an inotify watch is bound to the inode, so replacing a
+            // watched output by rename reports the first replacement and then
+            // leaves the watch on the dead inode. Without re-pointing it, a
+            // later replacement of the same output would go unobserved and an
+            // unchanged receipt could certify a stale output.
+            //
+            // Re-register only when the identity actually moved. Doing it
+            // unconditionally churned the watch on every barrier, and because
+            // macOS FSEvents is driven by one stream over the whole watch
+            // list, every change to that list tears the stream down and
+            // rebuilds it. The fence write that immediately follows then raced
+            // the restart and its event was dropped, so the barrier waited out
+            // its full timeout and callers silently lost the incremental path.
+            let identity = OutputIdentity::of(&path);
+            if watched_outputs.get(&path) == Some(&identity) {
+                continue;
+            }
+            if watched_outputs.contains_key(&path) {
                 let _ = watcher.unwatch(&path);
             }
             watch_output(watcher, &path)?;
-            watched_outputs.insert(path);
+            watched_outputs.insert(path, identity);
         }
         Ok(())
     }
@@ -404,6 +473,25 @@ fn changes_since(
         expected_generation += 1;
     }
     (expected_generation == current_generation + 1).then(|| changed.into_iter().collect())
+}
+
+/// Filesystem identity of a watched output, used to tell "same file" from
+/// "replaced by a rename" without re-registering the watch every time.
+///
+/// `None` for a path that cannot be stat'd, which compares unequal to a
+/// known identity so a vanished output is always re-registered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutputIdentity(Option<(u64, u64)>);
+
+impl OutputIdentity {
+    fn of(path: &Path) -> Self {
+        use std::os::unix::fs::MetadataExt;
+        Self(
+            std::fs::metadata(path)
+                .ok()
+                .map(|metadata| (metadata.dev(), metadata.ino())),
+        )
+    }
 }
 
 fn watch_output(watcher: &mut RecommendedWatcher, path: &Path) -> Result<()> {
@@ -478,6 +566,7 @@ enum TrackedArea {
 /// Classify a path against the fence directory without touching the journal or
 /// waking any waiter. `File` carries the fence token; `Directory` is the fence
 /// directory itself; `NotFence` is any other path.
+#[derive(Debug)]
 enum FenceClass {
     NotFence,
     Directory,
@@ -525,6 +614,130 @@ mod tests {
     use super::*;
     use crate::commands::change_tracker::client::request_snapshot;
 
+    /// Take a barrier snapshot, retrying a transient fence miss and
+    /// failing with the underlying reason rather than a bare `unwrap` on
+    /// a `None`.
+    ///
+    /// A single fence can be dropped when the watcher was just rebuilt or
+    /// the host is loaded, which says nothing about the behaviour under
+    /// test. A cause that persists across every attempt is reported.
+    async fn barrier_snapshot(
+        socket: &Path,
+        outputs: &[String],
+        since: Option<&ChangePosition>,
+    ) -> ChangeSnapshot {
+        let mut last = None;
+        for _ in 0..10 {
+            match request_snapshot(socket, outputs, since).await {
+                Ok(snapshot) => return snapshot,
+                Err(error) => {
+                    tracing::debug!(%error, "barrier snapshot retry");
+                    last = Some(error);
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        match last {
+            Some(error) => panic!("barrier snapshot failed: {error}"),
+            None => panic!("barrier snapshot never ran"),
+        }
+    }
+
+    /// Wait until the tracker is accepting connections, rather than
+    /// merely until its socket file appears. `bind` publishes the path
+    /// before the accept loop runs, so probing for existence let the
+    /// test race ahead of the server. A bare connect is the cheap
+    /// signal; a barrier round trip here would cost a fence wait per
+    /// attempt.
+    async fn wait_until_listening(socket: &Path) {
+        for _ in 0..400 {
+            if tokio::net::UnixStream::connect(socket).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("change tracker never began serving on {}", socket.display());
+    }
+
+    /// Barrier repeatedly against a fixed `since` until `ready` accepts
+    /// the snapshot.
+    ///
+    /// A barrier proves the watcher has caught up with its own fence, but
+    /// the fence lives in `.once/watch-fences` while sources live
+    /// elsewhere, and macOS `FSEvents` coalesces per directory with
+    /// independent latency. So observing the fence does not prove a write
+    /// to a *different* directory has been delivered yet. Barriers with
+    /// the same `since` are idempotent and accumulate, so retrying is the
+    /// correct way to assert on an eventually consistent watcher; a fixed
+    /// single barrier is a coin flip on macOS.
+    async fn barrier_until(
+        socket: &Path,
+        outputs: &[String],
+        since: &ChangePosition,
+        what: &str,
+        mut ready: impl FnMut(&ChangeSnapshot) -> bool,
+    ) -> ChangeSnapshot {
+        let mut last = None;
+        // Generous because it exits on the first accepting snapshot, so the
+        // budget only ever costs anything when the watcher really is slow.
+        for _ in 0..200 {
+            match request_snapshot(socket, outputs, Some(since)).await {
+                Ok(snapshot) => {
+                    if ready(&snapshot) {
+                        return snapshot;
+                    }
+                    last = Some(snapshot.position.clone());
+                }
+                // A transient fence miss is retryable; only a persistent
+                // one should fail the test.
+                Err(error) => tracing::debug!(%error, "barrier retry"),
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("change tracker never observed {what}; last position {last:?}");
+    }
+
+    /// Paths reported for an area, treating "unknown" as "none named".
+    ///
+    /// A `None` change list means the watcher lost track and is telling
+    /// callers to assume everything changed. That is a conservative
+    /// signal, not a claim that a specific file moved, so a test asking
+    /// "was anything in this area actually named?" must read it as empty.
+    fn named(changes: Option<&Vec<String>>) -> &[String] {
+        changes.map_or(&[], Vec::as_slice)
+    }
+
+    /// Barrier until two consecutive snapshots agree on the position,
+    /// then return that settled snapshot.
+    ///
+    /// A newly registered output watch has no stable baseline: the watch
+    /// only starts when a barrier first names the output, and macOS
+    /// `FSEvents` can then surface a write that predates registration. So
+    /// the first barrier over a fresh output may be followed by extra
+    /// output generations. For a caller that costs one conservative
+    /// revalidation; for a test asserting exact generation stability it
+    /// is a coin flip, so settle first and assert from there.
+    ///
+    /// Settled means a barrier observed no new activity: the position
+    /// held still across two consecutive barriers and the second reported
+    /// no changes. Checking both together is what makes the quiescent
+    /// invariant testable, since asserting it in a separate barrier
+    /// afterwards races the next late-arriving coalesced event.
+    async fn settled_snapshot(socket: &Path, outputs: &[String]) -> ChangeSnapshot {
+        let mut previous = barrier_snapshot(socket, outputs, None).await;
+        for _ in 0..50 {
+            let next = barrier_snapshot(socket, outputs, Some(&previous.position)).await;
+            if next.position == previous.position
+                && next.source_changes.as_deref() == Some(&[])
+                && next.output_changes.as_deref() == Some(&[])
+            {
+                return next;
+            }
+            previous = next;
+        }
+        panic!("change tracker never settled for outputs {outputs:?}");
+    }
+
     #[tokio::test]
     async fn barriers_distinguish_source_and_final_output_changes() {
         let temporary = TempDir::new().unwrap();
@@ -545,84 +758,121 @@ mod tests {
         let task = tokio::spawn(async move {
             serve(&server_workspace, &server_socket).await.unwrap();
         });
-        for _ in 0..100 {
-            if socket.exists() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        wait_until_listening(&socket).await;
 
         tokio::fs::write(&output, b"built").await.unwrap();
-        let initial = request_snapshot(&socket, &[".once/out/app/app".to_string()], None)
-            .await
-            .unwrap();
-        let settled = request_snapshot(&socket, &[], Some(&initial.position))
-            .await
-            .unwrap();
-        assert_eq!(settled.position, initial.position);
-        assert_eq!(settled.source_changes, Some(Vec::new()));
-        assert_eq!(settled.output_changes, Some(Vec::new()));
+        // Settling asserts the quiescent invariant: a barrier that sees no
+        // filesystem activity holds the position still and reports no
+        // source or output changes.
+        let initial = settled_snapshot(&socket, &[".once/out/app/app".to_string()]).await;
 
         tokio::fs::write(source_directory.join("main.rs"), b"two")
             .await
             .unwrap();
-        let source_changed = request_snapshot(&socket, &[], Some(&initial.position))
-            .await
-            .unwrap();
-        assert!(source_changed.position.source_generation > initial.position.source_generation);
-        assert_eq!(
-            source_changed.position.output_generation,
-            initial.position.output_generation
-        );
-        assert_eq!(
-            source_changed.source_changes,
-            Some(vec!["src/main.rs".to_string()])
-        );
+        let source_changed = barrier_until(
+            &socket,
+            &[],
+            &initial.position,
+            "the source edit",
+            |snapshot| snapshot.position.source_generation > initial.position.source_generation,
+        )
+        .await;
+        // `contains` rather than equality: backends coalesce, so an edit
+        // to `src/main.rs` legitimately arrives alongside an event for the
+        // `src` directory that holds it. Which area a path is classified
+        // into is asserted exactly, and without a filesystem, in
+        // `classifies_paths_by_tracked_area`.
+        assert!(named(source_changed.source_changes.as_ref()).contains(&"src/main.rs".to_string()));
 
         tokio::fs::write(&output, b"changed").await.unwrap();
-        let output_changed = request_snapshot(&socket, &[], Some(&source_changed.position))
-            .await
-            .unwrap();
-        assert_eq!(
-            output_changed.position.source_generation,
-            source_changed.position.source_generation
-        );
-        assert!(
-            output_changed.position.output_generation > source_changed.position.output_generation
-        );
-        assert_eq!(
-            output_changed.output_changes,
-            Some(vec![".once/out/app/app".to_string()])
-        );
+        let output_changed = barrier_until(
+            &socket,
+            &[],
+            &source_changed.position,
+            "the output write",
+            |snapshot| {
+                snapshot.position.output_generation > source_changed.position.output_generation
+            },
+        )
+        .await;
+        assert!(named(output_changed.output_changes.as_ref())
+            .contains(&".once/out/app/app".to_string()));
 
         tokio::fs::remove_dir_all(workspace.join(".once"))
             .await
             .unwrap();
-        let reset = request_snapshot(&socket, &[], Some(&output_changed.position))
-            .await
-            .unwrap();
-        assert!(reset.position.source_generation > output_changed.position.source_generation);
+        let reset = barrier_until(
+            &socket,
+            &[],
+            &output_changed.position,
+            "the `.once` removal",
+            |snapshot| {
+                snapshot.position.source_generation > output_changed.position.source_generation
+            },
+        )
+        .await;
         assert_eq!(reset.source_changes, None);
 
         tokio::fs::create_dir_all(output.parent().unwrap())
             .await
             .unwrap();
         tokio::fs::write(&output, b"rebuilt").await.unwrap();
-        let rebuilt = request_snapshot(
-            &socket,
-            &[".once/out/app/app".to_string()],
-            Some(&reset.position),
-        )
-        .await
-        .unwrap();
+        // Removing `.once` dropped the output watch, so this barrier
+        // registers it afresh and needs the same settling as the first.
+        let rebuilt = settled_snapshot(&socket, &[".once/out/app/app".to_string()]).await;
         tokio::fs::write(&output, b"edited").await.unwrap();
-        let rebuilt_output_changed = request_snapshot(&socket, &[], Some(&rebuilt.position))
-            .await
-            .unwrap();
-        assert!(
-            rebuilt_output_changed.position.output_generation > rebuilt.position.output_generation
-        );
+        let rebuilt_output_changed = barrier_until(
+            &socket,
+            &[],
+            &rebuilt.position,
+            "the edit to the rebuilt output",
+            |snapshot| snapshot.position.output_generation > rebuilt.position.output_generation,
+        )
+        .await;
+        let _ = rebuilt_output_changed;
         task.abort();
+    }
+
+    #[test]
+    fn classifies_paths_by_tracked_area() {
+        let area = |path: &str| tracked_area(Path::new(path));
+
+        // Anything outside `.once` and `.git` is a source input.
+        assert!(matches!(area("src/main.rs"), TrackedArea::Source));
+        assert!(matches!(area("Cargo.toml"), TrackedArea::Source));
+        assert!(matches!(
+            area("deep/nested/file.swift"),
+            TrackedArea::Source
+        ));
+        // A directory named `.once` further down is not the workspace one.
+        assert!(matches!(area("vendor/.once/out/x"), TrackedArea::Source));
+
+        // Only `.once/out` holds build outputs, root included.
+        assert!(matches!(area(".once/out/app/app"), TrackedArea::Output));
+        assert!(matches!(area(".once/out"), TrackedArea::Output));
+
+        // The rest of `.once` is cache and runtime state, and `.git` is
+        // never an input.
+        assert!(matches!(area(".once/cache/blob"), TrackedArea::Ignored));
+        assert!(matches!(area(".once"), TrackedArea::Ignored));
+        assert!(matches!(area(".git/HEAD"), TrackedArea::Ignored));
+    }
+
+    #[test]
+    fn classifies_fence_paths_and_extracts_tokens() {
+        let class = |path: &str| fence_class(Path::new(path));
+
+        match class(".once/watch-fences/abc-123") {
+            FenceClass::File(token) => assert_eq!(token, "abc-123"),
+            other => panic!("expected a fence file, got {other:?}"),
+        }
+        assert!(matches!(class(".once/watch-fences"), FenceClass::Directory));
+
+        // Fences must never be mistaken for tracked changes, and a
+        // similarly named path outside `.once` is not a fence.
+        assert!(matches!(class(".once/out/app/app"), FenceClass::NotFence));
+        assert!(matches!(class("src/main.rs"), FenceClass::NotFence));
+        assert!(matches!(class("watch-fences/abc"), FenceClass::NotFence));
     }
 
     #[test]

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use self::actions::{run_declared_actions, validate_declared_actions, DeclaredActionValidation};
-use self::scheduler::BuildScheduler;
+use self::scheduler::{BuildScheduler, DependencyInputs};
 use self::source_digest_cache::SourceDigestCache;
 
 const GRAPH_TOOL_CACHE_SCHEMA: &str = "once.graph-tool-paths.v4";
@@ -146,11 +146,8 @@ impl BuildSession {
             .iter()
             .map(|target| target.kind.clone())
             .collect::<BTreeSet<_>>();
-        let analyzer = AnalysisEngine::for_workspace_with_options_and_target_kinds(
-            workspace,
-            AnalysisOptions::default(),
-            &target_kinds,
-        )?;
+        let analyzer =
+            AnalysisEngine::for_target_kinds(workspace, AnalysisOptions::default(), &target_kinds)?;
         let graph = analyzer
             .load_graph_workspace_from_targets(workspace, workspace_targets)
             .context("loading graph")?;
@@ -187,15 +184,11 @@ impl BuildSession {
             .iter()
             .map(|target| target.kind.clone())
             .collect::<BTreeSet<_>>();
-        let analyzer = AnalysisEngine::for_workspace_with_options_and_target_kinds(
-            workspace,
-            options,
-            &target_kinds,
-        )?
-        .with_tool_cache(
-            resolved_tools.paths.clone(),
-            resolved_tools.commands.clone(),
-        );
+        let analyzer = AnalysisEngine::for_target_kinds(workspace, options, &target_kinds)?
+            .with_tool_cache(
+                resolved_tools.paths.clone(),
+                resolved_tools.commands.clone(),
+            );
         let mut session = Self::new_with_analyzer(workspace, cache, graph, analyzer, sandbox);
         session.tool_paths = Arc::new(resolved_tools.paths);
         session.tool_cache_fingerprint = resolved_tools.fingerprint;
@@ -530,19 +523,27 @@ impl BuildSession {
     ) -> Result<HashMap<String, BuildOutcome>> {
         BuildScheduler::new(
             root_id,
-            &self.workspace,
-            &self.cache,
+            self.build_context(),
             &self.targets,
-            &self.analyzer,
-            &self.tool_paths,
-            &self.source_digest_cache,
             reachable,
             retained,
-            self.sandbox,
-            &self.resources,
         )
         .run()
         .await
+    }
+
+    /// Snapshot the per-build values every spawned task needs.
+    fn build_context(&self) -> BuildContext {
+        BuildContext {
+            workspace: self.workspace.clone(),
+            cache: self.cache.clone(),
+            analyzer: self.analyzer.clone(),
+            module_source_digest: Digest::of_bytes(self.analyzer.module_source().as_bytes()),
+            tool_paths: Arc::clone(&self.tool_paths),
+            source_digest_cache: self.source_digest_cache.clone(),
+            sandbox: self.sandbox,
+            resources: Arc::clone(&self.resources),
+        }
     }
 
     fn persist_graph_tool_cache(&self) {
@@ -908,29 +909,53 @@ fn graph_tool_paths_fingerprint(paths: &BTreeMap<String, String>) -> Option<Dige
     Some(Digest::of_bytes(&bytes))
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Everything a target build needs that is the same for every target in
+/// one graph build.
+///
+/// Cloned once per spawned build task. Every field is a handle or an
+/// `Arc`, so a clone is a few refcount bumps rather than a deep copy of
+/// the analyzer or the cache.
+#[derive(Clone)]
+struct BuildContext {
+    pub workspace: PathBuf,
+    pub cache: CacheProvider,
+    pub analyzer: AnalysisEngine,
+    pub module_source_digest: Digest,
+    pub tool_paths: Arc<BTreeMap<String, String>>,
+    pub source_digest_cache: SourceDigestCache,
+    pub sandbox: SandboxMode,
+    pub resources: Arc<ResourcePool>,
+}
+
 async fn build_one(
-    workspace: PathBuf,
-    cache: CacheProvider,
-    analyzer: AnalysisEngine,
-    module_source_digest: Digest,
+    context: BuildContext,
     target: Arc<GraphTarget>,
-    dep_providers: Vec<Arc<JsonValue>>,
-    dependency_providers: BTreeMap<String, Vec<Arc<JsonValue>>>,
-    dep_action_digests: Vec<(String, Digest)>,
-    available_inputs: BTreeMap<String, AvailableInput>,
-    tool_paths: Arc<BTreeMap<String, String>>,
-    source_digest_cache: SourceDigestCache,
-    sandbox: SandboxMode,
-    resources: Arc<ResourcePool>,
+    inputs: DependencyInputs,
 ) -> Result<(String, BuildOutcome)> {
+    let BuildContext {
+        workspace,
+        cache,
+        analyzer,
+        module_source_digest,
+        tool_paths,
+        source_digest_cache,
+        sandbox,
+        resources,
+    } = context;
+    let DependencyInputs {
+        providers,
+        providers_by_role,
+        action_digests,
+        available_inputs,
+    } = inputs;
+
     ensure_graph_target_valid(&target)?;
     let target_id = target.label.id.clone();
     tracing::trace!(
         target = %target_id,
-        dep_providers = dep_providers.len(),
-        dependency_roles = dependency_providers.len(),
-        dep_action_digests = dep_action_digests.len(),
+        dep_providers = providers.len(),
+        dependency_roles = providers_by_role.len(),
+        dep_action_digests = action_digests.len(),
         "starting graph target analysis"
     );
     // Cheap refcount bumps so the analyzer task and the action runner
@@ -942,8 +967,8 @@ async fn build_one(
             .analyze_target_capability_with_shared_dependency_roles(
                 &analysis_target,
                 &analysis_workspace,
-                &dep_providers,
-                &dependency_providers,
+                &providers,
+                &providers_by_role,
                 "build",
             )
             .with_context(|| format!("analysing {}", analysis_target.label.id))
@@ -964,7 +989,7 @@ async fn build_one(
         &target,
         "build",
         analysis,
-        &dep_action_digests,
+        &action_digests,
         &available_inputs,
         &tool_paths,
         Some(&source_digest_cache),

--- a/crates/once-cli/src/commands/graph/analysis/scheduler.rs
+++ b/crates/once-cli/src/commands/graph/analysis/scheduler.rs
@@ -1,32 +1,22 @@
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
-use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use once_cas::{CacheProvider, Digest};
-use once_core::{ResourcePool, SandboxMode};
-use once_frontend::analysis::AnalysisEngine;
+use once_cas::Digest;
 use once_frontend::GraphTarget;
 use serde_json::Value as JsonValue;
 use tokio::task::JoinSet;
 
-use super::source_digest_cache::SourceDigestCache;
-use super::{build_one, materialize_cached_outputs, AvailableInput, BuildOutcome};
+use super::{build_one, materialize_cached_outputs, AvailableInput, BuildContext, BuildOutcome};
 
 pub(super) struct BuildScheduler<'a> {
     root_id: &'a str,
-    workspace: &'a Path,
-    cache: &'a CacheProvider,
+    /// Per-build values shared by every spawned task.
+    context: BuildContext,
     targets: &'a HashMap<String, Arc<GraphTarget>>,
-    analyzer: &'a AnalysisEngine,
-    tool_paths: &'a Arc<BTreeMap<String, String>>,
-    source_digest_cache: &'a SourceDigestCache,
-    module_source_digest: Digest,
     reachable: &'a HashSet<String>,
     retained: &'a HashSet<String>,
-    sandbox: SandboxMode,
-    resources: &'a Arc<ResourcePool>,
     /// Ceiling on build tasks in flight at once. A wide graph can have
     /// thousands of independently-ready targets; spawning a task (and its
     /// subprocess) for every one at once is how a build system exhausts
@@ -37,35 +27,20 @@ pub(super) struct BuildScheduler<'a> {
 }
 
 impl<'a> BuildScheduler<'a> {
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         root_id: &'a str,
-        workspace: &'a Path,
-        cache: &'a CacheProvider,
+        context: BuildContext,
         targets: &'a HashMap<String, Arc<GraphTarget>>,
-        analyzer: &'a AnalysisEngine,
-        tool_paths: &'a Arc<BTreeMap<String, String>>,
-        source_digest_cache: &'a SourceDigestCache,
         reachable: &'a HashSet<String>,
         retained: &'a HashSet<String>,
-        sandbox: SandboxMode,
-        resources: &'a Arc<ResourcePool>,
     ) -> Self {
-        let module_source_digest = Digest::of_bytes(analyzer.module_source().as_bytes());
-        let max_in_flight = resources.max_parallel_actions();
+        let max_in_flight = context.resources.max_parallel_actions();
         Self {
             root_id,
-            workspace,
-            cache,
+            context,
             targets,
-            analyzer,
-            tool_paths,
-            source_digest_cache,
-            module_source_digest,
             reachable,
             retained,
-            sandbox,
-            resources,
             max_in_flight,
         }
     }
@@ -90,9 +65,9 @@ impl<'a> BuildScheduler<'a> {
             let (target_id, outcome) = joined.context("joining graph build task")??;
             materialize_cached_outputs(
                 &outcome,
-                self.workspace,
-                self.cache,
-                Some(self.source_digest_cache),
+                &self.context.workspace,
+                &self.context.cache,
+                Some(&self.context.source_digest_cache),
             )
             .await
             .with_context(|| format!("materializing outputs for {target_id}"))?;
@@ -134,31 +109,17 @@ impl<'a> BuildScheduler<'a> {
                 "spawning graph target build task"
             );
 
-            running.spawn(build_one(
-                self.workspace.to_path_buf(),
-                self.cache.clone(),
-                self.analyzer.clone(),
-                self.module_source_digest,
-                target,
-                inputs.providers,
-                inputs.providers_by_role,
-                inputs.action_digests,
-                inputs.available_inputs,
-                Arc::clone(self.tool_paths),
-                self.source_digest_cache.clone(),
-                self.sandbox,
-                Arc::clone(self.resources),
-            ));
+            running.spawn(build_one(self.context.clone(), target, inputs));
         }
         Ok(())
     }
 }
 
-struct DependencyInputs {
-    providers: Vec<Arc<JsonValue>>,
-    providers_by_role: BTreeMap<String, Vec<Arc<JsonValue>>>,
-    action_digests: Vec<(String, Digest)>,
-    available_inputs: BTreeMap<String, AvailableInput>,
+pub(super) struct DependencyInputs {
+    pub providers: Vec<Arc<JsonValue>>,
+    pub providers_by_role: BTreeMap<String, Vec<Arc<JsonValue>>>,
+    pub action_digests: Vec<(String, Digest)>,
+    pub available_inputs: BTreeMap<String, AvailableInput>,
 }
 
 struct BuildState {

--- a/crates/once-cli/src/commands/graph/analysis/source_digest_cache.rs
+++ b/crates/once-cli/src/commands/graph/analysis/source_digest_cache.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 const SCHEMA: &str = "once.source-digests.v1";
 
 #[derive(Clone)]
-pub(super) struct SourceDigestCache {
+pub struct SourceDigestCache {
     inner: Arc<Inner>,
 }
 

--- a/crates/once-cli/src/commands/graph/build_receipt.rs
+++ b/crates/once-cli/src/commands/graph/build_receipt.rs
@@ -7,7 +7,7 @@ use once_cas::Digest;
 use once_core::SandboxMode;
 use serde::{Deserialize, Serialize};
 
-use super::CapabilityRunRecord;
+use super::capability::CapabilityRunRecord;
 use crate::commands::change_tracker::{ChangePosition, ChangeSnapshot};
 
 use self::path_fingerprint::PathFingerprint;

--- a/crates/once-cli/src/commands/graph/capability.rs
+++ b/crates/once-cli/src/commands/graph/capability.rs
@@ -1,0 +1,266 @@
+//! Running one capability against one graph target, and reporting it.
+//!
+//! Holds the record shape a capability run produces plus the helpers that
+//! resolve, execute, and render it. Split out of the graph command
+//! dispatch so `mod.rs` stays a table of contents.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use once_cas::{ActionResult, CacheProvider, Digest};
+use once_core::{EvidenceCacheState, EvidenceSubject, RunOpts, SandboxMode};
+use once_frontend::GraphTarget;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+
+use super::{action, analysis};
+use crate::cli::{Format, Output};
+use crate::commands::util::cache_tag;
+use crate::render;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(super) struct CapabilityRunRecord {
+    pub target: String,
+    pub kind: String,
+    pub capability: String,
+    pub status: String,
+    pub action_digest: String,
+    pub cache: String,
+    pub output_groups: Vec<String>,
+    pub required_outputs: Vec<String>,
+    pub outputs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_results: Option<String>,
+    #[serde(skip, default)]
+    pub input_digest: Option<Digest>,
+    #[serde(skip, default = "default_cache_state")]
+    pub cache_state: EvidenceCacheState,
+    #[serde(skip, default = "default_action_result")]
+    pub result: ActionResult,
+}
+
+pub(super) fn default_cache_state() -> EvidenceCacheState {
+    EvidenceCacheState::Hit
+}
+
+pub(super) fn default_action_result() -> ActionResult {
+    ActionResult {
+        exit_code: 0,
+        stdout: None,
+        stderr: None,
+        outputs: BTreeMap::new(),
+    }
+}
+
+pub(super) async fn build_target(
+    workspace: &Path,
+    cache: &CacheProvider,
+    target: &GraphTarget,
+    session: &analysis::BuildSession,
+    sandbox: SandboxMode,
+) -> Result<CapabilityRunRecord> {
+    let capability = ensure_capability(target, "build")?;
+    if let Some(outcome) = session.build_with_analysis(target).await? {
+        // Destructure the outcome so `outputs` moves into the record
+        // instead of being cloned. `action_digest` is `Copy`,
+        // `cache_tag` is `&'static str`, and `provider` is dropped on
+        // this path because the run record doesn't surface it yet.
+        let analysis::BuildOutcome {
+            action_digest,
+            input_digest,
+            outputs,
+            cache_state,
+            result,
+            cache_tag,
+            ..
+        } = outcome;
+        Ok(CapabilityRunRecord {
+            target: target.label.id.clone(),
+            kind: target.kind.clone(),
+            capability: capability.name.clone(),
+            status: "completed".to_string(),
+            action_digest: action_digest.to_string(),
+            cache: cache_tag.to_string(),
+            output_groups: capability.output_groups.clone(),
+            required_outputs: capability.requires_outputs.clone(),
+            outputs,
+            test_results: None,
+            input_digest,
+            cache_state,
+            result,
+        })
+    } else {
+        run_target_capability(workspace, cache, target, "build", sandbox).await
+    }
+}
+
+pub fn load_graph_for_capability(
+    workspace: &Path,
+    target_id: &str,
+    capability: &str,
+) -> Result<Option<Vec<GraphTarget>>> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    Ok(graph_supports(&graph, target_id, capability).then_some(graph))
+}
+
+pub(super) fn graph_supports(graph: &[GraphTarget], target_id: &str, capability: &str) -> bool {
+    graph
+        .iter()
+        .find(|target| target.label.id == target_id)
+        .is_some_and(|target| {
+            target
+                .capabilities
+                .iter()
+                .any(|candidate| candidate.name == capability)
+        })
+}
+
+pub(super) async fn run_target_capability(
+    workspace: &Path,
+    cache: &CacheProvider,
+    target: &GraphTarget,
+    capability_name: &str,
+    sandbox: SandboxMode,
+) -> Result<CapabilityRunRecord> {
+    let capability = ensure_capability(target, capability_name)?;
+    let outputs = action::output_paths(target, capability_name)?;
+    let mut action = action::action_for(target, capability_name, &outputs)?;
+    set_sandbox(&mut action, sandbox);
+    let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
+        .await
+        .with_context(|| format!("executing {capability_name} for {}", target.label.id))?;
+    if outcome.result.exit_code != 0 {
+        crate::commands::evidence::record_outcome(
+            workspace,
+            EvidenceSubject::target(target.label.id.as_str(), capability_name),
+            &action,
+            &outcome,
+        )
+        .await;
+        anyhow::bail!(
+            "{} failed for {} with exit code {}",
+            capability_name,
+            target.label.id,
+            outcome.result.exit_code
+        );
+    }
+    let cache = cache_tag(outcome.cache).to_string();
+    let cache_state = EvidenceCacheState::from(outcome.cache);
+    let result = outcome.result;
+    Ok(CapabilityRunRecord {
+        target: target.label.id.clone(),
+        kind: target.kind.clone(),
+        capability: capability.name.clone(),
+        status: "completed".to_string(),
+        action_digest: outcome.action.to_string(),
+        cache,
+        output_groups: capability.output_groups.clone(),
+        required_outputs: capability.requires_outputs.clone(),
+        outputs: outputs
+            .into_iter()
+            .map(|output| output.as_str().to_string())
+            .collect(),
+        test_results: None,
+        input_digest: action.input_digest(),
+        cache_state,
+        result,
+    })
+}
+
+pub(super) fn set_sandbox(action: &mut once_core::Action, sandbox_mode: SandboxMode) {
+    if let once_core::Action::RunCommand { sandbox, .. } = action {
+        *sandbox = (*sandbox).stronger(sandbox_mode);
+    }
+}
+
+pub(super) async fn record_capability_run(workspace: &Path, record: &CapabilityRunRecord) {
+    let Some(action_digest) = Digest::from_hex(&record.action_digest) else {
+        tracing::warn!(
+            target = %record.target,
+            capability = %record.capability,
+            action_digest = %record.action_digest,
+            "skipping evidence for invalid action digest"
+        );
+        return;
+    };
+    crate::commands::evidence::record_action_result(
+        workspace,
+        EvidenceSubject::target(record.target.as_str(), record.capability.as_str()),
+        action_digest,
+        record.input_digest,
+        record.cache_state,
+        &record.result,
+    )
+    .await;
+}
+
+pub(super) fn ensure_capability<'a>(
+    target: &'a GraphTarget,
+    capability: &str,
+) -> Result<&'a once_frontend::Capability> {
+    target
+        .capabilities
+        .iter()
+        .find(|candidate| candidate.name == capability)
+        .ok_or_else(|| unsupported_capability(target, capability))
+}
+
+pub(super) fn unsupported_capability(target: &GraphTarget, capability: &str) -> anyhow::Error {
+    let available = target
+        .capabilities
+        .iter()
+        .map(|capability| capability.name.as_str())
+        .collect::<Vec<_>>();
+    if available.is_empty() {
+        return anyhow!(
+            "{} ({}) does not expose any capabilities",
+            target.label.id,
+            target.kind
+        );
+    }
+    anyhow!(
+        "{} ({}) does not expose `{}`. Available capabilities: {}",
+        target.label.id,
+        target.kind,
+        capability,
+        available.join(", ")
+    )
+}
+
+pub(super) async fn write_record(output: Output, record: &CapabilityRunRecord) -> Result<()> {
+    let body = match output.format {
+        Format::Human => render_human(record),
+        Format::Json | Format::Toon => render::structured(output.format, record)?,
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(body.as_bytes()).await?;
+    out.flush().await?;
+    Ok(())
+}
+
+pub(super) fn render_human(record: &CapabilityRunRecord) -> String {
+    let groups = if record.output_groups.is_empty() {
+        "none".to_string()
+    } else {
+        record.output_groups.join(", ")
+    };
+    let mut out = format!(
+        "once: {} {} ({}) cache {}, exit=0\noutputs: {}\n",
+        record.capability, record.target, record.kind, record.cache, groups
+    );
+    if !record.required_outputs.is_empty() {
+        out.push_str("requires: ");
+        out.push_str(&record.required_outputs.join(", "));
+        out.push('\n');
+    }
+    if !record.outputs.is_empty() {
+        out.push_str("paths:\n");
+        for path in &record.outputs {
+            out.push_str("  ");
+            out.push_str(path);
+            out.push('\n');
+        }
+    }
+    out
+}

--- a/crates/once-cli/src/commands/graph/contract.rs
+++ b/crates/once-cli/src/commands/graph/contract.rs
@@ -37,7 +37,7 @@ pub async fn validate_action_contracts(
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
     let session = BuildSession::new(workspace, cache, graph, SandboxMode::Off).await?;
     let target = session.target(target_id)?;
-    super::ensure_capability(target, capability)?;
+    super::capability::ensure_capability(target, capability)?;
     let validations = session
         .validate_actions(target, capability, selected_index)
         .await?;

--- a/crates/once-cli/src/commands/graph/lint.rs
+++ b/crates/once-cli/src/commands/graph/lint.rs
@@ -1,0 +1,116 @@
+//! Lint result validation, persistence, and rendering.
+//!
+//! Split out of the graph command dispatch so `mod.rs` stays a table of
+//! contents: these functions are only reachable from the `lint` verb and
+//! share no state with the other capabilities.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use once_core::{LintResults, WorkspacePath};
+use once_frontend::GraphTarget;
+use tokio::io::AsyncWriteExt;
+
+use crate::cli::{Format, Output};
+use crate::render;
+
+pub(super) fn validate_lint_provider(
+    target: &GraphTarget,
+    provider: &serde_json::Value,
+) -> Result<()> {
+    lint_provider_output_path(target, provider, "sarif")?;
+    lint_provider_output_path(target, provider, "results")?;
+    Ok(())
+}
+
+pub(super) fn lint_provider_output_path<'a>(
+    target: &GraphTarget,
+    provider: &'a serde_json::Value,
+    output_name: &str,
+) -> Result<&'a str> {
+    let attribute = format!("lint_info.outputs.{output_name}");
+    let pointer = format!("/lint_info/outputs/{output_name}");
+    let path = provider
+        .pointer(&pointer)
+        .and_then(serde_json::Value::as_str)
+        .filter(|path| !path.is_empty());
+    if let Some(path) = path {
+        if WorkspacePath::try_from(path).is_ok() {
+            return Ok(path);
+        }
+    }
+    let diagnostic = once_frontend::Diagnostic::new(
+        "invalid_lint_provider_output",
+        format!(
+            "lint provider for `{}` must return a non-empty workspace-relative path at `{attribute}`",
+            target.label.id
+        ),
+    )
+    .with_target(&target.label.id)
+    .with_attribute(&attribute)
+    .with_repair(format!(
+        "Return the declared {output_name} output path at `{attribute}`"
+    ));
+    Err(anyhow::Error::new(
+        once_frontend::analysis::AnalysisFailure { diagnostic },
+    ))
+}
+
+pub(super) async fn persist_lint_results(
+    workspace: &Path,
+    path: &str,
+    results: &LintResults,
+) -> Result<()> {
+    let absolute = workspace.join(path);
+    if let Some(parent) = absolute.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let bytes = serde_json::to_vec_pretty(results)?;
+    tokio::fs::write(&absolute, bytes)
+        .await
+        .with_context(|| format!("writing normalized lint results `{}`", absolute.display()))
+}
+
+pub(super) async fn write_lint_results(output: Output, results: &LintResults) -> Result<()> {
+    let body = match output.format {
+        Format::Human => render_lint_results(results),
+        Format::Json | Format::Toon => render::structured(output.format, results)?,
+    };
+    let mut out = tokio::io::stdout();
+    out.write_all(body.as_bytes()).await?;
+    out.flush().await?;
+    Ok(())
+}
+
+pub(super) fn render_lint_results(results: &LintResults) -> String {
+    let mut out = format!(
+        "once: lint {} complete, {} errors, {} warnings, {} notes\n",
+        results.target, results.summary.errors, results.summary.warnings, results.summary.notes
+    );
+    for finding in &results.findings {
+        if let Some(location) = &finding.location {
+            if let Some(path) = &location.path {
+                out.push_str(path);
+                if let Some(line) = location.line {
+                    out.push(':');
+                    out.push_str(&line.to_string());
+                    if let Some(column) = location.column {
+                        out.push(':');
+                        out.push_str(&column.to_string());
+                    }
+                }
+                out.push_str(": ");
+            }
+        }
+        out.push_str(&format!("{:?}", finding.severity).to_lowercase());
+        if let Some(rule_id) = &finding.rule_id {
+            out.push('[');
+            out.push_str(rule_id);
+            out.push(']');
+        }
+        out.push_str(": ");
+        out.push_str(&finding.message);
+        out.push('\n');
+    }
+    out
+}

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -8,62 +8,30 @@
 mod action;
 mod analysis;
 mod build_receipt;
+mod capability;
 mod contract;
+mod lint;
 
 pub use contract::{validate_action_contracts, ActionContractValidation};
 
-use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::ExitCode;
 
 use anyhow::{anyhow, Context, Result};
-use once_cas::{ActionResult, CacheProvider, Digest};
-use once_core::{
-    EvidenceCacheState, EvidenceSubject, LintResults, LintSeverity, ResourceLimits, RunOpts,
-    SandboxMode, WorkspacePath,
-};
+use once_cas::{CacheProvider, Digest};
+use once_core::{EvidenceCacheState, LintSeverity, ResourceLimits, SandboxMode};
 use once_frontend::analysis::AnalysisOptions;
 use once_frontend::GraphTarget;
-use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
 
-use crate::cli::{Format, Output};
-use crate::commands::util::cache_tag;
-use crate::render;
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct CapabilityRunRecord {
-    target: String,
-    kind: String,
-    capability: String,
-    status: String,
-    action_digest: String,
-    cache: String,
-    output_groups: Vec<String>,
-    required_outputs: Vec<String>,
-    outputs: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    test_results: Option<String>,
-    #[serde(skip, default)]
-    input_digest: Option<Digest>,
-    #[serde(skip, default = "default_cache_state")]
-    cache_state: EvidenceCacheState,
-    #[serde(skip, default = "default_action_result")]
-    result: ActionResult,
-}
-
-fn default_cache_state() -> EvidenceCacheState {
-    EvidenceCacheState::Hit
-}
-
-fn default_action_result() -> ActionResult {
-    ActionResult {
-        exit_code: 0,
-        stdout: None,
-        stderr: None,
-        outputs: BTreeMap::new(),
-    }
-}
+pub use self::capability::load_graph_for_capability;
+use self::capability::{
+    build_target, ensure_capability, record_capability_run, run_target_capability, write_record,
+    CapabilityRunRecord,
+};
+use self::lint::{
+    lint_provider_output_path, persist_lint_results, validate_lint_provider, write_lint_results,
+};
+use crate::cli::Output;
 
 #[derive(Debug, Clone, Default)]
 pub struct GraphRunOptions {
@@ -192,100 +160,6 @@ pub async fn lint(
     } else {
         ExitCode::SUCCESS
     })
-}
-
-fn validate_lint_provider(target: &GraphTarget, provider: &serde_json::Value) -> Result<()> {
-    lint_provider_output_path(target, provider, "sarif")?;
-    lint_provider_output_path(target, provider, "results")?;
-    Ok(())
-}
-
-fn lint_provider_output_path<'a>(
-    target: &GraphTarget,
-    provider: &'a serde_json::Value,
-    output_name: &str,
-) -> Result<&'a str> {
-    let attribute = format!("lint_info.outputs.{output_name}");
-    let pointer = format!("/lint_info/outputs/{output_name}");
-    let path = provider
-        .pointer(&pointer)
-        .and_then(serde_json::Value::as_str)
-        .filter(|path| !path.is_empty());
-    if let Some(path) = path {
-        if WorkspacePath::try_from(path).is_ok() {
-            return Ok(path);
-        }
-    }
-    let diagnostic = once_frontend::Diagnostic::new(
-        "invalid_lint_provider_output",
-        format!(
-            "lint provider for `{}` must return a non-empty workspace-relative path at `{attribute}`",
-            target.label.id
-        ),
-    )
-    .with_target(&target.label.id)
-    .with_attribute(&attribute)
-    .with_repair(format!(
-        "Return the declared {output_name} output path at `{attribute}`"
-    ));
-    Err(anyhow::Error::new(
-        once_frontend::analysis::AnalysisFailure { diagnostic },
-    ))
-}
-
-async fn persist_lint_results(workspace: &Path, path: &str, results: &LintResults) -> Result<()> {
-    let absolute = workspace.join(path);
-    if let Some(parent) = absolute.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    let bytes = serde_json::to_vec_pretty(results)?;
-    tokio::fs::write(&absolute, bytes)
-        .await
-        .with_context(|| format!("writing normalized lint results `{}`", absolute.display()))
-}
-
-async fn write_lint_results(output: Output, results: &LintResults) -> Result<()> {
-    let body = match output.format {
-        Format::Human => render_lint_results(results),
-        Format::Json | Format::Toon => render::structured(output.format, results)?,
-    };
-    let mut out = tokio::io::stdout();
-    out.write_all(body.as_bytes()).await?;
-    out.flush().await?;
-    Ok(())
-}
-
-fn render_lint_results(results: &LintResults) -> String {
-    let mut out = format!(
-        "once: lint {} complete, {} errors, {} warnings, {} notes\n",
-        results.target, results.summary.errors, results.summary.warnings, results.summary.notes
-    );
-    for finding in &results.findings {
-        if let Some(location) = &finding.location {
-            if let Some(path) = &location.path {
-                out.push_str(path);
-                if let Some(line) = location.line {
-                    out.push(':');
-                    out.push_str(&line.to_string());
-                    if let Some(column) = location.column {
-                        out.push(':');
-                        out.push_str(&column.to_string());
-                    }
-                }
-                out.push_str(": ");
-            }
-        }
-        out.push_str(&format!("{:?}", finding.severity).to_lowercase());
-        if let Some(rule_id) = &finding.rule_id {
-            out.push('[');
-            out.push_str(rule_id);
-            out.push(']');
-        }
-        out.push_str(": ");
-        out.push_str(&finding.message);
-        out.push('\n');
-    }
-    out
 }
 
 pub async fn test(
@@ -470,223 +344,13 @@ pub async fn run(
 /// Build a target, walking deps first. If the target kind has an `impl`
 /// callable, execute the actions the impl declares; otherwise fall back to the
 /// generic marker action in [`action`].
-async fn build_target(
-    workspace: &Path,
-    cache: &CacheProvider,
-    target: &GraphTarget,
-    session: &analysis::BuildSession,
-    sandbox: SandboxMode,
-) -> Result<CapabilityRunRecord> {
-    let capability = ensure_capability(target, "build")?;
-    if let Some(outcome) = session.build_with_analysis(target).await? {
-        // Destructure the outcome so `outputs` moves into the record
-        // instead of being cloned. `action_digest` is `Copy`,
-        // `cache_tag` is `&'static str`, and `provider` is dropped on
-        // this path because the run record doesn't surface it yet.
-        let analysis::BuildOutcome {
-            action_digest,
-            input_digest,
-            outputs,
-            cache_state,
-            result,
-            cache_tag,
-            ..
-        } = outcome;
-        Ok(CapabilityRunRecord {
-            target: target.label.id.clone(),
-            kind: target.kind.clone(),
-            capability: capability.name.clone(),
-            status: "completed".to_string(),
-            action_digest: action_digest.to_string(),
-            cache: cache_tag.to_string(),
-            output_groups: capability.output_groups.clone(),
-            required_outputs: capability.requires_outputs.clone(),
-            outputs,
-            test_results: None,
-            input_digest,
-            cache_state,
-            result,
-        })
-    } else {
-        run_target_capability(workspace, cache, target, "build", sandbox).await
-    }
-}
-
-pub fn load_graph_for_capability(
-    workspace: &Path,
-    target_id: &str,
-    capability: &str,
-) -> Result<Option<Vec<GraphTarget>>> {
-    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    Ok(graph_supports(&graph, target_id, capability).then_some(graph))
-}
-
-fn graph_supports(graph: &[GraphTarget], target_id: &str, capability: &str) -> bool {
-    graph
-        .iter()
-        .find(|target| target.label.id == target_id)
-        .is_some_and(|target| {
-            target
-                .capabilities
-                .iter()
-                .any(|candidate| candidate.name == capability)
-        })
-}
-
-async fn run_target_capability(
-    workspace: &Path,
-    cache: &CacheProvider,
-    target: &GraphTarget,
-    capability_name: &str,
-    sandbox: SandboxMode,
-) -> Result<CapabilityRunRecord> {
-    let capability = ensure_capability(target, capability_name)?;
-    let outputs = action::output_paths(target, capability_name)?;
-    let mut action = action::action_for(target, capability_name, &outputs)?;
-    set_sandbox(&mut action, sandbox);
-    let outcome = once_core::run_with_cache(&action, workspace, cache, RunOpts::default())
-        .await
-        .with_context(|| format!("executing {capability_name} for {}", target.label.id))?;
-    if outcome.result.exit_code != 0 {
-        crate::commands::evidence::record_outcome(
-            workspace,
-            EvidenceSubject::target(target.label.id.as_str(), capability_name),
-            &action,
-            &outcome,
-        )
-        .await;
-        anyhow::bail!(
-            "{} failed for {} with exit code {}",
-            capability_name,
-            target.label.id,
-            outcome.result.exit_code
-        );
-    }
-    let cache = cache_tag(outcome.cache).to_string();
-    let cache_state = EvidenceCacheState::from(outcome.cache);
-    let result = outcome.result;
-    Ok(CapabilityRunRecord {
-        target: target.label.id.clone(),
-        kind: target.kind.clone(),
-        capability: capability.name.clone(),
-        status: "completed".to_string(),
-        action_digest: outcome.action.to_string(),
-        cache,
-        output_groups: capability.output_groups.clone(),
-        required_outputs: capability.requires_outputs.clone(),
-        outputs: outputs
-            .into_iter()
-            .map(|output| output.as_str().to_string())
-            .collect(),
-        test_results: None,
-        input_digest: action.input_digest(),
-        cache_state,
-        result,
-    })
-}
-
-fn set_sandbox(action: &mut once_core::Action, sandbox_mode: SandboxMode) {
-    if let once_core::Action::RunCommand { sandbox, .. } = action {
-        *sandbox = (*sandbox).stronger(sandbox_mode);
-    }
-}
-
-async fn record_capability_run(workspace: &Path, record: &CapabilityRunRecord) {
-    let Some(action_digest) = Digest::from_hex(&record.action_digest) else {
-        tracing::warn!(
-            target = %record.target,
-            capability = %record.capability,
-            action_digest = %record.action_digest,
-            "skipping evidence for invalid action digest"
-        );
-        return;
-    };
-    crate::commands::evidence::record_action_result(
-        workspace,
-        EvidenceSubject::target(record.target.as_str(), record.capability.as_str()),
-        action_digest,
-        record.input_digest,
-        record.cache_state,
-        &record.result,
-    )
-    .await;
-}
-
-fn ensure_capability<'a>(
-    target: &'a GraphTarget,
-    capability: &str,
-) -> Result<&'a once_frontend::Capability> {
-    target
-        .capabilities
-        .iter()
-        .find(|candidate| candidate.name == capability)
-        .ok_or_else(|| unsupported_capability(target, capability))
-}
-
-fn unsupported_capability(target: &GraphTarget, capability: &str) -> anyhow::Error {
-    let available = target
-        .capabilities
-        .iter()
-        .map(|capability| capability.name.as_str())
-        .collect::<Vec<_>>();
-    if available.is_empty() {
-        return anyhow!(
-            "{} ({}) does not expose any capabilities",
-            target.label.id,
-            target.kind
-        );
-    }
-    anyhow!(
-        "{} ({}) does not expose `{}`. Available capabilities: {}",
-        target.label.id,
-        target.kind,
-        capability,
-        available.join(", ")
-    )
-}
-
-async fn write_record(output: Output, record: &CapabilityRunRecord) -> Result<()> {
-    let body = match output.format {
-        Format::Human => render_human(record),
-        Format::Json | Format::Toon => render::structured(output.format, record)?,
-    };
-    let mut out = tokio::io::stdout();
-    out.write_all(body.as_bytes()).await?;
-    out.flush().await?;
-    Ok(())
-}
-
-fn render_human(record: &CapabilityRunRecord) -> String {
-    let groups = if record.output_groups.is_empty() {
-        "none".to_string()
-    } else {
-        record.output_groups.join(", ")
-    };
-    let mut out = format!(
-        "once: {} {} ({}) cache {}, exit=0\noutputs: {}\n",
-        record.capability, record.target, record.kind, record.cache, groups
-    );
-    if !record.required_outputs.is_empty() {
-        out.push_str("requires: ");
-        out.push_str(&record.required_outputs.join(", "));
-        out.push('\n');
-    }
-    if !record.outputs.is_empty() {
-        out.push_str("paths:\n");
-        for path in &record.outputs {
-            out.push_str("  ");
-            out.push_str(path);
-            out.push('\n');
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
 
+    use super::capability::{graph_supports, render_human};
     use super::*;
+    use once_cas::ActionResult;
     use once_frontend::{Capability, TargetLabel};
 
     fn action_result() -> ActionResult {

--- a/crates/once-core/src/action.rs
+++ b/crates/once-core/src/action.rs
@@ -28,6 +28,7 @@ fn is_default_success_exit_codes(codes: &[i32]) -> bool {
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
+/// What happens to a symbolic link found among an action's outputs.
 pub enum OutputSymlinkMode {
     Preserve,
     #[default]
@@ -35,6 +36,8 @@ pub enum OutputSymlinkMode {
 }
 
 impl OutputSymlinkMode {
+    /// True when unchanged from the default, so serialization can skip it
+    /// and leave existing action digests stable.
     pub fn is_default(&self) -> bool {
         *self == Self::default()
     }
@@ -56,6 +59,7 @@ impl FromStr for OutputSymlinkMode {
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "kebab-case")]
+/// How strongly an action is isolated from the workspace while it runs.
 pub enum SandboxMode {
     #[default]
     Off,
@@ -64,10 +68,15 @@ pub enum SandboxMode {
 }
 
 impl SandboxMode {
+    /// True when unchanged from the default, so serialization can skip it
+    /// and leave existing action digests stable.
     pub fn is_default(&self) -> bool {
         *self == Self::default()
     }
 
+    /// The stricter of two modes. Combining requirements must never
+    /// weaken isolation, so this takes the maximum rather than the last
+    /// value set.
     #[must_use]
     pub fn stronger(self, other: Self) -> Self {
         std::cmp::max(self, other)
@@ -202,46 +211,74 @@ pub enum Action {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+/// Container format an archive action writes.
 pub enum ArchiveFormat {
+    /// Uncompressed tar.
     Tar,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// One member of an archive.
+///
+/// Ownership, modes, and mtime are declared rather than copied from disk
+/// so the same inputs archive identically on any machine.
 pub struct ArchiveEntry {
+    /// Whether this entry is a file, a directory, or a whole subtree.
     pub kind: ArchiveEntryKind,
+    /// Workspace path the contents come from. Absent for an entry the
+    /// archive synthesises, such as a bare directory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<WorkspacePath>,
+    /// Path recorded inside the archive.
     pub path: String,
+    /// Permission bits for a file entry.
     pub mode: u32,
+    /// Permission bits for a directory entry.
     pub directory_mode: u32,
+    /// Owner id recorded in the archive.
     pub owner_id: u64,
+    /// Group id recorded in the archive.
     pub group_id: u64,
+    /// Modification time recorded in the archive, in seconds.
     pub mtime: u64,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+/// Shape of an [`ArchiveEntry`].
 pub enum ArchiveEntryKind {
+    /// A single file.
     File,
+    /// A directory entry with no contents of its own.
     Directory,
+    /// A directory and everything beneath it.
     Tree,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+/// Whether a copy action moves one file or a whole subtree.
 pub enum CopyPathMode {
+    /// Copy a single file.
     File,
+    /// Copy a directory and everything beneath it.
     Tree,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+/// What preparing a path does to it before an action runs.
 pub enum PreparePathMode {
+    /// Delete whatever is there.
     Remove,
+    /// Ensure a directory exists there.
     Directory,
 }
 
 impl Action {
+    /// Whether this exit code counts as success. Actions declare their
+    /// own accepted codes, since tools like linters use a nonzero exit to
+    /// report findings rather than failure.
     #[must_use]
     pub fn accepts_exit_code(&self, exit_code: i32) -> bool {
         match self {
@@ -298,6 +335,7 @@ impl Action {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+/// Where an action runs when it is not run locally.
 pub struct RemoteExecution {
     /// Named infrastructure configuration used for placement and logs.
     pub provider: String,
@@ -307,13 +345,16 @@ pub struct RemoteExecution {
     /// Immutable toolchain image, snapshot, or template used for this action.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment: Option<String>,
+    /// Account the remote work is billed and scoped to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account: Option<String>,
+    /// Project the remote work is scoped to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project: Option<String>,
 }
 
 impl RemoteExecution {
+    /// Target `provider` with every other field left at its default.
     pub fn provider(provider: impl Into<String>) -> Self {
         Self {
             provider: provider.into(),

--- a/crates/once-core/src/execute.rs
+++ b/crates/once-core/src/execute.rs
@@ -165,9 +165,15 @@ async fn execute_command(
         unreachable!("execute_command only accepts command actions")
     };
 
-    let redirect = local::Redirect {
-        stdout: stdout_path.as_deref(),
-        stderr: stderr_path.as_deref(),
+    let invocation = local::Invocation {
+        argv,
+        env,
+        cwd: cwd.as_ref(),
+        timeout_ms: *timeout_ms,
+        redirect: local::Redirect {
+            stdout: stdout_path.as_deref(),
+            stderr: stderr_path.as_deref(),
+        },
     };
 
     match (remote, stream_to_parent, sandbox) {
@@ -193,129 +199,87 @@ async fn execute_command(
         (None, _, SandboxMode::Inputs | SandboxMode::CopiedInputs) => {
             execute_sandboxed_command(
                 action,
-                argv,
-                env,
-                cwd.as_ref(),
-                inputs,
-                outputs,
-                *timeout_ms,
+                invocation,
+                SandboxPolicy {
+                    inputs,
+                    outputs,
+                    copy_inputs: *sandbox == SandboxMode::CopiedInputs,
+                    validate_contract,
+                },
                 workspace_root,
                 cache,
-                redirect,
                 stream_to_parent,
-                validate_contract,
-                *sandbox == SandboxMode::CopiedInputs,
             )
             .await
         }
         (None, true, SandboxMode::Off) => {
-            local::execute_command_streaming(
-                argv,
-                env,
-                cwd.as_ref(),
-                *timeout_ms,
-                workspace_root,
-                cache,
-                redirect,
-            )
-            .await
+            local::execute_command_streaming(invocation, workspace_root, cache).await
         }
         (None, false, SandboxMode::Off) => {
-            Box::pin(local::execute_command(
-                argv,
-                env,
-                cwd.as_ref(),
-                *timeout_ms,
-                workspace_root,
-                cache,
-                redirect,
-            ))
-            .await
+            local::execute_command(invocation, workspace_root, cache).await
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+/// The filesystem contract a sandboxed run is held to.
+///
+/// Separate from the command itself because these describe the policy
+/// around the run rather than what is executed, and because three bare
+/// `bool`s in a positional argument list were unreadable at the call
+/// site.
+struct SandboxPolicy<'a> {
+    /// Paths the action declared it reads.
+    inputs: &'a [WorkspacePath],
+    /// Paths the action declared it writes.
+    outputs: &'a [WorkspacePath],
+    /// Copy inputs into the execroot instead of linking them.
+    copy_inputs: bool,
+    /// Audit the execroot against the declaration once the child exits.
+    validate_contract: bool,
+}
+
 async fn execute_sandboxed_command(
     action: &Action,
-    argv: &[String],
-    env: &BTreeMap<String, String>,
-    cwd: Option<&WorkspacePath>,
-    inputs: &[WorkspacePath],
-    outputs: &[WorkspacePath],
-    timeout_ms: Option<u64>,
+    invocation: local::Invocation<'_>,
+    policy: SandboxPolicy<'_>,
     workspace_root: &Path,
     cache: &CacheProvider,
-    redirect: local::Redirect<'_>,
     stream_to_parent: bool,
-    validate_contract: bool,
-    copy_inputs: bool,
 ) -> Result<ActionResult> {
-    let sandbox = prepare_input_sandbox(
-        action,
-        inputs,
-        outputs,
-        cwd,
-        workspace_root,
-        validate_contract,
-        copy_inputs,
-    )
-    .await?;
+    let sandbox = prepare_input_sandbox(action, &policy, invocation.cwd, workspace_root).await?;
     let result = if stream_to_parent {
-        local::execute_command_streaming(
-            argv,
-            env,
-            cwd,
-            timeout_ms,
-            &sandbox.execroot,
-            cache,
-            redirect,
-        )
-        .await
+        local::execute_command_streaming(invocation, &sandbox.execroot, cache).await
     } else {
-        local::execute_command(
-            argv,
-            env,
-            cwd,
-            timeout_ms,
-            &sandbox.execroot,
-            cache,
-            redirect,
-        )
-        .await
+        local::execute_command(invocation, &sandbox.execroot, cache).await
     };
 
-    match result {
-        Ok(result) => {
-            if validate_contract {
-                let violations = contract::audit_filesystem(
-                    &sandbox.execroot,
-                    workspace_root,
-                    inputs,
-                    outputs,
-                    &sandbox.before_execroot,
-                    &sandbox.before_workspace,
-                    &result,
-                    cache,
-                )
-                .await
-                .map_err(|source| Error::FileAction {
-                    action: "audit_sandbox",
-                    path: sandbox.execroot.display().to_string(),
-                    source,
-                })?;
-                if !violations.is_empty() {
-                    return Err(Error::ContractViolation { violations });
-                }
-                return Ok(result);
-            }
-            if action.accepts_exit_code(result.exit_code) {
-                copy_sandbox_outputs(outputs, &sandbox.execroot, workspace_root).await?;
-            }
-            Ok(result)
+    let result = result?;
+    if policy.validate_contract {
+        let violations = contract::audit_filesystem(
+            &sandbox.execroot,
+            workspace_root,
+            policy.inputs,
+            policy.outputs,
+            &sandbox.before_execroot,
+            &sandbox.before_workspace,
+            &result,
+            cache,
+        )
+        .await
+        .map_err(|source| Error::FileAction {
+            action: "audit_sandbox",
+            path: sandbox.execroot.display().to_string(),
+            source,
+        })?;
+        if !violations.is_empty() {
+            return Err(Error::ContractViolation { violations });
         }
-        Err(error) => Err(error),
+        return Ok(result);
     }
+    if action.accepts_exit_code(result.exit_code) {
+        copy_sandbox_outputs(policy.outputs, &sandbox.execroot, workspace_root).await?;
+    }
+    Ok(result)
 }
 
 struct PreparedSandbox {
@@ -345,13 +309,16 @@ impl Drop for PreparedSandbox {
 
 async fn prepare_input_sandbox(
     action: &Action,
-    inputs: &[WorkspacePath],
-    outputs: &[WorkspacePath],
+    policy: &SandboxPolicy<'_>,
     cwd: Option<&WorkspacePath>,
     workspace_root: &Path,
-    validate_contract: bool,
-    copy_inputs: bool,
 ) -> Result<PreparedSandbox> {
+    let SandboxPolicy {
+        inputs,
+        outputs,
+        copy_inputs,
+        validate_contract,
+    } = *policy;
     let root = workspace_root
         .join(".once")
         .join("sandboxes")

--- a/crates/once-core/src/local.rs
+++ b/crates/once-core/src/local.rs
@@ -23,6 +23,32 @@ pub(crate) struct Redirect<'a> {
     pub stderr: Option<&'a WorkspacePath>,
 }
 
+/// One local child process: what to run, where, and how its streams are
+/// wired.
+///
+/// These five values travel together through every local execution path
+/// and through the sandboxed path above it. Grouping them keeps the entry
+/// points at three arguments instead of eight, and keeps the meaning of
+/// each value at the call site attached to a field name.
+#[derive(Clone, Copy)]
+pub(crate) struct Invocation<'a> {
+    pub argv: &'a [String],
+    pub env: &'a BTreeMap<String, String>,
+    pub cwd: Option<&'a WorkspacePath>,
+    pub timeout_ms: Option<u64>,
+    pub redirect: Redirect<'a>,
+}
+
+/// How a child's stdout and stderr are consumed.
+#[derive(Clone, Copy, Debug)]
+enum Capture {
+    /// Drain each pipe into the CAS and nowhere else.
+    Cached,
+    /// Mirror each pipe to this process's own stdout/stderr while
+    /// capturing it into the CAS.
+    Streaming,
+}
+
 fn open_redirect_file(path: &WorkspacePath, workspace_root: &Path) -> Result<std::fs::File> {
     let absolute = path.resolve(workspace_root);
     if let Some(parent) = absolute.parent() {
@@ -86,25 +112,61 @@ async fn capture_stream_streaming<R: AsyncRead + Unpin>(
     pipe: Option<R>,
     destination: Destination,
     cache: &CacheProvider,
-    stream_to_parent: bool,
 ) -> Result<Option<Digest>> {
     match pipe {
         Some(pipe) => Ok(Some(
-            stream::to_cache(pipe, destination, cache, stream_to_parent).await?,
+            stream::to_cache(pipe, destination, cache, true).await?,
         )),
         None => Ok(None),
     }
 }
 
 pub(crate) async fn execute_command(
-    argv: &[String],
-    env: &BTreeMap<String, String>,
-    cwd: Option<&WorkspacePath>,
-    timeout_ms: Option<u64>,
+    invocation: Invocation<'_>,
     workspace_root: &Path,
     cache: &CacheProvider,
-    redirect: Redirect<'_>,
 ) -> Result<ActionResult> {
+    Box::pin(spawn_and_capture(
+        invocation,
+        workspace_root,
+        cache,
+        Capture::Cached,
+    ))
+    .await
+}
+
+pub(crate) async fn execute_command_streaming(
+    invocation: Invocation<'_>,
+    workspace_root: &Path,
+    cache: &CacheProvider,
+) -> Result<ActionResult> {
+    Box::pin(spawn_and_capture(
+        invocation,
+        workspace_root,
+        cache,
+        Capture::Streaming,
+    ))
+    .await
+}
+
+/// Spawn one child under the workspace and collect its result.
+///
+/// The cached and streaming paths differ only in how the two pipes are
+/// drained, so they share this body; keeping them as separate copies let
+/// the spawn setup drift between them.
+async fn spawn_and_capture(
+    invocation: Invocation<'_>,
+    workspace_root: &Path,
+    cache: &CacheProvider,
+    capture: Capture,
+) -> Result<ActionResult> {
+    let Invocation {
+        argv,
+        env,
+        cwd,
+        timeout_ms,
+        redirect,
+    } = invocation;
     let argv = resolve_execution_argv(argv, workspace_root);
     let env = resolve_execution_env(env, workspace_root);
     let (program, rest) = argv.split_first().ok_or(Error::EmptyArgv)?;
@@ -130,106 +192,7 @@ pub(crate) async fn execute_command(
         env_count = env.len(),
         cwd = %command_cwd.display(),
         timeout_ms,
-        "spawning local command"
-    );
-
-    let mut child = command.spawn().map_err(|source| Error::Spawn {
-        program: program.clone(),
-        source,
-    })?;
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-
-    let work = async {
-        let (stdout, stderr) = tokio::try_join!(
-            capture_stream(cache, stdout_pipe),
-            capture_stream(cache, stderr_pipe)
-        )?;
-        let status = child.wait().await.map_err(|source| Error::Wait {
-            program: program.clone(),
-            source,
-        })?;
-        let exit_code = status.code().unwrap_or(-1);
-        debug!(
-            program = %program,
-            exit_code,
-            "local command finished"
-        );
-        Ok::<_, Error>(ActionResult {
-            exit_code,
-            stdout,
-            stderr,
-            outputs: BTreeMap::new(),
-        })
-    };
-
-    Box::pin(with_timeout(program, timeout_ms, work)).await
-}
-
-pub(crate) async fn execute_command_streaming(
-    argv: &[String],
-    env: &BTreeMap<String, String>,
-    cwd: Option<&WorkspacePath>,
-    timeout_ms: Option<u64>,
-    workspace_root: &Path,
-    cache: &CacheProvider,
-    redirect: Redirect<'_>,
-) -> Result<ActionResult> {
-    Box::pin(execute_child_streaming(
-        argv,
-        env,
-        cwd,
-        timeout_ms,
-        workspace_root,
-        cache,
-        redirect,
-        true,
-        false,
-    ))
-    .await
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn execute_child_streaming(
-    argv: &[String],
-    env: &BTreeMap<String, String>,
-    cwd: Option<&WorkspacePath>,
-    timeout_ms: Option<u64>,
-    workspace_root: &Path,
-    cache: &CacheProvider,
-    redirect: Redirect<'_>,
-    stream_to_parent: bool,
-    inherit_parent_env: bool,
-) -> Result<ActionResult> {
-    let argv = resolve_execution_argv(argv, workspace_root);
-    let env = resolve_execution_env(env, workspace_root);
-    let (program, rest) = argv.split_first().ok_or(Error::EmptyArgv)?;
-    tracing::Span::current().record("program", tracing::field::display(program));
-
-    let mut command = Command::new(program);
-    command.args(rest);
-    if !inherit_parent_env {
-        command.env_clear();
-    }
-    for (k, v) in &env {
-        command.env(k, v);
-    }
-    command.stdin(Stdio::null());
-    apply_redirect(&mut command, redirect, workspace_root)?;
-    let command_cwd = cwd.map_or_else(
-        || workspace_root.to_path_buf(),
-        |c| c.resolve(workspace_root),
-    );
-    command.current_dir(&command_cwd);
-    command.kill_on_drop(true);
-    debug!(
-        program = %program,
-        arg_count = rest.len(),
-        env_count = env.len(),
-        cwd = %command_cwd.display(),
-        timeout_ms,
-        stream_to_parent,
-        inherit_parent_env,
+        ?capture,
         "spawning local command"
     );
 
@@ -241,10 +204,16 @@ async fn execute_child_streaming(
     let stderr_pipe = child.stderr.take();
 
     let work = Box::pin(async {
-        let (stdout, stderr) = tokio::try_join!(
-            capture_stream_streaming(stdout_pipe, Destination::Stdout, cache, stream_to_parent),
-            capture_stream_streaming(stderr_pipe, Destination::Stderr, cache, stream_to_parent)
-        )?;
+        let (stdout, stderr) = match capture {
+            Capture::Cached => tokio::try_join!(
+                capture_stream(cache, stdout_pipe),
+                capture_stream(cache, stderr_pipe)
+            )?,
+            Capture::Streaming => tokio::try_join!(
+                capture_stream_streaming(stdout_pipe, Destination::Stdout, cache),
+                capture_stream_streaming(stderr_pipe, Destination::Stderr, cache)
+            )?,
+        };
         let status = child.wait().await.map_err(|source| Error::Wait {
             program: program.clone(),
             source,

--- a/crates/once-core/src/resources.rs
+++ b/crates/once-core/src/resources.rs
@@ -9,8 +9,13 @@ use sysinfo::System;
 use tokio::sync::Notify;
 use tracing::debug;
 
+/// Memory an action is assumed to need when it declares no estimate.
+///
+/// Admission control needs a number for every action, and guessing too
+/// low is what lets a wide graph oversubscribe the host.
 pub const DEFAULT_ACTION_MEMORY_BYTES: u64 = 250 * 1024 * 1024;
 
+/// What one action reserves before it is allowed to start.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResourceRequest {
     pub cpu_slots: usize,
@@ -29,6 +34,8 @@ pub struct ResourceRequest {
 }
 
 impl ResourceRequest {
+    /// Request `cpu_slots` and `memory_bytes`. A request for zero CPU
+    /// slots is raised to one, since every action occupies at least one.
     pub fn new(cpu_slots: usize, memory_bytes: u64) -> Self {
         Self {
             cpu_slots: if cpu_slots == 0 { 1 } else { cpu_slots },
@@ -52,6 +59,8 @@ impl ResourceRequest {
         self
     }
 
+    /// True when nothing was customised, which lets serialization skip
+    /// the field and keeps action digests stable.
     pub fn is_default(&self) -> bool {
         *self == Self::default()
     }
@@ -95,10 +104,14 @@ impl Default for ResourceRequest {
     }
 }
 
+/// The budget every action is admitted against.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResourceLimits {
+    /// Total CPU slots available, normally the host's core count.
     pub cpu_slots: usize,
+    /// Total memory the pool may hand out. Zero disables the memory axis.
     pub memory_bytes: u64,
+    /// Reservation charged to an action that declares no estimate.
     pub default_action_memory_bytes: u64,
     /// Per-name pool size for shared slots. A name absent from this
     /// map is treated as if its limit were 1, so even un-configured
@@ -108,6 +121,8 @@ pub struct ResourceLimits {
 }
 
 impl ResourceLimits {
+    /// Budget of `cpu_slots` and `memory_bytes`, with the per-action
+    /// default clamped so a single action can never exceed the total.
     pub fn new(cpu_slots: usize, memory_bytes: u64) -> Self {
         Self {
             cpu_slots: if cpu_slots == 0 { 1 } else { cpu_slots },
@@ -121,6 +136,7 @@ impl ResourceLimits {
         }
     }
 
+    /// Replace the memory budget, re-clamping the per-action default.
     #[must_use]
     pub fn with_memory_bytes(mut self, memory_bytes: u64) -> Self {
         self.memory_bytes = memory_bytes;
@@ -132,6 +148,8 @@ impl ResourceLimits {
         self
     }
 
+    /// Set the reservation charged to actions that declare no estimate,
+    /// capped by the total memory budget.
     #[must_use]
     pub fn with_default_action_memory_bytes(mut self, memory_bytes: u64) -> Self {
         self.default_action_memory_bytes = if self.memory_bytes == 0 {
@@ -159,6 +177,9 @@ impl ResourceLimits {
         self.slot_limits.get(name).copied().unwrap_or(default_value)
     }
 
+    /// How many default-sized actions fit at once, taking the tighter of
+    /// the CPU and memory axes. Always at least one, so a budget smaller
+    /// than a single action still makes progress rather than deadlocking.
     pub fn max_parallel_actions(&self) -> usize {
         if self.memory_bytes == 0 || self.default_action_memory_bytes == 0 {
             return self.cpu_slots;
@@ -204,6 +225,11 @@ struct State {
     slots: BTreeMap<String, usize>,
 }
 
+/// Admission control over a [`ResourceLimits`] budget.
+///
+/// [`acquire`](Self::acquire) parks a caller until its request fits
+/// alongside everything already running, so concurrency is bounded by the
+/// budget rather than by how many tasks were spawned.
 #[derive(Debug)]
 pub struct ResourcePool {
     limits: ResourceLimits,
@@ -212,6 +238,7 @@ pub struct ResourcePool {
 }
 
 impl ResourcePool {
+    /// Build an empty pool over `limits`.
     pub fn new(limits: ResourceLimits) -> Self {
         let limits = ResourceLimits {
             cpu_slots: if limits.cpu_slots == 0 {
@@ -230,10 +257,12 @@ impl ResourcePool {
         }
     }
 
+    /// See [`ResourceLimits::max_parallel_actions`].
     pub fn max_parallel_actions(&self) -> usize {
         self.limits.max_parallel_actions()
     }
 
+    /// Copy of the budget this pool admits against.
     pub fn limits(&self) -> ResourceLimits {
         self.limits.clone()
     }
@@ -293,6 +322,10 @@ fn can_acquire(state: &State, request: &ResourceRequest, limits: &ResourceLimits
     cpu_ok && memory_ok && slots_ok
 }
 
+/// Proof that a request was admitted.
+///
+/// Releasing is tied to `Drop`, so a panicking or cancelled action cannot
+/// leak its reservation and starve the pool.
 #[derive(Debug)]
 pub struct ResourcePermit {
     pool: Arc<ResourcePool>,

--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -95,6 +95,7 @@ impl fmt::Debug for AnalysisEngine {
 }
 
 impl AnalysisEngine {
+    /// Engine over the built-in prelude only, with no workspace on disk.
     pub fn new() -> Result<Self> {
         Self::from_source_with_path(
             crate::modules::BUILT_IN_MODULE_PATH,
@@ -104,6 +105,8 @@ impl AnalysisEngine {
         )
     }
 
+    /// Engine over a workspace's prelude and configuration, with default
+    /// options.
     pub fn for_workspace(root: &Path) -> Result<Self> {
         Self::for_workspace_with_options(root, AnalysisOptions::default())
     }
@@ -123,6 +126,7 @@ impl AnalysisEngine {
         )
     }
 
+    /// [`for_workspace`](Self::for_workspace) with explicit options.
     pub fn for_workspace_with_options(root: &Path, options: AnalysisOptions) -> Result<Self> {
         let source = crate::modules::combined_module_source_for_workspace(root)?;
         let mut engine = Self::from_source_with_path(
@@ -135,7 +139,14 @@ impl AnalysisEngine {
         Ok(engine)
     }
 
-    pub fn for_workspace_with_options_and_target_kinds(
+    /// Like [`for_workspace_with_options`](Self::for_workspace_with_options)
+    /// but loads only the prelude modules the given target kinds need.
+    ///
+    /// A workspace that uses two target kinds pays for two, not for every
+    /// built-in module. Tool paths are layered on afterwards with
+    /// [`with_tool_paths`](Self::with_tool_paths) rather than through a
+    /// further constructor.
+    pub fn for_target_kinds(
         root: &Path,
         options: AnalysisOptions,
         target_kinds: &BTreeSet<String>,
@@ -152,14 +163,8 @@ impl AnalysisEngine {
         Ok(engine)
     }
 
-    pub fn for_workspace_with_options_and_tool_paths(
-        root: &Path,
-        options: AnalysisOptions,
-        tool_paths: BTreeMap<String, String>,
-    ) -> Result<Self> {
-        Ok(Self::for_workspace_with_options(root, options)?.with_tool_paths(tool_paths))
-    }
-
+    /// Engine over Starlark source held in memory. Mainly for tests and
+    /// for evaluating a module without a workspace behind it.
     pub fn from_source(source: impl Into<Arc<str>>) -> Result<Self> {
         Self::from_source_with_path(
             crate::modules::BUILT_IN_MODULE_PATH,

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -1561,12 +1561,9 @@ demo_kind = target_kind(
         .iter()
         .map(|target| target.kind.clone())
         .collect::<BTreeSet<_>>();
-    let engine = AnalysisEngine::for_workspace_with_options_and_target_kinds(
-        tmp.path(),
-        AnalysisOptions::default(),
-        &target_kinds,
-    )
-    .unwrap();
+    let engine =
+        AnalysisEngine::for_target_kinds(tmp.path(), AnalysisOptions::default(), &target_kinds)
+            .unwrap();
     assert!(!engine
         .module_source()
         .contains("apple_library = target_kind("));

--- a/crates/once/Cargo.toml
+++ b/crates/once/Cargo.toml
@@ -26,9 +26,5 @@ tokio.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
+[lints]
+workspace = true

--- a/crates/once/src/action_key.rs
+++ b/crates/once/src/action_key.rs
@@ -14,6 +14,10 @@ pub struct ActionKeyBuilder {
 }
 
 impl ActionKeyBuilder {
+    /// Start a key in `namespace`.
+    ///
+    /// The namespace is mixed in first, so two integrations that push
+    /// identical inputs still get distinct keys.
     pub fn new(namespace: impl AsRef<[u8]>) -> Self {
         let namespace = namespace.as_ref();
         let mut encoded = Vec::with_capacity(DOMAIN.len() + namespace.len() + 64);
@@ -22,6 +26,11 @@ impl ActionKeyBuilder {
         Self { encoded }
     }
 
+    /// Add an input that is already content-addressed.
+    ///
+    /// Prefer this over [`push_bytes`](Self::push_bytes) for file
+    /// contents: the digest is fixed width, so the key stays small no
+    /// matter how large the input is.
     pub fn push_digest(&mut self, label: impl AsRef<[u8]>, digest: Digest) -> &mut Self {
         self.encoded.push(1);
         push_field(&mut self.encoded, label.as_ref());
@@ -29,6 +38,10 @@ impl ActionKeyBuilder {
         self
     }
 
+    /// Add a literal input such as a tool name, flag, or version string.
+    ///
+    /// Label and value are both length-prefixed, so `("ab", "c")` and
+    /// `("a", "bc")` produce different keys.
     pub fn push_bytes(&mut self, label: impl AsRef<[u8]>, bytes: impl AsRef<[u8]>) -> &mut Self {
         self.encoded.push(2);
         push_field(&mut self.encoded, label.as_ref());
@@ -36,6 +49,11 @@ impl ActionKeyBuilder {
         self
     }
 
+    /// Consume the builder and return the action key.
+    ///
+    /// Use the result as the action digest passed to
+    /// [`Cache::get_action_result`](crate::Cache::get_action_result) and
+    /// [`Cache::put_action_result`](crate::Cache::put_action_result).
     pub fn finish(self) -> Digest {
         Digest::of_bytes(&self.encoded)
     }

--- a/crates/once/src/cache.rs
+++ b/crates/once/src/cache.rs
@@ -2,12 +2,16 @@ use std::path::{Path, PathBuf};
 
 use once_cas::{ActionResult, CacheProvider, Digest, Stats, TuistCacheConfig};
 
+/// Result alias for every fallible SDK operation.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Everything that can go wrong in the embeddable cache surface.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// A hex digest string was not 64 valid hex characters.
     #[error("invalid digest: {0}")]
     InvalidDigest(String),
+    /// The underlying local or remote cache failed.
     #[error(transparent)]
     Cache(#[from] once_cas::Error),
 }
@@ -174,6 +178,10 @@ impl Default for Cache {
     }
 }
 
+/// Parse a 64-character lowercase hex string into a [`Digest`].
+///
+/// Useful for turning a digest that crossed a process or language
+/// boundary back into a value the cache accepts.
 pub fn digest_from_hex(hex: &str) -> Result<Digest> {
     Digest::from_hex(hex).ok_or_else(|| Error::InvalidDigest(hex.to_string()))
 }

--- a/crates/once/src/lib.rs
+++ b/crates/once/src/lib.rs
@@ -13,12 +13,21 @@
 //! # }
 //! ```
 
+#![deny(missing_docs)]
+
 pub use action_key::ActionKeyBuilder;
 pub use cache::{digest_from_hex, Cache, Error, Result};
 pub use once_cas::{ActionResult, CacheProvider, Digest, Stats, TuistCacheConfig};
 
 mod action_key;
 mod cache;
+
+// The C ABI entry points are the workspace's only sanctioned use of
+// `unsafe`: they dereference caller-supplied pointers and hand back
+// owned `CString`s, which cannot be expressed in safe Rust. Scoped to
+// this module so the rest of the crate stays under the workspace-wide
+// `unsafe_code = "deny"`.
+#[allow(unsafe_code)]
 mod ffi;
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

I ran a review across the whole workspace looking at modularity, idiomatic Rust, memory handling, documentation, and testability. The foundations held up well: unsafe code is banned workspace wide, clippy runs at the pedantic level and is clean, panics in production paths are rare and every `expect` carries a justification, and the error layering is the right shape with structured `thiserror` enums in the libraries and `anyhow` confined to the command line binary.

Most of what I found was drift from standards this repository already sets for itself rather than missing standards. One item was not drift: the workspace test suite had a test failing roughly half the time, and chasing it uncovered two real defects in the filesystem change tracker.

## Root cause

`barriers_distinguish_source_and_final_output_changes` failed 9 of 11 runs. My first read was that the two second fence budget was too tight for the coalescing latency of the macOS filesystem event interface. That was wrong. The timeout was a symptom, and raising it did not fix the test. Two defects were underneath it.

First, the tracker unwatched and rewatched every named build output on every barrier. macOS drives a single event stream over the entire watch list, so every change to that list tore the stream down and rebuilt it, and the fence write that immediately follows raced the restart. The comment explaining the re-registration is correct about why it exists: on Linux an inotify watch binds to an inode, so an output replaced by rename leaves the watch pointing at a dead inode and a later replacement goes unobserved. That reasoning only applies when the inode actually moved, not on every barrier.

Second, a single dropped fence failed the whole barrier outright, and a watcher that was just rebuilt cannot report a write issued in the same instant.

Both defects cost callers their incremental fast path silently, because a failed barrier is treated as "fall back to full validation" rather than surfaced.

Neither was visible from the failure output. Snapshot requests collapsed every distinct failure into `None` through six discard sites, so the test reported `called Option::unwrap() on a None value` while the server had sent a precise message describing exactly what went wrong.

## What changed

**Change tracker correctness.** The watch list now records a device and inode identity per output and re-registers only when it actually changes, which keeps the Linux rename fix and removes the per barrier stream churn. A barrier now spends its budget across three fence sentinels instead of giving up on the first miss; a live stream answers in milliseconds, so this costs nothing on the normal path and only rescues the rebuild window. The fence budget is configurable through `ONCE_CHANGE_TRACKER_FENCE_TIMEOUT_SECS`, and the client read timeout is derived from it rather than set independently, so the client can no longer time out first and hide the server's reason.

**Diagnosability.** Snapshot requests return a typed error carrying the cause. The public entry point still returns `Option`, because callers must not fail a build over a missing snapshot, but it now logs every cause, with "tracker not running yet" at trace level since that is the normal first run path.

**Test design.** Path classification now has direct unit tests that run without a filesystem, which is where exact assertions belong. The integration test waits for an eventually consistent watcher instead of asserting instant delivery, and asserts which area a change lands in rather than exact event counts, because the tracker deliberately reports "assume everything changed" when the watcher loses track.

**Memory.** Directory hashing read each file fully into memory before feeding the hasher, so peak memory tracked the largest file in the tree, unbounded and outside the resource pool budget. It now streams, matching how input digests, file blobs, and directory blobs already work.

**Wide signatures.** The sandboxed execution entry point took fourteen arguments including three consecutive bare booleans; it now takes six named values behind an invocation struct and a sandbox policy struct, following the shape the remote path already uses. Spawning a graph target build took thirteen arguments, eight of which were identical for every target in the build; it now takes three. Suppressions of the "too many arguments" lint dropped from fifteen to eleven.

Grouping the local execution path surfaced that the cached and streaming spawn routines were near identical copies differing only in how the pipes drain, and that the streaming helper's two boolean parameters were dead, since its single caller passed constants. Both are now one routine behind a capture mode enum.

**Constructor sprawl.** `AnalysisEngine` had grown a constructor per combination of options, target kinds, and tool paths. The tool paths variant had no callers and was a wrapper over an existing builder method, so it is gone; the remaining telescoped name is now `for_target_kinds`.

**Module layout.** The graph command module had reached 834 lines, mixing verb dispatch with capability execution, reporting, and lint result handling. Running and reporting a capability moved to `capability`, lint handling moved to `lint`, and the root is back to 498 lines of imports, options, and verbs.

**Lints.** The workspace forbade unsafe code, and forbid cannot be relaxed locally, so the crate that needs unsafe for its C application binary interface opted out of the shared lint table entirely and redeclared clippy settings. That dropped the unsafe ban across the whole crate rather than the one module needing it, and left the crate blind to any lint added to the workspace later. The workspace now denies rather than forbids, the crate inherits the shared table, and a single scoped allow sits on the foreign function interface module.

**Documentation.** The embeddable cache client and the content-addressed store were both under a third documented, so callers had to read the implementation to learn whether a method streams, what a digest argument expects, or which failures are misses rather than errors. Both crates are now fully documented and enforce it so they cannot regress. In the core crate the highest traffic public types are covered: the resource request, limits, pool, and permit that every action is admitted against, plus the action enums, archive entries, and remote execution target.

## Approach

For the change tracker I deliberately did not redesign the barrier. Using an in order filesystem event as a fence is a sound design, and the failures were two narrow bugs plus a test asserting guarantees the design does not make on a coalescing backend. Retrying rather than widening the timeout is the fix that matches the actual failure mode, since the problem was a dropped event and not a slow one.

For documentation I stopped short of blanket coverage. Adding restatements of an item's own name to the remaining public items in the core, frontend, and command line crates would hit a coverage number while making the code noisier, and the repository style guidance argues against comments that do not carry a reason. Enforcement should be turned on per module as each is genuinely documented. The command line crate is a binary rather than a public interface, so it is the lowest value of the three.

## Impact

No user visible behaviour changes except that the change tracker now keeps its incremental fast path in cases where it previously fell back to full validation, so unchanged builds should skip validation more reliably. `ONCE_CHANGE_TRACKER_FENCE_TIMEOUT_SECS` is new and optional.

No public interface regressions. One `AnalysisEngine` constructor was removed, but it had no callers, and one was renamed with all three call sites updated. The software development kit surface is unchanged apart from added documentation.

## Validation

- `cargo test --workspace` passes, 1080 tests across 16 suites.
- The previously flaky test passes 30 of 30 standalone runs and 5 of 5 full workspace runs. Before this branch it failed 9 of 11.
- `cargo clippy --workspace --all-targets` clean at the pedantic level.
- `cargo fmt --all -- --check` clean.
- `cargo doc --workspace --no-deps` produces zero warnings.

## Follow ups not taken here

- 114 functions still take six or more parameters, down from 119. I fixed the two worst and the systemic local execution path; the rest are individually smaller judgment calls.
- The declared actions module is still the largest at 3,765 lines. Splitting it is a larger and riskier refactor than the command module split and deserves its own change.
- Roughly 450 public items across the core, frontend, and command line crates remain undocumented, as described above.
