### PR TITLE
feat(xcode): cache binary package artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1085,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3481,6 +3501,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "zip",
 ]
 
 [[package]]
@@ -7084,10 +7105,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ uuid = { version = "1", features = ["v7"] }
 walkdir = "2"
 zstd = "0.13"
 tar = "0.4"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [workspace.lints.rust]
 # `deny` rather than `forbid` so the C ABI layer can carve out a single

--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -1382,9 +1382,12 @@ async fn run_uncached_action(
         | Action::MaterializeHostTree { .. }
         | Action::PreparePath { .. }
         | Action::WriteTreeDigest { .. }
-        | Action::WriteArchive { .. } => once_core::run_uncached(action, workspace, cache, false)
-            .await
-            .map_err(Into::into),
+        | Action::WriteArchive { .. }
+        | Action::DownloadAndExtract { .. } => {
+            once_core::run_uncached(action, workspace, cache, false)
+                .await
+                .map_err(Into::into)
+        }
     }
 }
 
@@ -1778,6 +1781,7 @@ fn declared_arg_file_format_name(format: DeclaredArgFileFormat) -> &'static str 
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn operation_to_action(operation: DeclaredActionOperation, input_digest: Digest) -> Result<Action> {
     Ok(match operation {
         DeclaredActionOperation::WriteFile { path, bytes } => Action::WriteFile {
@@ -1877,6 +1881,18 @@ fn operation_to_action(operation: DeclaredActionOperation, input_digest: Digest)
             format,
             input_digest,
         )?,
+        DeclaredActionOperation::DownloadAndExtract {
+            url,
+            sha256,
+            destination,
+            authorization_env,
+        } => Action::DownloadAndExtract {
+            url,
+            sha256,
+            destination: workspace_path(&destination, "download_and_extract destination")?,
+            authorization_env,
+            input_digest: Some(input_digest),
+        },
     })
 }
 

--- a/crates/once-core/Cargo.toml
+++ b/crates/once-core/Cargo.toml
@@ -28,6 +28,7 @@ sha2.workspace = true
 sysinfo.workspace = true
 thiserror.workspace = true
 tar.workspace = true
+zip.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/once-core/src/action.rs
+++ b/crates/once-core/src/action.rs
@@ -263,6 +263,20 @@ pub enum Action {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         input_digest: Option<Digest>,
     },
+    /// Downloads a checksum-pinned ZIP archive and expands it into a directory.
+    ///
+    /// Authentication is deliberately an environment variable name, never a
+    /// header value, so action declarations, cache keys, logs, and evidence do
+    /// not contain credentials.
+    DownloadAndExtract {
+        url: String,
+        sha256: String,
+        destination: WorkspacePath,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        authorization_env: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        input_digest: Option<Digest>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -372,7 +386,8 @@ impl Action {
             | Action::MaterializeHostTree { .. }
             | Action::PreparePath { .. }
             | Action::WriteTreeDigest { .. }
-            | Action::WriteArchive { .. } => &DEFAULT_RESOURCE_REQUEST,
+            | Action::WriteArchive { .. }
+            | Action::DownloadAndExtract { .. } => &DEFAULT_RESOURCE_REQUEST,
         }
     }
 
@@ -386,7 +401,8 @@ impl Action {
             | Action::MaterializeHostTree { input_digest, .. }
             | Action::PreparePath { input_digest, .. }
             | Action::WriteTreeDigest { input_digest, .. }
-            | Action::WriteArchive { input_digest, .. } => *input_digest,
+            | Action::WriteArchive { input_digest, .. }
+            | Action::DownloadAndExtract { input_digest, .. } => *input_digest,
         }
     }
 }

--- a/crates/once-core/src/error.rs
+++ b/crates/once-core/src/error.rs
@@ -48,6 +48,16 @@ pub enum Error {
     InvalidHostFile { reason: String },
     #[error("invalid action contract validation: {reason}")]
     InvalidContractValidation { reason: String },
+    #[error("invalid download-and-extract action: {reason}")]
+    InvalidDownloadAndExtract { reason: String },
+    #[error("download authorization environment variable `{name}` is not set")]
+    DownloadAuthorizationMissing { name: String },
+    #[error("download checksum mismatch for `{url}`: expected {expected}, got {actual}")]
+    DownloadChecksumMismatch {
+        url: String,
+        expected: String,
+        actual: String,
+    },
     #[error("host file `{path}` changed after analysis: expected digest {expected}, got {actual}")]
     HostFileDigestMismatch {
         path: String,

--- a/crates/once-core/src/execute.rs
+++ b/crates/once-core/src/execute.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
+use futures::StreamExt;
 use once_cas::{ActionResult, CacheProvider};
 use sha2::Digest as ShaDigest;
+use tokio::io::AsyncWriteExt;
 
 use crate::{
     archive, contract, local, outputs, remote, Action, CopyPathMode, Error, OutputSymlinkMode,
@@ -45,6 +47,7 @@ pub(crate) async fn run(
     execute_portable_action(action, workspace_root, cache).await
 }
 
+#[allow(clippy::too_many_lines)]
 async fn execute_portable_action(
     action: &Action,
     workspace_root: &Path,
@@ -145,8 +148,274 @@ async fn execute_portable_action(
             }
             capture_file_action_outputs(&outputs, workspace_root, cache).await
         }
+        Action::DownloadAndExtract {
+            url,
+            sha256,
+            destination,
+            authorization_env,
+            ..
+        } => {
+            download_and_extract(
+                url,
+                sha256,
+                destination,
+                authorization_env.as_deref(),
+                workspace_root,
+            )
+            .await?;
+            capture_file_action_outputs(std::slice::from_ref(destination), workspace_root, cache)
+                .await
+        }
         Action::RunCommand { .. } => unreachable!("command actions are dispatched separately"),
     }
+}
+
+#[allow(clippy::too_many_lines)]
+async fn download_and_extract(
+    url: &str,
+    expected_sha256: &str,
+    destination: &WorkspacePath,
+    authorization_env: Option<&str>,
+    workspace_root: &Path,
+) -> Result<()> {
+    let parsed = reqwest::Url::parse(url).map_err(|source| Error::InvalidDownloadAndExtract {
+        reason: format!("invalid URL `{url}`: {source}"),
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(Error::InvalidDownloadAndExtract {
+            reason: "URL must use HTTP or HTTPS".to_string(),
+        });
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(Error::InvalidDownloadAndExtract {
+            reason: "URL user-info is not allowed; use authorization_env instead".to_string(),
+        });
+    }
+    if !is_sha256(expected_sha256) {
+        return Err(Error::InvalidDownloadAndExtract {
+            reason: "sha256 must be exactly 64 hexadecimal characters".to_string(),
+        });
+    }
+    let absolute_destination = destination.resolve(workspace_root);
+    let destination_parent =
+        absolute_destination
+            .parent()
+            .ok_or_else(|| Error::InvalidDownloadAndExtract {
+                reason: format!(
+                    "destination `{}` has no parent directory",
+                    destination.as_str()
+                ),
+            })?;
+    tokio::fs::create_dir_all(destination_parent)
+        .await
+        .map_err(|source| Error::FileAction {
+            action: "download_and_extract",
+            path: destination.as_str().to_string(),
+            source,
+        })?;
+
+    let client =
+        reqwest::Client::builder()
+            .build()
+            .map_err(|source| Error::InvalidDownloadAndExtract {
+                reason: format!("creating HTTP client: {source}"),
+            })?;
+    let mut request = client.get(parsed);
+    if let Some(name) = authorization_env {
+        let value = std::env::var(name)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| Error::DownloadAuthorizationMissing {
+                name: name.to_string(),
+            })?;
+        request = request.header(reqwest::header::AUTHORIZATION, value);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|source| Error::InvalidDownloadAndExtract {
+            reason: format!("requesting `{url}`: {source}"),
+        })?
+        .error_for_status()
+        .map_err(|source| Error::InvalidDownloadAndExtract {
+            reason: format!("requesting `{url}`: {source}"),
+        })?;
+
+    let archive = tempfile::NamedTempFile::new_in(destination_parent).map_err(|source| {
+        Error::FileAction {
+            action: "download_and_extract",
+            path: destination.as_str().to_string(),
+            source,
+        }
+    })?;
+    let archive_path = archive.path().to_path_buf();
+    let mut file = tokio::fs::File::create(&archive_path)
+        .await
+        .map_err(|source| Error::FileAction {
+            action: "download_and_extract",
+            path: archive_path.display().to_string(),
+            source,
+        })?;
+    let mut digest = sha2::Sha256::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| Error::InvalidDownloadAndExtract {
+            reason: format!("reading `{url}`: {source}"),
+        })?;
+        digest.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|source| Error::FileAction {
+                action: "download_and_extract",
+                path: archive_path.display().to_string(),
+                source,
+            })?;
+    }
+    file.flush().await.map_err(|source| Error::FileAction {
+        action: "download_and_extract",
+        path: archive_path.display().to_string(),
+        source,
+    })?;
+    drop(file);
+
+    let digest = digest.finalize();
+    let mut actual_sha256 = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut actual_sha256, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    if !actual_sha256.eq_ignore_ascii_case(expected_sha256) {
+        return Err(Error::DownloadChecksumMismatch {
+            url: url.to_string(),
+            expected: expected_sha256.to_string(),
+            actual: actual_sha256,
+        });
+    }
+
+    let extracted_destination = absolute_destination.clone();
+    let staging_parent = destination_parent.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let staging = tempfile::Builder::new()
+            .prefix(".once-download-")
+            .tempdir_in(&staging_parent)
+            .map_err(|source| Error::FileAction {
+                action: "download_and_extract",
+                path: staging_parent.display().to_string(),
+                source,
+            })?;
+        let staged_output = staging.path().join("output");
+        extract_zip_archive(&archive_path, &staged_output)?;
+        remove_path_blocking(&extracted_destination).map_err(|source| Error::FileAction {
+            action: "download_and_extract",
+            path: extracted_destination.display().to_string(),
+            source,
+        })?;
+        std::fs::rename(&staged_output, &extracted_destination).map_err(|source| {
+            Error::FileAction {
+                action: "download_and_extract",
+                path: extracted_destination.display().to_string(),
+                source,
+            }
+        })
+    })
+    .await
+    .map_err(|source| Error::FileAction {
+        action: "download_and_extract",
+        path: destination.as_str().to_string(),
+        source: std::io::Error::other(source.to_string()),
+    })??;
+    Ok(())
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn extract_zip_archive(archive_path: &Path, destination: &Path) -> Result<()> {
+    std::fs::create_dir_all(destination).map_err(|source| Error::FileAction {
+        action: "download_and_extract",
+        path: destination.display().to_string(),
+        source,
+    })?;
+    let archive_file = std::fs::File::open(archive_path).map_err(|source| Error::FileAction {
+        action: "download_and_extract",
+        path: archive_path.display().to_string(),
+        source,
+    })?;
+    let mut archive =
+        zip::ZipArchive::new(archive_file).map_err(|source| Error::InvalidDownloadAndExtract {
+            reason: format!("opening ZIP archive: {source}"),
+        })?;
+    for index in 0..archive.len() {
+        let mut entry =
+            archive
+                .by_index(index)
+                .map_err(|source| Error::InvalidDownloadAndExtract {
+                    reason: format!("reading ZIP entry {index}: {source}"),
+                })?;
+        let Some(relative) = entry.enclosed_name() else {
+            return Err(Error::InvalidDownloadAndExtract {
+                reason: format!("ZIP entry `{}` escapes the destination", entry.name()),
+            });
+        };
+        if relative.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        }) {
+            return Err(Error::InvalidDownloadAndExtract {
+                reason: format!("ZIP entry `{}` escapes the destination", entry.name()),
+            });
+        }
+        let output = destination.join(relative);
+        let unix_mode = entry.unix_mode().unwrap_or(0);
+        let file_type = unix_mode & 0o170_000;
+        if file_type != 0 && file_type != 0o100_000 && file_type != 0o040_000 {
+            return Err(Error::InvalidDownloadAndExtract {
+                reason: format!("ZIP entry `{}` has an unsupported file type", entry.name()),
+            });
+        }
+        if entry.is_dir() {
+            std::fs::create_dir_all(&output).map_err(|source| Error::FileAction {
+                action: "download_and_extract",
+                path: output.display().to_string(),
+                source,
+            })?;
+            continue;
+        }
+        let parent = output
+            .parent()
+            .ok_or_else(|| Error::InvalidDownloadAndExtract {
+                reason: format!("ZIP entry `{}` has no parent directory", entry.name()),
+            })?;
+        std::fs::create_dir_all(parent).map_err(|source| Error::FileAction {
+            action: "download_and_extract",
+            path: parent.display().to_string(),
+            source,
+        })?;
+        let mut output_file =
+            std::fs::File::create(&output).map_err(|source| Error::FileAction {
+                action: "download_and_extract",
+                path: output.display().to_string(),
+                source,
+            })?;
+        std::io::copy(&mut entry, &mut output_file).map_err(|source| Error::FileAction {
+            action: "download_and_extract",
+            path: output.display().to_string(),
+            source,
+        })?;
+        #[cfg(unix)]
+        if unix_mode != 0 {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&output, std::fs::Permissions::from_mode(unix_mode & 0o777))
+                .map_err(|source| Error::FileAction {
+                action: "download_and_extract",
+                path: output.display().to_string(),
+                source,
+            })?;
+        }
+    }
+    Ok(())
 }
 
 async fn execute_command(

--- a/crates/once-core/src/runner.rs
+++ b/crates/once-core/src/runner.rs
@@ -371,6 +371,8 @@ fn action_uses_cache(action: &Action) -> bool {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+    use std::fmt::Write as _;
+    use std::io::Cursor;
     use std::time::Duration;
 
     use crate::action::ACTION_DIGEST_DOMAIN;
@@ -380,7 +382,10 @@ mod tests {
         WorkspacePath,
     };
     use once_cas::{CacheProvider, Cas, Digest};
+    use sha2::Digest as _;
     use tempfile::TempDir;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     fn fresh_cas() -> (TempDir, Cas) {
         let tmp = TempDir::new().unwrap();
@@ -406,6 +411,34 @@ mod tests {
             success_exit_codes: vec![0],
             remote: None,
         }
+    }
+
+    fn archive_bytes() -> Vec<u8> {
+        let cursor = Cursor::new(Vec::new());
+        let mut archive = zip::ZipWriter::new(cursor);
+        let options = zip::write::SimpleFileOptions::default();
+        archive
+            .start_file("Vendor.xcframework/Info.plist", options)
+            .unwrap();
+        std::io::Write::write_all(&mut archive, b"fixture plist").unwrap();
+        archive.finish().unwrap().into_inner()
+    }
+
+    async fn serve_archive_once(bytes: Vec<u8>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                bytes.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(&bytes).await.unwrap();
+        });
+        format!("http://{address}/Vendor.zip")
     }
 
     #[tokio::test]
