### PR TITLE
feat(swift): add native Package.swift support

### DIFF
--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -9,6 +9,7 @@ use once_core::{LintSeverity, NetworkPolicy, SandboxMode, WorkspacePath};
 mod auth;
 mod cache;
 mod edit;
+mod native;
 mod query;
 mod runtime;
 mod toolchain;
@@ -16,6 +17,7 @@ mod toolchain;
 pub use auth::AuthCmd;
 pub use cache::{CacheActionCmd, CacheBlobCmd, CacheCmd};
 pub use edit::EditCmd;
+pub use native::NativeCmd;
 pub use query::QueryCmd;
 pub use runtime::RuntimeCmd;
 pub use toolchain::ToolchainCmd;
@@ -478,6 +480,13 @@ pub enum Cmd {
         cmd: Option<EditCmd>,
     },
 
+    /// Discover, inspect, and initialize native workspace roots.
+    #[command(arg_required_else_help = true)]
+    Native {
+        #[command(subcommand)]
+        cmd: Option<NativeCmd>,
+    },
+
     /// Expose Once's graph and memory queries to a coding agent.
     ///
     /// Speaks the Model Context Protocol over standard input and output so a
@@ -560,6 +569,13 @@ impl Cmd {
             }
             Self::Edit { cmd } => {
                 let mut path = vec!["edit"];
+                if let Some(cmd) = cmd {
+                    path.extend(cmd.surface_path());
+                }
+                path
+            }
+            Self::Native { cmd } => {
+                let mut path = vec!["native"];
                 if let Some(cmd) = cmd {
                     path.extend(cmd.surface_path());
                 }

--- a/crates/once-cli/src/cli/edit.rs
+++ b/crates/once-cli/src/cli/edit.rs
@@ -31,17 +31,6 @@ pub enum EditCmd {
         #[arg(long, default_value = "", value_name = "DIR")]
         destination: String,
     },
-
-    /// Initialize Once from a detected native project.
-    InitNativeProject {
-        /// Name discovered with `once query native-projects`.
-        name: String,
-        /// Package directory relative to the workspace root.
-        ///
-        /// This may be omitted when the native project has exactly one match.
-        #[arg(long, value_name = "PATH")]
-        package: Option<String>,
-    },
 }
 
 impl EditCmd {
@@ -49,7 +38,6 @@ impl EditCmd {
         match self {
             Self::Apply { .. } => vec!["apply"],
             Self::MaterializeExample { .. } => vec!["materialize-example"],
-            Self::InitNativeProject { .. } => vec!["init-native-project"],
         }
     }
 }

