### PR TITLE
fix(infra): stop once-postgres deadlocking CAPI node drains

### DIFF
--- a/infra/helm/once/templates/postgres-cluster.yaml
+++ b/infra/helm/once/templates/postgres-cluster.yaml
@@ -8,6 +8,19 @@ metadata:
 spec:
   instances: {{ .Values.postgres.instances }}
   imageName: {{ .Values.postgres.imageName }}
+  # No PodDisruptionBudget. CNPG's default emits a `<cluster>-primary` PDB
+  # with `minAvailable: 1` selecting the primary; at a single instance the
+  # primary is the only pod, so `disruptionsAllowed` is structurally 0 and
+  # the pod can never be evicted. A CAPI node drain then blocks forever,
+  # because the cluster's ClusterClass sets `nodeDrainTimeoutSeconds: 0` so
+  # a drain never kills an in-flight CI job. This pod wedged the deletion of
+  # a `tuist-md-processor` Machine from 2026-07-31.
+  #
+  # CNPG documents disabling PDBs as the right setting for a cluster that is
+  # not run for availability, which is this one: the database is empty and
+  # unused (no migrations, no `Repo.` call sites), kept only because the app
+  # still starts the Repo unconditionally.
+  enablePDB: false
   storage:
     size: {{ .Values.postgres.storageSize }}
     storageClass: {{ .Values.postgres.storageClass }}

--- a/infra/helm/once/values.yaml
+++ b/infra/helm/once/values.yaml
@@ -106,6 +106,10 @@ postgres:
   # replica pod and its 20Gi volume. Dropping Postgres entirely needs app
   # changes (Repo is started unconditionally and runtime.exs requires
   # DATABASE_URL), so that is left for the larger restructure.
+  #
+  # A single instance also requires `enablePDB: false` on the Cluster, or
+  # the pod becomes unevictable and deadlocks CAPI node drains. See the
+  # comment in templates/postgres-cluster.yaml.
   enabled: true
   instances: 1
   storageSize: 20Gi


### PR DESCRIPTION
## What changed

One field on the CNPG `Cluster`: `enablePDB: false`, plus the comment explaining why a single-instance cluster needs it.

## Why

`once-postgres-1` runs on a node in the **tuist production cluster**, and it has been blocking that node's deletion since 2026-07-31. Machine `tuist-md-processor-8tz5r-7tzhn-qwrzv` has sat in `Deleting` for 18 days reporting:

```
Drain not completed yet (started at 2026-07-31T05:56:35Z):
* Pod once-production/once-postgres-1: cannot evict pod as it would violate the pod's disruption budget. The disruption budget once-postgres-primary needs 1 healthy pods and has 1 currently
* Pod tuist-ops/tuist-ops-pg-1: cannot evict pod as it would violate the pod's disruption budget. The disruption budget tuist-ops-pg-primary needs 1 healthy pods and has 1 currently
```

CNPG emits a `<cluster>-primary` PodDisruptionBudget with `minAvailable: 1` selecting `cnpg.io/instanceRole: primary`. With one instance the primary is the only pod it can ever select, so the budget is structurally unsatisfiable:

```
once-postgres-primary  minAvailable=1  currentHealthy=1  desiredHealthy=1  expectedPods=1  disruptionsAllowed=0
```

Nothing breaks the tie. The tuist ClusterClass sets `nodeDrainTimeoutSeconds: 0` deliberately, so a drain waits forever rather than ever killing an in-flight CI job. The operator does try to resolve it on its own and logs `Primary is running on an unschedulable node, will try switching over` followed by `no valid candidates`, because at one instance there is nothing to promote to.

This became a trap on 2026-07-01 in #155, which took the cluster from two instances to one. That was the right call on cost; it just also removed the only thing making the pod evictable.

## Why not simply scale back to two instances

That is the obvious fix and it is the wrong one here.

- It reverts the #155 downsize, re-spending a pod and a 20Gi volume.
- It buys high availability for a database that is **empty and unused**. `web/priv/repo/migrations/` contains only `.gitkeep`, and there are no `Repo.` call sites anywhere in `web/lib`. The Repo exists because the Phoenix scaffold starts it unconditionally, which `values.yaml` already documents.

Paying for a standby replica of an empty database, in order to satisfy a disruption budget protecting availability nobody is relying on, is the wrong trade. Disabling the budget targets the actual problem.

CNPG's own CRD documentation for this field names this exact profile:

> setting it to `false` will result in the absence of any `PodDisruptionBudget` resource, permitting the shutdown of all nodes hosting the PostgreSQL cluster. This latter configuration is advisable for any PostgreSQL cluster employed for development/staging purposes.

## Why not drop Postgres entirely

That is the better end state and `values.yaml` already names it as the intent. It needs app changes (the Repo is started unconditionally in `application.ex`, and `runtime.exs` requires `DATABASE_URL`), so it is a larger change than unblocking a node drain that has been stuck for 18 days should wait on. This PR does not close that door; it just stops the current bleeding. Worth doing as the follow-up.

## Impact

- The pod becomes evictable. On the next drain attempt it is evicted and rescheduled onto a healthy node, reattaching the same PVC.
- **No data is deleted and no volume is destroyed.** `enablePDB` only controls whether the budget object exists; it does not touch storage. The eviction is a normal pod reschedule.
- Brief unavailability of a database with no readers or writers.
- Removes the trap permanently, so future node rolls are not blocked by this cluster.

## Validation

- `helm template` renders `enablePDB: false` on the Cluster with everything else unchanged, and the manifest parses.
- `infra/helm/once/tests/render-conditionals.sh` passes.
- The PDB status above was read from the live production cluster with read-only kubectl; the operator log lines came from the live `platform-cloudnative-pg` deployment.

## Related

The other half of the same wedge is the `tuist-ops` cluster, fixed in https://github.com/tuist/tuist/pull/12357, which also adds the missing metric that let this run 18 days unnoticed. **Both pods must move before the Machine can finish deleting**, so neither PR clears the drain alone.