@@ -734,6 +767,38 @@ mod tests {
             std::fs::read_to_string(tmp.path().join("out/layer.tar.sha256")).unwrap(),
             digest
         );
+    }
+
+    #[tokio::test]
+    async fn download_and_extract_restores_a_cached_archive_directory() {
+        let (tmp, cache) = fresh_cas();
+        let archive = archive_bytes();
+        let digest = sha2::Sha256::digest(&archive);
+        let mut checksum = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            write!(&mut checksum, "{byte:02x}").unwrap();
+        }
+        let url = serve_archive_once(archive).await;
+        let action = Action::DownloadAndExtract {
+            url,
+            sha256: checksum,
+            destination: WorkspacePath::try_from("out/Vendor").unwrap(),
+            authorization_env: Some("VENDOR_AUTHORIZATION".to_string()),
+            input_digest: Some(Digest::of_bytes(b"vendor-archive")),
+        };
+        std::env::set_var("VENDOR_AUTHORIZATION", "Bearer test-token");
+        let runner = Runner::new(cache, tmp.path(), RunOpts::default());
+
+        let first = runner.run(&action).await.unwrap();
+        assert_eq!(first.cache, CacheState::Miss);
+        let plist = tmp.path().join("out/Vendor/Vendor.xcframework/Info.plist");
+        assert_eq!(std::fs::read(&plist).unwrap(), b"fixture plist");
+
+        std::fs::remove_dir_all(tmp.path().join("out/Vendor")).unwrap();
+        let second = runner.run(&action).await.unwrap();
+        assert_eq!(second.cache, CacheState::Hit);
+        assert_eq!(std::fs::read(&plist).unwrap(), b"fixture plist");
+        std::env::remove_var("VENDOR_AUTHORIZATION");
     }
 
     #[tokio::test]

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -2108,6 +2108,26 @@ def _apple_xcframework_platform(platform):
         return "xros"
     return platform
 
+def _apple_xcframework_module_name(modulemaps, fallback):
+    for modulemap in modulemaps:
+        for raw_line in host_file_read(workspace_root() + "/" + modulemap).split("\n"):
+            parts = raw_line.strip().replace("{", " ").split()
+            if len(parts) >= 2 and parts[0] == "module":
+                return parts[1]
+            if len(parts) >= 3 and parts[0] == "framework" and parts[1] == "module":
+                return parts[2]
+            if len(parts) >= 3 and parts[0] == "explicit" and parts[1] == "module":
+                return parts[2]
+    return fallback
+
+def _apple_xcframework_static_library_name(path):
+    name = _basename(path)
+    if name.endswith(".a"):
+        name = name[:len(name) - 2]
+    if name.startswith("lib"):
+        name = name[3:]
+    return name
+
 def _apple_xcframework_import_impl(ctx):
     attrs = _resolve_attrs(ctx, ctx["attr"], ctx["label"]["id"], ["bundle"])
     bundle = attrs.get("bundle") or ""
@@ -2136,26 +2156,65 @@ def _apple_xcframework_import_impl(ctx):
         break
     if selected == None:
         fail(ctx["label"]["id"] + ": XCFramework `" + bundle + "` has no " + wanted_platform + " " + wanted_variant + " slice for " + wanted_arch)
