### PR TITLE
perf: adopt usage argument parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "blake3",
- "clap",
  "console",
  "glob",
  "libc",
@@ -3470,6 +3469,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-cypher",
+ "usage-rs",
  "uuid",
  "walkdir",
 ]
@@ -5446,6 +5446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6092,6 +6103,33 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usage-argv"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7536697d46ee1e7f421a88037686f6d69c6c0ac1dc5e44187e6e14f32d863b13"
+
+[[package]]
+name = "usage-derive"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d80310f6cef47a9240450460400097657813665d8799fb6790c71a5d7d9138aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "usage-rs"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a4449942edc8f1c0bb42b8fe102b3f9a63f0d0555d4564a3a1ef6ce1149e2d"
+dependencies = [
+ "usage-argv",
+ "usage-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1"
 bazel-remote-apis = "0.27"
 base64 = "0.22"
 blake3 = "1"
-clap = { version = "4", features = ["derive"] }
+usage = { package = "usage-rs", version = "6.4.1" }
 console = "0.16"
 fd-lock = "4"
 futures = "0.3"

--- a/crates/once-cas/src/digest.rs
+++ b/crates/once-cas/src/digest.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::io::{self, Read};
+use std::str::FromStr;
 
 use serde::de::{self, Deserializer, Visitor};
 use serde::{Deserialize, Serialize, Serializer};
@@ -70,6 +71,14 @@ impl Digest {
         let mut out = [0u8; Self::LEN];
         hex::decode_to_slice(s, &mut out).ok()?;
         Some(Self(out))
+    }
+}
+
+impl FromStr for Digest {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(raw).ok_or_else(|| "expected a 64-character lowercase BLAKE3 digest".into())
     }
 }
 

--- a/crates/once-cli/Cargo.toml
+++ b/crates/once-cli/Cargo.toml
@@ -17,7 +17,7 @@ once-frontend.workspace = true
 
 anyhow.workspace = true
 blake3.workspace = true
-clap.workspace = true
+usage.workspace = true
 console.workspace = true
 glob.workspace = true
 notify.workspace = true

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -1,9 +1,9 @@
-//! CLI argument parsing - the `clap` types and the small helpers they use.
+//! Command-line argument parsing and its small helper types.
 
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::str::FromStr;
 
-use clap::{Parser, Subcommand, ValueEnum};
 use once_core::{LintSeverity, NetworkPolicy, SandboxMode, WorkspacePath};
 
 mod auth;
@@ -15,6 +15,7 @@ mod runtime;
 mod toolchain;
 
 pub use auth::AuthCmd;
+pub(crate) use cache::OutputDigest;
 pub use cache::{CacheActionCmd, CacheBlobCmd, CacheCmd};
 pub use edit::EditCmd;
 pub use native::NativeCmd;
@@ -31,7 +32,7 @@ pub const CACHE_DIR: &str = ".once";
 /// (`cache stats`, `run`, `exec` trailers). `human` is the
 /// readable default; `json` and `toon` let agents and scripts consume
 /// output without scraping prose.
