### PR TITLE
feat(graph): add whole-graph content fingerprint

### DIFF
--- a/crates/once-cli/src/cli/query.rs
+++ b/crates/once-cli/src/cli/query.rs
@@ -82,6 +82,23 @@ pub enum QueryCmd {
         target: String,
     },
 
+    /// Compute a deterministic, content-addressed digest of the whole graph.
+    ///
+    /// Folds every target declaration, resolved source contents, the pinned
+    /// Mise toolchain (`mise.toml` and `mise.lock`), and the root workspace
+    /// manifest into one stable digest with categorized components.
+    GraphFingerprint {
+        /// Exclude resolved source file contents from the digest.
+        #[arg(long)]
+        no_sources: bool,
+        /// Exclude the Mise toolchain declarations from the digest.
+        #[arg(long)]
+        no_toolchain: bool,
+        /// Exclude the root workspace manifest from the digest.
+        #[arg(long)]
+        no_manifest: bool,
+    },
+
     /// List targets that expose the generic test capability.
     Tests,
 
@@ -207,6 +224,7 @@ impl QueryCmd {
             Self::ModuleContract => vec!["module-contract"],
             Self::ExternalSource { .. } => vec!["external-source"],
             Self::Target { .. } => vec!["target"],
+            Self::GraphFingerprint { .. } => vec!["graph-fingerprint"],
             Self::Tests => vec!["tests"],
             Self::AffectedTests { .. } => vec!["affected-tests"],
             Self::TestPlan { .. } => vec!["test-plan"],

--- a/crates/once-cli/src/commands/fingerprint.rs
+++ b/crates/once-cli/src/commands/fingerprint.rs
@@ -1,0 +1,348 @@
+//! Whole-graph content fingerprint.
+//!
+//! Produces a single deterministic digest that summarizes an entire
+//! loaded graph plus the workspace inputs that affect its outcomes:
+//! target declarations, resolved source contents, the pinned Mise
+//! toolchain, and the root workspace manifest. The digest composes the
+//! same `InputDigestBuilder` machinery per-action input fingerprints
+//! use, so the categorized components share one shape across the
+//! system.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use once_cas::Digest;
+use once_core::{digest_source_path, InputDigestBuilder, InputFingerprintComponent};
+use once_frontend::{GraphTarget, TOML_BUILD_FILE_NAME};
+use serde::{Deserialize, Serialize};
+
+/// Wire schema for the graph fingerprint record.
+pub const GRAPH_FINGERPRINT_SCHEMA: &str = "once.graph_fingerprint.v1";
+
+/// Domain-separation prefix for the whole-graph fingerprint. Bump the
+/// version when the canonical component encoding changes in a way that
+/// should invalidate every graph fingerprint.
+const GRAPH_FINGERPRINT_DOMAIN: &[u8] = b"once.graph.fingerprint.v1\0";
+
+/// Selects which content families the fingerprint folds in. The default
+/// includes everything: graph targets, resolved source contents, the
+/// Mise toolchain declarations, and the root workspace manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraphFingerprintOptions {
+    pub include_sources: bool,
+    pub include_toolchain: bool,
+    pub include_manifest: bool,
+}
+
+impl Default for GraphFingerprintOptions {
+    fn default() -> Self {
+        Self {
+            include_sources: true,
+            include_toolchain: true,
+            include_manifest: true,
+        }
+    }
+}
+
+/// Deterministic, content-addressed fingerprint of an entire loaded
+/// graph plus the workspace inputs that affect its outcomes.
+///
+/// The `digest` changes whenever a target declaration, a resolved
+/// source file, the pinned Mise toolchain, or the root manifest
+/// changes. `components` exposes the same categorized `(category,
+/// label, digest)` triples used by per-action input fingerprints, so a
+/// caller can see exactly which target, source, toolchain, or manifest
+/// input contributed to the digest without re-deriving it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GraphFingerprint {
+    pub schema: String,
+    pub digest: Digest,
+    pub target_count: usize,
+    pub source_count: usize,
+    pub components: Vec<InputFingerprintComponent>,
+}
+
+/// Compute a graph fingerprint for an already loaded graph.
+///
+/// The graph is sorted internally by target id, so the fingerprint is
+/// independent of discovery order. Source patterns are resolved through
+/// the same glob expander the build uses, then hashed by content.
+/// Missing `mise.toml`, `mise.lock`, and the root manifest are skipped
+/// rather than treated as errors, so workspaces that do not pin a Mise
+/// toolchain or ship a root manifest still fingerprint cleanly.
+pub fn graph_fingerprint(
+    workspace_root: &Path,
+    graph: &[GraphTarget],
+    options: GraphFingerprintOptions,
+) -> Result<GraphFingerprint> {
+    let mut builder = InputDigestBuilder::new(GRAPH_FINGERPRINT_DOMAIN);
+
+    let mut ordered = graph.to_vec();
+    ordered.sort_by(|a, b| a.label.id.cmp(&b.label.id));
+    for target in &ordered {
+        let body = serde_json::to_vec(target).context("serializing graph target")?;
+        let digest = Digest::of_bytes(&body);
+        builder.push_keyed_component(
+            "target",
+            target.label.id.as_str(),
+            target.label.id.as_bytes(),
+            &digest,
+        );
+    }
+
+    let mut source_count = 0usize;
+    if options.include_sources {
+        let mut sources = BTreeSet::new();
+        for target in &ordered {
+            let resolved = once_frontend::analysis::expand_globs_with_excludes(
+                workspace_root,
+                &target.label.package,
+                &target.srcs,
+                &[],
+            )
+            .with_context(|| format!("resolving sources for {}", target.label.id))?;
+            sources.extend(resolved);
+        }
+        for path in &sources {
+            if let Some(digest) = optional_digest(workspace_root, path)? {
+                builder.push_keyed_component("source", path.as_str(), path.as_bytes(), &digest);
+                source_count += 1;
+            }
+        }
+    }
+
+    if options.include_manifest {
+        if let Some(digest) = optional_digest(workspace_root, TOML_BUILD_FILE_NAME)? {
+            builder.push_keyed_component(
+                "manifest",
+                TOML_BUILD_FILE_NAME,
+                TOML_BUILD_FILE_NAME.as_bytes(),
+                &digest,
+            );
+        }
+    }
+
+    if options.include_toolchain {
+        for label in ["mise.toml", "mise.lock"] {
+            if let Some(digest) = optional_digest(workspace_root, label)? {
+                builder.push_keyed_component("toolchain", label, label.as_bytes(), &digest);
+            }
+        }
+    }
+
+    let manifest = builder.finish_with_fingerprint();
+    Ok(GraphFingerprint {
+        schema: GRAPH_FINGERPRINT_SCHEMA.to_string(),
+        digest: manifest.input_digest,
+        target_count: ordered.len(),
+        source_count,
+        components: manifest.components,
+    })
+}
+
+fn optional_digest(workspace_root: &Path, ws_rel: &str) -> Result<Option<Digest>> {
+    match digest_source_path(workspace_root, ws_rel) {
+        Ok(digest) => Ok(Some(digest)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(anyhow::anyhow!("failed to read {ws_rel}: {source}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use once_frontend::{AttrValue, Capability, TargetLabel};
+
+    fn target(id: &str, package: &str, name: &str, kind: &str, srcs: &[&str]) -> GraphTarget {
+        GraphTarget {
+            label: TargetLabel {
+                package: package.to_string(),
+                name: name.to_string(),
+                id: id.to_string(),
+            },
+            kind: kind.to_string(),
+            deps: Vec::new(),
+            dependency_edges: BTreeMap::new(),
+            srcs: srcs.iter().map(std::string::ToString::to_string).collect(),
+            visibility: Vec::new(),
+            attrs: BTreeMap::new(),
+            capabilities: vec![Capability {
+                name: "build".to_string(),
+                output_groups: vec!["default".to_string()],
+                requires_outputs: Vec::new(),
+            }],
+            providers: Vec::new(),
+            tools: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn empty_workspace() -> tempfile::TempDir {
+        tempfile::TempDir::new().unwrap()
+    }
+
+    fn write_source(tmp: &tempfile::TempDir, rel: &str, bytes: &[u8]) {
+        let path = tmp.path().join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn identical_graph_and_sources_are_deterministic() {
+        let graph = vec![target("pkg/a", "pkg", "a", "library", &["a.swift"])];
+        let tmp = empty_workspace();
+        write_source(&tmp, "pkg/a.swift", b"fn a() {}");
+
+        let first =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+        let second =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+        assert_eq!(first.digest, second.digest);
+        assert_eq!(first.schema, GRAPH_FINGERPRINT_SCHEMA);
+    }
+
+    #[test]
+    fn discovery_order_does_not_change_the_digest() {
+        let a = target("pkg/a", "pkg", "a", "library", &[]);
+        let b = target("pkg/b", "pkg", "b", "library", &[]);
+        let tmp = empty_workspace();
+
+        let forward = graph_fingerprint(
+            tmp.path(),
+            &[a.clone(), b.clone()],
+            GraphFingerprintOptions::default(),
+        )
+        .unwrap();
+        let reverse =
+            graph_fingerprint(tmp.path(), &[b, a], GraphFingerprintOptions::default()).unwrap();
+
+        assert_eq!(forward.digest, reverse.digest);
+    }
+
+    #[test]
+    fn changing_a_target_attribute_changes_the_digest() {
+        let graph = vec![target("pkg/a", "pkg", "a", "library", &[])];
+        let tmp = empty_workspace();
+        let before =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+
+        let mut changed = graph.clone();
+        changed[0]
+            .attrs
+            .insert("edition".to_string(), AttrValue::String("2021".to_string()));
+        let after =
+            graph_fingerprint(tmp.path(), &changed, GraphFingerprintOptions::default()).unwrap();
+
+        assert_ne!(before.digest, after.digest);
+        assert_eq!(after.target_count, 1);
+    }
+
+    #[test]
+    fn source_content_change_changes_the_digest() {
+        let graph = vec![target("pkg/a", "pkg", "a", "library", &["a.swift"])];
+        let tmp = empty_workspace();
+        write_source(&tmp, "pkg/a.swift", b"one");
+
+        let before =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+        write_source(&tmp, "pkg/a.swift", b"two");
+        let after =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+
+        assert_ne!(before.digest, after.digest);
+        assert_eq!(after.source_count, 1);
+        assert!(after.components.iter().any(|c| c.category == "source"));
+    }
+
+    #[test]
+    fn structure_only_ignores_source_content_changes() {
+        let graph = vec![target("pkg/a", "pkg", "a", "library", &["a.swift"])];
+        let tmp = empty_workspace();
+        write_source(&tmp, "pkg/a.swift", b"one");
+
+        let before = graph_fingerprint(
+            tmp.path(),
+            &graph,
+            GraphFingerprintOptions {
+                include_sources: false,
+                include_toolchain: false,
+                include_manifest: false,
+            },
+        )
+        .unwrap();
+        write_source(&tmp, "pkg/a.swift", b"two");
+        let after = graph_fingerprint(
+            tmp.path(),
+            &graph,
+            GraphFingerprintOptions {
+                include_sources: false,
+                include_toolchain: false,
+                include_manifest: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(before.digest, after.digest);
+        assert_eq!(after.source_count, 0);
+        assert!(!after.components.iter().any(|c| c.category == "source"));
+    }
+
+    #[test]
+    fn mise_toolchain_change_changes_the_digest() {
+        let graph = vec![target("pkg/a", "pkg", "a", "library", &[])];
+        let tmp = empty_workspace();
+        std::fs::write(tmp.path().join("mise.toml"), "[tools]\nrust = \"1.96.0\"\n").unwrap();
+
+        let before =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+        std::fs::write(tmp.path().join("mise.toml"), "[tools]\nrust = \"1.97.0\"\n").unwrap();
+        let after =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+
+        assert_ne!(before.digest, after.digest);
+        assert!(after
+            .components
+            .iter()
+            .any(|c| c.category == "toolchain" && c.label == "mise.toml"));
+    }
+
+    #[test]
+    fn missing_mise_config_is_skipped_not_an_error() {
+        let graph = vec![target("pkg/a", "pkg", "a", "library", &[])];
+        let tmp = empty_workspace();
+        let fingerprint =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+        assert!(!fingerprint
+            .components
+            .iter()
+            .any(|c| c.category == "toolchain"));
+    }
+
+    #[test]
+    fn components_are_categorized() {
+        let graph = vec![target("pkg/a", "pkg", "a", "library", &["a.swift"])];
+        let tmp = empty_workspace();
+        write_source(&tmp, "pkg/a.swift", b"fn a() {}");
+        std::fs::write(tmp.path().join("once.toml"), "[workspace]\n").unwrap();
+        std::fs::write(tmp.path().join("mise.toml"), "[tools]\n").unwrap();
+        std::fs::write(tmp.path().join("mise.lock"), "# lock\n").unwrap();
+
+        let fingerprint =
+            graph_fingerprint(tmp.path(), &graph, GraphFingerprintOptions::default()).unwrap();
+
+        let categories = fingerprint
+            .components
+            .iter()
+            .map(|c| c.category.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            categories,
+            ["manifest", "source", "target", "toolchain"]
+                .into_iter()
+                .collect::<BTreeSet<_>>()
+        );
+    }
+}

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -336,6 +336,7 @@ impl Server {
             "once_query_test_manifest" => self.tool_query_test_manifest(&call.arguments),
             "once_query_test_attempts" => self.tool_query_test_attempts(&call.arguments),
             "once_query_evidence" => self.tool_query_evidence(&call.arguments),
+            "once_query_graph_fingerprint" => self.tool_query_graph_fingerprint(&call.arguments),
             "once_query_module_contract" => crate::commands::query::module_contract_value(),
             "once_list_native_projects" => {
                 crate::commands::query::native_projects_value(&self.workspace)
@@ -545,6 +546,16 @@ impl Server {
             .await
         })?;
         Ok(serde_json::to_value(records)?)
+    }
+
+    fn tool_query_graph_fingerprint(&self, args: &Value) -> Result<Value> {
+        let args: GraphFingerprintArgs = serde_json::from_value(tool_args(args))?;
+        let options = crate::commands::fingerprint::GraphFingerprintOptions {
+            include_sources: args.include_sources,
+            include_toolchain: args.include_toolchain,
+            include_manifest: args.include_manifest,
+        };
+        crate::commands::query::graph_fingerprint_value(&self.workspace, options)
     }
 
     fn tool_fetch_external_source(args: &Value) -> Result<Value> {
@@ -994,6 +1005,21 @@ struct EvidenceQueryArgs {
     subject: Option<String>,
     #[serde(default = "default_evidence_limit")]
     limit: usize,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GraphFingerprintArgs {
+    #[serde(default = "default_true")]
+    include_sources: bool,
+    #[serde(default = "default_true")]
+    include_toolchain: bool,
+    #[serde(default = "default_true")]
+    include_manifest: bool,
 }
 
 #[derive(Deserialize, Default)]
@@ -1722,6 +1748,7 @@ demo_kind = target_kind(
                 "once_query_test_manifest".to_string(),
                 "once_query_test_attempts".to_string(),
                 "once_query_evidence".to_string(),
+                "once_query_graph_fingerprint".to_string(),
                 "once_validate_script".to_string(),
                 "once_validate_workspace".to_string(),
                 "once_validate_target".to_string(),
@@ -2099,6 +2126,61 @@ script_runtime = "sh"
             result["suggested_calls"][0]["tool"],
             "once_list_target_kinds"
         );
+    }
+
+    #[test]
+    fn graph_fingerprint_returns_a_stable_digest_with_categorized_components() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("once.toml"),
+            "[workspace]\ninclude = [\"once.toml\", \"pkg/once.toml\"]\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(tmp.path().join("pkg")).unwrap();
+        std::fs::write(
+            tmp.path().join("pkg/once.toml"),
+            "[[target]]\nname = \"lib\"\nkind = \"library\"\nsrcs = [\"lib.rs\"]\n",
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("pkg/lib.rs"), "fn lib() {}").unwrap();
+        std::fs::write(tmp.path().join("mise.toml"), "[tools]\nrust = \"1.96.0\"\n").unwrap();
+
+        let digest_for = |include_sources: bool| {
+            let response = server(tmp.path().to_path_buf()).dispatch(request(
+                "tools/call",
+                json!({
+                    "name": "once_query_graph_fingerprint",
+                    "arguments": { "include_sources": include_sources }
+                }),
+            ));
+            assert!(response.error.is_none(), "{response:?}");
+            response.result.unwrap()["structuredContent"]["result"].clone()
+        };
+
+        let with_sources = digest_for(true);
+        assert_eq!(with_sources["schema"], "once.graph_fingerprint.v1");
+        assert_eq!(with_sources["target_count"], 1);
+        assert_eq!(with_sources["source_count"], 1);
+        let digest = with_sources["digest"].as_str().unwrap().to_string();
+        assert_eq!(digest.len(), 64);
+
+        let categories = with_sources["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["category"].as_str().unwrap().to_string())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(categories.contains("target"));
+        assert!(categories.contains("source"));
+        assert!(categories.contains("toolchain"));
+
+        // Same graph and inputs resolve to the same digest.
+        assert_eq!(digest_for(true)["digest"], digest);
+
+        // Excluding sources produces a different digest and no source component.
+        let structure_only = digest_for(false);
+        assert_ne!(structure_only["digest"], digest);
+        assert_eq!(structure_only["source_count"], 0);
     }
 
     #[test]

--- a/crates/once-cli/src/commands/mcp/tools.rs
+++ b/crates/once-cli/src/commands/mcp/tools.rs
@@ -504,6 +504,32 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
             example_return: "[\n  {\n    \"schema\": \"once.evidence.v1\",\n    \"id\": \"8d65122cd9dcddc8d5d9a8458ff42a40fe3dd7acbd4e0563fd7f9e8fb19b0c44\",\n    \"kind\": \"action_result\",\n    \"subject\": { \"kind\": \"target\", \"id\": \"cli\", \"capability\": \"test\" },\n    \"status\": \"passed\",\n    \"action_digest\": \"0476bde2e7d8d1a64d9bd6f589ef5b443d0f60b71e2ad6f1c5bd7a2c4c41223f\",\n    \"input_digest\": \"8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccd5f5814ccfb820e6a41\",\n    \"input_fingerprint\": {\n      \"schema\": \"once.input_fingerprint.v1\",\n      \"input_digest\": \"8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccd5f5814ccfb820e6a41\",\n      \"components\": [\n        {\n          \"category\": \"source\",\n          \"label\": \"src/lib.rs\",\n          \"digest\": \"1111111111111111111111111111111111111111111111111111111111111111\"\n        },\n        {\n          \"category\": \"dependency\",\n          \"label\": \"core\",\n          \"digest\": \"2222222222222222222222222222222222222222222222222222222222222222\"\n        }\n      ]\n    },\n    \"cache\": \"miss\",\n    \"exit_code\": 0,\n    \"stdout\": \"b439bb065d84034c2e7172c1709eb28797c9bd7f2c64c5d1a1d9c1118f6f9d7e\",\n    \"created_at_unix_ms\": 1812345678901\n  }\n]",
         },
         ToolDefinition {
+            name: "once_query_graph_fingerprint",
+            description: "Compute a deterministic, content-addressed digest of the whole graph.",
+            long_description: "Returns the same record as `once query graph-fingerprint --format json`: a single stable digest that folds in every target declaration, the resolved contents of every declared source file, the pinned Mise toolchain (`mise.toml` and `mise.lock` when present), and the root workspace manifest. The digest changes whenever any of those inputs change, so two identical checkouts on different machines produce the same digest. `components` lists the categorized `(category, label, digest)` triples behind the digest, mirroring per-action input fingerprints, so a caller can see which target, source, toolchain, or manifest input contributed. Categories default to all on; set `include_sources`, `include_toolchain`, or `include_manifest` to false to scope the digest, for example to compare only graph structure across checkouts. The matching command-line operation is `once query graph-fingerprint [--no-sources --no-toolchain --no-manifest]`.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "include_sources": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Fold resolved source file contents into the digest."
+                    },
+                    "include_toolchain": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Fold the `mise.toml` and `mise.lock` declarations into the digest."
+                    },
+                    "include_manifest": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Fold the root `once.toml` manifest into the digest."
+                    }
+                }
+            }),
+            example_return: "{\n  \"schema\": \"once.graph_fingerprint.v1\",\n  \"digest\": \"a046fc32a4c232b7320b4249d630ec5a4fef9ae8c3313a65754f33cc31375676\",\n  \"target_count\": 2,\n  \"source_count\": 1,\n  \"components\": [\n    { \"category\": \"target\", \"label\": \"pkg/lib\", \"digest\": \"1111111111111111111111111111111111111111111111111111111111111111\" },\n    { \"category\": \"source\", \"label\": \"pkg/lib.rs\", \"digest\": \"2222222222222222222222222222222222222222222221111111111111111111\" },\n    { \"category\": \"toolchain\", \"label\": \"mise.toml\", \"digest\": \"3333333333333333333333333333333333333333333333333333333333333333\" }\n  ]\n}",
+        },
+        ToolDefinition {
             name: "once_validate_script",
             description: "Parse and validate an annotated script's cache contract.",
             long_description: "Reads a workspace-relative script, validates its shebang and `once` directives, and returns the parsed runtime, inputs, outputs, dependency scripts, fingerprints, environment names, working directory, remote policy, and output symlink policy. Put singular directives with quoted values directly after the shebang, for example `# once input \"input.txt\"` and `# once output \"output.txt\"`. Plural names, colon syntax, and unquoted paths are invalid. Invalid contracts return `{ valid: false, diagnostics: [...] }`, so callers can repair directive typos before execution. The matching command-line operation is `once query script <path>`.",

--- a/crates/once-cli/src/commands/mod.rs
+++ b/crates/once-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod change_tracker;
 pub mod edit;
 pub mod evidence;
 pub mod exec;
+pub mod fingerprint;
 pub mod graph;
 pub mod mcp;
 pub mod query;

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -717,6 +717,49 @@ pub async fn target(workspace: &Path, output: Output, target_id: &str) -> Result
     write_body(output, || render_target_human(&target), &target).await
 }
 
+pub async fn graph_fingerprint(
+    workspace: &Path,
+    output: Output,
+    options: crate::commands::fingerprint::GraphFingerprintOptions,
+) -> Result<()> {
+    let fingerprint = graph_fingerprint_value(workspace, options)?;
+    let record: crate::commands::fingerprint::GraphFingerprint =
+        serde_json::from_value(fingerprint)?;
+    write_body(output, || render_graph_fingerprint_human(&record), &record).await
+}
+
+pub(crate) fn graph_fingerprint_value(
+    workspace: &Path,
+    options: crate::commands::fingerprint::GraphFingerprintOptions,
+) -> Result<serde_json::Value> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    let fingerprint = crate::commands::fingerprint::graph_fingerprint(workspace, &graph, options)?;
+    Ok(serde_json::to_value(fingerprint)?)
+}
+
+fn render_graph_fingerprint_human(
+    fingerprint: &crate::commands::fingerprint::GraphFingerprint,
+) -> String {
+    use std::fmt::Write as _;
+    let mut counts = std::collections::BTreeMap::new();
+    for component in &fingerprint.components {
+        *counts.entry(component.category.as_str()).or_insert(0usize) += 1;
+    }
+    let mut out = String::new();
+    let _ = writeln!(out, "{}", fingerprint.digest);
+    let _ = writeln!(out, "schema: {}", fingerprint.schema);
+    let _ = writeln!(out, "targets: {}", fingerprint.target_count);
+    let _ = writeln!(out, "sources: {}", fingerprint.source_count);
+    if !counts.is_empty() {
+        out.push_str("components:");
+        for (category, count) in &counts {
+            let _ = write!(out, " {category}={count}");
+        }
+        out.push('\n');
+    }
+    out
+}
+
 pub async fn tests(workspace: &Path, output: Output) -> Result<()> {
     let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
     let records = test_records(workspace, &graph);

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -428,6 +428,20 @@ async fn run_query_command(
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
+        Some(cli::QueryCmd::GraphFingerprint {
+            no_sources,
+            no_toolchain,
+            no_manifest,
+        }) => {
+            let options = commands::fingerprint::GraphFingerprintOptions {
+                include_sources: !no_sources,
+                include_toolchain: !no_toolchain,
+                include_manifest: !no_manifest,
+            };
+            commands::query::graph_fingerprint(workspace, output, options)
+                .await
+                .map(|()| ExitCode::SUCCESS)
+        }
         Some(cli::QueryCmd::Tests) => commands::query::tests(workspace, output)
             .await
             .map(|()| ExitCode::SUCCESS),

--- a/crates/once-frontend/src/analysis/globals.rs
+++ b/crates/once-frontend/src/analysis/globals.rs
@@ -1342,7 +1342,7 @@ pub(super) fn expand_globs(
     expand_globs_with_excludes(workspace_root, package, patterns, &[])
 }
 
-fn expand_globs_with_excludes(
+pub fn expand_globs_with_excludes(
     workspace_root: &Path,
     package: &str,
     patterns: &[String],

--- a/crates/once-frontend/src/analysis/mod.rs
+++ b/crates/once-frontend/src/analysis/mod.rs
@@ -23,6 +23,7 @@ pub use engine::{
     analyze_target, target_kind_has_impl, AnalysisEngine, AnalysisFailure, AnalysisOptions,
     AnalysisResult,
 };
+pub use globals::expand_globs_with_excludes;
 pub use globals::globals_for_prelude;
 pub use store::{
     with_active_store, AnalysisStore, CachedToolCommand, DeclaredAction, DeclaredActionOperation,

--- a/spec/graph_fingerprint_spec.sh
+++ b/spec/graph_fingerprint_spec.sh
@@ -1,0 +1,86 @@
+#shellcheck shell=bash
+# End-to-end specs for the whole-graph content fingerprint.
+
+Describe 'once query graph-fingerprint'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  setup_graph_workspace() {
+    cat > "$WORKSPACE/once.toml" <<'EOF'
+[workspace]
+include = ["once.toml", "pkg/once.toml"]
+EOF
+    mkdir -p "$WORKSPACE/pkg"
+    cat > "$WORKSPACE/pkg/once.toml" <<'EOF'
+[[target]]
+name = "lib"
+kind = "library"
+srcs = ["lib.rs"]
+EOF
+    printf '%s\n' 'fn lib() {}' > "$WORKSPACE/pkg/lib.rs"
+    cat > "$WORKSPACE/mise.toml" <<'EOF'
+[tools]
+rust = "1.96.0"
+EOF
+  }
+
+  It 'returns the schema and categorized components'
+    setup_graph_workspace
+    When call once query graph-fingerprint --format json
+    The status should be success
+    The stdout should include '"once.graph_fingerprint.v1"'
+    The stdout should include '"category":"target"'
+    The stdout should include '"category":"source"'
+    The stdout should include '"category":"toolchain"'
+    The stdout should include '"category":"manifest"'
+  End
+
+  It 'produces a stable digest across runs'
+    setup_graph_workspace
+    once query graph-fingerprint --format json | jq -r '.digest' > "$WORKSPACE/one"
+    once query graph-fingerprint --format json | jq -r '.digest' > "$WORKSPACE/two"
+    one="$(cat "$WORKSPACE/one")"
+    two="$(cat "$WORKSPACE/two")"
+    The value "$one" should equal "$two"
+  End
+
+  It 'changes the digest when a tracked source changes'
+    setup_graph_workspace
+    once query graph-fingerprint --format json | jq -r '.digest' > "$WORKSPACE/before"
+    printf '%s\n' 'fn changed() {}' > "$WORKSPACE/pkg/lib.rs"
+    once query graph-fingerprint --format json | jq -r '.digest' > "$WORKSPACE/after"
+    before="$(cat "$WORKSPACE/before")"
+    after="$(cat "$WORKSPACE/after")"
+    The value "$before" should not equal "$after"
+  End
+
+  It 'changes the digest when the Mise toolchain declaration changes'
+    cat > "$WORKSPACE/once.toml" <<'EOF'
+[workspace]
+include = ["once.toml"]
+EOF
+    cat > "$WORKSPACE/mise.toml" <<'EOF'
+[tools]
+rust = "1.96.0"
+EOF
+    once query graph-fingerprint --format json | jq -r '.digest' > "$WORKSPACE/before"
+    cat > "$WORKSPACE/mise.toml" <<'EOF'
+[tools]
+rust = "1.97.0"
+EOF
+    once query graph-fingerprint --format json | jq -r '.digest' > "$WORKSPACE/after"
+    before="$(cat "$WORKSPACE/before")"
+    after="$(cat "$WORKSPACE/after")"
+    The value "$before" should not equal "$after"
+  End
+
+  It 'excludes source contents from a structure-only digest'
+    setup_graph_workspace
+    once query graph-fingerprint --no-sources --format json | jq -r '.digest' > "$WORKSPACE/before"
+    printf '%s\n' 'fn changed() {}' > "$WORKSPACE/pkg/lib.rs"
+    once query graph-fingerprint --no-sources --format json | jq -r '.digest' > "$WORKSPACE/after"
+    before="$(cat "$WORKSPACE/before")"
+    after="$(cat "$WORKSPACE/after")"
+    The value "$before" should equal "$after"
+  End
+End

--- a/web/priv/docs/reference/mcp/tools.md
+++ b/web/priv/docs/reference/mcp/tools.md
@@ -936,6 +936,53 @@ Returns the same record shape as `once query evidence --format json`: durable ac
 ]
 ```
 
+## `once_query_graph_fingerprint`
+
+Compute a deterministic, content-addressed digest of the whole graph.
+
+Returns the same record as `once query graph-fingerprint --format json`: a single stable digest that folds in every target declaration, the resolved contents of every declared source file, the pinned Mise toolchain (`mise.toml` and `mise.lock` when present), and the root workspace manifest. The digest changes whenever any of those inputs change, so two identical checkouts on different machines produce the same digest. `components` lists the categorized `(category, label, digest)` triples behind the digest, mirroring per-action input fingerprints, so a caller can see which target, source, toolchain, or manifest input contributed. Categories default to all on; set `include_sources`, `include_toolchain`, or `include_manifest` to false to scope the digest, for example to compare only graph structure across checkouts. The matching command-line operation is `once query graph-fingerprint [--no-sources --no-toolchain --no-manifest]`.
+
+**Input schema**
+
+```json
+{
+  "properties": {
+    "include_manifest": {
+      "default": true,
+      "description": "Fold the root `once.toml` manifest into the digest.",
+      "type": "boolean"
+    },
+    "include_sources": {
+      "default": true,
+      "description": "Fold resolved source file contents into the digest.",
+      "type": "boolean"
+    },
+    "include_toolchain": {
+      "default": true,
+      "description": "Fold the `mise.toml` and `mise.lock` declarations into the digest.",
+      "type": "boolean"
+    }
+  },
+  "type": "object"
+}
+```
+
+**Example return**
+
+```json
+{
+  "schema": "once.graph_fingerprint.v1",
+  "digest": "a046fc32a4c232b7320b4249d630ec5a4fef9ae8c3313a65754f33cc31375676",
+  "target_count": 2,
+  "source_count": 1,
+  "components": [
+    { "category": "target", "label": "pkg/lib", "digest": "1111111111111111111111111111111111111111111111111111111111111111" },
+    { "category": "source", "label": "pkg/lib.rs", "digest": "2222222222222222222222222222222222222222222221111111111111111111" },
+    { "category": "toolchain", "label": "mise.toml", "digest": "3333333333333333333333333333333333333333333333333333333333333333" }
+  ]
+}
+```
+
 ## `once_validate_script`
 
 Parse and validate an annotated script's cache contract.


### PR DESCRIPTION
## What changed

Adds a whole-graph content fingerprint: a single deterministic digest that summarizes an entire loaded graph plus every workspace input that affects its outcomes.

- New `commands::fingerprint` module that computes a `GraphFingerprint { schema, digest, target_count, source_count, components }` by composing the existing `InputDigestBuilder` and `InputFingerprintComponent` machinery from `once-core` that per-action input fingerprints already use.
- Each graph target is serialized and hashed (category `target`, sorted by id so the digest is discovery-order independent).
- Declared source globs are resolved through the same glob expander the build uses, then hashed by content (category `source`).
- The pinned Mise toolchain is folded in from `mise.toml` and `mise.lock` content (category `toolchain`), and the root `once.toml` manifest is folded in (category `manifest`). Missing files are skipped rather than treated as errors.
- Exposes the result through `once query graph-fingerprint` with `--no-sources`, `--no-toolchain`, and `--no-manifest` toggles, plus the matching `once_query_graph_fingerprint` MCP tool with the same options.
- To let the CLI composition resolve sources, exposes `expand_globs_with_excludes` from the frontend analysis module.
- Regenerates the committed MCP tools reference page.

## Why

There was no single, stable identifier for "the exact build this checkout produces." Detecting whether anything in a workspace changed required diffing many surfaces, and the Mise toolchain that execution depends on was not represented in any graph-level digest. A content-addressed fingerprint over the whole graph gives a portable id for change detection, cache keys, and reproducibility checks across machines.

## Approach

The fingerprint reuses the established `InputDigestBuilder` domain-prefixed encoding and the categorized `InputFingerprintComponent` triples so it shares one shape with the existing per-action input fingerprint system rather than introducing a parallel digest scheme. The domain prefix `once.graph.fingerprint.v1` partitions its cache namespace and can be bumped to invalidate every fingerprint when the encoding changes.

The Mise toolchain is captured as the content of `mise.toml` and `mise.lock`, which is the deterministic, portable representation: two identical checkouts on different machines resolve to the same tools and therefore the same digest. Resolving live tool binaries would make the digest host-specific and non-reproducible, so that is left as a possible future option rather than the default.

The composition lives in `once-cli` because it needs both the frontend graph types and the core digest primitives, and the crate layering deliberately keeps `once-frontend` free of a `once-core` dependency.

## Impact

- New read-only query surface. No changes to existing commands, the action cache, or build behavior.
- The fingerprint is ecosystem-neutral: it references Mise as the generic tool manager Once already uses for every toolchain, not any specific ecosystem.
- Every MCP tool keeps a matching CLI command, satisfying the parity invariant.

## Validation

- `once query graph-fingerprint` on this workspace yields a stable digest over 842 targets and 590 sources, identical across repeated runs.
- `--no-sources`, `--no-toolchain`, and `--no-manifest` each produce a different, scoped digest.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, and the ecosystem-neutrality architecture test pass.
- 8 fingerprint unit tests, 1 MCP integration test, 5 shellspec end-to-end tests, and the committed MCP tools reference test pass.

## Example help output

```
$ once query graph-fingerprint
eaab154a000a89bb710ea66d4919f84daadc12df766900a84b7928749a8147f1
schema: once.graph_fingerprint.v1
targets: 842
sources: 590
components: manifest=1 source=590 target=842 toolchain=1
```