-    framework = bundle + "/" + selected["LibraryIdentifier"] + "/" + selected["LibraryPath"]
-    absolute_framework = workspace_root() + "/" + framework
-    files = [path[len(workspace_root()) + 1:] for path in host_command([host_which("find"), absolute_framework, "-type", "f"]).split("\n") if path]
-    if not files:
-        fail(ctx["label"]["id"] + ": selected XCFramework slice is missing `" + framework + "`")
-    module_name = attrs.get("module_name") or _basename(selected["LibraryPath"]).replace(".framework", "")
-    binary = framework + "/" + module_name
-    linkage = "static" if "current ar archive" in host_command([host_which("file"), workspace_root() + "/" + binary]) else "dynamic"
-    own_bundle = _apple_framework_bundle(framework, module_name, files, ctx["label"]["id"])
+    library_path = selected.get("LibraryPath") or selected.get("BinaryPath") or ""
+    if not library_path:
+        fail(ctx["label"]["id"] + ": selected XCFramework slice has no library path")
+    slice_path = bundle + "/" + selected["LibraryIdentifier"]
+    library = slice_path + "/" + library_path
+    binary_path = selected.get("BinaryPath") or ""
+    if not binary_path:
+        binary_path = library_path + "/" + _basename(library_path).replace(".framework", "") if library_path.endswith(".framework") else library_path
+    binary = slice_path + "/" + binary_path
+    absolute_slice = workspace_root() + "/" + slice_path
+    files = [path[len(workspace_root()) + 1:] for path in host_command([host_which("find"), absolute_slice, "-type", "f"]).split("\n") if path]
+    is_framework = library_path.endswith(".framework")
+    expected_binary = binary if is_framework else library
+    if not files or expected_binary not in files:
+        fail(ctx["label"]["id"] + ": selected XCFramework slice is missing `" + library + "`")
+    linkage = "static" if library_path.endswith(".a") or "current ar archive" in host_command([host_which("file"), workspace_root() + "/" + binary]) else "dynamic"
+    if not is_framework:
+        headers_path = selected.get("HeadersPath") or ""
+        headers_dir = slice_path + "/" + headers_path if headers_path else ""
+        modulemaps = []
+        for path in files:
+            if path.endswith(".modulemap") and (not headers_dir or path.startswith(headers_dir + "/")):
+                modulemaps.append(path)
+        if not modulemaps:
+            for path in files:
+                if path.endswith(".modulemap"):
+                    modulemaps.append(path)
+        module_name = attrs.get("module_name") or _apple_xcframework_module_name(modulemaps, _apple_xcframework_static_library_name(library_path))
+        return {
+            "label_id": ctx["label"]["id"],
+            "framework_path": library,
+            "framework_module_name": module_name,
+            "framework_files": files,
+            "transitive_exported_header_dirs": [headers_dir] if headers_dir else [],
+            "transitive_modulemaps": modulemaps,
+            "transitive_archives": [binary] if linkage == "static" else [],
+            "transitive_framework_search_dirs": [],
+            "transitive_framework_files": files,
+            "transitive_link_framework_bundles": [],
+            "transitive_framework_bundles": [],
+            "transitive_frameworks": [],
+            "transitive_sdk_frameworks": [],
+            "transitive_weak_sdk_frameworks": [],
+            "transitive_sdk_dylibs": [],
+            "transitive_linkopts": [],
+        }
+    module_name = attrs.get("module_name") or _basename(library_path).replace(".framework", "")
+    own_bundle = _apple_framework_bundle(library, module_name, files, ctx["label"]["id"])
     own_bundle["linkage"] = linkage
     return {
         "label_id": ctx["label"]["id"],
-        "framework_path": framework,
+        "framework_path": library,
         "framework_module_name": module_name,
         "framework_files": files,
         "transitive_swiftmodule_dirs": [],
         "transitive_archives": [binary] if linkage == "static" else [],
         "transitive_link_framework_bundles": [own_bundle],
         "transitive_framework_bundles": [] if linkage == "static" else [own_bundle],
-        "transitive_frameworks": [] if linkage == "static" else [framework],
+        "transitive_frameworks": [] if linkage == "static" else [library],
         "transitive_sdk_frameworks": [],
         "transitive_weak_sdk_frameworks": [],
         "transitive_sdk_dylibs": [],
@@ -5806,15 +5865,16 @@ apple_library = target_kind(
 )
 
 apple_xcframework_import = target_kind(
-    docs = "Selects a platform and architecture slice from a prebuilt XCFramework and exposes it as an Apple framework dependency.",
+    docs = "Selects a platform and architecture slice from a prebuilt XCFramework and exposes its framework or static library to Apple targets.",
     impl = _apple_xcframework_import_impl,
     attrs = [
         attr("bundle", "string", required = True, docs = "Workspace-relative `.xcframework` bundle"),
         attr("platform", "string", required = True, docs = "Apple platform whose slice is imported", configurable = False),
         attr("sdk_variant", "string", default = "\"simulator\"", docs = "`simulator` or `device` slice selection", configurable = False),
         attr("arch", "string", docs = "Target architecture. Defaults to the execution host architecture.", configurable = False),
-        attr("module_name", "string", docs = "Framework module name. Defaults to the selected framework bundle name", configurable = False),
+        attr("module_name", "string", docs = "Framework or Clang module name. Defaults to the selected framework bundle name or static library module map", configurable = False),
     ],
+    deps = [dep("deps", ["artifact"], "Optional checksum-pinned archive artifact that materializes the XCFramework before this target is analysed.", max_count = 1)],
     providers = ["apple_linkable", "apple_framework", "apple_bundle"],
     capabilities = [capability("build", ["default", "framework"])],
     examples = [

--- a/crates/once-frontend/prelude/archive.star
+++ b/crates/once-frontend/prelude/archive.star
@@ -1,0 +1,43 @@
+def _archive_download_impl(ctx):
+    attrs = ctx["attr"]
+    destination = declare_output("archive")
+    identifier = "archive_download:" + ctx["label"]["id"]
+    authorization_env = attrs.get("authorization_env") or ""
+    if authorization_env:
+        download_and_extract(
+            attrs["url"],
+            attrs["sha256"],
+            destination,
+            authorization_env = authorization_env,
+            identifier = identifier,
+        )
+    else:
+        download_and_extract(
+            attrs["url"],
+            attrs["sha256"],
+            destination,
+            identifier = identifier,
+        )
+    return {
+        "label_id": ctx["label"]["id"],
+        "artifact_root": destination,
+    }
+
+archive_download = target_kind(
+    docs = "Downloads a checksum-pinned compressed archive into a cacheable directory output.",
+    impl = _archive_download_impl,
+    attrs = [
+        attr("url", "string", required = True, docs = "Web archive URL", configurable = False),
+        attr("sha256", "string", required = True, docs = "Expected SHA-256 archive checksum", configurable = False),
+        attr("authorization_env", "string", docs = "Optional environment-variable name that supplies a web Authorization header only while downloading", configurable = False),
+    ],
+    providers = ["artifact"],
+    capabilities = [capability("build", ["default", "artifact"])],
+    examples = [
+        example(
+            "archive-download-minimal",
+            name = "Checksum-pinned archive download",
+            use_when = "You need a verified compressed archive as the cached input to another target.",
+        ),
+    ],
+)

--- a/crates/once-frontend/prelude/examples/archive-download-minimal/once.toml
+++ b/crates/once-frontend/prelude/examples/archive-download-minimal/once.toml
@@ -1,0 +1,7 @@
+[[target]]
+name = "OnceSource"
+kind = "archive_download"
+
+[target.attrs]
+url = "https://codeload.github.com/tuist/once/zip/a63fc4d5d34a59845e2a7ad0bfb3d2adc1fc7c28"
+sha256 = "53c8832dda94ef6a7f75a5f57f49acd79e2b81c9cf86e2105dddf0f6ad2ba8b9"

--- a/crates/once-frontend/prelude/index.star
+++ b/crates/once-frontend/prelude/index.star
@@ -1,5 +1,6 @@
 PRELUDE_SOURCES = [
     "common.star",
+    "archive.star",
     "lint.star",
     "apple.star",
     "android.star",
@@ -22,12 +23,13 @@ PRELUDE_SOURCES = [
 ]
 
 PRELUDE_DEPENDENCIES = {
+    "xcode.star": ["apple.star", "archive.star"],
     "react_native.star": ["android.star"],
-    "xcode.star": ["apple.star"],
     "swift_package.star": ["apple.star", "xcode.star"],
 }
 
 PRELUDE_TARGET_KINDS = {
+    "archive.star": ["archive_download"],
     "lint.star": [
         "ruff_lint",
         "golangci_lint",

--- a/crates/once-frontend/prelude/react_native.star
+++ b/crates/once-frontend/prelude/react_native.star
@@ -1201,6 +1201,7 @@ _REACT_NATIVE_EXAMPLE = [
         "react-native-application-minimal",
         name = "React Native New Architecture application",
         use_when = "You want a current React Native application with Hermes, Fabric, iOS, Android, and Metro development mode.",
+        platforms = ["macos"],
     ),
 ]
 

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -1016,6 +1016,37 @@ def _xcode_workspace_input_path(path):
         return ""
     return relative
 
+def _xcode_target_input_path(ctx, path):
+    path = _xcode_workspace_input_path(path)
+    package = ctx["label"]["package"]
+    prefix = package + "/" if package else ""
+    if prefix and path.startswith(prefix):
+        return path[len(prefix):]
+    return path
+
+def _xcode_lowered_attrs(ctx, attrs):
+    for key in ["bridging_header", "prefix_header", "modulemap", "info_plist", "entitlements"]:
+        if attrs.get(key):
+            attrs[key] = _xcode_target_input_path(ctx, attrs[key])
+    for key in [
+        "exported_header_dirs",
+        "exported_headers",
+        "private_header_dirs",
+        "modulemap_headers",
+        "auxiliary_modulemaps",
+        "asset_catalogs",
+        "resources",
+        "structured_resources",
+    ]:
+        if attrs.get(key):
+            attrs[key] = [_xcode_target_input_path(ctx, path) for path in attrs[key]]
+    if attrs.get("per_source_clang_flags"):
+        attrs["per_source_clang_flags"] = {
+            _xcode_target_input_path(ctx, path): flags
+            for path, flags in attrs["per_source_clang_flags"].items()
+        }
+    return attrs
+
 def _xcode_script_path(value, subs):
     path = _xcode_resolve_vars(value or "", subs)
     if not path or path.startswith("$("):
@@ -2799,6 +2830,11 @@ def _xcode_test_host_ref(objects, settings, name_map):
 # ---------------------------------------------------------------------------
 
 def _xcode_workspace_resolver(ctx):
+    # `plutil` may be present off macOS, but only Xcode's `xcrun` supplies the
+    # SDK and compiler information this resolver needs. Probe it first so the
+    # generic resolver machinery can surface a structured unavailable-tool
+    # diagnostic instead of executing an incompatible `plutil`.
+    host_which("xcrun")
     entry_path = _xcode_project_path(ctx)
     configuration = ctx["attr"].get("configuration") or "Debug"
 
@@ -3152,11 +3188,13 @@ def _xcode_lower_target(ctx, objects, target, project_settings, name_to_id, dep_
         # whose only input is JavaScript.
         return None
 
+    attrs = _xcode_lowered_attrs(ctx, attrs)
+
     return {
         "name": sanitized,
         "kind": spec_kind,
         "deps": _unique(deps),
-        "srcs": files["sources"],
+        "srcs": [_xcode_target_input_path(ctx, path) for path in files["sources"]],
         "attrs": attrs,
     }
 

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -37,18 +37,17 @@ def _xcode_abs(path):
 def _xcode_project_path(ctx):
     configured = ctx["attr"].get("project")
     if configured:
-        return configured
+        package = ctx["label"]["package"]
+        return _xcode_join(package, configured) if package else configured
     candidates = [path for path in glob(["*.xcodeproj/project.pbxproj"]) if _ends_with(path, "/project.pbxproj")]
     if len(candidates) == 0:
         fail(ctx["label"]["id"] + ": no `project` attribute was set and no `*.xcodeproj/project.pbxproj` was found in the package")
     if len(candidates) > 1:
         fail(ctx["label"]["id"] + ": multiple Xcode projects found; set the `project` attribute to one of: " + ", ".join(candidates))
-    # candidates are workspace-relative; trim to package-relative.
-    package = ctx["label"]["package"]
-    relative = candidates[0]
-    if package and relative.startswith(package + "/"):
-        relative = relative[len(package) + 1:]
-    return relative
+    # `glob` always returns workspace-relative paths, including when the
+    # native seed belongs to a nested package. The resolver reads project
+    # files through the workspace root, so keep that coordinate system.
+    return _parent_dir(candidates[0])
 
 def _xcode_is_workspace(path):
     return _ends_with(path, ".xcworkspace") or _ends_with(path, "/contents.xcworkspacedata")
@@ -1395,36 +1394,6 @@ def _xcode_swift_package_info(ctx, package_dir, identity = ""):
         "info": info,
     }
 
-def _xcode_acquire_binary_package_artifacts(package):
-    package_path = package.get("path") or ""
-    if not package_path:
-        return
-    package_absolute = _xcode_abs(package_path)
-    mkdir = host_which("mkdir")
-    curl = host_which("curl")
-    ditto = host_which("ditto")
-    shasum = host_which("shasum")
-    for target in package["info"].get("targets") or []:
-        if (target.get("type") or "") != "binary":
-            continue
-        url = target.get("url") or ""
-        checksum = target.get("checksum") or ""
-        name = target.get("name") or ""
-        if not url or not checksum or not name:
-            continue
-        root = package_absolute + "/.once/binary-artifacts"
-        bundle = root + "/" + name + ".xcframework"
-        artifact_bundle = root + "/" + name + ".artifactbundle"
-        if _xcode_host_directory_exists(bundle) or _xcode_host_directory_exists(artifact_bundle):
-            continue
-        host_command([mkdir, "-p", root])
-        archive = root + "/" + name + ".zip"
-        host_command([curl, "--fail", "--location", "--retry", "2", "--output", archive, url])
-        actual = host_command([shasum, "-a", "256", archive]).split(" ")[0]
-        if actual.lower() != checksum.lower():
-            fail("binary package artifact checksum mismatch for `" + name + "`")
-        host_command([ditto, "-x", "-k", archive, root])
-
 def _xcode_local_swift_package_infos(ctx):
     # Package metadata is analysis input only. Compilation remains entirely in
     # Once's Apple target kinds, so resolving an Xcode workspace never invokes
@@ -1435,35 +1404,79 @@ def _xcode_local_swift_package_infos(ctx):
             continue
         package_dir = _parent_dir(manifest)
         info = _xcode_swift_package_info(ctx, package_dir)
-        _xcode_acquire_binary_package_artifacts(info)
         infos.append(info)
     return infos
 
-def _xcode_package_resolved_pins(ctx, project_path):
+def _xcode_workspace_resolved_path(workspace_path):
+    bundle = _parent_dir(workspace_path) if _ends_with(workspace_path, "/contents.xcworkspacedata") else workspace_path
+    return bundle + "/xcshareddata/swiftpm/Package.resolved"
+
+def _xcode_workspace_resolved_candidates():
+    root = _xcode_workspace_root()
+    if not root:
+        return []
+    find = host_which("find")
+    return sorted([
+        _xcode_workspace_relative(path)
+        for path in host_command([find, root, "-type", "f", "-path", "*.xcworkspace/xcshareddata/swiftpm/Package.resolved"]).split("\n")
+        if path
+    ])
+
+def _xcode_resolved_pins_from_path(path):
+    if not path:
+        return {}
+    absolute = _xcode_abs(path)
+    if not host_file_exists(absolute):
+        return {}
+    pins = {}
+    data = json_decode(host_file_read(absolute))
+    for pin in data.get("pins") or (data.get("object") or {}).get("pins") or []:
+        identity = (pin.get("identity") or pin.get("package") or "").lower()
+        if identity:
+            pins[identity] = pin
+    return pins
+
+def _xcode_pins_match_package_refs(pins, package_refs):
+    if not package_refs:
+        return True
+    for ref in package_refs.values():
+        identity = (ref.get("identity") or "").lower()
+        if identity and pins.get(identity):
+            return True
+    return False
+
+def _xcode_package_resolved_pins(ctx, entry_path, project_path, package_refs):
     bundle = project_path
     if _ends_with(bundle, "/project.pbxproj"):
         bundle = _parent_dir(bundle)
-    candidates = [
+    candidates = []
+    if _xcode_is_workspace(entry_path):
+        candidates.append(_xcode_workspace_resolved_path(entry_path))
+    candidates.extend([
         bundle + "/project.xcworkspace/xcshareddata/swiftpm/Package.resolved",
         bundle + "/project.workspace/xcshareddata/swiftpm/Package.resolved",
-    ]
+    ])
+    candidates.extend(_xcode_workspace_resolved_candidates())
+    seen = {}
+    fallback = {}
     for candidate in candidates:
-        absolute = _xcode_abs(candidate)
-        if not host_file_exists(absolute):
+        if candidate in seen:
             continue
-        pins = {}
-        for pin in json_decode(host_file_read(absolute)).get("pins") or []:
-            identity = (pin.get("identity") or "").lower()
-            if identity:
-                pins[identity] = pin
-        return pins
-    return {}
+        seen[candidate] = True
+        pins = _xcode_resolved_pins_from_path(candidate)
+        if not pins:
+            continue
+        if _xcode_pins_match_package_refs(pins, package_refs):
+            return pins
+        if not fallback:
+            fallback = pins
+    return fallback
 
-def _xcode_remote_swift_package_infos(ctx, project_path, package_refs):
+def _xcode_remote_swift_package_infos(ctx, entry_path, project_path, package_refs):
     # The lockfile is authoritative for source-control revisions. Git provides
     # source acquisition only; package manifests are then lowered to Once Apple
     # targets and compiled by Once rather than by Swift Package Manager.
-    pins = _xcode_package_resolved_pins(ctx, project_path)
+    pins = _xcode_package_resolved_pins(ctx, entry_path, project_path, package_refs)
     git = host_which("git")
     root = _xcode_workspace_root() + ".once/xcode-packages"
     infos = []
@@ -1506,23 +1519,12 @@ def _xcode_remote_swift_package_info(ctx, identity, pin, url = ""):
             host_command([git, "-C", absolute, "fetch", "--depth", "1", "origin", revision])
             host_command([git, "-C", absolute, "checkout", "--detach", revision])
     info = _xcode_swift_package_info(ctx, package_dir, identity)
-    _xcode_acquire_binary_package_artifacts(info)
     return info
 
 def _xcode_package_resolved_pins_at(package_path):
     if not package_path:
         return {}
-    resolved = _xcode_abs(package_path + "/Package.resolved")
-    if not host_file_exists(resolved):
-        return {}
-    pins = {}
-    data = json_decode(host_file_read(resolved))
-    entries = data.get("pins") or (data.get("object") or {}).get("pins") or []
-    for pin in entries:
-        identity = (pin.get("identity") or "").lower()
-        if identity:
-            pins[identity] = pin
-    return pins
+    return _xcode_resolved_pins_from_path(package_path + "/Package.resolved")
 
 def _xcode_expand_swift_package_infos(ctx, initial_infos):
     infos = list(initial_infos)
@@ -1646,20 +1648,34 @@ def _xcode_swift_package_target_datamodels(package_path, target):
         return []
     return [_xcode_workspace_relative(path) for path in host_command([host_which("find"), absolute, "-type", "d", "-name", "*.xcdatamodeld"]).split("\n") if path]
 
-def _xcode_swift_package_binary_bundles(package_path, target):
+def _xcode_swift_package_binary_artifact(ctx, package_path, target_id, target):
+    name = target.get("name") or ""
+    url = target.get("url") or ""
+    checksum = target.get("checksum") or ""
+    if name and url and checksum:
+        artifact_target = target_id + "_Artifact"
+        package = ctx["label"].get("package") or ""
+        output = ".once/out/" + ((package + "/") if package else "") + artifact_target + "/archive"
+        return {
+            "target": artifact_target,
+            "bundle": output + "/" + name + ".xcframework",
+            "url": url,
+            "sha256": checksum,
+        }
     target_path = target.get("path") or ""
     if target_path.endswith(".xcframework"):
         candidate = package_path + "/" + target_path
         absolute = _xcode_abs(candidate)
         if _xcode_host_directory_exists(absolute):
-            return [candidate]
+            return {"bundle": candidate}
     root = package_path or "."
     absolute = _xcode_abs(root)
     if not _xcode_host_directory_exists(absolute):
-        return []
-    name = target.get("name") or ""
+        return None
     bundles = [_xcode_workspace_relative(path) for path in host_command([host_which("find"), absolute, "-type", "d", "-name", name + ".xcframework"]).split("\n") if path]
-    return _unique(bundles)
+    if len(bundles) == 1:
+        return {"bundle": bundles[0]}
+    return None
 
 def _xcode_include_flags(paths):
     flags = []
@@ -1881,15 +1897,31 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
                 continue
             target_id = target_ids[identity + "\x1f" + name]
             if target_type == "binary":
-                bundles = _xcode_swift_package_binary_bundles(package_path, target)
-                if len(bundles) == 1:
+                artifact = _xcode_swift_package_binary_artifact(ctx, package_path, target_id, target)
+                if artifact != None:
+                    artifact_target = artifact.get("target") or ""
+                    if artifact_target:
+                        artifact_attrs = {
+                            "url": artifact["url"],
+                            "sha256": artifact["sha256"],
+                        }
+                        authorization_env = ctx["attr"].get("binary_artifact_authorization_env") or ""
+                        if authorization_env:
+                            artifact_attrs["authorization_env"] = authorization_env
+                        specs.append({
+                            "name": artifact_target,
+                            "kind": "archive_download",
+                            "deps": [],
+                            "srcs": [],
+                            "attrs": artifact_attrs,
+                        })
                     specs.append({
                         "name": target_id,
                         "kind": "apple_xcframework_import",
-                        "deps": [],
+                        "deps": ["./" + artifact_target] if artifact_target else [],
                         "srcs": [],
                         "attrs": {
-                            "bundle": bundles[0],
+                            "bundle": artifact["bundle"],
                             "platform": platform,
                             "sdk_variant": sdk_variant,
                         },
@@ -2854,7 +2886,7 @@ def _xcode_workspace_resolver(ctx):
         package_refs = _xcode_spm_package_refs(objects)
         package_infos = _xcode_expand_swift_package_infos(
             ctx,
-            local_package_infos + _xcode_remote_swift_package_infos(ctx, project_path, package_refs),
+            local_package_infos + _xcode_remote_swift_package_infos(ctx, entry_path, project_path, package_refs),
         )
         per_target_products = {}
         for target in native_targets:
@@ -3148,6 +3180,7 @@ xcode_workspace = target_kind(
         attr("configuration", "string", default = "Debug", docs = "Xcode build configuration whose settings drive target lowering.", configurable = False),
         attr("sdk_variant", "string", default = "simulator", docs = "`simulator` or `device` SDK selection applied to lowered Apple targets on non-macOS platforms.", configurable = False),
         attr("xcode_developer_dir", "string", docs = "Optional `DEVELOPER_DIR` override folded into lowered Apple target cache keys.", configurable = False),
+        attr("binary_artifact_authorization_env", "string", docs = "Optional environment-variable name supplying an Authorization header while downloading private binary package artifacts. The variable value is never recorded in the graph or cache.", configurable = False),
         attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative text globs supplied to native integration resolution. Defaults to srcs when empty.", configurable = False),
     ],
     resolver = _xcode_workspace_resolver,
@@ -3181,10 +3214,7 @@ xcode = native_project(
     markers = ["*.xcodeproj/project.pbxproj"],
     inputs = ["*.xcodeproj/**/*.xcscheme", "*.xcworkspace/contents.xcworkspacedata", "**/*.xcconfig"],
     exclude = _native_project_generated_dirs() + ["Pods", "Carthage", "DerivedData", "node_modules"],
-    on_match = "stop",
-    # The resolver reads project paths relative to the workspace root, so a seed
-    # is only synthesized for a project checked in beside the workspace root. A
-    # project nested deeper is declared explicitly from the root package.
-    max_depth = 1,
+    on_match = "all",
+    max_depth = 16,
     requires_tools = ["plutil", "xcrun"],
 )

--- a/crates/once-frontend/src/analysis/globals.rs
+++ b/crates/once-frontend/src/analysis/globals.rs
@@ -882,6 +882,73 @@ fn prelude_globals(builder: &mut GlobalsBuilder) {
         Ok(NoneType)
     }
 
+    /// Download a checksum-pinned ZIP archive and expand it into a declared
+    /// directory output. `authorization_env` is the name of an environment
+    /// variable read only when the action executes; its value is never stored
+    /// in the action declaration, action digest, or evidence.
+    fn download_and_extract(
+        url: &str,
+        sha256: &str,
+        destination: &str,
+        authorization_env: Option<String>,
+        identifier: Option<String>,
+        cacheable: Option<bool>,
+    ) -> anyhow::Result<NoneType> {
+        if !analysis_active() {
+            return Ok(NoneType);
+        }
+        if url.trim().is_empty() {
+            return Err(anyhow!("download_and_extract url must not be empty"));
+        }
+        if sha256.len() != 64 || !sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(anyhow!(
+                "download_and_extract sha256 must be exactly 64 hexadecimal characters"
+            ));
+        }
+        if authorization_env
+            .as_deref()
+            .is_some_and(|name| name.trim().is_empty())
+        {
+            return Err(anyhow!(
+                "download_and_extract authorization_env must not be empty"
+            ));
+        }
+        let action = DeclaredAction {
+            operation: Some(DeclaredActionOperation::DownloadAndExtract {
+                url: url.to_string(),
+                sha256: sha256.to_string(),
+                destination: destination.to_string(),
+                authorization_env,
+            }),
+            argv: Vec::new(),
+            arg_files: Vec::new(),
+            inputs: Vec::new(),
+            outputs: vec![destination.to_string()],
+            stdout: None,
+            stderr: None,
+            clean_paths: Vec::new(),
+            create_dirs: Vec::new(),
+            cwd: None,
+            env: BTreeMap::new(),
+            sandbox: None,
+            network: None,
+            success_exit_codes: vec![0],
+            cacheable: cacheable.unwrap_or(true),
+            inherit_parent_env: false,
+            depends_on_prior_actions: false,
+            toolchain_identity: None,
+            identifier: Some(
+                identifier.unwrap_or_else(|| format!("download_and_extract:{destination}")),
+            ),
+        };
+        with_store_mut(|store| {
+            if let Some(store) = store {
+                store.actions.push(action);
+            }
+        });
+        Ok(NoneType)
+    }
+
     /// Build a structured command-line fragment. `args` is a list of
     /// string arguments. When `use_arg_file` is set, it must be a dict
     /// with `path` plus optional `format` and `arg_format`. The supported
@@ -2435,6 +2502,7 @@ mod observation_completeness_tests {
         "cmd_args",
         "copy_path",
         "declare_output",
+        "download_and_extract",
         "execution_path",
         "json_decode",
         "link_path",

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -52,6 +52,12 @@ pub enum DeclaredActionOperation {
         sha256_output: Option<String>,
         format: DeclaredArchiveFormat,
     },
+    DownloadAndExtract {
+        url: String,
+        sha256: String,
+        destination: String,
+        authorization_env: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -1023,6 +1023,38 @@ fn materialize_host_file_records_a_content_addressed_operation() {
 }
 
 #[test]
+fn download_and_extract_records_a_checksum_pinned_operation() {
+    let tmp = TempDir::new().unwrap();
+    let store = store_for(tmp.path(), "p");
+    let (store, ()) = with_active_store(store, || {
+        run(r#"download_and_extract(
+    "https://downloads.example.test/Vendor.zip",
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    ".once/out/p/archive",
+    authorization_env = "VENDOR_AUTHORIZATION",
+    identifier = "vendor-artifact",
+)"#)
+        .unwrap();
+    });
+
+    assert_eq!(store.actions.len(), 1);
+    let action = &store.actions[0];
+    assert_eq!(action.inputs, Vec::<String>::new());
+    assert_eq!(action.outputs, vec![".once/out/p/archive".to_string()]);
+    assert_eq!(action.identifier.as_deref(), Some("vendor-artifact"));
+    assert!(!action.depends_on_prior_actions);
+    assert_eq!(
+        action.operation,
+        Some(DeclaredActionOperation::DownloadAndExtract {
+            url: "https://downloads.example.test/Vendor.zip".to_string(),
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            destination: ".once/out/p/archive".to_string(),
+            authorization_env: Some("VENDOR_AUTHORIZATION".to_string()),
+        })
+    );
+}
+
+#[test]
 fn materialize_host_tree_records_a_content_addressed_operation() {
     let tmp = TempDir::new().unwrap();
     let source = tmp.path().join("toolchain");

--- a/crates/once-frontend/src/module_contract.rs
+++ b/crates/once-frontend/src/module_contract.rs
@@ -348,6 +348,10 @@ pub fn module_authoring_contract() -> ModuleAuthoringContract {
                 "Declare a deterministic archive from explicit file, directory, and tree entries with fixed metadata.",
             ),
             entry(
+                "download_and_extract(url, sha256, destination, authorization_env = None, identifier = None, cacheable = True)",
+                "Download a checksum-pinned ZIP archive into a cacheable directory output. Authentication, when needed, is read from the named environment variable only while the action executes.",
+            ),
+            entry(
                 "cmd_args(args, use_arg_file = None)",
                 "Build a structured argument list, optionally backed by an argument file.",
             ),

--- a/crates/once-frontend/src/native_project.rs
+++ b/crates/once-frontend/src/native_project.rs
@@ -305,10 +305,10 @@ fn native_project_schema(name: String, dict: &DictRef<'_>) -> Result<NativeProje
     let exclude = string_list(dict, "exclude")?;
     let input_exclude = string_list(dict, "input_exclude")?;
     let on_match = required_string(dict, "on_match")?;
-    if on_match != "stop" && on_match != "descend" {
+    if on_match != "stop" && on_match != "descend" && on_match != "all" {
         return Err(native_project_error(
             &name,
-            format!("native project `{name}` on_match must be `stop` or `descend`"),
+            format!("native project `{name}` on_match must be `stop`, `descend`, or `all`"),
         ));
     }
     let max_depth = positive_usize(required_i32(dict, "max_depth")?, &name, "max_depth")?;
@@ -320,11 +320,14 @@ fn native_project_schema(name: String, dict: &DictRef<'_>) -> Result<NativeProje
     // walk visits files, so a primary marker that needs directory
     // expansion or a parent segment can only be matched by the
     // stop-mode directory pass.
-    if (marker_is_pattern(&markers[0]) || markers[0].contains('/')) && on_match != "stop" {
+    if (marker_is_pattern(&markers[0]) || markers[0].contains('/'))
+        && on_match != "stop"
+        && on_match != "all"
+    {
         return Err(native_project_error(
                         &name,
                         format!(
-                            "native project `{name}` marker `{}` spans a directory, so it requires on_match = \"stop\"",
+                            "native project `{name}` marker `{}` spans a directory, so it requires on_match = \"stop\" or \"all\"",
                             markers[0]
                         ),
                     ));
@@ -616,7 +619,7 @@ mod tests {
     }
 
     #[test]
-    fn built_in_native_projects_detect_xcode_projects_at_the_workspace_root() {
+    fn built_in_native_projects_detect_xcode_projects_in_nested_packages() {
         let temporary = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(temporary.path().join("Browser.xcodeproj")).unwrap();
         std::fs::write(
@@ -639,11 +642,16 @@ mod tests {
             .iter()
             .filter(|matched| matched.native_project == "xcode")
             .collect::<Vec<_>>();
-        assert_eq!(xcode.len(), 1);
-        assert!(xcode[0].package.is_empty());
+        assert_eq!(xcode.len(), 2);
+        assert_eq!(xcode[0].package, "");
         assert_eq!(
             xcode[0].markers,
             vec!["Browser.xcodeproj/project.pbxproj".to_string()]
+        );
+        assert_eq!(xcode[1].package, "ios");
+        assert_eq!(
+            xcode[1].markers,
+            vec!["Nested.xcodeproj/project.pbxproj".to_string()]
         );
     }
 

--- a/crates/once-frontend/src/native_project/discovery.rs
+++ b/crates/once-frontend/src/native_project/discovery.rs
@@ -78,6 +78,7 @@ struct DiscoveryScan<'a> {
     stop_markers: BTreeMap<&'a str, Vec<usize>>,
     descend_markers: BTreeMap<&'a str, Vec<usize>>,
     stop_schema_count: usize,
+    has_non_stop_schema: bool,
     retained: RetainedMatches,
 }
 
@@ -91,17 +92,21 @@ impl<'a> DiscoveryScan<'a> {
         let mut stop_markers = BTreeMap::<&str, Vec<usize>>::new();
         let mut descend_markers = BTreeMap::<&str, Vec<usize>>::new();
         for (index, schema) in schemas.iter().enumerate() {
-            let markers = if schema.on_match == "stop" {
-                &mut stop_markers
-            } else {
+            let markers = if schema.on_match == "descend" {
                 &mut descend_markers
+            } else {
+                &mut stop_markers
             };
             markers
                 .entry(schema.markers[0].as_str())
                 .or_default()
                 .push(index);
         }
-        let stop_schema_count = stop_markers.values().map(Vec::len).sum();
+        let stop_schema_count = schemas
+            .iter()
+            .filter(|schema| schema.on_match == "stop")
+            .count();
+        let has_non_stop_schema = schemas.iter().any(|schema| schema.on_match != "stop");
         Ok(Self {
             root,
             schemas,
@@ -109,6 +114,7 @@ impl<'a> DiscoveryScan<'a> {
             stop_markers,
             descend_markers,
             stop_schema_count,
+            has_non_stop_schema,
             retained: RetainedMatches::new(root, schemas.len(), retained_match_limit)?,
         })
     }
@@ -142,9 +148,10 @@ impl<'a> DiscoveryScan<'a> {
         let package = entry.path();
         let marker_depth = entry.depth().saturating_add(1);
         let mut package_name = None;
-        if self
-            .retained
-            .all_stop_schemas_rooted(self.stop_schema_count)
+        if !self.has_non_stop_schema
+            && self
+                .retained
+                .all_stop_schemas_rooted(self.stop_schema_count)
         {
             return Ok(());
         }

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -16240,6 +16240,6 @@ result = repr([
     let out = eval_prelude_source_to_repr(source).unwrap();
     assert_eq!(
         out,
-        r#"[["App"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["app/Source/Core/Feature.swift"], {"app/Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["app/App.swift"], "dev.once.App", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
+        r#"[["App"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["Source/Core/Feature.swift"], {"Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["App.swift"], "dev.once.App", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
     );
 }

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -94,6 +94,14 @@ fn apple_prelude_source() -> String {
     )
 }
 
+fn archive_prelude_source() -> String {
+    format!(
+        "{}\n{}",
+        include_str!("../prelude/common.star"),
+        include_str!("../prelude/archive.star")
+    )
+}
+
 fn android_prelude_source() -> String {
     format!(
         "{}\n{}",
@@ -14331,6 +14339,77 @@ result = repr(graph["products"]["FixtureShared\x1fShared"])
 }
 
 #[test]
+fn prelude_xcode_lowers_binary_package_artifacts_to_cached_dependencies() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+infos = [{{
+    "identity": "UrlPredictor",
+    "path": "Packages/UrlPredictor",
+    "info": {{
+        "products": [{{"name": "URLPredictorRust", "targets": ["URLPredictorRust"]}}],
+        "targets": [{{
+            "name": "URLPredictorRust",
+            "type": "binary",
+            "url": "https://downloads.example.test/URLPredictorRust.zip",
+            "checksum": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        }}],
+    }},
+}}]
+ctx = {{
+    "label": {{"package": "clients/ios", "id": "clients/ios/xcode"}},
+    "attr": {{"binary_artifact_authorization_env": "VENDOR_AUTHORIZATION"}},
+}}
+graph = _xcode_local_swift_package_specs(ctx, infos, "ios", "17.0", "simulator")
+result = repr([
+    graph["specs"][0]["kind"],
+    graph["specs"][0]["attrs"],
+    graph["specs"][1]["kind"],
+    graph["specs"][1]["deps"],
+    graph["specs"][1]["attrs"]["bundle"],
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["archive_download", {"url": "https://downloads.example.test/URLPredictorRust.zip", "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "authorization_env": "VENDOR_AUTHORIZATION"}, "apple_xcframework_import", ["./SwiftPackage_UrlPredictor_URLPredictorRust_Artifact"], ".once/out/clients/ios/SwiftPackage_UrlPredictor_URLPredictorRust_Artifact/archive/URLPredictorRust.xcframework"]"#
+    );
+}
+
+#[test]
+fn prelude_archive_download_omits_an_empty_authorization_env() {
+    let prelude = archive_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{
+    "label": {{"id": "downloads/Vendor"}},
+    "attr": {{
+        "url": "https://downloads.example.test/Vendor.zip",
+        "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    }},
+}}
+_archive_download_impl(ctx)
+result = repr("ok")
+"#
+    );
+    let workspace = TempDir::new().unwrap();
+    let store = store_for(workspace.path(), "downloads/Vendor");
+    let (store, result) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(result.unwrap(), r#""ok""#);
+    assert_eq!(store.actions.len(), 1);
+    assert_eq!(
+        store.actions[0].operation,
+        Some(DeclaredActionOperation::DownloadAndExtract {
+            url: "https://downloads.example.test/Vendor.zip".to_string(),
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            destination: ".once/out/downloads/Vendor/archive".to_string(),
+            authorization_env: None,
+        })
+    );
+}
+
+#[test]
 fn prelude_xcode_adds_package_identity_only_when_package_access_is_available() {
     let prelude = xcode_prelude_source();
     let source = format!(
@@ -14656,6 +14735,133 @@ result = repr(_collect_dep_compile_inputs(deps, "build")[5])
         eval_prelude_source_to_repr(source).unwrap(),
         r#"["out/spm/frameworks"]"#
     );
+}
+
+#[allow(clippy::too_many_lines)]
+#[test]
+fn prelude_apple_xcframework_import_exposes_static_clang_module_to_swift() {
+    let prelude = apple_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let package = workspace.path().join("App/Sources");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(
+        package.join("App.swift"),
+        "import URLPredictorRust\nfunc predictor() {}\n",
+    )
+    .unwrap();
+
+    let root = workspace.path().display().to_string();
+    let slice = "Vendor.xcframework/macos-arm64";
+    let archive = format!("{slice}/liburl_predictor.a");
+    let headers = format!("{slice}/Headers");
+    let modulemap = format!("{headers}/URLPredictorRust/module.modulemap");
+    let header = format!("{headers}/URLPredictorRust/ddg_url_predictor.h");
+    let available_libraries = serde_json::json!({
+        "AvailableLibraries": [{
+            "LibraryIdentifier": "macos-arm64",
+            "LibraryPath": "liburl_predictor.a",
+            "BinaryPath": "liburl_predictor.a",
+            "HeadersPath": "Headers",
+            "SupportedArchitectures": ["arm64"],
+            "SupportedPlatform": "macos",
+        }],
+    })
+    .to_string();
+    let slice_files = [
+        format!("{root}/{archive}"),
+        format!("{root}/{modulemap}"),
+        format!("{root}/{header}"),
+    ]
+    .join("\n");
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return {root:?}
+
+def host_arch():
+    return "arm64"
+
+def host_which(name):
+    return name
+
+def host_file_exists(path):
+    return path == workspace_root() + "/Vendor.xcframework/Info.plist"
+
+def host_file_read(path):
+    if path == workspace_root() + "/{modulemap}":
+        return "module URLPredictorRust {{\n  header \\\"ddg_url_predictor.h\\\"\n  export *\n}}\n"
+    fail("unexpected host_file_read: " + path)
+
+def host_command(argv, env = None, merge_stderr = None):
+    if argv[0] == "plutil":
+        return {available_libraries:?}
+    if argv[0] == "find":
+        return {slice_files:?}
+    if "--version" in argv:
+        return "Swift version 6.0\n"
+    fail("unexpected host_command: " + str(argv))
+
+import_ctx = {{
+    "label": {{"package": "", "name": "Vendor", "id": "Vendor"}},
+    "attr": {{
+        "bundle": "Vendor.xcframework",
+        "platform": "macos",
+        "sdk_variant": "simulator",
+        "arch": "arm64",
+    }},
+    "configuration": {{"tokens": []}},
+    "deps": [],
+    "srcs": [],
+    "build_dir": ".once/out/Vendor",
+    "capability": "build",
+}}
+dependency = _apple_xcframework_import_impl(import_ctx)
+ctx = {{
+    "label": {{"package": "App", "name": "App", "id": "App/App"}},
+    "attr": {{
+        "platform": "macos",
+        "module_name": "App",
+        "xcode_developer_dir": "/opt/Xcode/Developer",
+    }},
+    "configuration": {{"tokens": []}},
+    "deps": [dependency],
+    "srcs": ["Sources/**/*.swift"],
+    "build_dir": ".once/out/App/App",
+    "capability": "build",
+}}
+result = repr(_apple_library_impl(ctx))
+"#,
+    );
+    let store = store_for(workspace.path(), "App");
+    let (store, result) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    let provider = result.unwrap();
+    assert!(provider.contains(&archive), "{provider}");
+    let compiler = action_by_identifier(&store, "swift_module_compile_App");
+    assert!(
+        compiler
+            .argv
+            .windows(2)
+            .any(|args| { args == ["-Xcc".to_string(), format!("-fmodule-map-file={modulemap}")] }),
+        "Swift must receive the static XCFramework module map: {:?}",
+        compiler.argv
+    );
+    assert!(
+        compiler
+            .argv
+            .windows(2)
+            .any(|args| { args == ["-Xcc".to_string(), "-I".to_string()] })
+            && compiler.argv.contains(&headers),
+        "Swift must receive the static XCFramework headers: {:?}",
+        compiler.argv
+    );
+    for input in [&archive, &modulemap, &header] {
+        assert!(
+            compiler.inputs.contains(input),
+            "static XCFramework input `{input}` is missing from {:?}",
+            compiler.inputs
+        );
+    }
 }
 
 #[test]
@@ -15769,6 +15975,85 @@ result = repr(_xcode_parse_workspace_data({data:?}, ""))
 }
 
 #[test]
+fn prelude_xcode_uses_workspace_lockfile_for_a_nested_project() {
+    let prelude = xcode_prelude_source();
+    let unrelated = serde_json::json!({
+        "version": 3,
+        "pins": [{
+            "identity": "unrelated",
+            "kind": "remoteSourceControl",
+            "state": {"revision": "unrelated-revision"},
+        }],
+    })
+    .to_string();
+    let workspace = serde_json::json!({
+        "version": 1,
+        "object": {
+            "pins": [{
+                "package": "ProtonCore",
+                "repositoryURL": "https://example.invalid/protoncore.git",
+                "state": {"revision": "workspace-revision"},
+            }],
+        },
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+def host_which(name):
+    return name
+
+def host_command(argv, env = None, cwd = None, merge_stderr = None):
+    if argv[0] == "find":
+        return "/workspace/Other.xcworkspace/xcshareddata/swiftpm/Package.resolved\n/workspace/ProtonVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+    fail("unexpected host_command: " + str(argv))
+
+def host_file_exists(path):
+    return path.endswith("Other.xcworkspace/xcshareddata/swiftpm/Package.resolved") or path.endswith("ProtonVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved")
+
+def host_file_read(path):
+    if path.endswith("Other.xcworkspace/xcshareddata/swiftpm/Package.resolved"):
+        return {unrelated:?}
+    if path.endswith("ProtonVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved"):
+        return {workspace:?}
+    fail("unexpected host_file_read: " + path)
+
+refs = {{"PACKAGE": {{"identity": "protoncore"}}}}
+result = repr(_xcode_package_resolved_pins({{}}, "apps/ios/iOS.xcodeproj", "apps/ios/iOS.xcodeproj", refs))
+"#,
+    );
+
+    let result = eval_prelude_source_to_repr(source).unwrap();
+    assert!(result.contains("protoncore"), "{result}");
+    assert!(result.contains("workspace-revision"), "{result}");
+    assert!(!result.contains("unrelated-revision"), "{result}");
+}
+
+#[test]
+fn prelude_xcode_keeps_nested_project_paths_workspace_relative() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def glob(patterns):
+    return ["apps/ios/iOS.xcodeproj/project.pbxproj"]
+
+ctx = {{
+    "label": {{"package": "apps/ios", "id": "apps/ios/xcode"}},
+    "attr": {{}},
+}}
+result = repr(_xcode_project_path(ctx))
+"#,
+    );
+
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#""apps/ios/iOS.xcodeproj""#
+    );
+}
+
+#[test]
 #[allow(clippy::too_many_lines)]
 fn prelude_xcode_workspace_resolver_lowers_native_targets() {
     let prelude = xcode_prelude_source();
@@ -15955,6 +16240,6 @@ result = repr([
     let out = eval_prelude_source_to_repr(source).unwrap();
     assert_eq!(
         out,
-        r#"[["App"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["Source/Core/Feature.swift"], {"Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["App.swift"], "dev.once.App", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
+        r#"[["App"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["app/Source/Core/Feature.swift"], {"app/Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["app/App.swift"], "dev.once.App", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
     );
 }

--- a/web/lib/once_site_web/docs/sidebar.ex
+++ b/web/lib/once_site_web/docs/sidebar.ex
@@ -200,6 +200,7 @@ defmodule OnceSiteWeb.Docs.Sidebar do
                 apple_resource_bundle apple_thinned_package apple_test_bundle
                 apple_xcframework_import swift_package_workspace swift_package_dependencies swift_package_pin)
               ),
+              target_group("Core", ~w(archive_download)),
               target_group("Xcode", ~w(xcode_workspace)),
               target_group("Android", ~w(android_resource android_library android_local_test
                 android_instrumentation_test android_binary)),

--- a/web/priv/docs/reference/modules/index.md
+++ b/web/priv/docs/reference/modules/index.md
@@ -134,8 +134,9 @@ native = native_project(
   control directory is neither, and walking one to look for inputs is the
   largest avoidable cost of loading a large workspace.
 - `on_match = "stop"` keeps the shallowest matching root, which suits native
-  workspaces that own nested package manifests. `"descend"` also recognizes
-  nested projects.
+  workspaces that own nested package manifests. `"descend"` recognizes every
+  nested file marker. `"all"` recognizes every matching directory, including
+  directory-spanning markers such as `*.xcodeproj/project.pbxproj`.
 - `max_depth` bounds discovery.
 - `requires_tools` reports executables needed when the seed resolver runs.
 
@@ -599,6 +600,11 @@ separate update workflow.
   time. When requested, `sha256_output` records the
   [Secure Hash Algorithm 256-bit](https://csrc.nist.gov/pubs/fips/180-4/upd1/final)
   digest.
+- `download_and_extract(url, sha256, destination, authorization_env = None)`
+  streams a checksum-pinned [ZIP archive](https://www.loc.gov/preservation/digital/formats/fdd/fdd000354.shtml)
+  into a declared directory output. An optional environment-variable name
+  provides a web Authorization header only while the action executes, so its
+  value is excluded from action declarations, cache keys, logs, and evidence.
 - `toml_decode(src)` and `json_decode(src)` decode data into Starlark
   values.
 

--- a/web/priv/docs/reference/prelude/apple_xcframework_import.md
+++ b/web/priv/docs/reference/prelude/apple_xcframework_import.md
@@ -5,13 +5,16 @@ Prebuilt XCFramework import.
 ## Description
 
 Selects one platform and architecture slice from a prebuilt `.xcframework` and
-exposes it to Apple consumers as a framework dependency. The bundle's
+exposes it to Apple consumers as a framework or static-library dependency. The bundle's
 `Info.plist` is read to find the slice whose supported platform, platform
 variant, and architecture match the requested ones. The selected framework's
 linkage is detected from its binary, so a static slice is linked into the
 consumer while a dynamic slice is linked and embedded.
 
-The bundle is consumed where it sits. Nothing is recompiled.
+The bundle is consumed where it sits. Nothing is recompiled. A static-library
+slice exports its headers and module map to downstream compilation, then links
+its archive into the final consumer. The module name defaults to the selected
+framework name, or to the static-library module map when one is present.
 
 ## Attributes
 
@@ -31,6 +34,10 @@ platform select.
 The target emits `apple_linkable`, `apple_framework`, and `apple_bundle`, so
 applications, frameworks, libraries, and test bundles can depend on it through
 ordinary `deps` entries.
+
+The optional `deps` edge accepts one `artifact` provider. It lets a generated
+`archive_download` dependency materialize a remote bundle before this target is
+analysed.
 
 ## Capabilities
 

--- a/web/priv/docs/reference/prelude/archive_download.md
+++ b/web/priv/docs/reference/prelude/archive_download.md
@@ -1,0 +1,49 @@
+# `archive_download`
+
+Checksum-pinned archive download.
+
+## Description
+
+Downloads a [ZIP archive](https://www.loc.gov/preservation/digital/formats/fdd/fdd000354.shtml),
+checks its [Secure Hash Algorithm 256-bit](https://csrc.nist.gov/pubs/fips/180-4/upd1/final)
+digest, and materializes its contents as a cacheable directory. The source URL
+and checksum identify the action, so a cache hit restores the extracted
+directory without another download.
+
+Use `authorization_env` only when the archive server requires authentication.
+It names an environment variable that provides a web Authorization header
+while the action runs. Its value is never stored in the graph, action cache,
+logs, or build evidence.
+
+## Attributes
+
+| Attribute | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `url` | string | yes |  | Web archive URL |
+| `sha256` | string | yes |  | Expected 64-character Secure Hash Algorithm 256-bit digest |
+| `authorization_env` | string | no |  | Optional environment-variable name that supplies the web Authorization header while downloading |
+
+None of these attributes are configurable by platform select.
+
+## Providers and capabilities
+
+The target emits `artifact` and exposes `build` with `default` and `artifact`
+output groups. Consumers such as `apple_xcframework_import` can depend on the
+artifact so it is materialized before their analysis runs.
+
+## Limitations
+
+Only web-delivered ZIP archives are supported. The archive is verified before
+extraction and entries that escape the declared output directory are rejected.
+
+## Example
+
+```toml
+[[target]]
+name = "VendorArchive"
+kind = "archive_download"
+
+[target.attrs]
+url = "https://example.com/Vendor.zip"
+sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+```

--- a/web/priv/docs/reference/prelude/index.md
+++ b/web/priv/docs/reference/prelude/index.md
@@ -58,6 +58,11 @@ required analyzer is not built in.
 - [`apple_xcframework_import`](/reference/prelude/apple_xcframework_import):
   one platform and architecture slice of a prebuilt XCFramework
 
+## Core target kinds
+
+- [`archive_download`](/reference/prelude/archive_download): checksum-pinned
+  compressed archive materialized as a cacheable directory
+
 ## Xcode target kinds
 
 - [`xcode_workspace`](/reference/prelude/xcode_workspace): existing Xcode

--- a/web/priv/docs/reference/prelude/xcode_workspace.md
+++ b/web/priv/docs/reference/prelude/xcode_workspace.md
@@ -22,10 +22,14 @@ workspace references and merges their targets into one graph, so dependencies
 that cross a project boundary are wired. A referenced project that is not on
 disk is skipped instead of failing the graph.
 
-A project checked in beside the workspace root is also a recognized native
-project named `xcode`, so its seed is supplied without any `once.toml`. Use
-`once native init xcode` to persist the seed, or declare the
-target explicitly when the project lives in a subdirectory.
+Xcode projects, including projects in nested packages, are recognized as
+native projects named `xcode`, so their seeds are supplied without any
+`once.toml`. Use `once native init xcode` to persist a selected seed.
+
+When an Xcode project uses a workspace-level `Package.resolved`, Once uses its
+matching pinned revisions while lowering remote Swift packages. Checksum-pinned
+binary package archives download as normal cacheable dependencies instead of
+being fetched while the graph loads.
 
 See [Xcode Projects](/guide/graph/apple/xcode) for a walkthrough.
 
@@ -37,6 +41,7 @@ See [Xcode Projects](/guide/graph/apple/xcode) for a walkthrough.
 | `configuration` | string | no | `Debug` | Xcode build configuration whose settings drive target lowering |
 | `sdk_variant` | string | no | `simulator` | `simulator` or `device` selection applied to lowered targets on non-macOS platforms |
 | `xcode_developer_dir` | string | no | active Xcode | `DEVELOPER_DIR` override folded into lowered targets' cache keys |
+| `binary_artifact_authorization_env` | string | no |  | Environment-variable name that supplies a web Authorization header while downloading private binary package archives. Its value is not recorded. |
 | `resolver_inputs` | list&lt;string&gt; | no | `[]` | Package-relative text globs supplied to resolution. Defaults to `srcs` when empty |
 
 None of these attributes are configurable by platform select.
@@ -58,6 +63,7 @@ None of these attributes are configurable by platform select.
 | Unit test and interface test bundle | [`apple_test_bundle`](/reference/prelude/apple_test_bundle) |
 | Bundle | [`apple_resource_bundle`](/reference/prelude/apple_resource_bundle) |
 | Referenced `.xcframework` | [`apple_xcframework_import`](/reference/prelude/apple_xcframework_import) |
+| Remote binary Swift package target | [`archive_download`](/reference/prelude/archive_download), then [`apple_xcframework_import`](/reference/prelude/apple_xcframework_import) |
 
 ## Providers
 


### PR DESCRIPTION
## What changed

- Added a checksum-verified archive download target and cacheable download-and-extract action.
- Lowered binary Swift package artifacts into archive targets that feed Apple framework imports.
- Added support for static XCFramework slices, including headers and module maps.
- Discovered nested Xcode projects and workspace-level Swift Package Manager lockfiles.
- Added regression coverage, a starter example, and public reference documentation.

## Why

DuckDuckGo uses a static Rust-backed framework archive. Proton uses nested Xcode projects and a workspace-level package lockfile. Both shapes need to resolve through Once without downloading binary artifacts outside the cache.

## Root cause

Binary package artifacts were fetched as a resolver side effect, bypassing Once caching. Static archive metadata was not propagated to Swift consumers, and discovery only searched shallow Xcode project layouts.

## Approach

The new archive action streams a web download, verifies its Secure Hash Algorithm 256-bit digest, rejects unsafe archive entries, and captures its extracted output in the normal action cache. Optional credentials are read only from a named environment variable at execution time.

## Impact

Binary package artifacts now restore from cache, and nested Xcode workspaces can resolve their pinned dependencies. Remote source package cloning remains an analysis-time operation and still requires normal repository access on a cold checkout.

## Validation

- mise exec -- cargo test -p once-frontend --lib
- mise exec -- cargo test -p once-frontend --test prelude --quiet
- mise exec -- cargo test -p once-core --quiet
- mise exec -- cargo test -p once-cli --quiet
- mise exec -- cargo clippy --workspace --all-targets -- -D warnings
- mise exec -- cargo fmt --all -- --check
- git diff --check
- DuckDuckGo artifact build: initial cache miss, repeat cache hit, and dependent package build succeeded.
- DuckDuckGo and Proton application test suites require vendor signing credentials and private dependencies in this environment, so they did not execute.