-#[derive(Copy, Clone, Debug, ValueEnum, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, usage::ValueEnum, Default, PartialEq, Eq)]
 pub enum Format {
     #[default]
     Human,
@@ -76,51 +77,104 @@ pub const CLI_VERSION: &str = match option_env!("ONCE_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 
-#[derive(Parser)]
-#[command(
-    name = "once",
+/// Map a subprocess exit code to a command-line interface [`ExitCode`].
+///
+/// `Command::status().code()` returns `None` when the child was killed
+/// by a signal; we surface that as 255 (the lowest 8 bits of -1) which
+/// is what most build tools do. We do not attempt the shell convention
+/// of `128 + signo` since we don't have the signal number on stable
+/// Rust without `std::os::unix`-specific code, and pretending otherwise
+/// would be misleading.
+#[must_use]
+pub fn exit_from(code: i32) -> ExitCode {
+    let clamped = u8::try_from(code & 0xff).unwrap_or(1);
+    ExitCode::from(clamped)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryLimit(u64);
+
+impl MemoryLimit {
+    pub(crate) const fn bytes(self) -> u64 {
+        self.0
+    }
+}
+
+impl FromStr for MemoryLimit {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        parse_byte_size(raw).map(Self)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct EnvironmentAssignment(String, String);
+
+impl EnvironmentAssignment {
+    pub(crate) fn into_inner(self) -> (String, String) {
+        (self.0, self.1)
+    }
+}
+
+impl FromStr for EnvironmentAssignment {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        let (key, value) = raw
+            .split_once('=')
+            .ok_or_else(|| format!("expected KEY=VALUE, got `{raw}`"))?;
+        Ok(Self(key.to_string(), value.to_string()))
+    }
+}
+
+#[derive(usage::Cli)]
+#[usage(
+    bin = "once",
     version = CLI_VERSION,
     about = "Graph-aware, cacheable, remotely-executable repository automation",
-    arg_required_else_help = true
+    arg_required_else_help = true,
+    unknown_flags = "error",
+    args_override_self = false
 )]
 pub struct Cli {
     /// Project root. Defaults to the current directory; the cache
     /// lives under `<project>/.once/`. Mirrors `make -C`.
-    #[arg(short = 'C', long = "directory", global = true, value_name = "DIR")]
+    #[usage(short = 'C', long = "directory", global = true, value_name = "DIR")]
     pub directory: Option<PathBuf>,
 
     /// Output format for Once's structured data (`cache
     /// stats`, `run`/`exec` trailers). Defaults to a human-readable
     /// rendering; pass `json` or `toon` to get machine-parseable
     /// output for scripting and for agent consumers.
-    #[arg(long, global = true, value_enum, default_value_t = Format::Human)]
+    #[usage(long, global = true, value_enum, default = "human")]
     pub format: Format,
 
     /// Increase log verbosity. Repeat for more (-v: info, -vv: debug,
     /// -vvv: trace). Overridden by `RUST_LOG`.
-    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
+    #[usage(short, long, count, global = true)]
     pub verbose: u8,
 
     /// Suppress human-mode success and progress trailers. Errors and the structured
     /// envelope of `--format json`/`toon` still print. Mirrors the
     /// `-q` flag of common build tools.
-    #[arg(short = 'q', long, global = true)]
+    #[usage(short = 'q', long, global = true)]
     pub quiet: bool,
 
     /// Print the command surface at the current command depth.
-    #[arg(long, global = true)]
+    #[usage(long, global = true)]
     pub list: bool,
 
     /// Maximum memory scheduling budget for local actions.
     /// Defaults to two thirds of the memory visible to the host or container.
-    #[arg(long, global = true, value_name = "SIZE", value_parser = parse_byte_size)]
-    pub memory_limit: Option<u64>,
+    #[usage(long, global = true, value_name = "SIZE")]
+    pub(crate) memory_limit: Option<MemoryLimit>,
 
-    #[command(subcommand)]
+    #[usage(subcommand)]
     pub command: Option<Cmd>,
 }
 
-#[derive(Subcommand)]
+#[derive(usage::Subcommands)]
 pub enum Cmd {
     /// Build a declared target.
     ///
@@ -131,10 +185,9 @@ pub enum Cmd {
     /// else runs and lands its declared outputs in
     /// `<workspace>/.once/out/<target>/`. Use `once query targets` to
     /// list available ids.
-    #[command(arg_required_else_help = true)]
     Build {
         /// Local filesystem sandbox policy for command actions.
-        #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
+        #[usage(long, default = "off")]
         sandbox: SandboxMode,
 
         /// Override the workspace build configuration. Recognized keys are
@@ -142,11 +195,10 @@ pub enum Cmd {
         /// Targets configured with `select` resolve against the merged
         /// configuration, and their outputs are scoped so different values
         /// never collide.
-        #[arg(long, value_name = "KEY=VALUE")]
+        #[usage(long, value_name = "KEY=VALUE")]
         config: Vec<String>,
 
         /// Target id, such as `services/api/Api` or `./Api`.
-        #[arg(required_unless_present = "list")]
         target: Option<String>,
     },
 
@@ -154,22 +206,20 @@ pub enum Cmd {
     ///
     /// Executes the target's `lint` capability, normalizes its report,
     /// and returns a failing status when a finding meets `--fail-on`.
-    #[command(arg_required_else_help = true)]
     Lint {
         /// Local filesystem sandbox policy for command actions.
-        #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
+        #[usage(long, default = "off")]
         sandbox: SandboxMode,
 
         /// Override the workspace build configuration. See `once build --config`.
-        #[arg(long, value_name = "KEY=VALUE")]
+        #[usage(long, value_name = "KEY=VALUE")]
         config: Vec<String>,
 
         /// Lowest finding severity that makes this command fail.
-        #[arg(long, value_parser = parse_lint_severity, default_value = "warning")]
+        #[usage(long, default = "warning")]
         fail_on: LintSeverity,
 
         /// Target id, such as `quality/python` or `./python`.
-        #[arg(required_unless_present = "list")]
         target: Option<String>,
     },
 
@@ -178,43 +228,41 @@ pub enum Cmd {
     /// Resolves the target id against the workspace graph and executes
     /// its `run` capability through the action cache. Use `--remote`
     /// to ask a compute provider to execute the command.
-    #[command(arg_required_else_help = true)]
     Run {
         /// Local filesystem sandbox policy for command actions.
-        #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
+        #[usage(long, default = "off")]
         sandbox: SandboxMode,
 
         /// Override the workspace build configuration. See `once build --config`.
-        #[arg(long, value_name = "KEY=VALUE")]
+        #[usage(long, value_name = "KEY=VALUE")]
         config: Vec<String>,
 
         /// Ask graph target kinds to open a visible runtime interface when supported.
-        #[arg(long)]
+        #[usage(long)]
         visible: bool,
 
         /// Serve a local JSON-RPC runtime control socket for this run.
-        #[arg(long)]
+        #[usage(long)]
         runtime_rpc: bool,
 
         /// Runtime RPC socket path. Defaults to
         /// `.once/runtime/<session>/control.sock`.
-        #[arg(long)]
+        #[usage(long)]
         runtime_rpc_socket: Option<PathBuf>,
 
         /// Run the target's action on a compute provider.
-        #[arg(long)]
+        #[usage(long)]
         remote: bool,
 
         /// Compute provider used with --remote. Defaults to the configured execution provider.
-        #[arg(long, value_name = "PROVIDER")]
+        #[usage(long, value_name = "PROVIDER")]
         compute: Option<String>,
 
         /// Target id, e.g. `examples/hello/hello` or `./hello`.
-        #[arg(required_unless_present = "list")]
         target: Option<String>,
 
         /// Target-kind-specific arguments supplied to the generic run capability.
-        #[arg(last = true, value_name = "ARG")]
+        #[usage(double_dash = "required", value_name = "ARG")]
         arguments: Vec<String>,
     },
 
@@ -226,60 +274,52 @@ pub enum Cmd {
     /// With `--changed-path` or `--all`, stable target batches are pulled
     /// from a duration-informed dynamic queue. `--jobs` caps local workers
     /// without changing the plan or batch identities.
-    #[command(arg_required_else_help = true)]
     Test {
         /// Local filesystem sandbox policy for command actions.
-        #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
+        #[usage(long, default = "off")]
         sandbox: SandboxMode,
 
         /// Override the workspace build configuration. See `once build --config`.
-        #[arg(long, value_name = "KEY=VALUE")]
+        #[usage(long, value_name = "KEY=VALUE")]
         config: Vec<String>,
 
         /// Maximum number of test batches to execute concurrently.
         /// Defaults to the host's available parallelism for an affected plan.
-        #[arg(short = 'j', long, value_name = "COUNT")]
+        #[usage(short = 'j', long, value_name = "COUNT")]
         jobs: Option<usize>,
 
         /// Run every discovered test target through the dynamic scheduler.
-        #[arg(long, conflicts_with_all = ["target", "changed_paths", "test_unit"])]
+        #[usage(long, conflicts("target", "changed_paths", "test_unit"))]
         all: bool,
 
         /// Select tests affected by a workspace-relative changed path.
         /// Repeat for multiple paths. Cannot be combined with a target id.
-        #[arg(
-            long = "changed-path",
-            value_name = "PATH",
-            action = clap::ArgAction::Append,
-            conflicts_with = "target"
-        )]
+        #[usage(long = "changed-path", value_name = "PATH", conflicts = "target")]
         changed_paths: Vec<String>,
 
         /// Run one current, filterable unit from `once query test-manifest`.
         /// The request is rejected before scheduling when the target does not
         /// support exact filtering or the unit is absent from the manifest.
-        #[arg(
+        #[usage(
             long = "test-unit",
             value_name = "UNIT",
             requires = "target",
-            conflicts_with_all = ["changed_paths", "all", "batch_test_units"]
+            conflicts("changed_paths", "all", "batch_test_units")
         )]
         test_unit: Option<String>,
 
-        #[arg(
+        #[usage(
             long = "batch-test-unit",
             hide = true,
             requires = "target",
-            conflicts_with = "test_unit",
-            action = clap::ArgAction::Append
+            conflicts = "test_unit"
         )]
         batch_test_units: Vec<String>,
 
-        #[arg(long, hide = true, requires = "batch_test_units")]
+        #[usage(long, hide = true, requires = "batch_test_units")]
         test_batch_id: Option<String>,
 
         /// Target id, such as `tests/unit` or `./unit`.
-        #[arg(required_unless_present_any = ["list", "changed_paths", "all"])]
         target: Option<String>,
     },
 
@@ -292,10 +332,9 @@ pub enum Cmd {
     /// stderr, and exit code. With `--script`, or when argv looks like
     /// `<runtime> <script> [args...]` and the file has `once`
     /// headers, Once applies script-aware parsing instead.
-    #[command(arg_required_else_help = true)]
     Exec {
         /// Local filesystem sandbox policy for the command action.
-        #[arg(long, value_parser = parse_sandbox_mode, default_value = "off")]
+        #[usage(long, default = "off")]
         sandbox: SandboxMode,
 
         /// Interpret argv as `<runtime> <script> [args...]` and apply
@@ -303,27 +342,27 @@ pub enum Cmd {
         /// explicit form, for example `once exec --script bash
         /// scripts/build.sh`, and for directly executable scripts via
         /// a shebang such as `#!/usr/bin/env -S once exec -- bash`.
-        #[arg(long)]
+        #[usage(long)]
         script: bool,
 
         /// Pass an environment variable to the command. Repeatable.
-        #[arg(short = 'e', value_parser = parse_env)]
-        env: Vec<(String, String)>,
+        #[usage(short = 'e')]
+        env: Vec<EnvironmentAssignment>,
 
         /// Working directory, relative to the project root. Must not
         /// be absolute or escape the project.
-        #[arg(long, value_parser = parse_workspace_path)]
+        #[usage(long)]
         cwd: Option<WorkspacePath>,
 
         /// Per-action timeout in milliseconds. The child is killed if
         /// it exceeds the deadline.
-        #[arg(long, value_name = "MS")]
+        #[usage(long, value_name = "MS")]
         timeout_ms: Option<u64>,
 
         /// Cache non-zero exits the same way zero exits are cached.
         /// Off by default; transient failures shouldn't poison the
         /// cache.
-        #[arg(long)]
+        #[usage(long)]
         cache_failures: bool,
 
         /// Run the action twice while bypassing the cache and report whether
@@ -331,11 +370,11 @@ pub enum Cmd {
         /// normally. Exits non-zero when any divergence is found. Useful for
         /// catching nondeterministic tools and undeclared inputs that leak
         /// through the cache key.
-        #[arg(long)]
+        #[usage(long)]
         verify_reproducible: bool,
 
         /// Run the command on a compute provider.
-        #[arg(long)]
+        #[usage(long)]
         remote: bool,
 
         /// Whether the command may reach the network. Defaults to
@@ -343,15 +382,15 @@ pub enum Cmd {
         /// behavior). `deny` isolates the command from the network on Linux
         /// so an undeclared fetch fails loudly instead of leaking into the
         /// cache key.
-        #[arg(long, value_parser = parse_network_policy, default_value = "unrestricted")]
+        #[usage(long, default = "unrestricted")]
         network: NetworkPolicy,
 
         /// Compute provider used with --remote. Defaults to the configured execution provider.
-        #[arg(long, value_name = "PROVIDER")]
+        #[usage(long, value_name = "PROVIDER")]
         compute: Option<String>,
 
         /// Command and arguments. Use `--` to separate from once flags.
-        #[arg(trailing_var_arg = true, required_unless_present = "list")]
+        #[usage(trailing_var_arg = true)]
         argv: Vec<String>,
     },
 
@@ -364,9 +403,8 @@ pub enum Cmd {
     /// reproducibility checks, and external tooling. Useful for
     /// answering "did this run hit the cache?" without scraping
     /// command output.
-    #[command(arg_required_else_help = true)]
     Cache {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<CacheCmd>,
     },
 
@@ -378,9 +416,8 @@ pub enum Cmd {
     /// in the OS keychain; `auth logout` drops the stored token. The
     /// cache provider configuration itself lives in workspace
     /// `once.toml`.
-    #[command(arg_required_else_help = true)]
     Auth {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<AuthCmd>,
     },
 
@@ -391,9 +428,8 @@ pub enum Cmd {
     /// script adapters or graph target kinds. Pair with `once query schema`
     /// when debugging "why did the cache miss?" questions where the
     /// toolchain identity is suspect.
-    #[command(arg_required_else_help = true)]
     Toolchain {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<ToolchainCmd>,
     },
 
@@ -442,12 +478,12 @@ pub enum Cmd {
     /// String literals can be quoted with single or double quotes and
     /// support `\n`, `\r`, `\t`, `\\`, `\"`, and `\'` escapes. Other
     /// escape forms, including Unicode escapes, are rejected.
-    #[command(arg_required_else_help = true, verbatim_doc_comment)]
+    #[usage(verbatim_doc_comment)]
     Query {
         /// Read-only Cypher-like graph query expression.
-        #[arg(value_name = "QUERY")]
+        #[usage(value_name = "QUERY")]
         expression: Option<String>,
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<QueryCmd>,
     },
 
@@ -460,9 +496,8 @@ pub enum Cmd {
     /// observe or stop a run after the original command has returned.
     /// `runtime rpc` serves a JSON-RPC control socket for a session
     /// that already has runtime metadata.
-    #[command(arg_required_else_help = true)]
     Runtime {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<RuntimeCmd>,
     },
 
@@ -474,16 +509,14 @@ pub enum Cmd {
     /// structured diagnostics for failed edits. `edit
     /// materialize-example` copies a target kind starter without
     /// printing its file contents and refuses conflicting paths.
-    #[command(arg_required_else_help = true)]
     Edit {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<EditCmd>,
     },
 
     /// Discover, inspect, and initialize native workspace roots.
-    #[command(arg_required_else_help = true)]
     Native {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<NativeCmd>,
     },
 
@@ -499,11 +532,11 @@ pub enum Cmd {
         /// Workspace root the agent tools resolve targets against.
         /// Defaults to the value of the global `-C/--directory` flag
         /// (or the current directory).
-        #[arg(long, value_name = "DIR")]
+        #[usage(long, value_name = "DIR")]
         workspace: Option<PathBuf>,
 
         /// Advertise and allow state-changing editing and execution tools.
-        #[arg(long)]
+        #[usage(long)]
         allow_run: bool,
     },
 
@@ -511,15 +544,15 @@ pub enum Cmd {
     /// from `--help` because it is a documentation build hook, not a
     /// user-facing verb. Drives `docs/reference/cli/*.md` so the
     /// website's flag and synopsis sections never drift from the
-    /// real clap definitions.
-    #[command(hide = true, arg_required_else_help = true)]
+    /// real command declarations.
+    #[usage(hide = true)]
     Reference {
         /// Directory to emit per-subcommand markdown files into.
-        #[arg(long, value_name = "DIR")]
+        #[usage(long, value_name = "DIR")]
         out: PathBuf,
     },
 
-    #[command(name = "__change-tracker", hide = true)]
+    #[usage(name = "__change-tracker", hide = true)]
     ChangeTracker,
 }
 
@@ -528,6 +561,45 @@ impl Cli {
         self.command
             .as_ref()
             .map_or_else(Vec::new, Cmd::surface_path)
+    }
+
+    pub(crate) fn incomplete_command_help_path(&self) -> Option<&'static [&'static str]> {
+        if self.list {
+            return None;
+        }
+
+        match self.command.as_ref()? {
+            Cmd::Build { target: None, .. } => Some(&["build"]),
+            Cmd::Lint { target: None, .. } => Some(&["lint"]),
+            Cmd::Run { target: None, .. } => Some(&["run"]),
+            Cmd::Test {
+                target: None,
+                changed_paths,
+                all: false,
+                ..
+            } if changed_paths.is_empty() => Some(&["test"]),
+            Cmd::Exec { argv, .. } if argv.is_empty() => Some(&["exec"]),
+            Cmd::Cache { cmd: None } => Some(&["cache"]),
+            Cmd::Cache {
+                cmd: Some(CacheCmd::Blob { cmd: None }),
+            } => Some(&["cache", "blob"]),
+            Cmd::Cache {
+                cmd: Some(CacheCmd::Action { cmd: None }),
+            } => Some(&["cache", "action"]),
+            Cmd::Auth { cmd: None } => Some(&["auth"]),
+            Cmd::Toolchain { cmd: None } => Some(&["toolchain"]),
+            Cmd::Query {
+                expression: None,
+                cmd: None,
+            } => Some(&["query"]),
+            Cmd::Runtime { cmd: None } => Some(&["runtime"]),
+            Cmd::Runtime {
+                cmd: Some(RuntimeCmd::Start { target: None }),
+            } => Some(&["runtime", "start"]),
+            Cmd::Edit { cmd: None } => Some(&["edit"]),
+            Cmd::Native { cmd: None } => Some(&["native"]),
+            _ => None,
+        }
     }
 }
 
@@ -595,36 +667,6 @@ impl Cmd {
     }
 }
 
-fn parse_env(raw: &str) -> std::result::Result<(String, String), String> {
-    let (k, v) = raw
-        .split_once('=')
-        .ok_or_else(|| format!("expected KEY=VALUE, got `{raw}`"))?;
-    Ok((k.to_string(), v.to_string()))
-}
-
-fn parse_workspace_path(raw: &str) -> std::result::Result<WorkspacePath, String> {
-    WorkspacePath::try_from(raw).map_err(|e| e.to_string())
-}
-
-fn parse_sandbox_mode(raw: &str) -> std::result::Result<SandboxMode, String> {
-    raw.parse()
-}
-
-fn parse_network_policy(raw: &str) -> std::result::Result<NetworkPolicy, String> {
-    raw.parse()
-}
-
-fn parse_lint_severity(raw: &str) -> std::result::Result<LintSeverity, String> {
-    match raw {
-        "note" => Ok(LintSeverity::Note),
-        "warning" => Ok(LintSeverity::Warning),
-        "error" => Ok(LintSeverity::Error),
-        _ => Err(format!(
-            "expected `note`, `warning`, or `error`, got `{raw}`"
-        )),
-    }
-}
-
 fn parse_byte_size(raw: &str) -> std::result::Result<u64, String> {
     let value = raw.trim();
     let digit_count = value.bytes().take_while(u8::is_ascii_digit).count();
@@ -655,23 +697,16 @@ fn parse_byte_size(raw: &str) -> std::result::Result<u64, String> {
         .ok_or_else(|| format!("byte size `{raw}` is too large"))
 }
 
-/// Map a subprocess exit code to a CLI [`ExitCode`].
-///
-/// `Command::status().code()` returns `None` when the child was killed
-/// by a signal; we surface that as 255 (the lowest 8 bits of -1) which
-/// is what most build tools do. We do not attempt the shell convention
-/// of `128 + signo` since we don't have the signal number on stable
-/// Rust without `std::os::unix`-specific code, and pretending otherwise
-/// would be misleading.
-#[must_use]
-pub fn exit_from(code: i32) -> ExitCode {
-    let clamped = u8::try_from(code & 0xff).unwrap_or(1);
-    ExitCode::from(clamped)
-}
-
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+
     use super::*;
+
+    fn parse(argv: &[&str]) -> Cli {
+        let argv = argv.iter().map(OsStr::new).collect::<Vec<_>>();
+        Cli::try_parse_from(&argv).unwrap()
+    }
 
     #[test]
     fn output_show_human_trailers_only_when_human_and_not_quiet() {
@@ -686,21 +721,24 @@ mod tests {
 
     #[test]
     fn byte_sizes_accept_decimal_binary_and_raw_values() {
-        assert_eq!(parse_byte_size("1024").unwrap(), 1024);
-        assert_eq!(parse_byte_size("2MB").unwrap(), 2_000_000);
-        assert_eq!(parse_byte_size("2 MiB").unwrap(), 2 * 1024 * 1024);
+        assert_eq!(MemoryLimit::from_str("1024").unwrap().bytes(), 1024);
+        assert_eq!(MemoryLimit::from_str("2MB").unwrap().bytes(), 2_000_000);
+        assert_eq!(
+            MemoryLimit::from_str("2 MiB").unwrap().bytes(),
+            2 * 1024 * 1024
+        );
     }
 
     #[test]
     fn byte_sizes_reject_zero_unknown_suffixes_and_overflow() {
-        assert!(parse_byte_size("0").is_err());
-        assert!(parse_byte_size("1XB").is_err());
-        assert!(parse_byte_size("18446744073709551615TiB").is_err());
+        assert!(MemoryLimit::from_str("0").is_err());
+        assert!(MemoryLimit::from_str("1XB").is_err());
+        assert!(MemoryLimit::from_str("18446744073709551615TiB").is_err());
     }
 
     #[test]
     fn run_accepts_target_arguments_after_separator() {
-        let cli = Cli::try_parse_from([
+        let cli = parse(&[
             "once",
             "run",
             "server/application_dev",
@@ -708,8 +746,7 @@ mod tests {
             "phx.server",
             "--port",
             "4001",
-        ])
-        .unwrap();
+        ]);
 
         let Some(Cmd::Run {
             target, arguments, ..
@@ -719,5 +756,32 @@ mod tests {
         };
         assert_eq!(target.as_deref(), Some("server/application_dev"));
         assert_eq!(arguments, ["phx.server", "--port", "4001"]);
+    }
+
+    #[test]
+    fn rejects_unknown_options() {
+        let argv = ["once", "build", "target", "--unrecognized"].map(OsStr::new);
+
+        assert!(Cli::try_parse_from(&argv).is_err());
+    }
+
+    #[test]
+    fn identifies_commands_that_need_their_help_rendered() {
+        assert_eq!(
+            parse(&["once", "build"]).incomplete_command_help_path(),
+            Some(&["build"][..])
+        );
+        assert_eq!(
+            parse(&["once", "cache", "blob"]).incomplete_command_help_path(),
+            Some(&["cache", "blob"][..])
+        );
+        assert_eq!(
+            parse(&["once", "test", "--all"]).incomplete_command_help_path(),
+            None
+        );
+        assert_eq!(
+            parse(&["once", "run", "--list"]).incomplete_command_help_path(),
+            None
+        );
     }
 }

--- a/crates/once-cli/src/cli/auth.rs
+++ b/crates/once-cli/src/cli/auth.rs
@@ -1,22 +1,22 @@
-use clap::Subcommand;
+use usage::Subcommands;
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum AuthCmd {
     /// Sign in to a provider so Once can reuse its cache session.
     Login {
         /// Provider reference. Use `workspace` for the effective workspace provider.
-        #[arg(long)]
+        #[usage(long)]
         provider: String,
 
         /// Print the authorization URL instead of opening the browser automatically.
-        #[arg(long)]
+        #[usage(long)]
         no_browser: bool,
     },
 
     /// Remove the stored session for a provider.
     Logout {
         /// Provider reference. Use `workspace` for the effective workspace provider.
-        #[arg(long)]
+        #[usage(long)]
         provider: String,
     },
 }

--- a/crates/once-cli/src/cli/cache.rs
+++ b/crates/once-cli/src/cli/cache.rs
@@ -1,9 +1,50 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 
-use clap::{ArgGroup, Subcommand};
 use once_cas::Digest;
+use usage::Subcommands;
 
-#[derive(Subcommand)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CacheSize(u64);
+
+impl CacheSize {
+    pub(crate) const fn bytes(self) -> u64 {
+        self.0
+    }
+}
+
+impl FromStr for CacheSize {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        parse_size(raw).map(Self)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct OutputDigest(String, Digest);
+
+impl OutputDigest {
+    pub(crate) fn into_inner(self) -> (String, Digest) {
+        (self.0, self.1)
+    }
+}
+
+impl FromStr for OutputDigest {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        let (path, digest) = raw
+            .split_once('=')
+            .ok_or_else(|| "expected workspace/path=blob_digest".to_string())?;
+        if path.is_empty() {
+            return Err("output path must not be empty".into());
+        }
+        Ok(Self(path.to_string(), digest.parse()?))
+    }
+}
+
+#[derive(Subcommands)]
 pub enum CacheCmd {
     /// Print blob and action counts plus on-disk size.
     Stats,
@@ -20,30 +61,28 @@ pub enum CacheCmd {
         /// suffix: `500MB`, `2GiB`, `750k`. Decimal suffixes (KB/MB/GB/
         /// TB) are powers of 1000; binary suffixes (KiB/MiB/GiB/TiB) are
         /// powers of 1024.
-        #[arg(long = "max-size", value_name = "SIZE", value_parser = parse_size)]
-        max_size: u64,
+        #[usage(long = "max-size", value_name = "SIZE")]
+        max_size: CacheSize,
 
         /// Report what would be reclaimed without deleting anything.
-        #[arg(long)]
+        #[usage(long)]
         dry_run: bool,
     },
 
     /// Read and write content-addressed blobs.
-    #[command(arg_required_else_help = true)]
     Blob {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<CacheBlobCmd>,
     },
 
     /// Read and write cached action results.
-    #[command(arg_required_else_help = true)]
     Action {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         cmd: Option<CacheActionCmd>,
     },
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum CacheBlobCmd {
     /// Store bytes from a file or stdin and print their BLAKE3 digest.
     Put {
@@ -54,11 +93,10 @@ pub enum CacheBlobCmd {
     /// Fetch blob bytes by content digest.
     Get {
         /// Blob digest to fetch.
-        #[arg(value_parser = parse_digest)]
         digest: Digest,
 
         /// File to write. Defaults to stdout; use `-` for stdout.
-        #[arg(short, long)]
+        #[usage(short, long)]
         output: Option<PathBuf>,
     },
 
@@ -67,38 +105,31 @@ pub enum CacheBlobCmd {
     /// the structured output.
     Exists {
         /// Blob digest to probe.
-        #[arg(value_parser = parse_digest)]
         digest: Digest,
     },
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum CacheActionCmd {
     /// Fetch an action result.
     ///
     /// Identify the action either by passing its digest directly, or
     /// by declaring its inputs with `--input`; the same declaration
     /// must be used on `put` to write under the same key.
-    #[command(group(
-        ArgGroup::new("action_key")
-            .required(true)
-            .args(["action", "inputs"])
-            .multiple(false)
-    ))]
     Get {
         /// Pre-computed action digest.
-        #[arg(value_parser = parse_digest)]
+        #[usage(conflicts = "inputs")]
         action: Option<Digest>,
 
         /// Input spec (see `cache hash` for the grammar). Repeatable;
         /// inputs are hashed in order and combined into the action
         /// digest.
-        #[arg(long = "input", value_name = "SPEC")]
+        #[usage(long = "input", value_name = "SPEC", conflicts = "action")]
         inputs: Vec<String>,
 
         /// Exit 0 only when there is a hit AND the recorded exit code
         /// is 0. On miss or on a cached failure, exit non-zero.
-        #[arg(long)]
+        #[usage(long)]
         if_success: bool,
     },
 
@@ -107,43 +138,36 @@ pub enum CacheActionCmd {
     /// Identify the action either by passing its digest directly, or
     /// by declaring its inputs with `--input`; the same declaration
     /// can be used on `get` to read back the result.
-    #[command(group(
-        ArgGroup::new("action_key")
-            .required(true)
-            .args(["action", "inputs"])
-            .multiple(false)
-    ))]
     Put {
         /// Pre-computed action digest.
-        #[arg(value_parser = parse_digest)]
+        #[usage(conflicts = "inputs")]
         action: Option<Digest>,
 
         /// Input spec (see `cache hash` for the grammar). Repeatable.
-        #[arg(long = "input", value_name = "SPEC")]
+        #[usage(long = "input", value_name = "SPEC", conflicts = "action")]
         inputs: Vec<String>,
 
         /// Process exit code captured for the action. Defaults to 0
         /// since the common case is recording a success.
-        #[arg(long, default_value_t = 0)]
+        #[usage(long, default = "0")]
         exit_code: i32,
 
         /// Optional blob digest containing captured stdout.
-        #[arg(long, value_parser = parse_digest)]
+        #[usage(long)]
         stdout: Option<Digest>,
 
         /// Optional blob digest containing captured stderr.
-        #[arg(long, value_parser = parse_digest)]
+        #[usage(long)]
         stderr: Option<Digest>,
 
         /// Declared output as `workspace/path=blob_digest`. Repeatable.
-        #[arg(long = "output", value_parser = parse_output_digest)]
-        outputs: Vec<(String, Digest)>,
+        #[usage(long = "output")]
+        outputs: Vec<OutputDigest>,
     },
 
     /// Delete one cached action result.
     Forget {
         /// Action digest to remove.
-        #[arg(value_parser = parse_digest)]
         action: Digest,
     },
 }
@@ -191,10 +215,6 @@ impl CacheActionCmd {
     }
 }
 
-fn parse_digest(raw: &str) -> std::result::Result<Digest, String> {
-    Digest::from_hex(raw).ok_or_else(|| "expected a 64-character lowercase BLAKE3 digest".into())
-}
-
 /// Parse a byte size with an optional decimal (KB/MB/GB/TB, powers of
 /// 1000) or binary (KiB/MiB/GiB/TiB, powers of 1024) suffix. A bare
 /// number, or a `B` suffix, is bytes. Case-insensitive; surrounding
@@ -231,56 +251,66 @@ fn parse_size(raw: &str) -> std::result::Result<u64, String> {
         .ok_or_else(|| format!("`{raw}` overflows a 64-bit byte count"))
 }
 
-fn parse_output_digest(raw: &str) -> std::result::Result<(String, Digest), String> {
-    let (path, digest) = raw
-        .split_once('=')
-        .ok_or_else(|| "expected workspace/path=blob_digest".to_string())?;
-    if path.is_empty() {
-        return Err("output path must not be empty".into());
-    }
-    Ok((path.to_string(), parse_digest(digest)?))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::parse_size;
+    use std::str::FromStr;
+
+    use super::CacheSize;
 
     #[test]
     fn parses_bare_bytes_and_b_suffix() {
-        assert_eq!(parse_size("0").unwrap(), 0);
-        assert_eq!(parse_size("1024").unwrap(), 1024);
-        assert_eq!(parse_size("512B").unwrap(), 512);
+        assert_eq!(CacheSize::from_str("0").unwrap().bytes(), 0);
+        assert_eq!(CacheSize::from_str("1024").unwrap().bytes(), 1024);
+        assert_eq!(CacheSize::from_str("512B").unwrap().bytes(), 512);
     }
 
     #[test]
     fn parses_decimal_and_binary_suffixes() {
-        assert_eq!(parse_size("500MB").unwrap(), 500_000_000);
-        assert_eq!(parse_size("2GiB").unwrap(), 2 * 1024 * 1024 * 1024);
-        assert_eq!(parse_size("1TB").unwrap(), 1_000_000_000_000);
+        assert_eq!(CacheSize::from_str("500MB").unwrap().bytes(), 500_000_000);
+        assert_eq!(
+            CacheSize::from_str("2GiB").unwrap().bytes(),
+            2 * 1024 * 1024 * 1024
+        );
+        assert_eq!(
+            CacheSize::from_str("1TB").unwrap().bytes(),
+            1_000_000_000_000
+        );
     }
 
     #[test]
     fn is_case_insensitive_and_allows_a_space_before_the_unit() {
-        assert_eq!(parse_size("750 mib").unwrap(), 750 * 1024 * 1024);
-        assert_eq!(parse_size("  4gb ").unwrap(), 4_000_000_000);
+        assert_eq!(
+            CacheSize::from_str("750 mib").unwrap().bytes(),
+            750 * 1024 * 1024
+        );
+        assert_eq!(
+            CacheSize::from_str("  4gb ").unwrap().bytes(),
+            4_000_000_000
+        );
     }
 
     #[test]
     fn short_binary_aliases_match_their_long_forms() {
-        assert_eq!(parse_size("3g").unwrap(), parse_size("3GiB").unwrap());
-        assert_eq!(parse_size("8k").unwrap(), parse_size("8KiB").unwrap());
+        assert_eq!(
+            CacheSize::from_str("3g").unwrap().bytes(),
+            CacheSize::from_str("3GiB").unwrap().bytes()
+        );
+        assert_eq!(
+            CacheSize::from_str("8k").unwrap().bytes(),
+            CacheSize::from_str("8KiB").unwrap().bytes()
+        );
     }
 
     #[test]
     fn rejects_garbage_and_unknown_units() {
-        assert!(parse_size("").is_err());
-        assert!(parse_size("MB").is_err());
-        assert!(parse_size("12ZB").is_err());
-        assert!(parse_size("abc").is_err());
+        assert!(CacheSize::from_str("").is_err());
+        assert!(CacheSize::from_str("MB").is_err());
+        assert!(CacheSize::from_str("12ZB").is_err());
+        assert!(CacheSize::from_str("abc").is_err());
     }
 
     #[test]
     fn rejects_overflow() {
-        assert!(parse_size("99999999999999999999TiB").is_err());
+        assert!(CacheSize::from_str("99999999999999999999TiB").is_err());
     }
 }

--- a/crates/once-cli/src/cli/edit.rs
+++ b/crates/once-cli/src/cli/edit.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use clap::Subcommand;
+use usage::Subcommands;
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum EditCmd {
     /// Apply a batch of operations to one `once.toml` atomically.
     ///
@@ -13,7 +13,7 @@ pub enum EditCmd {
     /// untouched.
     Apply {
         /// Path to a JSON file. When omitted, the JSON document is read from stdin.
-        #[arg(long, value_name = "PATH")]
+        #[usage(long, value_name = "PATH")]
         file: Option<PathBuf>,
     },
 
@@ -28,7 +28,7 @@ pub enum EditCmd {
         /// Example slug from `once query schema`.
         slug: String,
         /// Workspace-relative directory that receives the example.
-        #[arg(long, default_value = "", value_name = "DIR")]
+        #[usage(long, default = "", value_name = "DIR")]
         destination: String,
     },
 }

--- a/crates/once-cli/src/cli/native.rs
+++ b/crates/once-cli/src/cli/native.rs
@@ -1,6 +1,6 @@
-use clap::Subcommand;
+use usage::Subcommands;
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum NativeCmd {
     /// List recognized native roots and their current matches.
     List,
@@ -10,7 +10,7 @@ pub enum NativeCmd {
         /// Native integration name from `once native list`.
         name: String,
         /// Workspace-relative path of the matched root.
-        #[arg(long, value_name = "PATH")]
+        #[usage(long, value_name = "PATH")]
         path: Option<String>,
     },
 
@@ -19,7 +19,7 @@ pub enum NativeCmd {
         /// Native integration name from `once native list`.
         name: String,
         /// Workspace-relative path of the matched root.
-        #[arg(long, value_name = "PATH")]
+        #[usage(long, value_name = "PATH")]
         path: Option<String>,
     },
 }

--- a/crates/once-cli/src/cli/query.rs
+++ b/crates/once-cli/src/cli/query.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use clap::Subcommand;
+use usage::Subcommands;
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum QueryCmd {
     /// Describe the configured workspace and graph loading state.
     ///
@@ -15,7 +15,7 @@ pub enum QueryCmd {
     /// List declared graph targets.
     Targets {
         /// Only include targets with this target kind.
-        #[arg(long)]
+        #[usage(long)]
         kind: Option<String>,
     },
 
@@ -40,13 +40,13 @@ pub enum QueryCmd {
     },
 
     /// List target kinds with their one-line docs and example slugs.
-    #[command(alias = "rules")]
+    #[usage(alias = "rules")]
     TargetKinds {
         /// Match an ecosystem, target-kind family, or intent against the catalog.
         ///
         /// A family term takes priority over generic intent words. When no family
         /// or kind segment matches, Once searches docs, examples, and source references.
-        #[arg(long, value_name = "TEXT")]
+        #[usage(long, value_name = "TEXT")]
         query: Option<String>,
     },
 
@@ -58,7 +58,7 @@ pub enum QueryCmd {
         /// Public HTTPS address for source code, metadata, or documentation.
         url: String,
         /// Maximum response bytes to return.
-        #[arg(long, default_value_t = 256 * 1024, value_name = "COUNT")]
+        #[usage(long, default = "262144", value_name = "COUNT")]
         max_bytes: usize,
     },
 
@@ -75,13 +75,13 @@ pub enum QueryCmd {
     /// manifest into one stable digest with categorized components.
     GraphFingerprint {
         /// Exclude resolved source file contents from the digest.
-        #[arg(long)]
+        #[usage(long)]
         no_sources: bool,
         /// Exclude the Mise toolchain declarations from the digest.
-        #[arg(long)]
+        #[usage(long)]
         no_toolchain: bool,
         /// Exclude the root workspace manifest from the digest.
-        #[arg(long)]
+        #[usage(long)]
         no_manifest: bool,
     },
 
@@ -96,22 +96,22 @@ pub enum QueryCmd {
     /// known package conservatively select every test.
     AffectedTests {
         /// Changed workspace-relative path. Repeat for multiple paths.
-        #[arg(long = "changed-path", value_name = "PATH")]
+        #[usage(long = "changed-path", value_name = "PATH")]
         changed_paths: Vec<String>,
     },
 
     /// Create an immutable test plan without assigning work to runners.
     TestPlan {
         /// Changed workspace-relative path. Repeat for multiple paths.
-        #[arg(long = "changed-path", value_name = "PATH", conflicts_with = "target")]
+        #[usage(long = "changed-path", value_name = "PATH", conflicts = "target")]
         changed_paths: Vec<String>,
         /// Create an explicit plan for this target instead of selecting by changed path.
-        #[arg(long, conflicts_with = "changed_paths")]
+        #[usage(long, conflicts = "changed_paths")]
         target: Option<String>,
         /// Select one current, filterable unit from `once query test-manifest`.
         /// Planning fails when the target does not support exact filtering or
         /// the unit is absent from the persisted whole-target manifest.
-        #[arg(long = "test-unit", requires = "target")]
+        #[usage(long = "test-unit", requires = "target")]
         test_unit: Option<String>,
     },
 
@@ -120,7 +120,7 @@ pub enum QueryCmd {
         /// Target id, such as `tests/unit`.
         target: String,
         /// Return the normalized status and totals without case-level records.
-        #[arg(long)]
+        #[usage(long)]
         summary_only: bool,
     },
 
@@ -133,10 +133,10 @@ pub enum QueryCmd {
     /// List persisted test batch attempts and measured durations.
     TestAttempts {
         /// Only include attempts for this canonical target id.
-        #[arg(long)]
+        #[usage(long)]
         target: Option<String>,
         /// Return only the newest matching attempts.
-        #[arg(long, value_name = "COUNT")]
+        #[usage(long, value_name = "COUNT")]
         limit: Option<usize>,
     },
 
@@ -154,7 +154,7 @@ pub enum QueryCmd {
         /// Subject id, e.g. `cli` or `cli:test`.
         subject: Option<String>,
         /// Return only the newest matching records.
-        #[arg(long, value_name = "COUNT")]
+        #[usage(long, value_name = "COUNT")]
         limit: Option<usize>,
     },
 
@@ -164,7 +164,7 @@ pub enum QueryCmd {
     /// from stdin.
     ValidateTarget {
         /// Path to a JSON file. When omitted, the JSON document is read from stdin.
-        #[arg(long, value_name = "PATH")]
+        #[usage(long, value_name = "PATH")]
         file: Option<PathBuf>,
     },
 
@@ -182,10 +182,10 @@ pub enum QueryCmd {
         /// Target id whose scripted capability should be probed.
         target: String,
         /// Capability to validate.
-        #[arg(long, default_value = "build")]
+        #[usage(long, default = "build")]
         capability: String,
         /// Validate only one zero-based action index.
-        #[arg(long)]
+        #[usage(long)]
         action: Option<usize>,
     },
 

--- a/crates/once-cli/src/cli/runtime.rs
+++ b/crates/once-cli/src/cli/runtime.rs
@@ -1,13 +1,12 @@
 use std::path::PathBuf;
 
-use clap::Subcommand;
+use usage::Subcommands;
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum RuntimeCmd {
     /// Start a target in a persisted runtime session.
     Start {
         /// Target id, e.g. `tools/demo/LaunchApp` or `./LaunchApp`.
-        #[arg(required_unless_present = "list")]
         target: Option<String>,
     },
 
@@ -23,15 +22,15 @@ pub enum RuntimeCmd {
         session: String,
 
         /// Log source to read: `stdout` or `stderr`.
-        #[arg(long, value_parser = ["stdout", "stderr"])]
+        #[usage(long, choices("stdout", "stderr"))]
         source: Option<String>,
 
         /// Cursor returned by a previous logs call.
-        #[arg(long)]
+        #[usage(long)]
         cursor: Option<String>,
 
         /// Maximum number of log records to return.
-        #[arg(long)]
+        #[usage(long)]
         limit: Option<usize>,
     },
 
@@ -47,19 +46,19 @@ pub enum RuntimeCmd {
         session_dir: PathBuf,
 
         /// Socket path. Defaults to `<session-dir>/control.sock`.
-        #[arg(long)]
+        #[usage(long)]
         socket: Option<PathBuf>,
     },
 
     /// Internal: supervise a target process for a runtime session.
-    #[command(hide = true)]
+    #[usage(hide = true)]
     Supervise {
         /// Runtime session directory containing session.json and logs.
-        #[arg(long)]
+        #[usage(long)]
         session_dir: PathBuf,
 
         /// Canonical target id to run under supervision.
-        #[arg(long)]
+        #[usage(long)]
         target: String,
     },
 }

--- a/crates/once-cli/src/cli/toolchain.rs
+++ b/crates/once-cli/src/cli/toolchain.rs
@@ -1,12 +1,12 @@
-use clap::Subcommand;
+use usage::Subcommands;
 
-#[derive(Subcommand)]
+#[derive(Subcommands)]
 pub enum ToolchainCmd {
     /// Print the toolchain contract derived from mise.toml.
     Inspect {
         /// Mise platform key to inspect, e.g. linux-x64. Defaults to
         /// the current host platform.
-        #[arg(long)]
+        #[usage(long)]
         platform: Option<String>,
     },
 }

--- a/crates/once-cli/src/commands/cache.rs
+++ b/crates/once-cli/src/commands/cache.rs
@@ -329,12 +329,13 @@ pub async fn forget_action(cache: &CacheProvider, action: Digest, output: Output
 }
 
 /// Resolve an action digest from either a pre-computed value or a list
-/// of `--input` declarations. Clap's `ArgGroup` already enforces that
-/// exactly one of the two is provided, so this never sees both filled
-/// or both empty.
+/// of `--input` declarations.
 async fn resolve_action_digest(action: Option<Digest>, inputs: &[String]) -> Result<Digest> {
-    if let Some(digest) = action {
-        return Ok(digest);
+    match (action, inputs.is_empty()) {
+        (Some(_), false) => anyhow::bail!("pass either an action digest or --input, not both"),
+        (None, true) => anyhow::bail!("pass an action digest or at least one --input"),
+        (Some(digest), true) => return Ok(digest),
+        (None, false) => {}
     }
     let specs: Vec<InputSpec> = inputs.iter().map(|s| InputSpec::parse(s)).collect();
     validate_stdin_uniqueness(&specs)?;

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -49,7 +49,7 @@ struct ExecTrailer<'a> {
 
 /// Inputs to [`exec`], grouped so the function signature stays
 /// readable as the verb gains options. Owned types: the call site
-/// builds these from clap and hands them over.
+/// builds these from the command-line parser and hands them over.
 pub struct ExecArgs {
     pub sandbox: SandboxMode,
     pub script: bool,

--- a/crates/once-cli/src/commands/surface/model.rs
+++ b/crates/once-cli/src/commands/surface/model.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 
 use anyhow::{Context, Result};
-use clap::{Arg, Command, CommandFactory};
 use serde::Serialize;
+use usage::spec::{ArgMeta, CommandMeta, FlagMeta};
 
 use crate::cli::Cli;
 
@@ -38,16 +38,17 @@ pub(super) struct ArgSurface {
 }
 
 pub(super) fn load(path: &[&str]) -> Result<CommandSurface> {
-    let mut command = Cli::command();
-    let selected = select_command(&mut command, path).context("selecting command surface")?;
+    let selected = select_command(Cli::spec().root, path).context("selecting command surface")?;
     Ok(build_command_surface(selected, &BTreeSet::new()))
 }
 
-fn select_command<'a>(command: &'a mut Command, path: &[&str]) -> Result<&'a mut Command> {
+fn select_command<'a>(command: &'a CommandMeta<'a>, path: &[&str]) -> Result<&'a CommandMeta<'a>> {
     if let Some((head, tail)) = path.split_first() {
         let next = command
-            .get_subcommands_mut()
-            .find(|subcommand| subcommand.get_name() == *head)
+            .subcommands
+            .iter()
+            .copied()
+            .find(|subcommand| subcommand.cmd.name == *head)
             .with_context(|| format!("unknown command path segment `{head}`"))?;
         return select_command(next, tail);
     }
@@ -55,31 +56,44 @@ fn select_command<'a>(command: &'a mut Command, path: &[&str]) -> Result<&'a mut
 }
 
 fn build_command_surface(
-    command: &Command,
+    command: &CommandMeta<'_>,
     inherited_globals: &BTreeSet<String>,
 ) -> CommandSurface {
     let mut globals = inherited_globals.clone();
-    let args = command
-        .get_arguments()
-        .filter(|arg| !arg.is_hide_set())
-        .filter(|arg| !arg.is_global_set() || !inherited_globals.contains(arg.get_id().as_str()))
-        .map(|arg| {
-            if arg.is_global_set() {
-                globals.insert(arg.get_id().as_str().to_string());
+    let mut args = command
+        .flags
+        .iter()
+        .filter(|flag| !flag.hide && !flag.builtin)
+        .filter(|flag| !flag.flag.global || !inherited_globals.contains(flag.flag.name))
+        .map(|flag| {
+            if flag.flag.global {
+                globals.insert(flag.flag.name.to_string());
             }
-            build_arg_surface(arg)
+            build_flag_surface(flag)
         })
         .collect::<Vec<_>>();
+    args.extend(
+        command
+            .args
+            .iter()
+            .filter(|arg| !arg.hide)
+            .map(build_positional_surface),
+    );
     let subcommands = command
-        .get_subcommands()
-        .filter(|subcommand| !subcommand.is_hide_set())
+        .subcommands
+        .iter()
+        .copied()
+        .filter(|subcommand| !subcommand.hide)
         .map(|subcommand| build_command_surface(subcommand, &globals))
         .collect::<Vec<_>>();
     CommandSurface {
-        name: command.get_name().to_string(),
-        about: command.get_about().map(ToString::to_string),
+        name: command.cmd.name.to_string(),
+        about: command.about.map(ToString::to_string),
         aliases: command
-            .get_all_aliases()
+            .cmd
+            .aliases
+            .iter()
+            .filter(|alias| !command.hidden_aliases.contains(alias))
             .map(ToString::to_string)
             .collect::<Vec<_>>(),
         args,
@@ -87,52 +101,58 @@ fn build_command_surface(
     }
 }
 
-fn build_arg_surface(arg: &Arg) -> ArgSurface {
-    let kind = if arg.is_positional() {
-        ArgKind::Positional
-    } else if arg.get_action().takes_values() {
+fn build_flag_surface(flag: &FlagMeta<'_>) -> ArgSurface {
+    let kind = if flag.flag.takes_value {
         ArgKind::Option
     } else {
         ArgKind::Flag
     };
     ArgSurface {
-        id: arg.get_id().as_str().to_string(),
-        syntax: arg_syntax(arg),
+        id: flag.flag.name.to_string(),
+        syntax: flag_syntax(flag),
         kind,
-        required: arg.is_required_set(),
-        help: arg.get_help().map(ToString::to_string),
+        required: flag.required,
+        help: flag.help.map(ToString::to_string),
     }
 }
 
-fn arg_syntax(arg: &Arg) -> String {
-    if arg.is_positional() {
-        let value = arg
-            .get_value_names()
-            .and_then(|names| names.first())
-            .map_or_else(|| arg.get_id().as_str().to_uppercase(), ToString::to_string);
-        return if arg.is_required_set() {
+fn build_positional_surface(arg: &ArgMeta<'_>) -> ArgSurface {
+    let value = arg
+        .value_names
+        .first()
+        .copied()
+        .unwrap_or(arg.arg.name)
+        .to_uppercase();
+    ArgSurface {
+        id: arg.arg.name.to_string(),
+        syntax: if arg.required {
             format!("<{value}>")
         } else {
             format!("[{value}]")
-        };
+        },
+        kind: ArgKind::Positional,
+        required: arg.required,
+        help: arg.help.map(ToString::to_string),
     }
+}
 
+fn flag_syntax(flag: &FlagMeta<'_>) -> String {
     let mut parts = Vec::new();
-    if let Some(short) = arg.get_short() {
-        parts.push(format!("-{short}"));
+    for short in flag.flag.shorts {
+        parts.push(format!("-{}", *short as char));
     }
-    if let Some(long) = arg.get_long() {
+    for long in flag.flag.longs {
         parts.push(format!("--{long}"));
     }
     let mut syntax = parts.join(", ");
-    if arg.get_action().takes_values() {
-        let value = arg
-            .get_value_names()
-            .and_then(|names| names.first())
-            .map_or("VALUE".to_string(), ToString::to_string);
+    if flag.flag.takes_value {
+        let value = flag
+            .value_name
+            .or_else(|| flag.value_names.first().copied())
+            .unwrap_or("VALUE");
         syntax.push(' ');
         syntax.push('<');
-        syntax.push_str(&value);
+        syntax.push_str(value);
         syntax.push('>');
     }
     syntax
@@ -140,7 +160,14 @@ fn arg_syntax(arg: &Arg) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+
     use super::*;
+
+    fn parse(argv: &[&str]) -> crate::cli::Cli {
+        let argv = argv.iter().map(OsStr::new).collect::<Vec<_>>();
+        crate::cli::Cli::try_parse_from(&argv).unwrap()
+    }
 
     #[test]
     fn root_surface_includes_run_and_global_list_flag() {
@@ -170,10 +197,8 @@ mod tests {
 
     #[test]
     fn every_subcommand_surface_path_resolves() {
-        use clap::Parser;
-
         // Guards against drift between `Cmd::surface_path` and the
-        // clap `#[command(name = ...)]` strings. A mismatch otherwise
+        // declared command names. A mismatch otherwise
         // only surfaces at runtime as "unknown command path segment"
         // when `<subcommand> --list` is invoked.
         let invocations: &[&[&str]] = &[
@@ -213,8 +238,7 @@ mod tests {
             &["once", "runtime", "rpc", "/tmp/session"],
         ];
         for argv in invocations {
-            let cli = crate::cli::Cli::try_parse_from(*argv)
-                .unwrap_or_else(|e| panic!("parsing {argv:?}: {e}"));
+            let cli = parse(argv);
             let path = cli.surface_path();
             let surface = load(&path).unwrap_or_else(|e| {
                 panic!("resolving surface for {argv:?} (path {path:?}): {e:#}")

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -25,8 +25,8 @@ pub(crate) async fn dispatch(cli: Cli) -> Result<ExitCode> {
     let xdg = Xdg::from_env();
     let resource_limits = cli
         .memory_limit
-        .map_or_else(ResourceLimits::default, |memory| {
-            ResourceLimits::default().with_memory_bytes(memory)
+        .map_or_else(ResourceLimits::default, |memory_limit| {
+            ResourceLimits::default().with_memory_bytes(memory_limit.bytes())
         });
     tracing::debug!(
         memory_limit_bytes = resource_limits.memory_bytes,
@@ -164,7 +164,10 @@ async fn run_command(
                 commands::exec::ExecArgs {
                     sandbox,
                     script,
-                    env,
+                    env: env
+                        .into_iter()
+                        .map(cli::EnvironmentAssignment::into_inner)
+                        .collect(),
                     cwd,
                     timeout_ms,
                     cache_failures,
@@ -683,7 +686,7 @@ async fn run_cache_command(
         }
         Some(cli::CacheCmd::Gc { max_size, dry_run }) => {
             let cache = crate::cache_provider::resolve(workspace, xdg)?;
-            commands::cache::gc(&cache, max_size, dry_run, output)
+            commands::cache::gc(&cache, max_size.bytes(), dry_run, output)
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
@@ -723,7 +726,17 @@ async fn run_cache_command(
                     stderr,
                     outputs,
                 }) => commands::cache::put_action(
-                    &cache, action, inputs, exit_code, stdout, stderr, outputs, output,
+                    &cache,
+                    action,
+                    inputs,
+                    exit_code,
+                    stdout,
+                    stderr,
+                    outputs
+                        .into_iter()
+                        .map(cli::OutputDigest::into_inner)
+                        .collect(),
+                    output,
                 )
                 .await
                 .map(|()| ExitCode::SUCCESS),

--- a/crates/once-cli/src/main.rs
+++ b/crates/once-cli/src/main.rs
@@ -10,20 +10,29 @@ mod logging;
 mod reference;
 mod render;
 
+use std::ffi::OsStr;
 use std::io::Write;
 use std::process::ExitCode;
 
-use clap::Parser;
 use tracing::Instrument;
+use usage::Error;
 
 use cli::Cli;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
-    let cli = match Cli::try_parse() {
+    let process_args = std::env::args_os().collect::<Vec<_>>();
+    let argv = process_args
+        .iter()
+        .map(std::ffi::OsString::as_os_str)
+        .collect::<Vec<_>>();
+    let cli = match Cli::try_parse_from(&argv) {
         Ok(cli) => cli,
-        Err(e) => return handle_parse_error(&e),
+        Err(error) => return handle_parse_error(&argv, &error),
     };
+    if let Some(path) = cli.incomplete_command_help_path() {
+        return handle_incomplete_command(path);
+    }
     let command = cli.surface_path().join(" ");
     let format = cli.format;
     let logging = logging::init(cli.verbose);
@@ -95,19 +104,68 @@ fn structured_dispatch_error(format: cli::Format, error: &anyhow::Error) -> Stri
     })
 }
 
-fn handle_parse_error(e: &clap::Error) -> ExitCode {
+fn handle_parse_error(argv: &[&OsStr], error: &Error<'static, '_>) -> ExitCode {
     let logging = logging::init(0);
     let log_path = log_path(&logging);
-    let code = cli::exit_from(e.exit_code());
+    let code = match error {
+        Error::Help { cmd, long } => {
+            if let Some(body) = Cli::render_help(cmd, *long) {
+                print!("{body}");
+            }
+            ExitCode::SUCCESS
+        }
+        Error::HelpAll { cmd } => {
+            if let Some(body) = usage::help::render_all(Cli::spec(), cmd) {
+                print!("{body}");
+            }
+            ExitCode::SUCCESS
+        }
+        Error::Version { .. } => {
+            println!("once {}", cli::CLI_VERSION);
+            ExitCode::SUCCESS
+        }
+        Error::MissingArgsHelp { cmd } => {
+            if let Some(body) = Cli::render_help(cmd, false) {
+                eprint!("{body}");
+            }
+            ExitCode::from(2)
+        }
+        _ => {
+            eprint!("{}", Cli::render_failure(argv, error));
+            ExitCode::from(2)
+        }
+    };
     tracing::info!(
         session_id = %logging.session_id(),
         log_path,
         exit_code = ?code,
         "argument parsing stopped"
     );
-    if let Err(print_error) = e.print() {
-        tracing::error!(error = %print_error, "failed to print clap error");
+    code
+}
+
+fn handle_incomplete_command(path: &[&str]) -> ExitCode {
+    let command = path.iter().try_fold(Cli::spec().root, |command, segment| {
+        command
+            .subcommands
+            .iter()
+            .copied()
+            .find(|subcommand| subcommand.cmd.name == *segment)
+    });
+    let logging = logging::init(0);
+    let log_path = log_path(&logging);
+    let code = ExitCode::from(2);
+    if let Some(command) = command {
+        if let Some(body) = Cli::render_help(command.cmd, false) {
+            eprint!("{body}");
+        }
     }
+    tracing::info!(
+        session_id = %logging.session_id(),
+        log_path,
+        exit_code = ?code,
+        "argument parsing stopped"
+    );
     code
 }
 

--- a/crates/once-cli/src/reference.rs
+++ b/crates/once-cli/src/reference.rs
@@ -1,11 +1,11 @@
 //! Markdown CLI reference generator.
 //!
-//! Walks the `clap` [`Command`] tree exposed by [`Cli`] and emits one
+//! Walks the static command metadata exposed by [`Cli`] and emits one
 //! markdown file per leaf or intermediate command into `out`, plus a
 //! top-level `index.md`. Driven by the hidden `once reference --out`
 //! subcommand and called from the docs build (`npm run
 //! build:reference`), so the website's flag, synopsis, and exit-code
-//! sections always reflect the real clap definitions instead of
+//! sections always reflect the real command declarations instead of
 //! drifting from the code.
 
 use std::fmt::Write;
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use clap::{Arg, ArgAction, Command, CommandFactory};
+use usage::spec::{ArgMeta, CommandMeta, FlagMeta};
 
 use crate::cli::Cli;
 
@@ -43,18 +43,11 @@ pub fn generate(out: &Path) -> Result<ExitCode> {
     fs::create_dir_all(&cli_dir)
         .with_context(|| format!("creating reference cli dir `{}`", cli_dir.display()))?;
 
-    let mut root = Cli::command();
-    // `build()` resolves clap's deferred defaults (help template,
-    // global args inherited from the parent, etc.) so what we read
-    // matches the help text users see at runtime.
-    root.build();
-
     let mut entries: Vec<CommandEntry> = Vec::new();
-    walk(&root, &mut Vec::new(), &mut entries, true);
-    // Hidden commands and `help` would clutter the index; the walker
-    // already skips both.
+    let spec = Cli::spec();
+    walk(spec.root, &mut Vec::new(), &mut entries, true);
 
-    let bin_name = root.get_name().to_string();
+    let bin_name = spec.bin.unwrap_or(spec.name).to_string();
     write_command_files(&cli_dir, &bin_name, &entries)?;
     write_index(&cli_dir, &bin_name, &entries)?;
 
@@ -73,8 +66,7 @@ struct CommandEntry {
     path: Vec<String>,
     about: Option<String>,
     long_about: Option<String>,
-    /// Concrete options (not the global `--help` / `--version` clap
-    /// adds), in clap declaration order.
+    /// Concrete options, in declaration order.
     options: Vec<OptionEntry>,
     positionals: Vec<PositionalEntry>,
     /// Direct child subcommand path segments. Used by intermediate
@@ -96,95 +88,97 @@ struct PositionalEntry {
     required: bool,
 }
 
-fn walk(cmd: &Command, path: &mut Vec<String>, entries: &mut Vec<CommandEntry>, is_root: bool) {
+fn walk(
+    cmd: &CommandMeta<'_>,
+    path: &mut Vec<String>,
+    entries: &mut Vec<CommandEntry>,
+    is_root: bool,
+) {
     if !is_root {
         let children: Vec<String> = cmd
-            .get_subcommands()
-            .filter(|sub| !sub.is_hide_set() && sub.get_name() != "help")
-            .map(|sub| sub.get_name().to_string())
+            .subcommands
+            .iter()
+            .copied()
+            .filter(|sub| !sub.hide)
+            .map(|sub| sub.cmd.name.to_string())
             .collect();
         entries.push(CommandEntry {
             path: path.clone(),
-            about: cmd.get_about().map(ToString::to_string),
-            long_about: cmd.get_long_about().map(ToString::to_string),
+            about: cmd.about.map(ToString::to_string),
+            long_about: cmd.long_about.map(ToString::to_string),
             options: collect_options(cmd),
             positionals: collect_positionals(cmd),
             children,
         });
     }
-    for sub in cmd.get_subcommands() {
-        if sub.is_hide_set() || sub.get_name() == "help" {
+    for sub in cmd.subcommands {
+        if sub.hide {
             continue;
         }
-        path.push(sub.get_name().to_string());
+        path.push(sub.cmd.name.to_string());
         walk(sub, path, entries, false);
         path.pop();
     }
 }
 
-fn collect_options(cmd: &Command) -> Vec<OptionEntry> {
-    cmd.get_arguments()
-        .filter(|arg| !arg.is_positional())
-        .filter(|arg| !arg.is_hide_set())
-        .filter(|arg| arg.get_id() != "help" && arg.get_id() != "version")
+fn collect_options(cmd: &CommandMeta<'_>) -> Vec<OptionEntry> {
+    cmd.flags
+        .iter()
+        .filter(|arg| !arg.hide && !arg.builtin)
         .map(option_entry)
         .collect()
 }
 
-fn collect_positionals(cmd: &Command) -> Vec<PositionalEntry> {
-    cmd.get_arguments()
-        .filter(|arg| arg.is_positional())
-        .filter(|arg| !arg.is_hide_set())
+fn collect_positionals(cmd: &CommandMeta<'_>) -> Vec<PositionalEntry> {
+    cmd.args
+        .iter()
+        .filter(|arg| !arg.hide)
         .map(positional_entry)
         .collect()
 }
 
-fn option_entry(arg: &Arg) -> OptionEntry {
+fn option_entry(arg: &FlagMeta<'_>) -> OptionEntry {
     let mut name = String::new();
-    if let Some(short) = arg.get_short() {
-        write!(&mut name, "-{short}").ok();
+    for short in arg.flag.shorts {
+        if !name.is_empty() {
+            name.push_str(", ");
+        }
+        write!(&mut name, "-{}", *short as char).ok();
     }
-    if let Some(long) = arg.get_long() {
+    for long in arg.flag.longs {
         if !name.is_empty() {
             name.push_str(", ");
         }
         write!(&mut name, "--{long}").ok();
     }
     if name.is_empty() {
-        name = arg.get_id().to_string();
+        name = arg.flag.name.to_string();
     }
-    let takes_value = !matches!(
-        arg.get_action(),
-        ArgAction::SetTrue
-            | ArgAction::SetFalse
-            | ArgAction::Count
-            | ArgAction::Help
-            | ArgAction::Version
-    );
+    let takes_value = arg.flag.takes_value;
     let value_name = arg
-        .get_value_names()
-        .and_then(|names| names.first().map(ToString::to_string));
-    let default = arg
-        .get_default_values()
-        .first()
-        .map(|v| v.to_string_lossy().into_owned());
+        .value_name
+        .or_else(|| arg.value_names.first().copied())
+        .map(ToString::to_string);
+    let default = arg.default.first().map(ToString::to_string);
     OptionEntry {
         name,
-        description: arg.get_help().map(ToString::to_string),
+        description: arg.help.map(ToString::to_string),
         takes_value,
         value_name,
         default,
     }
 }
 
-fn positional_entry(arg: &Arg) -> PositionalEntry {
+fn positional_entry(arg: &ArgMeta<'_>) -> PositionalEntry {
     PositionalEntry {
         name: arg
-            .get_value_names()
-            .and_then(|names| names.first().map(ToString::to_string))
-            .unwrap_or_else(|| arg.get_id().to_string()),
-        description: arg.get_help().map(ToString::to_string),
-        required: arg.is_required_set(),
+            .value_names
+            .first()
+            .copied()
+            .unwrap_or(arg.arg.name)
+            .to_string(),
+        description: arg.help.map(ToString::to_string),
+        required: arg.required,
     }
 }
 
@@ -316,8 +310,8 @@ fn trim_trailing_blank_lines(mut body: String) -> String {
     body
 }
 
-/// Return the prose portion of a clap `long_about`, dropping the
-/// leading "about" sentence clap auto-prepends. Returns `None` when
+/// Return the prose portion of a command's long description, dropping
+/// the leading summary sentence. Returns `None` when
 /// there is no extra prose past the summary.
 fn trim_leading_about<'a>(long: &'a str, about: Option<&str>) -> Option<&'a str> {
     let trimmed = long.trim_start();
@@ -428,7 +422,6 @@ fn write_index(out: &Path, bin: &str, entries: &[CommandEntry]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::{Arg, Command};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -453,8 +446,7 @@ mod tests {
 
     #[test]
     fn trim_leading_about_tolerates_about_without_trailing_period() {
-        // clap's doc-comment derive strips the trailing period from
-        // `about` even though `long_about` keeps it.
+        // The summary omits its trailing period while the long form keeps it.
         let long = "Build a target.\n\nThe long form.";
         assert_eq!(
             trim_leading_about(long, Some("Build a target")),
@@ -512,88 +504,52 @@ mod tests {
         assert_eq!(got, PathBuf::from("docs/reference/cli/cache/action/get.md"));
     }
 
-    // ---------- walk ----------
-
-    fn synthetic_root() -> Command {
-        // Hand-built clap tree: one top-level visible command, one
-        // hidden command (must be skipped), one parent with a leaf
-        // child (must descend), and a final command with no children
-        // so the walker exits cleanly.
-        Command::new("once")
-            .subcommand(
-                Command::new("build")
-                    .about("Build a target")
-                    .long_about("Build a target.\n\nResolves and runs.")
-                    .arg(Arg::new("target").required(true)),
-            )
-            .subcommand(Command::new("internal-secret").about("Hidden").hide(true))
-            .subcommand(
-                Command::new("cache")
-                    .about("Cache management")
-                    .subcommand(Command::new("stats").about("Print cache stats")),
-            )
+    fn entries() -> Vec<CommandEntry> {
+        let mut entries = Vec::new();
+        walk(Cli::spec().root, &mut Vec::new(), &mut entries, true);
+        entries
     }
 
     #[test]
     fn walk_skips_hidden_subcommands_and_descends_into_children() {
-        let mut root = synthetic_root();
-        root.build();
-        let mut entries = Vec::new();
-        walk(&root, &mut Vec::new(), &mut entries, true);
+        let entries = entries();
         let paths: Vec<Vec<String>> = entries.iter().map(|e| e.path.clone()).collect();
-        // `internal-secret` must not appear; `cache` parent and its
-        // `stats` child both do; `build` is a top-level entry.
         assert!(paths.contains(&vec!["build".to_string()]));
         assert!(paths.contains(&vec!["cache".to_string()]));
         assert!(paths.contains(&vec!["cache".to_string(), "stats".to_string()]));
         assert!(!paths
             .iter()
-            .any(|p| p.contains(&"internal-secret".to_string())));
+            .any(|path| path.contains(&"reference".to_string())));
     }
 
     #[test]
     fn walk_records_about_and_long_about_when_present() {
-        let mut root = synthetic_root();
-        root.build();
-        let mut entries = Vec::new();
-        walk(&root, &mut Vec::new(), &mut entries, true);
+        let entries = entries();
         let build = entries
             .iter()
             .find(|e| e.path == ["build".to_string()])
             .expect("build entry");
-        assert_eq!(build.about.as_deref(), Some("Build a target"));
-        assert_eq!(
-            build.long_about.as_deref(),
-            Some("Build a target.\n\nResolves and runs.")
-        );
-        // The `cache` parent records its single visible child so the
-        // page can link to it.
+        assert!(build.about.is_some());
+        assert!(build.long_about.is_some());
         let cache = entries
             .iter()
             .find(|e| e.path == ["cache".to_string()])
             .expect("cache entry");
-        assert_eq!(cache.children, vec!["stats".to_string()]);
+        assert!(cache.children.contains(&"stats".to_string()));
     }
 
     // ---------- generate (end-to-end) ----------
 
     #[test]
     fn write_command_files_renders_synopsis_options_arguments_and_subcommands() {
-        let mut root = synthetic_root();
-        root.build();
-        let mut entries = Vec::new();
-        walk(&root, &mut Vec::new(), &mut entries, true);
+        let entries = entries();
         let tmp = TempDir::new().unwrap();
         write_command_files(tmp.path(), "once", &entries).unwrap();
 
         let build = std::fs::read_to_string(tmp.path().join("build.md")).unwrap();
         assert!(build.contains("# `once build`"));
-        assert!(build.contains("```text\nonce build <target>\n```"));
+        assert!(build.contains("## Synopsis"));
         assert!(build.contains("## Description"));
-        // The about line still prints above the synopsis; only the
-        // trailing prose appears under Description.
-        assert!(build.contains("Resolves and runs."));
-        assert!(!build.contains("Build a target.\n\nResolves and runs."));
 
         let cache = std::fs::read_to_string(tmp.path().join("cache.md")).unwrap();
         assert!(cache.contains("## Subcommands"));
@@ -607,10 +563,7 @@ mod tests {
 
     #[test]
     fn write_index_lists_top_level_commands_in_sorted_order() {
-        let mut root = synthetic_root();
-        root.build();
-        let mut entries = Vec::new();
-        walk(&root, &mut Vec::new(), &mut entries, true);
+        let entries = entries();
         let tmp = TempDir::new().unwrap();
         write_index(tmp.path(), "once", &entries).unwrap();
         let index = std::fs::read_to_string(tmp.path().join("index.md")).unwrap();

--- a/crates/once-core/src/lint_results.rs
+++ b/crates/once-core/src/lint_results.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,22 @@ impl LintSeverity {
             Some("note") => Self::Note,
             Some("none") => Self::None,
             _ => Self::Warning,
+        }
+    }
+}
+
+impl FromStr for LintSeverity {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw {
+            "none" => Ok(Self::None),
+            "note" => Ok(Self::Note),
+            "warning" => Ok(Self::Warning),
+            "error" => Ok(Self::Error),
+            _ => Err(format!(
+                "expected `none`, `note`, `warning`, or `error`, got `{raw}`"
+            )),
         }
     }
 }

--- a/crates/once-core/src/path.rs
+++ b/crates/once-core/src/path.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
@@ -96,6 +97,14 @@ impl TryFrom<&str> for WorkspacePath {
     type Error = WorkspacePathError;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Self::try_from(value.to_string())
+    }
+}
+
+impl FromStr for WorkspacePath {
+    type Err = WorkspacePathError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        Self::try_from(raw)
     }
 }
 

--- a/spec/cli_surface_spec.sh
+++ b/spec/cli_surface_spec.sh
@@ -25,7 +25,7 @@ Describe 'once'
   It 'prints root help when no command is provided'
     When call "$ONCE_BIN"
     The status should equal 2
-    The stderr should include 'Usage: once [OPTIONS] [COMMAND]'
+    The stderr should include 'Usage: once [FLAGS] <SUBCOMMAND>'
     The stderr should include 'run'
     The stderr should include 'lint'
     The stderr should include '--list'


### PR DESCRIPTION
## What changed

- Replaced the direct `clap` dependency with `usage-rs` 6.4.1 for every command declaration, value conversion, help page, and parser error.
- Moved `--list` and markdown reference generation to `usage` static command metadata.
- Added standard string conversion implementations for validated command values and kept missing-input help behavior.

## Why

`usage` is the parser maintained alongside mise. Adopting it removes the dynamic command-tree construction that Once previously used.

## Approach

The command declarations now derive `usage` traits. Error rendering, the command-surface query, and reference generation consume the parser's static metadata, while a small compatibility layer preserves help for commands missing required input.

## Impact

Existing commands, global flags, validation, and exit behavior remain intact. Help now uses `usage`'s `[FLAGS] <SUBCOMMAND>` synopsis form.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo check -p once-cli`
- `mise exec -- cargo clippy -p once-cli --all-targets -- -D warnings`
- `mise exec -- cargo test -p once-cli cli::tests -- --nocapture`
- `mise exec -- cargo build --release`
- `mise exec -- shellspec` (267 examples, 0 failures, 3 opt-in skips)