--- a/crates/once-cli/src/cli/native.rs
+++ b/crates/once-cli/src/cli/native.rs
@@ -1,0 +1,35 @@
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum NativeCmd {
+    /// List recognized native roots and their current matches.
+    List,
+
+    /// Show the typed graph derived from one native root.
+    Show {
+        /// Native integration name from `once native list`.
+        name: String,
+        /// Workspace-relative path of the matched root.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+
+    /// Store one detected native seed in `once.toml`.
+    Init {
+        /// Native integration name from `once native list`.
+        name: String,
+        /// Workspace-relative path of the matched root.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+}
+
+impl NativeCmd {
+    pub fn surface_path(&self) -> Vec<&'static str> {
+        match self {
+            Self::List => vec!["list"],
+            Self::Show { .. } => vec!["show"],
+            Self::Init { .. } => vec!["init"],
+        }
+    }
+}

--- a/crates/once-cli/src/cli/query.rs
+++ b/crates/once-cli/src/cli/query.rs
@@ -50,20 +50,6 @@ pub enum QueryCmd {
         query: Option<String>,
     },
 
-    /// List native project declarations and current marker matches.
-    NativeProjects,
-
-    /// Preview the typed graph derived from one native project.
-    NativeProject {
-        /// Name discovered with `once query native-projects`.
-        name: String,
-        /// Package directory relative to the workspace root.
-        ///
-        /// This may be omitted when the native project has exactly one match.
-        #[arg(long, value_name = "PATH")]
-        package: Option<String>,
-    },
-
     /// Return the project-module authoring contract, starters, and result examples.
     ModuleContract,
 
@@ -219,8 +205,6 @@ impl QueryCmd {
             Self::Schema { .. } => vec!["schema"],
             Self::Example { .. } => vec!["example"],
             Self::TargetKinds { .. } => vec!["target-kinds"],
-            Self::NativeProjects => vec!["native-projects"],
-            Self::NativeProject { .. } => vec!["native-project"],
             Self::ModuleContract => vec!["module-contract"],
             Self::ExternalSource { .. } => vec!["external-source"],
             Self::Target { .. } => vec!["target"],

--- a/crates/once-cli/src/commands/mcp.rs
+++ b/crates/once-cli/src/commands/mcp.rs
@@ -338,11 +338,9 @@ impl Server {
             "once_query_evidence" => self.tool_query_evidence(&call.arguments),
             "once_query_graph_fingerprint" => self.tool_query_graph_fingerprint(&call.arguments),
             "once_query_module_contract" => crate::commands::query::module_contract_value(),
-            "once_list_native_projects" => {
-                crate::commands::query::native_projects_value(&self.workspace)
-            }
-            "once_preview_native_project" => self.tool_preview_native_project(&call.arguments),
-            "once_init_native_project" => self.tool_init_native_project(&call.arguments),
+            "once_native_list" => crate::commands::query::native_projects_value(&self.workspace),
+            "once_native_show" => self.tool_preview_native_project(&call.arguments),
+            "once_native_init" => self.tool_init_native_project(&call.arguments),
             "once_fetch_external_source" => Self::tool_fetch_external_source(&call.arguments),
             "once_validate_module" => self.tool_validate_module(&call.arguments),
             "once_validate_workspace" => {
@@ -446,20 +444,20 @@ impl Server {
     }
 
     fn tool_preview_native_project(&self, args: &Value) -> Result<Value> {
-        let args: NativeProjectArgs = serde_json::from_value(tool_args(args))?;
+        let args: NativeArgs = serde_json::from_value(tool_args(args))?;
         crate::commands::query::native_project_preview_value(
             &self.workspace,
             &args.name,
-            args.package.as_deref(),
+            args.path.as_deref(),
         )
     }
 
     fn tool_init_native_project(&self, args: &Value) -> Result<Value> {
-        let args: NativeProjectArgs = serde_json::from_value(tool_args(args))?;
+        let args: NativeArgs = serde_json::from_value(tool_args(args))?;
         crate::commands::edit::init_native_project_json(
             &self.workspace,
             &args.name,
-            args.package.as_deref(),
+            args.path.as_deref(),
         )
     }
 
@@ -1075,10 +1073,10 @@ struct MaterializeExampleArgs {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct NativeProjectArgs {
+struct NativeArgs {
     name: String,
     #[serde(default)]
-    package: Option<String>,
+    path: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -1735,8 +1733,8 @@ demo_kind = target_kind(
                 "once_query_schema".to_string(),
                 "once_query_example".to_string(),
                 "once_list_target_kinds".to_string(),
-                "once_list_native_projects".to_string(),
-                "once_preview_native_project".to_string(),
+                "once_native_list".to_string(),
+                "once_native_show".to_string(),
                 "once_query_module_contract".to_string(),
                 "once_fetch_external_source".to_string(),
                 "once_validate_module".to_string(),
@@ -2002,7 +2000,7 @@ script_runtime = "sh"
         assert!(names.contains(&"once_apply_edit".to_string()));
         assert!(names.contains(&"once_materialize_example".to_string()));
         assert!(names.contains(&"once_exec_script".to_string()));
-        assert!(names.contains(&"once_init_native_project".to_string()));
+        assert!(names.contains(&"once_native_init".to_string()));
 
         for tool in result["tools"].as_array().unwrap() {
             assert!(tool["outputSchema"].is_object());
@@ -2040,7 +2038,7 @@ script_runtime = "sh"
             "once_exec_script",
             "once_apply_edit",
             "once_materialize_example",
-            "once_init_native_project",
+            "once_native_init",
         ] {
             let response = server(tmp.path().to_path_buf()).dispatch(request(
                 "tools/call",

--- a/crates/once-cli/src/commands/mcp/tools.rs
+++ b/crates/once-cli/src/commands/mcp/tools.rs
@@ -41,7 +41,7 @@ pub(super) fn tool_requires_allow_run(name: &str) -> bool {
             | "once_stop_runtime"
             | "once_apply_edit"
             | "once_materialize_example"
-            | "once_init_native_project"
+            | "once_native_init"
     )
 }
 
@@ -50,8 +50,8 @@ fn tool_annotations(name: &str) -> Value {
         || matches!(
             name,
             "once_list_target_kinds"
-                | "once_list_native_projects"
-                | "once_preview_native_project"
+                | "once_native_list"
+                | "once_native_show"
                 | "once_get_target"
                 | "once_fetch_external_source"
                 | "once_validate_module"
@@ -63,7 +63,7 @@ fn tool_annotations(name: &str) -> Value {
         );
     let destructive = matches!(
         name,
-        "once_apply_edit" | "once_init_native_project" | "once_stop_runtime"
+        "once_apply_edit" | "once_native_init" | "once_stop_runtime"
     );
     let idempotent = read_only
         || matches!(
@@ -73,7 +73,7 @@ fn tool_annotations(name: &str) -> Value {
                 | "once_runtime_status"
                 | "once_runtime_logs"
                 | "once_materialize_example"
-                | "once_init_native_project"
+                | "once_native_init"
         );
     json!({
         "readOnlyHint": read_only,
@@ -220,9 +220,9 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
             example_return: "[\n  {\n    \"kind\": \"library\",\n    \"docs\": \"Reusable library target...\",\n    \"source_references\": [\n      { \"system\": \"Example Build\", \"symbol\": \"example_library\",\n        \"url\": \"https://example.com/example_library\", \"use_when\": \"...\",\n        \"content_digest\": \"...\" }\n    ],\n    \"examples\": [\n      { \"slug\": \"library-minimal\", \"name\": \"Minimal library\", \"use_when\": \"...\" }\n    ]\n  }\n]",
         },
         ToolDefinition {
-            name: "once_list_native_projects",
-            description: "List native project declarations and the roots they currently recognize.",
-            long_description: "Returns each enabled native project's name, documentation, marker files, additional resolver inputs, seed target kind, and current package matches. Detection reads file names only and does not execute native project code. The matching command-line operation is `once query native-projects --format json`.",
+            name: "once_native_list",
+            description: "List native integrations and the workspace roots they currently recognize.",
+            long_description: "Returns each enabled native integration's name, documentation, marker files, additional resolver inputs, seed target kind, and current matches. Detection reads file names only and does not execute native code. The matching command-line operation is `once native list --format json`.",
             input_schema: json!({
                 "type": "object",
                 "properties": {}
@@ -230,19 +230,19 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
             example_return: "{\n  \"native_projects\": [\n    { \"name\": \"native\", \"docs\": \"Recognize a native project.\", \"markers\": [\"project.native\"], \"target_kind\": \"native_workspace\", \"target_name\": \"native\" }\n  ],\n  \"matches\": [\n    { \"native_project\": \"native\", \"package\": \"\", \"markers\": [\"project.native\"], \"seed_target\": \"native\" }\n  ]\n}",
         },
         ToolDefinition {
-            name: "once_preview_native_project",
-            description: "Preview the seed target and complete typed graph derived by one detected native project.",
-            long_description: "Runs the selected native project's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `package` when the native project has one match. Expanded dependency graphs can be very large. For a loaded project, prefer `once_query_workspace`, filtered `once_query_targets`, `once_query_tests`, and `once_get_target` when the complete graph is not needed. The matching command-line operation is `once query native-project <name> [--package <path>] --format json`.",
+            name: "once_native_show",
+            description: "Preview the seed target and complete typed graph derived by one detected native integration.",
+            long_description: "Runs the selected native integration's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `path` when it has one match. Expanded dependency graphs can be very large. For a loaded project, prefer `once_query_workspace`, filtered `once_query_targets`, `once_query_tests`, and `once_get_target` when the complete graph is not needed. The matching command-line operation is `once native show <name> [--path <path>] --format json`.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Name discovered with `once_list_native_projects`."
+                        "description": "Name discovered with `once_native_list`."
                     },
-                    "package": {
+                    "path": {
                         "type": "string",
-                        "description": "Package path from the native project match. Use an empty string for the workspace root."
+                        "description": "Workspace-relative root path from the native match. Use an empty string for the workspace root."
                     }
                 },
                 "required": ["name"]
@@ -250,19 +250,19 @@ pub fn tool_catalog() -> Vec<ToolDefinition> {
             example_return: "{\n  \"native_project\": { \"name\": \"native\", \"target_kind\": \"native_workspace\" },\n  \"matched\": { \"native_project\": \"native\", \"package\": \"\", \"seed_target\": \"native\" },\n  \"seed\": { \"name\": \"native\", \"kind\": \"native_workspace\" },\n  \"targets\": [ { \"label\": { \"id\": \"native\" }, \"kind\": \"native_workspace\" } ]\n}",
         },
         ToolDefinition {
-            name: "once_init_native_project",
-            description: "Initialize Once from one detected native project.",
-            long_description: "This state-changing tool is available only when the server starts with `once mcp --allow-run`. It writes the native project's validated seed target through the manifest editor while preserving unrelated configuration and comments. Repeating an identical initialization is idempotent. A conflicting target with the same name is rejected. The matching command-line operation is `once edit init-native-project <name> [--package <path>]`.",
+            name: "once_native_init",
+            description: "Initialize Once from one detected native integration.",
+            long_description: "This state-changing tool is available only when the server starts with `once mcp --allow-run`. It writes the native integration's validated seed target through the manifest editor while preserving unrelated configuration and comments. Repeating an identical initialization is idempotent. A conflicting target with the same name is rejected. The matching command-line operation is `once native init <name> [--path <path>]`.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Name discovered with `once_list_native_projects`."
+                        "description": "Name discovered with `once_native_list`."
                     },
-                    "package": {
+                    "path": {
                         "type": "string",
-                        "description": "Package path from the native project match. Use an empty string for the workspace root."
+                        "description": "Workspace-relative root path from the native match. Use an empty string for the workspace root."
                     }
                 },
                 "required": ["name"]

--- a/crates/once-cli/src/commands/query.rs
+++ b/crates/once-cli/src/commands/query.rs
@@ -551,10 +551,10 @@ pub(crate) fn native_project_package(
     match packages.as_slice() {
         [package] => Ok(package.clone()),
         [] => anyhow::bail!(
-            "native project `{name}` does not match this workspace; inspect `once query native-projects`"
+            "native integration `{name}` does not match this workspace; inspect `once native list`"
         ),
         _ => anyhow::bail!(
-            "native project `{name}` has multiple matches; pass `--package` with one of: {}",
+            "native integration `{name}` has multiple matches; pass `--path` with one of: {}",
             packages
                 .iter()
                 .map(|package| if package.is_empty() {

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -214,6 +214,7 @@ async fn run_command(
             run_query_command(workspace, output, expression.as_deref(), cmd).await
         }
         Cmd::Edit { cmd } => run_edit_command(workspace, output, cmd).await,
+        Cmd::Native { cmd } => run_native_command(workspace, output, cmd).await,
         Cmd::Runtime { cmd } => run_runtime_command(workspace, output, cmd).await,
         Cmd::Mcp {
             workspace: workspace_override,
@@ -443,14 +444,6 @@ async fn run_query_command(
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
-        Some(cli::QueryCmd::NativeProjects) => commands::query::native_projects(workspace, output)
-            .await
-            .map(|()| ExitCode::SUCCESS),
-        Some(cli::QueryCmd::NativeProject { name, package }) => {
-            commands::query::native_project(workspace, output, &name, package.as_deref())
-                .await
-                .map(|()| ExitCode::SUCCESS)
-        }
         Some(cli::QueryCmd::ModuleContract) => commands::query::module_contract(output)
             .await
             .map(|()| ExitCode::SUCCESS),
@@ -580,12 +573,30 @@ async fn run_edit_command(
         }) => commands::edit::materialize_example(workspace, output, &kind, &slug, &destination)
             .await
             .map(|()| ExitCode::SUCCESS),
-        Some(cli::EditCmd::InitNativeProject { name, package }) => {
-            commands::edit::init_native_project(workspace, output, &name, package.as_deref())
+        None => anyhow::bail!("edit subcommand required"),
+    }
+}
+
+async fn run_native_command(
+    workspace: &Path,
+    output: Output,
+    command: Option<cli::NativeCmd>,
+) -> Result<ExitCode> {
+    match command {
+        Some(cli::NativeCmd::List) => commands::query::native_projects(workspace, output)
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Some(cli::NativeCmd::Show { name, path }) => {
+            commands::query::native_project(workspace, output, &name, path.as_deref())
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
-        None => anyhow::bail!("edit subcommand required"),
+        Some(cli::NativeCmd::Init { name, path }) => {
+            commands::edit::init_native_project(workspace, output, &name, path.as_deref())
+                .await
+                .map(|()| ExitCode::SUCCESS)
+        }
+        None => anyhow::bail!("native subcommand required"),
     }
 }
 

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -5403,6 +5403,8 @@ def _swiftpm_swift_executable(requested_swift, xcode_developer_dir, swiftc_path)
 
 def _swift_package_dependencies_resolver(ctx):
     attrs = ctx["attrs"]
+    if attrs.get("_lazy_resolution") or False:
+        return {"targets": []}
     files = ctx["files"]
     resolved_file = _swiftpm_package_file(attrs, attrs.get("resolved_file") or "Package.resolved")
     resolved_content = files.get(resolved_file)
@@ -5518,7 +5520,7 @@ def _swift_package_dependencies_impl(ctx):
     if remote_identities and not vendor_path_attr and not allow_network:
         fail(ctx["label"]["id"] + ": locked remote Swift packages require vendor_path for a network-independent build or allow_network = true for explicit network access")
     build_inputs = list(all_srcs)
-    clean_paths = [scratch]
+    clean_paths = [bin_dir]
     if vendor_path_attr:
         vendor_path = _swiftpm_package_path(ctx, vendor_path_attr)
         copy_path(
@@ -5531,7 +5533,6 @@ def _swift_package_dependencies_impl(ctx):
         )
         build_inputs.append(scratch)
         # A tree copy replaces its destination, so removed vendor checkouts cannot persist.
-        clean_paths = [bin_dir]
 
     argv = [
         swift,
@@ -5634,6 +5635,7 @@ swift_package_dependencies = target_kind(
         attr("resolved_identities", "list<string>", default = "[]", docs = "Synthetic package identities populated by the resolver.", configurable = False),
         attr("_remote_identities", "list<string>", default = "[]", docs = "Remote package identities populated by the resolver for execution policy.", configurable = False),
         attr("_locked_pins", "list<string>", default = "[]", docs = "Resolver-owned immutable package state included in native build action identities.", configurable = False),
+        attr("_lazy_resolution", "bool", default = "false", docs = "Resolver-owned marker that defers remote package inspection until the build action.", configurable = False),
     ],
     deps = [
         dep("deps", ["swift_package_pin"], "Locked direct package dependencies emitted by the resolver."),

--- a/crates/once-frontend/prelude/elixir.star
+++ b/crates/once-frontend/prelude/elixir.star
@@ -3246,7 +3246,7 @@ _MIX_RELEASE_ATTRS = [
 _MIX_WORKSPACE_ATTRS = [
     attr("manifest", "string", default = "mix.exs", docs = "Package-relative Mix project file adapted into Once targets.", configurable = False),
     attr("lockfile", "string", default = "mix.lock", docs = "Package-relative Mix lockfile used when the project declares external dependencies.", configurable = False),
-    attr("resolver_inputs", "list<string>", default = "[]", docs = "Project files supplied to native project resolution. Defaults to srcs when empty.", configurable = False),
+    attr("resolver_inputs", "list<string>", default = "[]", docs = "Project files supplied to native integration resolution. Defaults to srcs when empty.", configurable = False),
 ]
 
 _MIX_DEPENDENCIES_ATTRS = [
@@ -3290,14 +3290,14 @@ _MIX_PACKAGE_ATTRS = _ELIXIR_LIBRARY_ATTRS + [
 mix_workspace = target_kind(
     docs = "Derives first-class Once dependency, application, lint, test, and release targets from a native Mix project.",
     attrs = _MIX_WORKSPACE_ATTRS,
-    deps = [dep("deps", ["mix_project", "mix_workspace"], "Default development application or nested workspace emitted by native project discovery.")],
+    deps = [dep("deps", ["mix_project", "mix_workspace"], "Default development application or nested workspace emitted by native integration discovery.")],
     providers = ["mix_workspace"],
     capabilities = [capability("build", [])],
     tools = _ELIXIR_TOOLS,
     examples = [
         example(
             "mix-workspace-native-project",
-            name = "Mix native project seed",
+            name = "Mix native integration seed",
             use_when = "Use this when a Mix project should derive build, lint, test, and release targets from mix.exs.",
         ),
     ],

--- a/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/Package.swift
+++ b/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "OnceNativeSwiftPackage",
+    products: [
+        .library(name: "OnceNativeSwiftPackage", targets: ["OnceNativeSwiftPackage"]),
+    ],
+    targets: [
+        .target(name: "OnceNativeSwiftPackage"),
+        .testTarget(name: "OnceNativeSwiftPackageTests", dependencies: ["OnceNativeSwiftPackage"]),
+    ]
+)

--- a/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/Sources/OnceNativeSwiftPackage/Greeting.swift
+++ b/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/Sources/OnceNativeSwiftPackage/Greeting.swift
@@ -1,0 +1,3 @@
+public func greeting() -> String {
+    "Hello from Once"
+}

--- a/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/Tests/OnceNativeSwiftPackageTests/GreetingTests.swift
+++ b/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/Tests/OnceNativeSwiftPackageTests/GreetingTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import OnceNativeSwiftPackage
+
+@Test func greetingIsAvailable() {
+    #expect(greeting() == "Hello from Once")
+}

--- a/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/once.toml
+++ b/crates/once-frontend/prelude/examples/swift-package-workspace-native-project/once.toml
@@ -1,0 +1,7 @@
+[[target]]
+name = "swift_package"
+kind = "swift_package_workspace"
+srcs = ["Package.swift", "Sources/**/*.swift", "Tests/**/*.swift"]
+
+[target.attrs]
+resolver_inputs = ["Package.swift", "Sources/**/*.swift", "Tests/**/*.swift"]

--- a/crates/once-frontend/prelude/examples/xcode-generated-source-e2e/once.toml
+++ b/crates/once-frontend/prelude/examples/xcode-generated-source-e2e/once.toml
@@ -1,7 +1,12 @@
 [[target]]
 name = "generated"
 kind = "xcode_workspace"
-srcs = ["Generated.xcodeproj/project.pbxproj", "Hello.swift"]
+srcs = [
+    "Generated.xcodeproj/project.pbxproj",
+    "Hello.swift",
+    "Packages/Shared/Package.swift",
+    "Packages/Shared/Sources/Shared/Shared.swift",
+]
 
 [target.attrs]
 project = "Generated.xcodeproj"

--- a/crates/once-frontend/prelude/index.star
+++ b/crates/once-frontend/prelude/index.star
@@ -6,6 +6,7 @@ PRELUDE_SOURCES = [
     "go.star",
     "rust.star",
     "xcode.star",
+    "swift_package.star",
     "c.star",
     "cmake.star",
     "zig.star",
@@ -23,6 +24,7 @@ PRELUDE_SOURCES = [
 PRELUDE_DEPENDENCIES = {
     "react_native.star": ["android.star"],
     "xcode.star": ["apple.star"],
+    "swift_package.star": ["apple.star", "xcode.star"],
 }
 
 PRELUDE_TARGET_KINDS = {
@@ -55,6 +57,7 @@ PRELUDE_TARGET_KINDS = {
         "apple_test_bundle",
         "shellspec_test",
     ],
+    "swift_package.star": ["swift_package_workspace"],
     "go.star": [
         "go_dependencies",
         "go_module",

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -3468,7 +3468,7 @@ cargo_workspace = target_kind(
     attrs = [
         attr("manifest", "string", default = "Cargo.toml", docs = "Package-relative Cargo manifest path passed to `cargo metadata --manifest-path`.", configurable = False),
         attr("lockfile", "string", default = "Cargo.lock", docs = "Package-relative Cargo lockfile path read as a declared resolver input.", configurable = False),
-        attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative text globs supplied to native project resolution. Defaults to srcs when empty.", configurable = False),
+        attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative text globs supplied to native integration resolution. Defaults to srcs when empty.", configurable = False),
         attr("metadata_file", "string", docs = "Optional checked-in JavaScript Object Notation output from cargo metadata.", configurable = False),
         attr("host_metadata_file", "string", docs = "Optional checked-in host Cargo metadata snapshot.", configurable = False),
         attr("vendor_dir", "string", docs = "Optional package-relative directory containing pre-vendored crate sources. When omitted, Once snapshots locked sources from Cargo's local cache into target outputs.", configurable = False),
@@ -3480,14 +3480,14 @@ cargo_workspace = target_kind(
         attr("build_script_tools", "list<string>", default = str(_CARGO_BUILD_SCRIPT_TOOLS), docs = "Host tool names that package build scripts may invoke. Each name is resolved on PATH during graph loading and its directory joins the build script's search path; names that resolve to nothing are ignored. Set an empty list to give build scripts nothing beyond the Rust and C toolchains.", configurable = False),
     ],
     resolver = _cargo_workspace_resolver,
-    deps = [dep("deps", ["rust_crate", "rust_proc_macro", "rust_binary"], "Default first-party Cargo products emitted by native project discovery.")],
+    deps = [dep("deps", ["rust_crate", "rust_proc_macro", "rust_binary"], "Default first-party Cargo products emitted by native integration discovery.")],
     providers = ["cargo_workspace"],
     capabilities = [capability("build", [])],
     tools = [_RUST_TOOL],
     examples = [
         example(
             "cargo-workspace-native-project",
-            name = "Cargo native project seed",
+            name = "Cargo native integration seed",
             use_when = "Use this when a Cargo project should derive first-party build and test targets from Cargo.toml.",
         ),
     ],

--- a/crates/once-frontend/prelude/swift_package.star
+++ b/crates/once-frontend/prelude/swift_package.star
@@ -1,0 +1,80 @@
+def _swift_package_workspace_resolver(ctx):
+    attrs = ctx["attrs"]
+    package_path = attrs.get("package_path") or "."
+    if package_path.startswith("./"):
+        package_path = package_path[2:]
+    if package_path == ".":
+        package_path = ""
+    manifest = _swiftpm_manifest_file(attrs)
+    if not ctx["files"].get(manifest):
+        fail(ctx["label"]["id"] + ": Swift package manifest `" + manifest + "` is missing; include it in resolver_inputs, or srcs when resolver_inputs is omitted")
+    swiftc = _resolve_swiftc(attrs.get("platform") or "macos", attrs.get("sdk_variant") or "simulator", attrs.get("xcode_developer_dir") or "")
+    swift = _swiftpm_swift_executable(attrs.get("swift") or "swift", attrs.get("xcode_developer_dir") or "", swiftc["swiftc_path"])
+    info = json_decode(host_command([swift, "package", "dump-package", "--package-path", _swiftpm_absolute_package_path(ctx, attrs.get("package_path") or ".")], env = swiftc["env"]))
+    package = {"identity": _basename(package_path) or info.get("name") or ctx["label"]["name"], "path": package_path, "info": info}
+    remote_products = _swift_package_remote_products(ctx, info)
+    lazy_dependency = _xcode_swift_package_target_id(package["identity"], "RemoteDependencies") if remote_products else ""
+    graph = _xcode_local_swift_package_specs(ctx, [package], attrs.get("platform") or "macos", attrs.get("minimum_os") or "13.0", attrs.get("sdk_variant") or "simulator", remote_products, lazy_dependency)
+    if lazy_dependency:
+        graph["specs"].append({
+            "name": lazy_dependency,
+            "kind": "swift_package_dependencies",
+            "deps": [],
+            "srcs": sorted(ctx["files"].keys()),
+            "attrs": {
+                "package_path": attrs.get("package_path") or ".",
+                "allow_network": True,
+                "products": sorted(_swift_package_remote_product_names(remote_products)),
+                "platform": attrs.get("platform") or "macos",
+                "minimum_os": attrs.get("minimum_os") or "13.0",
+                "sdk_variant": attrs.get("sdk_variant") or "simulator",
+                "swift": attrs.get("swift") or "swift",
+                "xcode_developer_dir": attrs.get("xcode_developer_dir") or "",
+                "_lazy_resolution": True,
+            },
+        })
+    roots = []
+    for product in info.get("products") or []:
+        target_id = graph["products"].get(package["identity"] + "\x1f" + (product.get("name") or ""))
+        if target_id and target_id not in roots:
+            roots.append(target_id)
+    return {"targets": graph["specs"], "roots": roots}
+
+def _swift_package_remote_products(ctx, info):
+    resolved = ctx["files"].get("Package.resolved")
+    if resolved == None:
+        return {}
+    remote_identities = {}
+    for pin in _swiftpm_resolved_pins(json_decode(resolved)):
+        if _swiftpm_pin_requires_network(pin):
+            remote_identities[pin["identity"].lower()] = True
+    products = {}
+    for target in info.get("targets") or []:
+        for dependency in target.get("dependencies") or []:
+            values = dependency.get("product") or []
+            if not values:
+                continue
+            name = values[0] or ""
+            identity = values[1] if len(values) > 1 and type(values[1]) == "string" else ""
+            if name and identity.lower() in remote_identities:
+                products[identity.lower() + "\x1f" + name] = True
+    return products
+
+def _swift_package_remote_product_names(products):
+    names = []
+    for value in products.keys():
+        name = value.split("\x1f")[1]
+        if name not in names:
+            names.append(name)
+    return names
+
+def _swift_package_workspace_impl(ctx):
+    return {"label_id": ctx["label"]["id"], "swift_package_workspace": True, "targets": ctx["deps"]}
+
+swift_package_workspace = target_kind(
+    docs = "Native Swift Package Manager workspace seed. Its resolver reads Package.swift and lowers each first-party library, executable, macro, binary, and test target into the existing Apple target kinds. Locked remote products become a dependency action that fetches only when a build needs it.",
+    attrs = [attr("package_path", "string", default = ".", docs = "Package-relative directory containing Package.swift. Defaults to the native integration package.", configurable = False), attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative source globs supplied to native integration resolution. Defaults to srcs when empty.", configurable = False), attr("platform", "string", default = "macos", docs = "Apple platform used when lowering the Swift package targets.", configurable = False), attr("minimum_os", "string", default = "13.0", docs = "Minimum Apple operating system version used when lowering package targets.", configurable = False), attr("sdk_variant", "string", default = "simulator", docs = "Simulator or device software development kit selection. Ignored for macOS.", configurable = False), attr("swift", "string", default = "swift", docs = "Swift Package Manager executable or workspace-relative executable path. The default selects the executable paired with the resolved Swift compiler.", configurable = False), attr("xcode_developer_dir", "string", docs = "Pin a specific Xcode developer directory for Swift and the Apple software development kit.", configurable = False)],
+    resolver = _swift_package_workspace_resolver, deps = [dep("deps", ["apple_linkable", "apple_test_bundle", "native_linkable"], "First-party Swift package products emitted by native integration discovery.")], providers = ["swift_package_workspace"], capabilities = [capability("build", [])], tools = [tool("swift", ["swift", "swiftc"])], examples = [example("swift-package-workspace-native-project", name = "Swift Package Manager native integration seed", use_when = "Use this when a Swift Package Manager workspace should derive first-party build and test targets from Package.swift.", platforms = ["macos"])], impl = _swift_package_workspace_impl,
+)
+
+swift_package = native_project(target_kind = "swift_package_workspace", docs = "Recognizes a native Swift Package Manager workspace from Package.swift.", markers = ["Package.swift"], target_name = "swift_package", inputs = ["Package.resolved", "Sources/**/*", "Tests/**/*", "Plugins/**/*", "Macros/**/*", "**/Package.swift", "**/Package.resolved"], exclude = _native_project_generated_dirs() + [".build", ".swiftpm", "Pods", "Carthage", "DerivedData", "node_modules"], input_exclude = [".build", ".git"], on_match = "stop", requires_tools = ["swift", "swiftc"])

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -1,4 +1,4 @@
-# Xcode native project reader.
+# Xcode native integration reader.
 #
 # The `xcode_workspace` target kind is a graph resolver: it reads an Xcode
 # project (`project.pbxproj`), flattens its layered build settings (project,
@@ -1731,7 +1731,7 @@ def _xcode_package_condition_allows(condition, platform):
     wanted = "macos" if platform == "macosx" else platform
     return wanted.lower() in [name.lower() for name in names]
 
-def _xcode_swift_package_dependencies(target, identity, target_ids, product_ids, platform):
+def _xcode_swift_package_dependencies(target, identity, target_ids, product_ids, platform, lazy_products = {}, lazy_dependency = ""):
     deps = []
     for dependency in target.get("dependencies") or []:
         for key in ["byName", "product", "target"]:
@@ -1751,6 +1751,8 @@ def _xcode_swift_package_dependencies(target, identity, target_ids, product_ids,
             dep_id = target_ids.get(package_identity + "\x1f" + name) or target_ids.get(package_identity.lower() + "\x1f" + name) or product_ids.get(package_identity + "\x1f" + name) or product_ids.get(package_identity.lower() + "\x1f" + name) or product_ids.get(name)
             if dep_id and dep_id not in deps:
                 deps.append("./" + dep_id)
+            elif lazy_dependency and lazy_products.get(package_identity.lower() + "\x1f" + name) and "./" + lazy_dependency not in deps:
+                deps.append("./" + lazy_dependency)
     return deps
 
 def _xcode_swift_imports(sources):
@@ -1832,7 +1834,7 @@ def _xcode_swift_package_target_flags(target, platform, default_language_mode):
         "language_mode": swift_language_mode,
     }
 
-def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant):
+def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant, lazy_products = {}, lazy_dependency = ""):
     # Lower source package targets as ordinary Apple libraries. Products merely
     # name one or more targets, so consumers depend on the product's primary
     # target while that target keeps its declared package dependencies.
@@ -1901,7 +1903,7 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
             uses_xctest = any(["import XCTest" in host_file_read(_xcode_abs(source)) for source in sources if source.endswith(".swift")])
             if target_type == "macro":
                 flags = _xcode_swift_package_target_flags(target, "macos", default_language_mode)
-                dependencies = _xcode_swift_package_dependencies(target, identity, host_target_ids, host_product_ids, "macos")
+                dependencies = _xcode_swift_package_dependencies(target, identity, host_target_ids, host_product_ids, "macos", lazy_products, lazy_dependency)
                 specs.append({
                     "name": target_id,
                     "kind": "swift_macro",
@@ -1941,7 +1943,7 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
                 resource_accessor = _xcode_swift_package_resource_accessor(package, target, variant_id, any([source.endswith(".swift") for source in sources]))
                 if resource_accessor:
                     prebuild_actions.append(resource_accessor)
-                dependencies = _xcode_swift_package_dependencies(target, identity, variant["target_ids"], variant["product_ids"], variant_platform)
+                dependencies = _xcode_swift_package_dependencies(target, identity, variant["target_ids"], variant["product_ids"], variant_platform, lazy_products, lazy_dependency)
                 resource_paths = _xcode_swift_package_resource_paths(package_path, target)
                 structured_resource_paths = _xcode_swift_package_structured_resource_paths(package_path, target)
                 resource_bundle_name = _xcode_swift_package_resource_bundle_name(package, target) if resource_paths else ""
@@ -3136,7 +3138,7 @@ def _xcode_workspace_impl(ctx):
     return {}
 
 # ---------------------------------------------------------------------------
-# Public target kind + native project
+# Public target kind + native integration
 # ---------------------------------------------------------------------------
 
 xcode_workspace = target_kind(
@@ -3146,7 +3148,7 @@ xcode_workspace = target_kind(
         attr("configuration", "string", default = "Debug", docs = "Xcode build configuration whose settings drive target lowering.", configurable = False),
         attr("sdk_variant", "string", default = "simulator", docs = "`simulator` or `device` SDK selection applied to lowered Apple targets on non-macOS platforms.", configurable = False),
         attr("xcode_developer_dir", "string", docs = "Optional `DEVELOPER_DIR` override folded into lowered Apple target cache keys.", configurable = False),
-        attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative text globs supplied to native project resolution. Defaults to srcs when empty.", configurable = False),
+        attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative text globs supplied to native integration resolution. Defaults to srcs when empty.", configurable = False),
     ],
     resolver = _xcode_workspace_resolver,
     deps = [dep("deps", ["apple_linkable", "apple_application", "apple_test_bundle", "native_linkable"], "Native Xcode targets lowered into Apple application, library, framework, and test targets.")],
@@ -3156,7 +3158,7 @@ xcode_workspace = target_kind(
     examples = [
         example(
             "xcode-workspace-native-project",
-            name = "Xcode native project seed",
+            name = "Xcode native integration seed",
             use_when = "Use this when an Xcode project should derive Apple application, framework, and test targets from project.pbxproj.",
             platforms = ["macos"],
         ),

--- a/crates/once-frontend/src/native_project.rs
+++ b/crates/once-frontend/src/native_project.rs
@@ -648,6 +648,39 @@ mod tests {
     }
 
     #[test]
+    fn built_in_native_projects_detect_swift_packages_without_execution() {
+        let temporary = tempfile::tempdir().unwrap();
+        std::fs::write(temporary.path().join("Package.swift"), "not Swift").unwrap();
+        std::fs::create_dir_all(temporary.path().join("Examples/Nested")).unwrap();
+        std::fs::write(
+            temporary.path().join("Examples/Nested/Package.swift"),
+            "not Swift",
+        )
+        .unwrap();
+        std::fs::create_dir_all(temporary.path().join(".build/checkouts/Dependency")).unwrap();
+        std::fs::write(
+            temporary
+                .path()
+                .join(".build/checkouts/Dependency/Package.swift"),
+            "not Swift",
+        )
+        .unwrap();
+
+        let matches = detect_native_projects(temporary.path()).unwrap();
+
+        assert!(matches.iter().any(|matched| {
+            matched.native_project == "swift_package" && matched.package.is_empty()
+        }));
+        assert!(!matches.iter().any(|matched| {
+            matched.native_project == "swift_package" && matched.package == "Examples/Nested"
+        }));
+        assert!(!matches.iter().any(|matched| {
+            matched.native_project == "swift_package"
+                && matched.package == ".build/checkouts/Dependency"
+        }));
+    }
+
+    #[test]
     fn built_in_native_projects_detect_native_markers_without_execution() {
         let temporary = tempfile::tempdir().unwrap();
         std::fs::write(temporary.path().join("mix.exs"), "raise \"not executed\"\n").unwrap();

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -207,6 +207,114 @@ fn cargo_native_project_loads_without_a_once_manifest() {
     );
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn swift_package_native_project_loads_without_a_once_manifest() {
+    let schemas = built_in_target_kind_schemas_result().expect("built-in target kind schemas load");
+    let schema = schemas
+        .iter()
+        .find(|schema| schema.kind == "swift_package_workspace")
+        .expect("swift_package_workspace schema");
+    let bundle = load_target_kind_example(schema, "swift-package-workspace-native-project")
+        .expect("Swift Package Manager native project example materializes");
+    let tmp = TempDir::new().expect("tempdir");
+    materialize(tmp.path(), &bundle);
+    fs::remove_file(tmp.path().join("once.toml")).expect("remove explicit Once manifest");
+
+    let graph = once_frontend::load_graph_workspace(tmp.path())
+        .expect("Swift Package Manager native project graph loads without once.toml");
+    assert!(
+        !tmp.path().join(".build").exists(),
+        "Swift package graph loading must not create Swift Package Manager build state"
+    );
+    let kinds_by_id = graph
+        .iter()
+        .map(|target| (target.label.id.as_str(), target.kind.as_str()))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(
+        kinds_by_id.get("swift_package"),
+        Some(&"swift_package_workspace")
+    );
+    assert_eq!(
+        kinds_by_id.get("SwiftPackage_OnceNativeSwiftPackage_OnceNativeSwiftPackage"),
+        Some(&"apple_library")
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn swift_package_native_project_defers_remote_packages_until_build() {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join("Sources/App")).expect("source directory");
+    fs::write(
+        tmp.path().join("Package.swift"),
+        r#"// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "LazyRemote",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+    ],
+    targets: [
+        .target(name: "App", dependencies: [
+            .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        ]),
+    ]
+)
+"#,
+    )
+    .expect("package manifest");
+    fs::write(
+        tmp.path().join("Package.resolved"),
+        r#"{
+  "version": 3,
+  "pins": [
+    {
+      "identity": "swift-argument-parser",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-argument-parser.git",
+      "state": {
+        "revision": "d3f6f4d8adfda4094733522fe7d4d0df8d67dbe0",
+        "version": "1.5.0"
+      }
+    }
+  ]
+}
+"#,
+    )
+    .expect("package lock");
+    fs::write(
+        tmp.path().join("Sources/App/App.swift"),
+        "import ArgumentParser\n",
+    )
+    .expect("source file");
+
+    let graph = once_frontend::load_graph_workspace(tmp.path())
+        .expect("native graph loads without fetching remote packages");
+    assert!(
+        !tmp.path().join(".build").exists(),
+        "graph loading must not fetch remote Swift packages"
+    );
+    let remote = graph
+        .iter()
+        .find(|target| target.label.id == "SwiftPackage_LazyRemote_RemoteDependencies")
+        .expect("lazy remote dependency target");
+    assert_eq!(remote.kind, "swift_package_dependencies");
+    assert_eq!(
+        remote.attrs.get("_lazy_resolution"),
+        Some(&AttrValue::Bool(true))
+    );
+    let app = graph
+        .iter()
+        .find(|target| target.label.id == "SwiftPackage_LazyRemote_App")
+        .expect("first-party app target");
+    assert!(app
+        .deps
+        .contains(&"SwiftPackage_LazyRemote_RemoteDependencies".to_string()));
+}
+
 #[cfg(unix)]
 #[test]
 fn mix_native_project_lints_in_the_development_environment() {

--- a/rfcs/0007-native-project-discovery.md
+++ b/rfcs/0007-native-project-discovery.md
@@ -12,7 +12,7 @@ resolver reads authoritative native metadata and emits the detailed Once
 targets. This keeps one graph expansion mechanism and keeps Rust independent
 of individual ecosystems.
 
-The discovered seed is ephemeral. `once edit init-native-project` can
+The discovered seed is ephemeral. `once native init` can
 materialize the same seed into `once.toml` when a repository wants to review
 and store that choice.
 
@@ -147,9 +147,9 @@ operations:
 
 | Command line | Model Context Protocol tool | Result |
 | --- | --- | --- |
-| `once query native-projects` | `once_list_native_projects` | List declarations and marker matches without running resolvers |
-| `once query native-project <name> [--package <path>]` | `once_preview_native_project` | Preview one exact seed and its expanded graph |
-| `once edit init-native-project <name> [--package <path>]` | `once_init_native_project` | Materialize one validated seed |
+| `once native list` | `once_native_list` | List declarations and marker matches without running resolvers |
+| `once native show <name> [--path <path>]` | `once_native_show` | Preview one exact seed and its expanded graph |
+| `once native init <name> [--path <path>]` | `once_native_init` | Materialize one validated seed |
 
 Initialization writes only the seed. Resolver-emitted dependency and product
 targets remain derived from native metadata.

--- a/web/lib/once_site_web/docs/sidebar.ex
+++ b/web/lib/once_site_web/docs/sidebar.ex
@@ -78,10 +78,10 @@ defmodule OnceSiteWeb.Docs.Sidebar do
             slug: "/docs/guide/graph/apple",
             icon: "apple",
             items: [
-              %Item{label: "Xcode Projects", slug: "/docs/guide/graph/apple/xcode"}
+              %Item{label: "Xcode Projects", slug: "/docs/guide/graph/apple/xcode"},
+              %Item{label: "Swift Packages", slug: "/docs/guide/graph/swift-packages"}
             ]
           },
-          %Item{label: "Swift Packages", slug: "/docs/guide/graph/swift-packages", icon: "swift"},
           %Item{label: "Android", slug: "/docs/guide/graph/android", icon: "android"},
           %Item{label: "C and C++", slug: "/docs/guide/graph/c", icon: "cplusplus"},
           %Item{label: "CMake", slug: "/docs/guide/graph/cmake", icon: "cplusplus"},
@@ -194,9 +194,12 @@ defmodule OnceSiteWeb.Docs.Sidebar do
                 "Linting",
                 ~w(ruff_lint eslint_lint golangci_lint swiftlint_lint detekt_lint credo_lint rubocop_lint)
               ),
-              target_group("Apple", ~w(apple_library swift_macro apple_framework apple_application
+              target_group(
+                "Apple",
+                ~w(apple_library swift_macro apple_framework apple_application
                 apple_resource_bundle apple_thinned_package apple_test_bundle
-                apple_xcframework_import swift_package_dependencies swift_package_pin)),
+                apple_xcframework_import swift_package_workspace swift_package_dependencies swift_package_pin)
+              ),
               target_group("Xcode", ~w(xcode_workspace)),
               target_group("Android", ~w(android_resource android_library android_local_test
                 android_instrumentation_test android_binary)),

--- a/web/priv/changelog/2026-07-28-native-mix-project-graphs.md
+++ b/web/priv/changelog/2026-07-28-native-mix-project-graphs.md
@@ -19,6 +19,6 @@ applications and nested Mix projects receive package-qualified targets, and
 structured diagnostics explain unsupported dependency build managers or
 missing materialized sources.
 
-Start by running `once query native-project mix`, inspect the derived targets
+Start by running `once native show mix`, inspect the derived targets
 with `once query targets`, then use `once build`, `once run`, and `once test`
 with the target identifiers Once reports.

--- a/web/priv/changelog/2026-07-29-native-cargo-project-graphs.md
+++ b/web/priv/changelog/2026-07-29-native-cargo-project-graphs.md
@@ -19,6 +19,6 @@ toolchain selected by the project's configuration. Test targets report their
 results through the same normalized shape as the other ecosystems, so scheduled
 runs, change-scoped selection, and summaries work the same way.
 
-Start by running `once query native-project cargo`, inspect the derived targets
+Start by running `once native show cargo`, inspect the derived targets
 with `once query targets`, then use `once build`, `once run`, and `once test`
 with the target identifiers Once reports.

--- a/web/priv/docs/guide/graph/apple/xcode.md
+++ b/web/priv/docs/guide/graph/apple/xcode.md
@@ -38,7 +38,7 @@ project, so there is nothing to write. From the directory holding the
 `.xcodeproj`:
 
 ```sh
-once query native-projects
+once native list
 once query targets
 ```
 
@@ -49,7 +49,7 @@ immediately, with no `once.toml` in the repository.
 Persist the seed only when you want it under version control:
 
 ```sh
-once edit init-native-project xcode
+once native init xcode
 ```
 
 That writes the seed target and nothing else. The `.xcodeproj` stays

--- a/web/priv/docs/guide/graph/elixir.md
+++ b/web/priv/docs/guide/graph/elixir.md
@@ -63,8 +63,8 @@ the same lockfile.
 From the directory that contains `mix.exs`, inspect the match and the graph:
 
 ```sh
-once query native-projects
-once query native-project mix
+once native list
+once native show mix
 once query targets
 ```
 
@@ -72,7 +72,7 @@ No `once.toml` is required, and these commands do not write one. If the
 workspace contains several Mix projects, select one explicitly:
 
 ```sh
-once query native-project mix --package apps/accounts
+once native show mix --path apps/accounts
 ```
 
 The identifiers printed by `once query targets` are the source of truth. For a
@@ -141,7 +141,7 @@ Initialization is optional. Use it when the repository should make its native
 project selection explicit:
 
 ```sh
-once edit init-native-project mix
+once native init mix
 ```
 
 This writes only the `mix_workspace` seed. The detailed targets remain derived
@@ -173,7 +173,7 @@ back to an opaque build.
   declare a `mix_release` target with `pre_tasks`. Once does not infer
   framework conventions.
 - Native project evaluation requires Erlang 27 or newer.
-- Use `once query native-project mix --package <path>` when more than one
+- Use `once native show mix --path <path>` when more than one
   `mix.exs` matches the workspace.
 
 ## Author a Graph When You Need More Control

--- a/web/priv/docs/guide/graph/index.md
+++ b/web/priv/docs/guide/graph/index.md
@@ -138,8 +138,8 @@ helps you decide when a typed target is a better fit than a script.
 
 ## Start From A Native Project
 
-Once can recognize supported native project descriptions before a package has
-an explicit target. A native project supplies an ephemeral seed target, then
+Once can recognize supported native workspace descriptions before a package has
+an explicit target. A native integration supplies an ephemeral seed target, then
 the seed's ordinary resolver derives the detailed typed graph from native
 metadata.
 
@@ -148,32 +148,34 @@ lockfile and locked dependency sources available. Detection only reads marker
 names, but preview and normal graph loading may run the native resolver and
 require those sources.
 
-Inspect the available native projects and their current matches:
+Inspect the available native integrations and their current matches:
 
 ```sh
-once query native-projects
+once native list
 ```
 
 Preview one match without changing the repository:
 
 ```sh
-once query native-project mix
-once query native-project cargo
-once query native-project xcode
+once native show mix
+once native show cargo
+once native show xcode
+once native show swift_package
 ```
 
 The preview includes the exact seed and every resolver-emitted target. Normal
 build, run, and test commands can use that ephemeral graph immediately.
 
-Initialize the seed when the native project selection should be reviewed and stored:
+Initialize the seed when the native integration selection should be reviewed and stored:
 
 ```sh
-once edit init-native-project mix
-once edit init-native-project cargo
-once edit init-native-project xcode
+once native init mix
+once native init cargo
+once native init xcode
+once native init swift_package
 ```
 
-Initialization writes only the seed target to `once.toml`. The native project
+Initialization writes only the seed target to `once.toml`. The native integration
 description and lockfile remain authoritative for dependencies, products,
 tests, and releases. Repeating an identical initialization makes no change.
 
@@ -183,7 +185,7 @@ and introduce a project Starlark module only when reusable behavior is missing
 from the built-in target kinds.
 
 An explicit Once target for the same target kind takes precedence in its
-package. Unrelated targets do not hide a native project in the same package or
+package. Unrelated targets do not hide a native integration in the same package or
 elsewhere in the workspace.
 
 An Xcode project checked in beside the repository root is recognized the same
@@ -192,7 +194,7 @@ frameworks, libraries, resource bundles, and test bundles, so a repository with
 no `once.toml` at all can be queried and built directly:
 
 ```sh
-once query native-project xcode
+once native show xcode
 once query targets
 once build MyApp
 ```
@@ -200,6 +202,21 @@ once build MyApp
 [Xcode Projects](/guide/graph/apple/xcode) walks through the full flow,
 including workspaces with several projects, build configurations, and current
 limitations.
+
+A Swift Package Manager workspace is recognized from `Package.swift`. Its
+native seed lowers first-party package targets into the existing Apple target
+kinds, without requiring an `once.toml` file:
+
+```sh
+once native show swift_package
+once query targets
+once build MyLibrary
+```
+
+For a repository with several packages, pass `--path` using the directory
+shown by `once native list`. The [Swift Packages](/guide/graph/swift-packages)
+guide covers native package workspaces, locked external package graphs, and
+network policy.
 
 Every built-in target kind also ships a complete starter with manifests and
 source files. Discover the available slugs, then materialize one directly:

--- a/web/priv/docs/guide/graph/rust.md
+++ b/web/priv/docs/guide/graph/rust.md
@@ -56,7 +56,7 @@ From the directory that contains the root `Cargo.toml`, inspect the match and
 the first-party targets:
 
 ```sh
-once query native-projects
+once native list
 once query targets --kind rust_binary
 once query targets --kind rust_library
 once query targets --kind rust_test
@@ -66,7 +66,7 @@ No `once.toml` is required, and these commands do not write one. If a
 repository contains several independent Cargo projects, select one explicitly:
 
 ```sh
-once query native-project cargo --package tools/linter
+once native show cargo --path tools/linter
 ```
 
 The `cargo_workspace` seed runs locked, offline Cargo metadata. It emits
@@ -77,7 +77,7 @@ The complete preview includes locked external packages, so it can be large.
 Request it only when you need to inspect the full expansion:
 
 ```sh
-once query native-project cargo
+once native show cargo
 ```
 
 The identifiers printed by `once query targets` are the source of truth.
@@ -87,7 +87,7 @@ normally derives `cargo_hello_bin_hello` and
 `cargo_hello_bin_hello_unit_tests`.
 
 Cargo workspaces use their shallowest matching `Cargo.toml`, so member
-manifests do not create duplicate native project seeds. Cargo remains
+manifests do not create duplicate native integration seeds. Cargo remains
 authoritative for workspace membership, default members, features, target
 metadata, and resolved versions. Local path packages outside the workspace
 remain dependency targets instead of becoming first-party workspace members.
@@ -169,7 +169,7 @@ Initialization is optional. Use it when the repository should make its native
 project selection explicit:
 
 ```sh
-once edit init-native-project cargo
+once native init cargo
 ```
 
 This writes only the `cargo_workspace` seed. The detailed targets remain
@@ -195,7 +195,7 @@ the complete seed contract.
   the same Cargo home and retry.
 - If a binary or example is absent, inspect its `required-features`, initialize
   the seed, and select those features explicitly.
-- Use `once query native-project cargo --package <path>` when more than one
+- Use `once native show cargo --path <path>` when more than one
   independent `Cargo.toml` matches the workspace.
 - A build script that invokes a host tool needs that tool named in
   `build_script_tools`. The seed already lists the build tools that packages

--- a/web/priv/docs/guide/graph/swift-packages.md
+++ b/web/priv/docs/guide/graph/swift-packages.md
@@ -5,10 +5,41 @@ next: false
 
 # Swift Packages
 
-Once can import a locked Swift Package Manager graph and expose selected static
-products to Apple libraries, frameworks, applications, and tests. Swift Package
-Manager remains authoritative for package manifests, version selection, and
-`Package.resolved`; Once makes the locked result queryable and cacheable.
+Once reads `Package.swift` and derives first-party package targets as Once
+targets. Swift Package Manager remains authoritative for manifests, version
+selection, and `Package.resolved`; Once uses that information to build and
+cache the targets it derives.
+
+## Start From A Native Package
+
+Once recognizes `Package.swift` automatically and lowers first-party package
+targets into the existing Apple target kinds. This works without `once.toml`:
+
+```sh
+once native list
+once native show swift_package
+once query targets
+```
+
+If a repository contains several package roots, select the workspace-relative
+root path reported by discovery:
+
+```sh
+once native show swift_package --path modules/service
+```
+
+The generated `swift_package_workspace` seed reads the package manifest and
+derives first-party libraries, executables, macros, binary targets, and tests.
+Discovery skips generated `.build` and `.swiftpm` directories. Store the seed
+only when it should be reviewed in `once.toml`:
+
+```sh
+once native init swift_package
+```
+
+By default, native package lowering does not fetch remote dependencies during
+graph loading. See [`swift_package_workspace`](/reference/prelude/swift_package_workspace)
+for its complete contract.
 
 When the Xcode workspace resolver lowers package sources into Apple targets,
 compiler language and access-control flags follow the manifest tools version.
@@ -30,170 +61,19 @@ Start with the [Apple guide](/guide/graph/apple) if a first-party Apple target
 does not build yet. Package integration is easier to diagnose after the local
 compiler, software development kit, linker, and code-signing path work.
 
-## Declare the Locked Package Graph
+## Packages With Remote Dependencies
 
-Keep package declarations in `Package.swift` and exact remote selections in
-`Package.resolved`. A checked-in dependency graph avoids running package
-inspection while Once loads the graph.
+Commit `Package.resolved` with `Package.swift`. Native discovery reads those
+files locally and never downloads packages. When a build first needs a locked
+remote product, Once fetches and builds it as a dependency action. Later builds
+reuse that action from the cache while the manifest, lock file, and Swift
+toolchain remain unchanged.
 
-```toml
-[[target]]
-name = "Packages"
-kind = "swift_package_dependencies"
-srcs = [
-  "Package.swift",
-  "Package.resolved",
-  "swiftpm-dependencies.json",
-  "Sources/**/*.swift",
-  "Vendor/Greeting/**/*.swift",
-  "Vendor/Greeting/Package.swift",
-]
-
-[target.attrs]
-package_path = "."
-resolved_file = "Package.resolved"
-resolver_inputs = [
-  "Package.swift",
-  "Package.resolved",
-  "swiftpm-dependencies.json",
-  "Vendor/Greeting/Package.swift",
-]
-graph_file = "swiftpm-dependencies.json"
-products = ["Root", "Greeting"]
-platform = "macos"
-minimum_os = "13.0"
-```
-
-Every name in `products` must be a static library product. Include the root
-facade and every transitive archive needed by downstream links. Once does not
-guess archive names for automatic library products.
-
-`resolved_file` and `graph_file` are relative to `package_path`. Their defaults
-therefore follow a package moved into a workspace subdirectory.
-
-The bundled starter uses this layout:
-
-```text
-Package.swift
-Package.resolved
-swiftpm-dependencies.json
-Sources/Root/Root.swift
-Vendor/Greeting/Package.swift
-Vendor/Greeting/Sources/Greeting/Greeting.swift
-```
-
-`Root` imports `Greeting` and exposes one function to first-party consumers.
-The local package keeps the starter network-independent while exercising the
-same package graph and product linking boundary as a vendored remote package.
-
-## Connect a First-Party Consumer
-
-Add the dependency-set target to an ordinary Apple target:
-
-```toml
-[[target]]
-name = "Consumer"
-kind = "apple_application"
-srcs = ["Consumer/**/*.swift"]
-deps = ["./Packages"]
-
-[target.attrs]
-platform = "macos"
-bundle_id = "dev.once.Consumer"
-minimum_os = "13.0"
-```
-
-The consumer can import the root product normally:
-
-```swift
-import Root
-
-@main
-struct Consumer {
-    static func main() {
-        print(greet())
-    }
-}
-```
-
-The `deps` edge carries the package module directory, selected archives,
-frameworks, dynamic libraries, and linker options into the Apple target.
-
-## Query and Build the Expanded Graph
-
-Inspect the synthetic pins and the two buildable targets before execution:
+The ordinary workflow stays the same:
 
 ```sh
-once query targets --kind swift_package_pin
-once query capabilities Packages
-once query capabilities Consumer
-once build Consumer
-./.once/out/Consumer/Consumer.app/Consumer
+once native show swift_package
+once build SwiftPackage_MyPackage_MyLibrary
 ```
 
-The starter creates a `swiftpm-greeting-local` pin, performs one locked package
-build for `Root` and `Greeting`, and links both products into `Consumer`. Running
-the built application prints `Hello from a locked local package`.
-
-Synthetic `swift_package_pin` targets carry identity, revision, version,
-checksum, location, and package-to-package edges. They have no compile action.
-The `swift_package_dependencies` owner performs the locked native package build
-and emits the provider used by the local Apple consumer.
-
-## Update or Vendor Packages Explicitly
-
-Update package state outside an ordinary Once build:
-
-```sh
-xcrun swift package resolve
-xcrun swift package show-dependencies --format json > swiftpm-dependencies.raw.json
-# Add the Once provenance fields, then save the result as swiftpm-dependencies.json.
-once query targets --kind swift_package_pin
-once build Consumer
-```
-
-The Swift Package Manager command emits only its raw package graph. Review
-that graph and `Package.resolved` together, then add the required provenance
-fields before using it as `swiftpm-dependencies.json`. The
-[JavaScript Object Notation](https://www.json.org/json-en.html) graph snapshot
-must contain every locked pin, or graph loading rejects
-it as stale. Add `once_manifest` with the exact `Package.swift` text and
-`once_resolved` with the exact `Package.resolved` text. This makes manifest,
-lockfile, and local dependency changes reject a stale graph. Add `once_inputs`
-as a map containing every exact resolver input except the graph snapshot
-itself. Include each workspace-local package manifest in `resolver_inputs` so
-its dependency edges participate in that binding. Any graph node without a
-lock entry must resolve to a workspace-local path. For
-network-independent remote builds, set `vendor_path` to a complete Swift
-Package Manager scratch tree containing the matching checkouts,
-repositories, and workspace state. Once copies that tree into target-local
-output before building, so the checked-in vendor state is not mutated.
-
-Without a graph snapshot, graph loading runs locked package inspection in a
-disposable `.once` scratch directory. Remote packages require an explicit
-`allow_network = true` for that live inspection. A configured `vendor_path`
-requires a checked-in graph snapshot, which prevents analysis from mutating the
-vendored tree. Automatic version selection remains disabled. Once does not
-independently sandbox Swift Package Manager network access during a build, so an
-incomplete vendored tree can still cause native package-manager access. By
-default, Once uses the Swift Package Manager executable paired with the Apple
-compiler selected through Xcode, so package modules and first-party consumers
-cannot silently compile with different Swift versions.
-
-Locked package identities, versions, revisions, and checksums participate in
-the native build action identity even when `Package.resolved` is kept only in
-`resolver_inputs`. Updating a pin therefore invalidates the package build
-without requiring the lock file to be duplicated in `srcs`.
-
-## Current Boundary
-
-The adapter currently exposes explicit static products for one Apple platform
-and architecture per target. Resource bundles, binary artifacts, and build-tool
-plugins need typed provider fields before Once can safely embed or execute them.
-Use a first-party static package facade or a script for those packages until
-their artifacts are represented explicitly.
-
-See [`swift_package_dependencies`](/reference/prelude/swift_package_dependencies)
-for every attribute and provider field, and
-[`swift_package_pin`](/reference/prelude/swift_package_pin) for the synthetic
-locked identity shape.
+There is no initialization step or network setting for the native workflow.

--- a/web/priv/docs/guide/index.md
+++ b/web/priv/docs/guide/index.md
@@ -1,12 +1,12 @@
 # Guides
 
-Once meets a project where it is. Start from native project metadata, cache the
+Once meets a project where it is. Start from native workspace metadata, cache the
 automation that already works, and add a typed graph only where more structure
 helps.
 
 ## Start with an existing project
 
-Once can recognize supported native projects and make their build, test, and
+Once can recognize supported native workspaces and make their build, test, and
 run capabilities available without requiring changes to their project files.
 Native project descriptions and lockfiles remain authoritative. Read the
 [Typed Graph guide](/guide/graph/#start-from-a-native-project) to discover and

--- a/web/priv/docs/reference/mcp/tools.md
+++ b/web/priv/docs/reference/mcp/tools.md
@@ -294,11 +294,11 @@ Lightweight discovery entry point. Returns matching target kinds with documentat
 ]
 ```
 
-## `once_list_native_projects`
+## `once_native_list`
 
-List native project declarations and the roots they currently recognize.
+List native integrations and the workspace roots they currently recognize.
 
-Returns each enabled native project's name, documentation, marker files, additional resolver inputs, seed target kind, and current package matches. Detection reads file names only and does not execute native project code. The matching command-line operation is `once query native-projects --format json`.
+Returns each enabled native integration's name, documentation, marker files, additional resolver inputs, seed target kind, and current matches. Detection reads file names only and does not execute native code. The matching command-line operation is `once native list --format json`.
 
 **Input schema**
 
@@ -322,11 +322,11 @@ Returns each enabled native project's name, documentation, marker files, additio
 }
 ```
 
-## `once_preview_native_project`
+## `once_native_show`
 
-Preview the seed target and complete typed graph derived by one detected native project.
+Preview the seed target and complete typed graph derived by one detected native integration.
 
-Runs the selected native project's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `package` when the native project has one match. Expanded dependency graphs can be very large. For a loaded project, prefer `once_query_workspace`, filtered `once_query_targets`, `once_query_tests`, and `once_get_target` when the complete graph is not needed. The matching command-line operation is `once query native-project <name> [--package <path>] --format json`.
+Runs the selected native integration's ordinary target-kind resolver without writing a manifest, then returns its declaration, detection evidence, seed target, and expanded typed targets. Omit `path` when it has one match. Expanded dependency graphs can be very large. For a loaded project, prefer `once_query_workspace`, filtered `once_query_targets`, `once_query_tests`, and `once_get_target` when the complete graph is not needed. The matching command-line operation is `once native show <name> [--path <path>] --format json`.
 
 **Input schema**
 
@@ -336,11 +336,11 @@ Runs the selected native project's ordinary target-kind resolver without writing
   "properties": {
     "name": {
       "type": "string",
-      "description": "Name discovered with `once_list_native_projects`."
+      "description": "Name discovered with `once_native_list`."
     },
-    "package": {
+    "path": {
       "type": "string",
-      "description": "Package path from the native project match. Use an empty string for the workspace root."
+      "description": "Workspace-relative root path from the native match. Use an empty string for the workspace root."
     }
   },
   "required": [
@@ -360,11 +360,11 @@ Runs the selected native project's ordinary target-kind resolver without writing
 }
 ```
 
-## `once_init_native_project`
+## `once_native_init`
 
-Initialize Once from one detected native project.
+Initialize Once from one detected native integration.
 
-This state-changing tool is available only when the server starts with `once mcp --allow-run`. It writes the native project's validated seed target through the manifest editor while preserving unrelated configuration and comments. Repeating an identical initialization is idempotent. A conflicting target with the same name is rejected. The matching command-line operation is `once edit init-native-project <name> [--package <path>]`.
+This state-changing tool is available only when the server starts with `once mcp --allow-run`. It writes the native integration's validated seed target through the manifest editor while preserving unrelated configuration and comments. Repeating an identical initialization is idempotent. A conflicting target with the same name is rejected. The matching command-line operation is `once native init <name> [--path <path>]`.
 
 **Input schema**
 
@@ -374,11 +374,11 @@ This state-changing tool is available only when the server starts with `once mcp
   "properties": {
     "name": {
       "type": "string",
-      "description": "Name discovered with `once_list_native_projects`."
+      "description": "Name discovered with `once_native_list`."
     },
-    "package": {
+    "path": {
       "type": "string",
-      "description": "Package path from the native project match. Use an empty string for the workspace root."
+      "description": "Workspace-relative root path from the native match. Use an empty string for the workspace root."
     }
   },
   "required": [

--- a/web/priv/docs/reference/modules/index.md
+++ b/web/priv/docs/reference/modules/index.md
@@ -97,7 +97,7 @@ one default dependency and reports an attribute-scoped repair before analysis.
 
 ## Native Project Discovery Contract
 
-`native_project(...)` lets a module recognize an ecosystem-native project and
+`native_project(...)` lets a module recognize an ecosystem-native integration and
 map it to one ordinary seed target. The seed target's resolver emits the
 detailed graph through the same typed resolver contract as
 manifest-authored targets.
@@ -107,7 +107,7 @@ native = native_project(
     name = "native",
     target_kind = "native_workspace",
     target_name = "native",
-    docs = "Recognizes a native project.",
+    docs = "Recognizes a native integration.",
     markers = ["project.native"],
     inputs = ["project.lock", "config/**/*"],
     exclude = ["build"],
@@ -119,7 +119,7 @@ native = native_project(
 ```
 
 - `target_kind` names the target kind instantiated by the seed. Schema loading
-  rejects a native project that references an unknown target kind.
+  rejects a native integration that references an unknown target kind.
 - `markers` lists files that must all exist in one directory. The first entry
   drives the bounded scan.
 - `inputs` adds optional text globs to the seed's resolver inputs. Markers are
@@ -148,23 +148,23 @@ error if a workspace produces more, rather than allowing repository size to
 drive unbounded memory growth. Narrow the workspace include or exclude patterns,
 or use `on_match = "stop"` when nested projects belong to one workspace.
 
-Native project discovery provides ephemeral seeds in packages that have no explicit Once
+Native discovery provides ephemeral seeds in workspace roots that have no explicit Once
 targets. Explicit targets take precedence only in their own package, so an
-unrelated root target does not hide native projects elsewhere in a monorepo.
+unrelated root target does not hide native roots elsewhere in a monorepo.
 The configured workspace include and exclude patterns still define the
 boundary.
 
-Discover and preview native projects from the command line:
+Discover and preview native roots from the command line:
 
 ```sh
-once query native-projects
-once query native-project native
+once native list
+once native show native
 ```
 
 Initialize only the stable seed when the repository should own the selection:
 
 ```sh
-once edit init-native-project native
+once native init native
 ```
 
 Initialization is idempotent and preserves unrelated `once.toml` configuration and
@@ -172,8 +172,7 @@ comments. Resolver-emitted dependency and product targets remain derived from
 the native manifest and lockfile.
 
 [Model Context Protocol](https://modelcontextprotocol.io/) callers use the
-matching `once_list_native_projects`, `once_preview_native_project`, and
-`once_init_native_project` tools.
+matching `once_native_list`, `once_native_show`, and `once_native_init` tools.
 
 ## Dependency Resolver Contract
 

--- a/web/priv/docs/reference/prelude/cargo_workspace.md
+++ b/web/priv/docs/reference/prelude/cargo_workspace.md
@@ -70,17 +70,17 @@ cargo fetch --locked
 Once never performs that network operation while loading or building the
 graph.
 
-Discover and preview the native project:
+Discover and preview the native integration:
 
 ```sh
-once query native-projects
-once query native-project cargo
+once native list
+once native show cargo
 ```
 
 Initialize the seed:
 
 ```sh
-once edit init-native-project cargo
+once native init cargo
 ```
 
 The imported target is equivalent to:
@@ -104,6 +104,6 @@ express.
 ## Sources
 
 - [Cargo metadata](https://doc.rust-lang.org/stable/cargo/commands/cargo-metadata.html)
-  defines the native project graph.
+  defines the native integration graph.
 - [The Cargo lockfile](https://doc.rust-lang.org/cargo/reference/lockfile.html)
   defines resolved versions and checksums.

--- a/web/priv/docs/reference/prelude/index.md
+++ b/web/priv/docs/reference/prelude/index.md
@@ -83,6 +83,8 @@ you already have.
 
 ## Swift target kinds
 
+- [`swift_package_workspace`](/reference/prelude/swift_package_workspace):
+  native Swift Package Manager workspace lowered into first-party Apple targets
 - [`swift_package_dependencies`](/reference/prelude/swift_package_dependencies):
   locked Swift package graph and selected static products exposed to Apple
   targets
@@ -106,7 +108,7 @@ you already have.
 
 ## Elixir target kinds
 
-- [`mix_workspace`](/reference/prelude/mix_workspace): native project seed
+- [`mix_workspace`](/reference/prelude/mix_workspace): native integration seed
   that derives development, test, production, lint, test, and release targets
   from `mix.exs`
 - [`mix_dependencies`](/reference/prelude/mix_dependencies): locked Mix and Hex
@@ -163,7 +165,7 @@ you already have.
 
 ## Rust target kinds
 
-- [`cargo_workspace`](/reference/prelude/cargo_workspace): native project seed
+- [`cargo_workspace`](/reference/prelude/cargo_workspace): native integration seed
   that derives first-party and locked external targets from `Cargo.toml`
 - [`cargo_dependencies`](/reference/prelude/cargo_dependencies): cacheable
   Cargo dependency set consumed by Rust targets

--- a/web/priv/docs/reference/prelude/mix_workspace.md
+++ b/web/priv/docs/reference/prelude/mix_workspace.md
@@ -52,17 +52,17 @@ The target emits `mix_workspace`.
 
 ## Direct Use
 
-Discover and preview the native project:
+Discover and preview the native integration:
 
 ```sh
-once query native-projects
-once query native-project mix
+once native list
+once native show mix
 ```
 
 Initialize the seed:
 
 ```sh
-once edit init-native-project mix
+once native init mix
 ```
 
 The imported target is equivalent to:

--- a/web/priv/docs/reference/prelude/swift_package_workspace.md
+++ b/web/priv/docs/reference/prelude/swift_package_workspace.md
@@ -1,0 +1,93 @@
+# `swift_package_workspace`
+
+Native Swift Package Manager workspace seed.
+
+## Description
+
+`swift_package_workspace` reads `Package.swift` through Swift Package Manager
+and lowers first-party libraries, executables, macros, binary targets, and
+tests into the existing Apple target kinds. The package manifest remains
+authoritative for products, target dependencies, source layout, compiler
+settings, resources, and platform constraints.
+
+Once discovers a workspace automatically from `Package.swift`. A repository
+without `once.toml` can therefore query and build its first-party package
+targets directly. Discovery skips generated package-manager state such as
+`.build` and `.swiftpm`.
+
+Remote package metadata is not fetched during graph loading. When a first-party
+target needs a product from a locked remote package, the resolver adds a
+dependency action that fetches and builds that product only when a build needs
+it. The action is keyed by the package manifest, lock file, and Swift toolchain.
+
+## Attributes
+
+| Attribute | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `package_path` | string | no | `.` | Package-relative directory containing `Package.swift` |
+| `resolver_inputs` | list&lt;string&gt; | no | `srcs` | Package-relative source globs available while deriving the graph |
+| `platform` | string | no | `macos` | Apple platform used when lowering package targets |
+| `minimum_os` | string | no | `13.0` | Minimum operating system version for lowered targets |
+| `sdk_variant` | string | no | `simulator` | Simulator or device software development kit selection; ignored for macOS |
+| `swift` | string | no | `swift` | Swift Package Manager executable; the default is paired with the selected Swift compiler |
+| `xcode_developer_dir` | string | no |  | Specific Xcode developer directory |
+
+## Providers and capabilities
+
+The target emits `swift_package_workspace` and exposes the `build` capability.
+The resolver emits the first-party Apple targets that implement the actual
+build products.
+
+## Direct use
+
+Discover and preview a package without writing a manifest:
+
+```sh
+once native list
+once native show swift_package
+```
+
+For a repository with several package roots, select one workspace-relative root
+path:
+
+```sh
+once native show swift_package --path modules/service
+```
+
+Store the generated seed only when it should be reviewed in `once.toml`:
+
+```sh
+once native init swift_package
+```
+
+The imported seed is equivalent to:
+
+```toml
+[[target]]
+name = "swift_package"
+kind = "swift_package_workspace"
+srcs = ["Package.swift"]
+
+[target.attrs]
+resolver_inputs = [
+  "Package.swift",
+  "Package.resolved",
+  "Sources/**/*",
+  "Tests/**/*",
+  "Plugins/**/*",
+  "Macros/**/*",
+  "**/Package.swift",
+  "**/Package.resolved",
+]
+```
+
+Use [`swift_package_dependencies`](/reference/prelude/swift_package_dependencies)
+when an explicit Apple target needs selected static products from a locked
+package graph rather than native first-party package lowering.
+
+## Sources
+
+- [Swift Package Manager](https://www.swift.org/documentation/package-manager/)
+  defines package manifests, products, and target metadata.
+- [`dump-package` documentation](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Usage.md)
+  describes the package metadata command used during graph loading.

--- a/web/priv/docs/reference/prelude/xcode_workspace.md
+++ b/web/priv/docs/reference/prelude/xcode_workspace.md
@@ -24,7 +24,7 @@ disk is skipped instead of failing the graph.
 
 A project checked in beside the workspace root is also a recognized native
 project named `xcode`, so its seed is supplied without any `once.toml`. Use
-`once edit init-native-project xcode` to persist the seed, or declare the
+`once native init xcode` to persist the seed, or declare the
 target explicitly when the project lives in a subdirectory.
 
 See [Xcode Projects](/guide/graph/apple/xcode) for a walkthrough.


### PR DESCRIPTION
## What changed

- Added native Swift Package Manager workspace discovery from `Package.swift`, with a portable starter and native graph tests.
- Added lazy remote-product actions. Discovery reads checked-in package metadata without downloading dependencies; the first build that needs a locked remote product fetches and builds it.
- Moved native discovery to `once native list`, `once native show`, and `once native init`, with `--path` for a workspace-relative root.
- Renamed the matching Model Context Protocol tools and refreshed the Cargo, Mix, Xcode, and Swift Package Manager documentation.
- Reworked the Swift Packages guide around the native workflow and nested it under Apple in the documentation sidebar.

## Why

A `Package.swift` workspace should work as a native project without a hand-authored Once manifest. Remote packages should not slow down graph discovery or require persisting a network setting before a build.

## Approach

The Swift target kinds own package-specific resolution. The generic Rust implementation remains unaware of Swift Package Manager. A generated dependency action is keyed by the manifest, lock file, and selected Swift toolchain, so unchanged remote products can be restored from the action cache.

## Impact

Repositories can discover and inspect Swift Package Manager workspaces immediately. Existing native command users should migrate to the `once native` command family and use `--path` when discovery finds more than one root.

## Validation

- `mise exec -- cargo test -p once-cli`
- `mise exec -- cargo test -p once-frontend --test examples native_project`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- mix format --check-formatted`
- `mise exec -- mix test test/once_site_web/docs/sidebar_test.exs`
- `once native show swift_package` against the bundled starter and FeatherCMS
