### PR TITLE
feat(graph): invocation-scoped build configuration via --config

### DIFF
--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -135,6 +135,14 @@ pub enum Cmd {
         #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
         sandbox: SandboxMode,
 
+        /// Override the workspace build configuration. Recognized keys are
+        /// `os`, `arch`, and `token` (repeatable), supplied as `KEY=VALUE`.
+        /// Targets configured with `select` resolve against the merged
+        /// configuration, and their outputs are scoped so different values
+        /// never collide.
+        #[arg(long, value_name = "KEY=VALUE")]
+        config: Vec<String>,
+
         /// Target id, such as `services/api/Api` or `./Api`.
         #[arg(required_unless_present = "list")]
         target: Option<String>,
@@ -149,6 +157,10 @@ pub enum Cmd {
         /// Local filesystem sandbox policy for command actions.
         #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
         sandbox: SandboxMode,
+
+        /// Override the workspace build configuration. See `once build --config`.
+        #[arg(long, value_name = "KEY=VALUE")]
+        config: Vec<String>,
 
         /// Lowest finding severity that makes this command fail.
         #[arg(long, value_parser = parse_lint_severity, default_value = "warning")]
@@ -169,6 +181,10 @@ pub enum Cmd {
         /// Local filesystem sandbox policy for command actions.
         #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
         sandbox: SandboxMode,
+
+        /// Override the workspace build configuration. See `once build --config`.
+        #[arg(long, value_name = "KEY=VALUE")]
+        config: Vec<String>,
 
         /// Ask graph target kinds to open a visible runtime interface when supported.
         #[arg(long)]
@@ -213,6 +229,10 @@ pub enum Cmd {
         /// Local filesystem sandbox policy for command actions.
         #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
         sandbox: SandboxMode,
+
+        /// Override the workspace build configuration. See `once build --config`.
+        #[arg(long, value_name = "KEY=VALUE")]
+        config: Vec<String>,
 
         /// Maximum number of test batches to execute concurrently.
         /// Defaults to the host's available parallelism for an affected plan.

--- a/crates/once-cli/src/commands/change_tracker/client.rs
+++ b/crates/once-cli/src/commands/change_tracker/client.rs
@@ -52,7 +52,18 @@ pub(super) async fn snapshot(
     for _ in 0..50 {
         match request_snapshot(socket, outputs, since).await {
             Ok(snapshot) => return Some(snapshot),
-            Err(error) => last_error = Some(error),
+            // Keep polling only while the daemon is not accepting
+            // connections yet, since that is the only state a retry can
+            // clear. Any other outcome means the daemon answered, or its
+            // own bounded barrier wait elapsed; re-issuing a full barrier
+            // would multiply that per-request timeout by the remaining
+            // iterations and stall the build for minutes. Fall back to
+            // full validation instead.
+            Err(error) if error.is_unreachable() => last_error = Some(error),
+            Err(error) => {
+                last_error = Some(error);
+                break;
+            }
         }
         sleep(Duration::from_millis(10)).await;
     }
@@ -220,5 +231,48 @@ mod tests {
 
         // A second call for the same executable reuses the same copy.
         assert_eq!(tracker_launcher(&socket).unwrap(), launcher);
+    }
+
+    // A daemon that is reachable but keeps rejecting the barrier stands in
+    // for a workspace whose filesystem events never reach the watcher. The
+    // client must fall back to full validation after a single answered
+    // barrier rather than re-issuing it once per retry iteration, which
+    // would multiply the per-request timeout into a multi-minute stall.
+    #[tokio::test]
+    async fn snapshot_stops_polling_once_the_daemon_answers() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        use tokio::net::UnixListener;
+
+        let directory = tempfile::TempDir::new().unwrap();
+        let socket = directory.path().join("tracker.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        let barriers = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&barriers);
+        let server = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                counter.fetch_add(1, Ordering::SeqCst);
+                let (read, mut write) = stream.into_split();
+                let mut line = String::new();
+                let _ = BufReader::new(read).read_line(&mut line).await;
+                let _ = write.write_all(b"{\"error\":\"barrier rejected\"}\n").await;
+                let _ = write.shutdown().await;
+            }
+        });
+
+        let outcome = snapshot(directory.path(), &socket, &[], None).await;
+        server.abort();
+
+        assert!(
+            outcome.is_none(),
+            "a rejected barrier must fall back to full validation"
+        );
+        let observed = barriers.load(Ordering::SeqCst);
+        assert!(
+            observed <= 5,
+            "client re-issued the barrier {observed} times instead of falling back once the daemon answered"
+        );
     }
 }

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -31,6 +31,7 @@ use once_core::{
     EvidenceCacheState, InputFingerprintManifest, ResourceLimits, ResourcePool, SandboxMode,
 };
 use once_frontend::analysis::{AnalysisEngine, AnalysisOptions, CachedToolCommand};
+use once_frontend::ConfigurationOverrides;
 use once_frontend::GraphTarget;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -38,6 +39,8 @@ use serde_json::Value as JsonValue;
 use self::actions::{run_declared_actions, validate_declared_actions, DeclaredActionValidation};
 use self::scheduler::BuildScheduler;
 use self::source_digest_cache::SourceDigestCache;
+
+use super::configuration::ResolvedConfiguration;
 
 const GRAPH_TOOL_CACHE_SCHEMA: &str = "once.graph-tool-paths.v4";
 const GRAPH_TOOL_ENVIRONMENT_KEYS: &[&str] = &[
@@ -138,13 +141,15 @@ pub(super) struct BuildSession {
 }
 
 impl BuildSession {
-    pub(super) async fn load_workspace(
+    pub(super) async fn load_workspace_with_configuration(
         workspace: &Path,
         cache: &CacheProvider,
         sandbox: SandboxMode,
+        resolved: &ResolvedConfiguration,
     ) -> Result<Self> {
         let workspace_targets =
-            once_frontend::load_workspace(workspace).context("loading workspace")?;
+            once_frontend::load_workspace_with_configuration(workspace, &resolved.configuration)
+                .context("loading workspace")?;
         let target_kinds = workspace_targets
             .iter()
             .map(|target| target.kind.clone())
@@ -153,7 +158,8 @@ impl BuildSession {
             workspace,
             AnalysisOptions::default(),
             &target_kinds,
-        )?;
+        )?
+        .with_configuration(resolved.configuration.clone(), resolved.path_suffix.clone());
         let graph = analyzer
             .load_graph_workspace_from_targets(workspace, workspace_targets)
             .context("loading graph")?;
@@ -185,6 +191,22 @@ impl BuildSession {
         options: AnalysisOptions,
         sandbox: SandboxMode,
     ) -> Result<Self> {
+        let resolved =
+            super::configuration::resolve(workspace, &ConfigurationOverrides::default())?;
+        Self::new_with_options_with_configuration(
+            workspace, cache, graph, options, sandbox, &resolved,
+        )
+        .await
+    }
+
+    pub(super) async fn new_with_options_with_configuration(
+        workspace: &Path,
+        cache: &CacheProvider,
+        graph: Vec<GraphTarget>,
+        options: AnalysisOptions,
+        sandbox: SandboxMode,
+        resolved: &ResolvedConfiguration,
+    ) -> Result<Self> {
         let resolved_tools = resolve_graph_tools(workspace, &graph).await?;
         let target_kinds = graph
             .iter()
@@ -195,6 +217,7 @@ impl BuildSession {
             options,
             &target_kinds,
         )?
+        .with_configuration(resolved.configuration.clone(), resolved.path_suffix.clone())
         .with_tool_cache(
             resolved_tools.paths.clone(),
             resolved_tools.commands.clone(),

--- a/crates/once-cli/src/commands/graph/analysis/tests.rs
+++ b/crates/once-cli/src/commands/graph/analysis/tests.rs
@@ -340,6 +340,38 @@ async fn independent_dependencies_run_in_parallel() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn configuration_path_suffix_scopes_build_outputs() {
+    let workspace = tempfile::tempdir().unwrap();
+    let cache = CacheProvider::open_local(workspace.path().join(".once/cache"));
+    let graph = vec![test_target("Scoped", &[], "printf scoped > \"$1\"")];
+    let analyzer = AnalysisEngine::from_source(GRAPH_TEST_PRELUDE)
+        .unwrap()
+        .with_configuration(
+            once_frontend::BuildConfiguration::default(),
+            "/cfg-abcd1234".to_string(),
+        );
+    let session = BuildSession::new_with_analyzer(
+        workspace.path(),
+        &cache,
+        graph.clone(),
+        analyzer,
+        SandboxMode::default(),
+    );
+
+    let outcome = session
+        .build_with_analysis(&graph[0])
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        outcome.outputs,
+        vec![".once/out/Scoped/cfg-abcd1234/Scoped-build.txt".to_string()]
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn cached_dependency_outputs_are_materialized_before_dependents_run() {
     let workspace = tempfile::tempdir().unwrap();
     let cache = CacheProvider::open_local(workspace.path().join(".once/cache"));
@@ -571,10 +603,16 @@ kind = "custom"
     )
     .unwrap();
     let cache = CacheProvider::open_local(workspace.path().join(".once/cache"));
-    let build_session =
-        BuildSession::load_workspace(workspace.path(), &cache, SandboxMode::default())
-            .await
-            .unwrap();
+    let resolved =
+        crate::commands::graph::resolve_invocation_configuration(workspace.path(), &[]).unwrap();
+    let build_session = BuildSession::load_workspace_with_configuration(
+        workspace.path(),
+        &cache,
+        SandboxMode::default(),
+        &resolved,
+    )
+    .await
+    .unwrap();
     let graph = once_frontend::load_graph_workspace(workspace.path()).unwrap();
     let run_session = BuildSession::new_with_options(
         workspace.path(),

--- a/crates/once-cli/src/commands/graph/build_receipt.rs
+++ b/crates/once-cli/src/commands/graph/build_receipt.rs
@@ -19,6 +19,11 @@ pub(super) struct BuildReceipt {
     schema: String,
     target: String,
     sandbox: String,
+    /// Content digest of the effective build configuration. Defaults to
+    /// empty for receipts written before this field existed, which are
+    /// always the workspace-default configuration.
+    #[serde(default)]
+    configuration: String,
     environment: BTreeMap<String, Option<String>>,
     host_paths: BTreeMap<String, Option<PathFingerprint>>,
     source_digests: BTreeMap<String, Digest>,
@@ -37,8 +42,9 @@ pub(super) async fn read(
     workspace: &Path,
     target: &str,
     sandbox: SandboxMode,
+    configuration_path_suffix: &str,
 ) -> Option<BuildReceipt> {
-    let path = receipt_path(workspace, target, sandbox);
+    let path = receipt_path(workspace, target, sandbox, configuration_path_suffix);
     let raw = tokio::fs::read(&path).await.ok()?;
     serde_json::from_slice::<BuildReceipt>(&raw).ok()
 }
@@ -51,6 +57,7 @@ pub(super) async fn load(
     workspace: &Path,
     target: &str,
     sandbox: SandboxMode,
+    configuration_path_suffix: &str,
     snapshot: Option<&ChangeSnapshot>,
     receipt: Option<BuildReceipt>,
 ) -> Option<CapabilityRunRecord> {
@@ -105,7 +112,11 @@ pub(super) async fn load(
     if receipt.position != snapshot.position {
         receipt.position = snapshot.position.clone();
         receipt.source_digests.clear();
-        if let Err(error) = write_receipt(&receipt_path(workspace, target, sandbox), &receipt).await
+        if let Err(error) = write_receipt(
+            &receipt_path(workspace, target, sandbox, configuration_path_suffix),
+            &receipt,
+        )
+        .await
         {
             tracing::debug!(%error, target, "failed to advance reconciled build receipt");
         }
@@ -120,10 +131,13 @@ pub(super) async fn load(
     Some(receipt.record)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn store(
     workspace: &Path,
     target: &str,
     sandbox: SandboxMode,
+    configuration_path_suffix: &str,
+    configuration_digest: Digest,
     snapshot: &ChangeSnapshot,
     observations: Observations<'_>,
     record: &CapabilityRunRecord,
@@ -135,6 +149,7 @@ pub(super) async fn store(
         schema: SCHEMA.to_string(),
         target: target.to_string(),
         sandbox: sandbox_key(sandbox),
+        configuration: configuration_digest.to_hex(),
         environment: observations.environment.clone(),
         host_paths: path_fingerprint::capture(observations.host_paths),
         source_digests: observations.source_digests.clone(),
@@ -142,15 +157,23 @@ pub(super) async fn store(
         position: snapshot.position.clone(),
         record: record.clone(),
     };
-    if let Err(error) = write_receipt(&receipt_path(workspace, target, sandbox), &receipt).await {
+    if let Err(error) = write_receipt(
+        &receipt_path(workspace, target, sandbox, configuration_path_suffix),
+        &receipt,
+    )
+    .await
+    {
         tracing::debug!(%error, target, "failed to persist build receipt");
     }
 }
 
-/// Remove any stored receipt for a target so a later invocation cannot reuse
-/// it. Used when the completed build is uncacheable and must run every time.
-pub(super) async fn clear(workspace: &Path, target: &str, sandbox: SandboxMode) {
-    let path = receipt_path(workspace, target, sandbox);
+pub(super) async fn clear(
+    workspace: &Path,
+    target: &str,
+    sandbox: SandboxMode,
+    configuration_path_suffix: &str,
+) {
+    let path = receipt_path(workspace, target, sandbox, configuration_path_suffix);
     if let Err(error) = tokio::fs::remove_file(&path).await {
         if error.kind() != std::io::ErrorKind::NotFound {
             tracing::debug!(%error, target, "failed to clear build receipt");
@@ -169,8 +192,23 @@ async fn write_receipt(path: &Path, receipt: &BuildReceipt) -> anyhow::Result<()
     Ok(())
 }
 
-fn receipt_path(workspace: &Path, target: &str, sandbox: SandboxMode) -> PathBuf {
-    let key = Digest::of_bytes(format!("{target}\0{}", sandbox_key(sandbox)).as_bytes());
+fn receipt_path(
+    workspace: &Path,
+    target: &str,
+    sandbox: SandboxMode,
+    configuration_path_suffix: &str,
+) -> PathBuf {
+    // The configuration suffix is part of the hashed key so two
+    // configurations of the same target never share a receipt file. The
+    // workspace-default suffix is empty, so baseline receipts land at the
+    // same path as before.
+    let key = Digest::of_bytes(
+        format!(
+            "{target}{configuration_path_suffix}\0{}",
+            sandbox_key(sandbox)
+        )
+        .as_bytes(),
+    );
     workspace
         .join(".once")
         .join("build-receipts")
@@ -219,6 +257,12 @@ mod tests {
 
     use super::*;
 
+    const TEST_CONFIGURATION_PATH_SUFFIX: &str = "";
+
+    fn test_configuration_digest() -> Digest {
+        Digest::of_bytes(b"test-configuration")
+    }
+
     fn record() -> CapabilityRunRecord {
         CapabilityRunRecord {
             target: "app".to_string(),
@@ -256,6 +300,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn receipt_requires_the_same_tracker_snapshot_and_outputs() {
         let temporary = TempDir::new().unwrap();
         let output = temporary.path().join(".once/out/app/app");
@@ -271,6 +316,8 @@ mod tests {
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+            test_configuration_digest(),
             &snapshot,
             Observations {
                 environment: &environment,
@@ -281,11 +328,18 @@ mod tests {
         )
         .await;
 
-        let receipt = read(temporary.path(), "app", SandboxMode::Off).await;
+        let receipt = read(
+            temporary.path(),
+            "app",
+            SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+        )
+        .await;
         let loaded = load(
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
             Some(&snapshot),
             receipt,
         )
@@ -301,11 +355,18 @@ mod tests {
             source_changes: None,
             ..snapshot.clone()
         };
-        let receipt = read(temporary.path(), "app", SandboxMode::Off).await;
+        let receipt = read(
+            temporary.path(),
+            "app",
+            SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+        )
+        .await;
         assert!(load(
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
             Some(&changed),
             receipt,
         )
@@ -319,6 +380,8 @@ mod tests {
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+            test_configuration_digest(),
             &snapshot,
             Observations {
                 environment: &environment,
@@ -328,11 +391,18 @@ mod tests {
             &record(),
         )
         .await;
-        let receipt = read(temporary.path(), "app", SandboxMode::Off).await;
+        let receipt = read(
+            temporary.path(),
+            "app",
+            SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+        )
+        .await;
         assert!(load(
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
             Some(&snapshot),
             receipt,
         )
@@ -340,11 +410,18 @@ mod tests {
         .is_some());
 
         tokio::fs::write(host_tool, b"two").await.unwrap();
-        let receipt = read(temporary.path(), "app", SandboxMode::Off).await;
+        let receipt = read(
+            temporary.path(),
+            "app",
+            SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+        )
+        .await;
         assert!(load(
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
             Some(&snapshot),
             receipt,
         )
@@ -374,6 +451,8 @@ mod tests {
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+            test_configuration_digest(),
             &initial,
             Observations {
                 environment: &environment,
@@ -392,11 +471,18 @@ mod tests {
             source_changes: Some(vec!["src/main.rs".to_string()]),
             ..initial.clone()
         };
-        let receipt = read(temporary.path(), "app", SandboxMode::Off).await;
+        let receipt = read(
+            temporary.path(),
+            "app",
+            SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+        )
+        .await;
         assert!(load(
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
             Some(&changed),
             receipt,
         )
@@ -412,11 +498,18 @@ mod tests {
             source_changes: Some(vec!["src/main.rs".to_string()]),
             ..changed
         };
-        let receipt = read(temporary.path(), "app", SandboxMode::Off).await;
+        let receipt = read(
+            temporary.path(),
+            "app",
+            SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
+        )
+        .await;
         assert!(load(
             temporary.path(),
             "app",
             SandboxMode::Off,
+            TEST_CONFIGURATION_PATH_SUFFIX,
             Some(&changed_again),
             receipt,
         )

--- a/crates/once-cli/src/commands/graph/configuration.rs
+++ b/crates/once-cli/src/commands/graph/configuration.rs
@@ -1,0 +1,128 @@
+//! Invocation-scoped build configuration.
+//!
+//! Parses `--config` overrides, merges them over the workspace-declared
+//! configuration, and derives the configuration identity that scopes
+//! configured targets. The effective configuration drives dependency
+//! selection and Starlark analysis; its digest scopes output directories
+//! and build receipts so two invocations with different overrides never
+//! share results. When the overrides reproduce the workspace-default
+//! configuration the path suffix is empty, keeping output paths
+//! byte-identical to invocations that pass no overrides.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use once_cas::Digest;
+use once_frontend::{load_workspace_configuration, BuildConfiguration, ConfigurationOverrides};
+
+/// Number of configuration-digest hex characters folded into an output
+/// path segment. Long enough to make collisions between two distinct
+/// configurations negligible.
+const PATH_DIGEST_HEX_LEN: usize = 16;
+
+/// Recognized `--config` keys.
+const KEY_OS: &str = "os";
+const KEY_ARCH: &str = "arch";
+const KEY_TOKEN: &str = "token";
+
+/// The effective configuration for one invocation plus the identity
+/// derived from it.
+#[derive(Debug, Clone)]
+pub struct ResolvedConfiguration {
+    pub configuration: BuildConfiguration,
+    /// Segment appended after a target id in output and receipt paths.
+    /// Empty for the workspace-default configuration.
+    pub path_suffix: String,
+    pub digest: Digest,
+}
+
+/// Parse repeated `KEY=VALUE` override strings into typed overrides.
+///
+/// Recognized keys are `os`, `arch`, and `token` (repeatable).
+pub fn parse_overrides(raw: &[String]) -> Result<ConfigurationOverrides> {
+    let mut overrides = ConfigurationOverrides::default();
+    for entry in raw {
+        let (key, value) = entry
+            .split_once('=')
+            .with_context(|| format!("--config expects `KEY=VALUE`, got `{entry}`"))?;
+        let key = key.trim();
+        let value = value.trim();
+        if value.is_empty() {
+            bail!("--config `{key}` has an empty value");
+        }
+        match key {
+            KEY_OS => overrides.os = Some(value.to_string()),
+            KEY_ARCH => overrides.arch = Some(value.to_string()),
+            KEY_TOKEN => overrides.tokens.push(value.to_string()),
+            other => bail!(
+                "unknown --config key `{other}` (expected `{KEY_OS}`, `{KEY_ARCH}`, or `{KEY_TOKEN}`)"
+            ),
+        }
+    }
+    Ok(overrides)
+}
+
+/// Merge invocation overrides over the workspace-declared configuration
+/// and derive the identity that scopes configured targets.
+pub fn resolve(
+    workspace: &Path,
+    overrides: &ConfigurationOverrides,
+) -> Result<ResolvedConfiguration> {
+    let baseline = load_workspace_configuration(workspace)?;
+    let effective = baseline.merged_with(overrides);
+    let effective_digest = Digest::of_bytes(&effective.canonical_bytes());
+    let baseline_digest = Digest::of_bytes(&baseline.canonical_bytes());
+    let path_suffix = if effective_digest == baseline_digest {
+        String::new()
+    } else {
+        format!("/cfg-{}", &effective_digest.to_hex()[..PATH_DIGEST_HEX_LEN])
+    };
+    tracing::debug!(
+        baseline_configuration = %baseline_digest,
+        effective_configuration = %effective_digest,
+        path_suffix = %path_suffix,
+        "resolved invocation configuration"
+    );
+    Ok(ResolvedConfiguration {
+        configuration: effective,
+        path_suffix,
+        digest: effective_digest,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_os_arch_and_token_overrides() {
+        let overrides = parse_overrides(&[
+            "os=ios".to_string(),
+            "arch=arm64".to_string(),
+            "token=release".to_string(),
+            "token=simulator".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(overrides.os.as_deref(), Some("ios"));
+        assert_eq!(overrides.arch.as_deref(), Some("arm64"));
+        assert_eq!(overrides.tokens, vec!["release", "simulator"]);
+    }
+
+    #[test]
+    fn rejects_unknown_config_key() {
+        let error = parse_overrides(&["mode=release".to_string()]).unwrap_err();
+        assert!(error.to_string().contains("unknown --config key"));
+    }
+
+    #[test]
+    fn rejects_config_without_equals() {
+        let error = parse_overrides(&["release".to_string()]).unwrap_err();
+        assert!(error.to_string().contains("KEY=VALUE"));
+    }
+
+    #[test]
+    fn rejects_empty_config_value() {
+        let error = parse_overrides(&["os=".to_string()]).unwrap_err();
+        assert!(error.to_string().contains("empty value"));
+    }
+}

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -8,6 +8,7 @@
 mod action;
 mod analysis;
 mod build_receipt;
+mod configuration;
 mod contract;
 
 pub use contract::{validate_action_contracts, ActionContractValidation};
@@ -67,6 +68,19 @@ fn default_action_result() -> ActionResult {
     }
 }
 
+pub(crate) use configuration::ResolvedConfiguration;
+
+/// Parse `--config` override strings and merge them over the
+/// workspace-declared configuration into the invocation-scoped
+/// configuration that build, lint, run, and test consume.
+pub(crate) fn resolve_invocation_configuration(
+    workspace: &Path,
+    overrides: &[String],
+) -> Result<ResolvedConfiguration> {
+    let parsed = configuration::parse_overrides(overrides)?;
+    configuration::resolve(workspace, &parsed)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct GraphRunOptions {
     pub visible: bool,
@@ -80,9 +94,11 @@ pub async fn build(
     target_id: &str,
     sandbox: SandboxMode,
     resource_limits: ResourceLimits,
+    resolved: &configuration::ResolvedConfiguration,
 ) -> Result<ExitCode> {
     let xdg = once_core::Xdg::from_env();
-    let stored_receipt = build_receipt::read(workspace, target_id, sandbox).await;
+    let stored_receipt =
+        build_receipt::read(workspace, target_id, sandbox, &resolved.path_suffix).await;
     let prior_position = stored_receipt.as_ref().map(build_receipt::position);
     let initial_snapshot =
         crate::commands::change_tracker::snapshot(workspace, &xdg, &[], prior_position).await;
@@ -90,6 +106,7 @@ pub async fn build(
         workspace,
         target_id,
         sandbox,
+        &resolved.path_suffix,
         initial_snapshot.as_ref(),
         stored_receipt,
     )
@@ -98,9 +115,11 @@ pub async fn build(
         write_record(output, &record).await?;
         return Ok(ExitCode::SUCCESS);
     }
-    let session = analysis::BuildSession::load_workspace(workspace, cache, sandbox)
-        .await?
-        .with_resource_limits(resource_limits);
+    let session = analysis::BuildSession::load_workspace_with_configuration(
+        workspace, cache, sandbox, resolved,
+    )
+    .await?
+    .with_resource_limits(resource_limits);
     let target = session.target(target_id)?;
     let record = build_target(workspace, cache, target, &session, sandbox).await?;
     record_capability_run(workspace, &record).await;
@@ -109,7 +128,7 @@ pub async fn build(
     // every invocation. Never persist a receipt for it, and drop any stale one,
     // so the fast path can never skip its mandatory work.
     if record.cache_state == EvidenceCacheState::Bypass {
-        build_receipt::clear(workspace, target_id, sandbox).await;
+        build_receipt::clear(workspace, target_id, sandbox, &resolved.path_suffix).await;
         write_record(output, &record).await?;
         return Ok(ExitCode::SUCCESS);
     }
@@ -134,6 +153,8 @@ pub async fn build(
                 workspace,
                 target_id,
                 sandbox,
+                &resolved.path_suffix,
+                resolved.digest,
                 &final_snapshot,
                 build_receipt::Observations {
                     environment: &environment,
@@ -149,6 +170,7 @@ pub async fn build(
     Ok(ExitCode::SUCCESS)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn lint(
     workspace: &Path,
     cache: &CacheProvider,
@@ -157,11 +179,21 @@ pub async fn lint(
     sandbox: SandboxMode,
     fail_on: LintSeverity,
     resource_limits: ResourceLimits,
+    resolved: &configuration::ResolvedConfiguration,
 ) -> Result<ExitCode> {
-    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
-    let session = analysis::BuildSession::new(workspace, cache, graph, sandbox)
-        .await?
-        .with_resource_limits(resource_limits);
+    let graph =
+        once_frontend::load_graph_workspace_with_configuration(workspace, &resolved.configuration)
+            .context("loading graph")?;
+    let session = analysis::BuildSession::new_with_options_with_configuration(
+        workspace,
+        cache,
+        graph,
+        AnalysisOptions::default(),
+        sandbox,
+        resolved,
+    )
+    .await?
+    .with_resource_limits(resource_limits);
     let target = session.target(target_id)?;
     let capability = ensure_capability(target, "lint")?;
     let outcome = session
@@ -298,6 +330,7 @@ pub async fn test(
     target_id: &str,
     sandbox: SandboxMode,
     resource_limits: ResourceLimits,
+    resolved: &configuration::ResolvedConfiguration,
 ) -> Result<ExitCode> {
     test_with_filters(
         workspace,
@@ -308,6 +341,7 @@ pub async fn test(
         &[],
         None,
         resource_limits,
+        resolved,
     )
     .await
 }
@@ -322,13 +356,16 @@ pub async fn test_with_filters(
     test_filters: &[String],
     test_batch_id: Option<&str>,
     resource_limits: ResourceLimits,
+    resolved: &configuration::ResolvedConfiguration,
 ) -> Result<ExitCode> {
     if let Some(batch_id) = test_batch_id {
         if Digest::from_hex(batch_id).is_none() {
             anyhow::bail!("invalid internal test batch identifier");
         }
     }
-    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    let graph =
+        once_frontend::load_graph_workspace_with_configuration(workspace, &resolved.configuration)
+            .context("loading graph")?;
     if !test_filters.is_empty() {
         let manifest =
             crate::commands::query::test_manifest_record_with_graph(workspace, target_id, &graph)?;
@@ -336,7 +373,7 @@ pub async fn test_with_filters(
             crate::commands::query::validate_test_unit(&manifest, target_id, test_filter)?;
         }
     }
-    let session = analysis::BuildSession::new_with_options(
+    let session = analysis::BuildSession::new_with_options_with_configuration(
         workspace,
         cache,
         graph,
@@ -346,6 +383,7 @@ pub async fn test_with_filters(
             ..AnalysisOptions::default()
         },
         sandbox,
+        resolved,
     )
     .await?
     .with_resource_limits(resource_limits);
@@ -414,8 +452,9 @@ pub async fn run(
     options: GraphRunOptions,
     sandbox: SandboxMode,
     resource_limits: ResourceLimits,
+    resolved: &configuration::ResolvedConfiguration,
 ) -> Result<ExitCode> {
-    let session = analysis::BuildSession::new_with_options(
+    let session = analysis::BuildSession::new_with_options_with_configuration(
         workspace,
         cache,
         graph,
@@ -425,6 +464,7 @@ pub async fn run(
             ..AnalysisOptions::default()
         },
         sandbox,
+        resolved,
     )
     .await?
     .with_resource_limits(resource_limits);
@@ -521,12 +561,15 @@ async fn build_target(
     }
 }
 
-pub fn load_graph_for_capability(
+pub fn load_graph_for_capability_with_configuration(
     workspace: &Path,
     target_id: &str,
     capability: &str,
+    resolved: &ResolvedConfiguration,
 ) -> Result<Option<Vec<GraphTarget>>> {
-    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    let graph =
+        once_frontend::load_graph_workspace_with_configuration(workspace, &resolved.configuration)
+            .context("loading graph")?;
     Ok(graph_supports(&graph, target_id, capability).then_some(graph))
 }
 

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -78,14 +78,30 @@ async fn run_command(
 ) -> Result<ExitCode> {
     match command {
         Cmd::Auth { cmd } => run_auth_command(workspace, xdg, output, cmd).await,
-        Cmd::Build { target, sandbox } => {
-            dispatch_build(workspace, xdg, output, target, sandbox, resource_limits).await
+        Cmd::Build {
+            target,
+            sandbox,
+            config,
+        } => {
+            let resolved = commands::graph::resolve_invocation_configuration(workspace, &config)?;
+            dispatch_build(
+                workspace,
+                xdg,
+                output,
+                target,
+                sandbox,
+                resource_limits,
+                resolved,
+            )
+            .await
         }
         Cmd::Lint {
             target,
             sandbox,
+            config,
             fail_on,
         } => {
+            let resolved = commands::graph::resolve_invocation_configuration(workspace, &config)?;
             dispatch_lint(
                 workspace,
                 xdg,
@@ -94,12 +110,14 @@ async fn run_command(
                 sandbox,
                 fail_on,
                 resource_limits,
+                resolved,
             )
             .await
         }
         Cmd::Run {
             target,
             sandbox,
+            config,
             visible,
             runtime_rpc,
             runtime_rpc_socket,
@@ -107,6 +125,7 @@ async fn run_command(
             compute,
             arguments,
         } => {
+            let resolved = commands::graph::resolve_invocation_configuration(workspace, &config)?;
             Box::pin(dispatch_run(
                 workspace,
                 xdg,
@@ -120,6 +139,7 @@ async fn run_command(
                     resource_limits: resource_limits.clone(),
                     arguments,
                     remote: resolve_remote_execution(workspace, xdg, remote, compute.as_deref())?,
+                    resolved,
                 },
             ))
             .await
@@ -157,6 +177,7 @@ async fn run_command(
         Cmd::Test {
             target,
             sandbox,
+            config,
             jobs,
             all,
             changed_paths,
@@ -164,6 +185,7 @@ async fn run_command(
             batch_test_units,
             test_batch_id,
         } => {
+            let resolved = commands::graph::resolve_invocation_configuration(workspace, &config)?;
             Box::pin(dispatch_test(
                 workspace,
                 xdg,
@@ -178,6 +200,7 @@ async fn run_command(
                     batch_test_units,
                     test_batch_id,
                     resource_limits: resource_limits.clone(),
+                    resolved,
                 },
             ))
             .await
@@ -243,6 +266,7 @@ mod tests {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_build(
     workspace: &Path,
     xdg: &Xdg,
@@ -250,6 +274,7 @@ async fn dispatch_build(
     target: Option<String>,
     sandbox: SandboxMode,
     resource_limits: &ResourceLimits,
+    resolved: commands::graph::ResolvedConfiguration,
 ) -> Result<ExitCode> {
     let target = resolve_required_target(workspace, target)?;
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
@@ -260,10 +285,12 @@ async fn dispatch_build(
         &target,
         sandbox,
         resource_limits.clone(),
+        &resolved,
     ))
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_lint(
     workspace: &Path,
     xdg: &Xdg,
@@ -272,6 +299,7 @@ async fn dispatch_lint(
     sandbox: SandboxMode,
     fail_on: once_core::LintSeverity,
     resource_limits: &ResourceLimits,
+    resolved: commands::graph::ResolvedConfiguration,
 ) -> Result<ExitCode> {
     let target = resolve_required_target(workspace, target)?;
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
@@ -283,6 +311,7 @@ async fn dispatch_lint(
         sandbox,
         fail_on,
         resource_limits.clone(),
+        &resolved,
     ))
     .await
 }
@@ -298,6 +327,7 @@ struct TestDispatchArgs {
     batch_test_units: Vec<String>,
     test_batch_id: Option<String>,
     resource_limits: ResourceLimits,
+    resolved: commands::graph::ResolvedConfiguration,
 }
 
 async fn dispatch_test(workspace: &Path, xdg: &Xdg, args: TestDispatchArgs) -> Result<ExitCode> {
@@ -313,6 +343,7 @@ async fn dispatch_test(workspace: &Path, xdg: &Xdg, args: TestDispatchArgs) -> R
             &args.batch_test_units,
             args.test_batch_id.as_deref(),
             args.resource_limits,
+            &args.resolved,
         ))
         .await;
     }
@@ -327,6 +358,7 @@ async fn dispatch_test(workspace: &Path, xdg: &Xdg, args: TestDispatchArgs) -> R
             &target,
             args.sandbox,
             args.resource_limits,
+            &args.resolved,
         ))
         .await;
     }
@@ -688,6 +720,7 @@ struct RunDispatchArgs {
     resource_limits: ResourceLimits,
     arguments: Vec<String>,
     remote: Option<RemoteExecution>,
+    resolved: commands::graph::ResolvedConfiguration,
 }
 
 async fn dispatch_run(workspace: &Path, xdg: &Xdg, args: RunDispatchArgs) -> Result<ExitCode> {
@@ -701,11 +734,15 @@ async fn dispatch_run(workspace: &Path, xdg: &Xdg, args: RunDispatchArgs) -> Res
         resource_limits,
         arguments,
         remote,
+        resolved,
     } = args;
     let resolved_target = resolve_required_target(workspace, target.clone())?;
-    if let Some(graph) =
-        commands::graph::load_graph_for_capability(workspace, &resolved_target, "run")?
-    {
+    if let Some(graph) = commands::graph::load_graph_for_capability_with_configuration(
+        workspace,
+        &resolved_target,
+        "run",
+        &resolved,
+    )? {
         if runtime_rpc || runtime_rpc_socket.is_some() {
             anyhow::bail!("--runtime-rpc is only supported for executable script targets");
         }
@@ -723,6 +760,7 @@ async fn dispatch_run(workspace: &Path, xdg: &Xdg, args: RunDispatchArgs) -> Res
             commands::graph::GraphRunOptions { visible, arguments },
             sandbox,
             resource_limits,
+            &resolved,
         ))
         .await;
     }

--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -77,6 +77,7 @@ pub struct AnalysisEngine {
     host_cache: HostCache,
     options: AnalysisOptions,
     configuration: crate::manifest::BuildConfiguration,
+    configuration_path_suffix: String,
 }
 
 impl fmt::Debug for AnalysisEngine {
@@ -90,6 +91,7 @@ impl fmt::Debug for AnalysisEngine {
             .field("host_cache", &self.host_cache)
             .field("options", &self.options)
             .field("configuration", &self.configuration)
+            .field("configuration_path_suffix", &self.configuration_path_suffix)
             .finish()
     }
 }
@@ -195,6 +197,7 @@ impl AnalysisEngine {
             host_cache: HostCache::default(),
             options,
             configuration: crate::manifest::BuildConfiguration::default(),
+            configuration_path_suffix: String::new(),
         })
     }
 
@@ -229,6 +232,23 @@ impl AnalysisEngine {
     #[must_use]
     pub fn with_tool_paths(mut self, tool_paths: BTreeMap<String, String>) -> Self {
         self.host_cache = HostCache::with_tool_paths(tool_paths);
+        self
+    }
+
+    /// Set the effective configuration and its output-path suffix.
+    ///
+    /// The configuration drives Starlark analysis and dependency selection;
+    /// the suffix scopes analysis output directories so two invocations
+    /// with different configurations never share build outputs. An empty
+    /// suffix keeps paths identical to the workspace-default case.
+    #[must_use]
+    pub fn with_configuration(
+        mut self,
+        configuration: crate::manifest::BuildConfiguration,
+        configuration_path_suffix: String,
+    ) -> Self {
+        self.configuration = configuration;
+        self.configuration_path_suffix = configuration_path_suffix;
         self
     }
 
@@ -351,6 +371,7 @@ impl AnalysisEngine {
             capability,
             options: self.options.clone(),
             configuration: &self.configuration,
+            configuration_path_suffix: &self.configuration_path_suffix,
         };
         analyze_target_with_host_cache(
             &self.module,
@@ -409,6 +430,7 @@ struct TargetAnalysis<'a> {
     capability: &'a str,
     options: AnalysisOptions,
     configuration: &'a crate::manifest::BuildConfiguration,
+    configuration_path_suffix: &'a str,
 }
 
 fn analyze_target_with_host_cache(
@@ -417,8 +439,14 @@ fn analyze_target_with_host_cache(
     host_cache: HostCache,
     analysis: &TargetAnalysis<'_>,
 ) -> Result<AnalysisResult> {
-    let build_dir = format!(".once/out/{}", analysis.target.label.id);
-    let scratch_dir = format!(".once/tmp/analysis/{}", analysis.target.label.id);
+    let build_dir = format!(
+        ".once/out/{}{}",
+        analysis.target.label.id, analysis.configuration_path_suffix
+    );
+    let scratch_dir = format!(
+        ".once/tmp/analysis/{}{}",
+        analysis.target.label.id, analysis.configuration_path_suffix
+    );
     let store = AnalysisStore::with_host_cache(
         analysis.workspace_root.to_path_buf(),
         analysis.target.label.package.clone(),

--- a/crates/once-frontend/src/graph.rs
+++ b/crates/once-frontend/src/graph.rs
@@ -14,8 +14,9 @@ use starlark::values::Value;
 
 use crate::analysis::select_branches;
 use crate::error::{Error, Result};
+use crate::manifest::BuildConfiguration;
 use crate::target::{AttrValue, Target};
-use crate::workspace::load_workspace;
+use crate::workspace::{load_workspace, load_workspace_with_configuration};
 
 /// Fully qualified graph target label.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -307,7 +308,22 @@ pub struct DepSchema {
 
 pub fn load_graph_workspace(root: &Path) -> Result<Vec<GraphTarget>> {
     let schemas = target_kind_schemas_for_workspace(root)?;
-    load_graph_workspace_with_schemas(root, &schemas)
+    load_graph_workspace_with_targets_and_schemas(root, load_workspace(root)?, &schemas)
+}
+
+/// Load the graph using an explicit configuration, layered over the
+/// workspace-declared one. Mirrors [`load_graph_workspace`] for callers
+/// that carry invocation-time overrides.
+pub fn load_graph_workspace_with_configuration(
+    root: &Path,
+    configuration: &BuildConfiguration,
+) -> Result<Vec<GraphTarget>> {
+    let schemas = target_kind_schemas_for_workspace(root)?;
+    load_graph_workspace_with_targets_and_schemas(
+        root,
+        load_workspace_with_configuration(root, configuration)?,
+        &schemas,
+    )
 }
 
 pub(crate) fn load_graph_workspace_with_compiled_schemas(
@@ -328,13 +344,6 @@ pub(crate) fn load_graph_workspace_with_compiled_schemas_and_targets(
 ) -> Result<Vec<GraphTarget>> {
     let schemas = target_kind_schemas_for_workspace_from_compiled(root, compiled_schemas)?;
     load_graph_workspace_with_targets_and_schemas(root, targets, &schemas)
-}
-
-fn load_graph_workspace_with_schemas(
-    root: &Path,
-    schemas: &[TargetKindSchema],
-) -> Result<Vec<GraphTarget>> {
-    load_graph_workspace_with_targets_and_schemas(root, load_workspace(root)?, schemas)
 }
 
 pub(crate) fn load_graph_workspace_with_targets_and_schemas(

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -42,14 +42,14 @@ pub use examples::{load_example_bundle, load_target_kind_example};
 pub use graph::{
     built_in_target_kind_schema, built_in_target_kind_schemas, built_in_target_kind_schemas_result,
     graph_from_targets, graph_from_targets_result, load_graph_workspace,
-    target_kind_schemas_for_workspace, validate_module_source, AttrSchema, Capability, DepSchema,
-    Diagnostic, GraphTarget, SourceReference, TargetKindExample, TargetKindExampleBundle,
-    TargetKindExampleFile, TargetKindExampleRoot, TargetKindExampleSource, TargetKindSchema,
-    TargetLabel, ToolRequirement,
+    load_graph_workspace_with_configuration, target_kind_schemas_for_workspace,
+    validate_module_source, AttrSchema, Capability, DepSchema, Diagnostic, GraphTarget,
+    SourceReference, TargetKindExample, TargetKindExampleBundle, TargetKindExampleFile,
+    TargetKindExampleRoot, TargetKindExampleSource, TargetKindSchema, TargetLabel, ToolRequirement,
 };
 pub use manifest::{
     load_cache_provider_toml_str, load_infrastructure_toml_str, load_toml_str,
-    load_workspace_configuration, BuildConfiguration,
+    load_workspace_configuration, BuildConfiguration, ConfigurationOverrides,
 };
 pub use manifest_editor::{
     apply_operations, apply_operations_with_schemas, EditOperation, TargetSpec, TargetUpdate,
@@ -69,6 +69,6 @@ pub use target_ref::{
 pub use target_validator::validate_target;
 pub use workspace::{
     load_cache_provider, load_cache_provider_override, load_file, load_infrastructure_config,
-    load_workspace,
+    load_workspace, load_workspace_with_configuration,
 };
 pub use workspace_validator::{validate_workspace, validate_workspace_graph};

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -46,6 +46,28 @@ pub struct BuildConfiguration {
     pub tokens: Vec<String>,
 }
 
+/// Invocation-time overrides layered on top of the workspace-default
+/// [`BuildConfiguration`].
+///
+/// `os` and `arch` replace the workspace values; `tokens` are appended.
+/// The merged configuration drives dependency selection and Starlark
+/// analysis, and its canonical encoding participates in configured-target
+/// identity so two invocations with different overrides never share outputs
+/// or receipts.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConfigurationOverrides {
+    pub os: Option<String>,
+    pub arch: Option<String>,
+    pub tokens: Vec<String>,
+}
+
+impl ConfigurationOverrides {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.os.is_none() && self.arch.is_none() && self.tokens.is_empty()
+    }
+}
+
 impl BuildConfiguration {
     fn host() -> Self {
         Self::new(std::env::consts::OS, std::env::consts::ARCH, Vec::new())
@@ -92,6 +114,51 @@ impl BuildConfiguration {
             tokens.push("default".to_string());
         }
         Self { os, arch, tokens }
+    }
+}
+
+impl BuildConfiguration {
+    /// Merge invocation-time overrides over this configuration.
+    ///
+    /// Platform-derived tokens (for the original operating system and
+    /// architecture) are re-derived for the resulting platform, while
+    /// any extra workspace tokens are preserved and the override tokens
+    /// are appended. This keeps the token list consistent when an override
+    /// changes the target platform.
+    #[must_use]
+    pub fn merged_with(&self, overrides: &ConfigurationOverrides) -> Self {
+        let os = overrides.os.clone().unwrap_or_else(|| self.os.clone());
+        let arch = overrides.arch.clone().unwrap_or_else(|| self.arch.clone());
+        let baseline_platform = select_tokens_for(&self.os, &self.arch);
+        let extra: Vec<String> = self
+            .tokens
+            .iter()
+            .filter(|token| *token != "default" && !baseline_platform.contains(token))
+            .cloned()
+            .chain(overrides.tokens.iter().cloned())
+            .collect();
+        Self::new(&os, &arch, extra)
+    }
+
+    /// Canonical, content-addressed encoding of this configuration.
+    ///
+    /// Callers hash these bytes to form a stable configuration identity.
+    /// The domain prefix partitions this encoding from other hashed
+    /// payloads so a configuration digest can never collide with an
+    /// unrelated one.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(48 + self.os.len() + self.arch.len());
+        bytes.extend_from_slice(b"once.configuration.v1\0");
+        bytes.extend_from_slice(self.os.as_bytes());
+        bytes.push(0);
+        bytes.extend_from_slice(self.arch.as_bytes());
+        bytes.push(0);
+        for token in &self.tokens {
+            bytes.extend_from_slice(token.as_bytes());
+            bytes.push(0);
+        }
+        bytes
     }
 }
 
@@ -844,5 +911,48 @@ deps = { select = { release = ["./Optimized"], default = ["./Portable"] } }
                 "aarch64"
             ]
         );
+    }
+
+    #[test]
+    fn configuration_canonical_bytes_are_stable() {
+        let left = BuildConfiguration::new("macos", "aarch64", Vec::new());
+        let right = BuildConfiguration::new("macos", "aarch64", Vec::new());
+        assert_eq!(left.canonical_bytes(), right.canonical_bytes());
+    }
+
+    #[test]
+    fn configuration_canonical_bytes_differ_when_tokens_differ() {
+        let debug = BuildConfiguration::new("macos", "aarch64", Vec::new());
+        let release = BuildConfiguration::new("macos", "aarch64", vec!["release".to_string()]);
+        assert_ne!(debug.canonical_bytes(), release.canonical_bytes());
+    }
+
+    #[test]
+    fn configuration_merge_appends_tokens_and_preserves_extra_tokens() {
+        let baseline =
+            BuildConfiguration::new("macos", "aarch64", vec!["distribution".to_string()]);
+        let merged = baseline.merged_with(&ConfigurationOverrides {
+            tokens: vec!["release".to_string()],
+            ..ConfigurationOverrides::default()
+        });
+        // Platform tokens are re-derived for the unchanged platform.
+        assert!(merged.tokens.contains(&"macos-arm64".to_string()));
+        // Workspace extra tokens survive a merge.
+        assert!(merged.tokens.contains(&"distribution".to_string()));
+        // Override tokens are appended.
+        assert!(merged.tokens.contains(&"release".to_string()));
+    }
+
+    #[test]
+    fn configuration_merge_rederives_platform_tokens_when_architecture_changes() {
+        let baseline = BuildConfiguration::new("macos", "aarch64", Vec::new());
+        let merged = baseline.merged_with(&ConfigurationOverrides {
+            arch: Some("x86_64".to_string()),
+            ..ConfigurationOverrides::default()
+        });
+        assert_eq!(merged.arch, "x86_64");
+        // The old platform token must not survive an architecture change.
+        assert!(!merged.tokens.contains(&"macos-arm64".to_string()));
+        assert!(merged.tokens.contains(&"macos-x86_64".to_string()));
     }
 }

--- a/crates/once-frontend/src/workspace.rs
+++ b/crates/once-frontend/src/workspace.rs
@@ -32,7 +32,19 @@ pub fn load_file(path: &Path) -> Result<Vec<Target>> {
 /// Recursively scan `root` for `once.toml` files and return every
 /// script-like target they declare.
 pub fn load_workspace(root: &Path) -> Result<Vec<Target>> {
-    let scan = load_workspace_scan(root)?;
+    let configuration = crate::manifest::load_workspace_configuration(root)?;
+    load_workspace_with_configuration(root, &configuration)
+}
+
+/// Load the workspace using an explicit configuration rather than the
+/// one declared in `once.toml`. Invocation-time overrides flow through
+/// here so dependency selection and Starlark analysis observe the same
+/// configuration that scopes target identity.
+pub fn load_workspace_with_configuration(
+    root: &Path,
+    configuration: &BuildConfiguration,
+) -> Result<Vec<Target>> {
+    let scan = load_workspace_scan_with_configuration(root, configuration)?;
     let walker = WalkDir::new(root)
         .follow_links(false)
         .into_iter()
@@ -202,6 +214,15 @@ impl WorkspaceScan {
             .iter()
             .any(|pattern| pattern.matches(&descendant))
     }
+}
+
+pub(crate) fn load_workspace_scan_with_configuration(
+    root: &Path,
+    configuration: &BuildConfiguration,
+) -> Result<WorkspaceScan> {
+    let mut scan = load_workspace_scan(root)?;
+    scan.configuration = configuration.clone();
+    Ok(scan)
 }
 
 pub(crate) fn load_workspace_scan(root: &Path) -> Result<WorkspaceScan> {

--- a/web/lib/once_site_web/docs/sidebar.ex
+++ b/web/lib/once_site_web/docs/sidebar.ex
@@ -70,6 +70,7 @@ defmodule OnceSiteWeb.Docs.Sidebar do
         items: [
           %Item{label: "Overview", slug: "/docs/guide/graph"},
           %Item{label: "Ecosystems", slug: "/docs/guide/graph/ecosystems"},
+          %Item{label: "Configurations", slug: "/docs/guide/graph/configuration"},
           %Item{label: "Testing and Scheduling", slug: "/docs/guide/graph/testing"},
           %Item{label: "Linting", slug: "/docs/guide/graph/linting"},
           %Item{label: "Apple", slug: "/docs/guide/graph/apple", icon: "apple"},

--- a/web/priv/docs/guide/graph/android.md
+++ b/web/priv/docs/guide/graph/android.md
@@ -217,6 +217,10 @@ Attributes that choose the configuration, including `compile_sdk` and
 `min_sdk_version`, must remain literal. The target kind schema identifies any
 other non-configurable attributes.
 
+See the [configurations guide](/guide/graph/configuration) for how
+`--config` overrides these tokens per invocation and how the effective
+configuration scopes outputs.
+
 ## Connect Native Dependencies
 
 An `android_binary` can consume native shared libraries through normal

--- a/web/priv/docs/guide/graph/apple.md
+++ b/web/priv/docs/guide/graph/apple.md
@@ -209,6 +209,10 @@ Attributes that determine the configuration, including `platform`,
 `sdk_variant`, `archs`, and `mac_catalyst`, must remain literal. The target
 kind schema identifies any other non-configurable attributes.
 
+See the [configurations guide](/guide/graph/configuration) for how
+`--config` overrides these tokens per invocation and how the effective
+configuration scopes outputs.
+
 ## Connect Native Dependencies
 
 Apple targets can consume native outputs from other ecosystems through normal

--- a/web/priv/docs/guide/graph/configuration.md
+++ b/web/priv/docs/guide/graph/configuration.md
@@ -1,0 +1,79 @@
+# Configurations
+
+A target's behavior can vary by configuration: which platform it targets,
+which dependencies it pulls in, or which build mode it uses. Once keeps the
+declared graph static while letting its configured projection change between
+invocations. The same target identifier can resolve to different dependencies
+and actions without editing the manifest.
+
+Configuration plays two roles. It selects which branch of a `select` value a
+target uses, and it feeds target-kind analysis with the platform and tokens
+the target runs against. The effective configuration is also part of a
+target's identity, so two invocations with different configurations never
+share outputs or receipts: each lands in its own scoped output directory and
+its own action-cache partition.
+
+## Declare workspace defaults
+
+The workspace root manifest fixes the default configuration every invocation
+starts from:
+
+```toml
+[workspace.configuration]
+os = "linux"
+arch = "arm64"
+tokens = ["release"]
+```
+
+Once normalizes common names (`darwin` to `macos`, `arm64` to `aarch64`,
+`amd64` to `x86_64`) and derives an ordered set of selection tokens from the
+operating system and architecture, then appends the extra `tokens` and
+`default`. Inspect the resolved set with `once query workspace`. The
+[manifest reference](/reference/manifest) describes the table and
+normalization in full.
+
+## Override per invocation
+
+Pass `--config KEY=VALUE` to `once build`, `once lint`, `once run`, or
+`once test` to override the workspace defaults for a single invocation.
+Recognized keys are `os`, `arch`, and `token`:
+
+```sh
+once build apps/Support --config os=ios --config arch=arm64
+once build apps/Support --config token=simulator
+```
+
+`os` and `arch` replace the workspace values; each `token` is appended to the
+selection tokens. When an override changes the operating system or
+architecture, Once re-derives the platform tokens for the new target platform
+so stale tokens do not survive. Overrides apply on top of the workspace
+defaults, and only the resulting values affect target identity, not the flags
+that produced them.
+
+Because the effective configuration scopes outputs and receipts, building the
+same target under two configurations from one checkout keeps both results:
+
+```sh
+once build apps/Support                         # default configuration
+once build apps/Support --config token=release  # separate, scoped outputs
+```
+
+A later invocation with the same overrides reuses the scoped receipt and
+reports a cache hit, while an invocation with no overrides is unaffected.
+
+## Choose values with select
+
+Configurable attributes and dependencies use `select` to vary by token. A
+target can choose its dependencies for the configured platform:
+
+```toml
+[target.deps.select]
+macos = ["./apple_support"]
+linux = ["./linux_support"]
+default = ["./portable_support"]
+```
+
+When several branches could match, the most specific one wins, and `default`
+is the fallback. Each ecosystem adds its own tokens and restrictions; see the
+"Choose values by configuration" section of the relevant ecosystem guide, such
+as [Apple](/guide/graph/apple).

--- a/web/priv/docs/reference/manifest.md
+++ b/web/priv/docs/reference/manifest.md
@@ -63,6 +63,11 @@ operating-system and architecture combinations, their aliases, the individual
 values, the additional `tokens`, and `default`. Use `once query workspace` to
 inspect the exact configuration seen by target kinds.
 
+`once build`, `once lint`, `once run`, and `once test` accept `--config`
+overrides that layer on top of these workspace defaults for a single
+invocation. See the [configurations guide](/guide/graph/configuration) for
+the override model, precedence, and how outputs stay separated.
+
 An execution-only provider can select a sandbox adapter and immutable tool
 environment:
 


### PR DESCRIPTION
## What changed

- Adds a `--config KEY=VALUE` flag (repeatable) to `once build`, `once lint`, `once run`, and `once test`. Recognized keys are `os`, `arch`, and `token`.
- The override values merge over the workspace configuration declared in `once.toml`, and the merged result travels as one canonical object through target loading, `select` dependency resolution, Starlark analysis (`ctx["configuration"]`), and action execution.
- The configuration's content digest now participates in configured-target identity: analysis output directories and build receipts are scoped by it, so two invocations with different overrides produce separate outputs and receipts.
- Build receipts record the effective configuration digest. Existing receipts written before this change still parse, since the new field defaults for them.

## Why

Configuration was previously workspace-static: it came only from `[workspace.configuration]` in `once.toml`, so a single target could not be built under two different configurations from the same checkout, and there was no invocation-time channel to feed a value that `select` branches and target-kind analysis could react to. The design notes in the build graph RFC already call for a configured-graph phase that resolves platforms, constraints, and toolchains; this is the first concrete step toward that model, starting with the invocation-time input channel and the identity work that keeps it safe.

The reason overrides and identity had to land together is that exposing `--config` without scoping outputs and receipts would let two configurations of the same target clobber each other's outputs and reuse each other's build receipts. Threading the configuration digest into output paths and receipt keys first would have been dead plumbing with no testable behavior, so they ship as one change.

## Approach

The declared graph stays static. What becomes invocation-scoped is its configured projection.

- `BuildConfiguration` gains a stable, domain-prefixed content encoding (`canonical_bytes`) used to derive a digest, plus a `ConfigurationOverrides` type and a `merged_with` operation. Merging re-derives platform tokens when `os` or `arch` change, preserves extra workspace tokens, and appends override tokens.
- New config-aware loaders (`load_workspace_with_configuration`, `load_graph_workspace_with_configuration`) resolve `select` dependency branches against the effective configuration rather than always the workspace default.
- The analysis engine exposes `with_configuration(configuration, path_suffix)`. The suffix is empty when the merged configuration equals the workspace default, and `/cfg-<digest>` otherwise, which is what keeps a no-`--config` invocation byte-identical to today.
- Output directories and the build-receipt path key both fold the suffix in, and the receipt body records the digest. The receipt schema string is unchanged so old receipts keep parsing.

The target map remains keyed by label for now. That keying only becomes load-bearing once transitions (one session holding a target under multiple configurations) exist, which is later work; until then a session carries a single configuration, so keying by label is still correct.

## Impact

- No change to existing behavior when `--config` is not passed: output paths, receipt paths, and cache keys are identical to before.
- `once query` and `once mcp` are read-only discovery surfaces and still resolve against the workspace-default configuration; the override channel does not yet reach them.
- The dynamic test scheduler used by `once test --all`, `--changed-path`, and `--jobs` also still runs on the workspace-default configuration. The override channel applies to `once test <target>` and the batch path.
- Later steps in this direction: structured `select` conditions replacing ordered-token matching, lowering annotated scripts into the shared configured graph, and transitions for cases like multi-architecture builds.

## Validation

```
mise exec -- cargo clippy --workspace --all-targets -- -D warnings   # clean
mise exec -- cargo fmt --all -- --check                              # clean
mise exec -- cargo test -p once-frontend -p once-cli                 # config tests pass
```

End-to-end against a small workspace whose root target selects between two dependencies with `deps = { select = { release = ["./ReleaseDep"], default = ["./DebugDep"] } }`:

```
once build Root                         # default branch, output .once/out/Root/marker.txt = "DebugDep"
once build Root --config token=release  # release branch, output .once/out/Root/cfg-f8c3.../marker.txt = "ReleaseDep"
once build Root --config token=release  # cache: hit (scoped receipt)
once build Root                         # cache: hit (baseline receipt, untouched)
```

Both configurations coexist without clobbering each other. An unknown key fails cleanly: `once build Root --config flavor=debug` reports `unknown --config key 'flavor' (expected 'os', 'arch', or 'token')`.

## Example help output

```
$ once build --help
      --config <KEY=VALUE>
          Override the workspace build configuration. Recognized keys are `os`, `arch`, and `token`
          (repeatable), supplied as `KEY=VALUE`. Targets configured with `select` resolve against
          the merged configuration, and their outputs are scoped so different values never collide.
```
