### PR TITLE
feat(swift): compile native package dependencies directly

### DIFF
--- a/crates/once-frontend/prelude/swift_package.star
+++ b/crates/once-frontend/prelude/swift_package.star
@@ -12,27 +12,8 @@ def _swift_package_workspace_resolver(ctx):
     swift = _swiftpm_swift_executable(attrs.get("swift") or "swift", attrs.get("xcode_developer_dir") or "", swiftc["swiftc_path"])
     info = json_decode(host_command([swift, "package", "dump-package", "--package-path", _swiftpm_absolute_package_path(ctx, attrs.get("package_path") or ".")], env = swiftc["env"]))
     package = {"identity": _basename(package_path) or info.get("name") or ctx["label"]["name"], "path": package_path, "info": info}
-    remote_products = _swift_package_remote_products(ctx, info)
-    lazy_dependency = _xcode_swift_package_target_id(package["identity"], "RemoteDependencies") if remote_products else ""
-    graph = _xcode_local_swift_package_specs(ctx, [package], attrs.get("platform") or "macos", attrs.get("minimum_os") or "13.0", attrs.get("sdk_variant") or "simulator", remote_products, lazy_dependency)
-    if lazy_dependency:
-        graph["specs"].append({
-            "name": lazy_dependency,
-            "kind": "swift_package_dependencies",
-            "deps": [],
-            "srcs": sorted(ctx["files"].keys()),
-            "attrs": {
-                "package_path": attrs.get("package_path") or ".",
-                "allow_network": True,
-                "products": sorted(_swift_package_remote_product_names(remote_products)),
-                "platform": attrs.get("platform") or "macos",
-                "minimum_os": attrs.get("minimum_os") or "13.0",
-                "sdk_variant": attrs.get("sdk_variant") or "simulator",
-                "swift": attrs.get("swift") or "swift",
-                "xcode_developer_dir": attrs.get("xcode_developer_dir") or "",
-                "_lazy_resolution": True,
-            },
-        })
+    packages = [package] + _swift_package_remote_infos(ctx)
+    graph = _xcode_local_swift_package_specs(ctx, packages, attrs.get("platform") or "macos", attrs.get("minimum_os") or "13.0", attrs.get("sdk_variant") or "simulator")
     roots = []
     for product in info.get("products") or []:
         target_id = graph["products"].get(package["identity"] + "\x1f" + (product.get("name") or ""))
@@ -40,39 +21,41 @@ def _swift_package_workspace_resolver(ctx):
             roots.append(target_id)
     return {"targets": graph["specs"], "roots": roots}
 
-def _swift_package_remote_products(ctx, info):
+def _swift_package_remote_infos(ctx):
     resolved = ctx["files"].get("Package.resolved")
     if resolved == None:
-        return {}
-    remote_identities = {}
+        return []
+    infos = []
     for pin in _swiftpm_resolved_pins(json_decode(resolved)):
-        if _swiftpm_pin_requires_network(pin):
-            remote_identities[pin["identity"].lower()] = True
-    products = {}
-    for target in info.get("targets") or []:
-        for dependency in target.get("dependencies") or []:
-            values = dependency.get("product") or []
-            if not values:
-                continue
-            name = values[0] or ""
-            identity = values[1] if len(values) > 1 and type(values[1]) == "string" else ""
-            if name and identity.lower() in remote_identities:
-                products[identity.lower() + "\x1f" + name] = True
-    return products
-
-def _swift_package_remote_product_names(products):
-    names = []
-    for value in products.keys():
-        name = value.split("\x1f")[1]
-        if name not in names:
-            names.append(name)
-    return names
+        if not _swiftpm_pin_requires_network(pin):
+            continue
+        if pin.get("kind") != "remoteSourceControl":
+            fail("native Swift package integration supports locked source-control dependencies, but `" + pin["identity"] + "` has source kind `" + (pin.get("kind") or "unknown") + "`")
+        raw_pin = {
+            "identity": pin["identity"],
+            "kind": pin.get("kind") or "",
+            "location": pin.get("location") or "",
+            "state": {
+                "revision": pin.get("revision") or "",
+                "version": pin.get("version") or "",
+                "branch": pin.get("branch") or "",
+            },
+        }
+        info = _xcode_remote_swift_package_info(
+            ctx,
+            pin["identity"],
+            raw_pin,
+            checkout_root = ".once/swift-package-packages",
+        )
+        if info:
+            infos.append(info)
+    return infos
 
 def _swift_package_workspace_impl(ctx):
     return {"label_id": ctx["label"]["id"], "swift_package_workspace": True, "targets": ctx["deps"]}
 
 swift_package_workspace = target_kind(
-    docs = "Native Swift Package Manager workspace seed. Its resolver reads Package.swift and lowers each first-party library, executable, macro, binary, and test target into the existing Apple target kinds. Locked remote products become a dependency action that fetches only when a build needs it.",
+    docs = "Native Swift Package Manager workspace seed. Its resolver reads Package.swift, materializes locked source-control dependency sources, and lowers every library, executable, macro, binary, and test target into the existing Apple target kinds for direct compilation.",
     attrs = [attr("package_path", "string", default = ".", docs = "Package-relative directory containing Package.swift. Defaults to the native integration package.", configurable = False), attr("resolver_inputs", "list<string>", default = "[]", docs = "Package-relative source globs supplied to native integration resolution. Defaults to srcs when empty.", configurable = False), attr("platform", "string", default = "macos", docs = "Apple platform used when lowering the Swift package targets.", configurable = False), attr("minimum_os", "string", default = "13.0", docs = "Minimum Apple operating system version used when lowering package targets.", configurable = False), attr("sdk_variant", "string", default = "simulator", docs = "Simulator or device software development kit selection. Ignored for macOS.", configurable = False), attr("swift", "string", default = "swift", docs = "Swift Package Manager executable or workspace-relative executable path. The default selects the executable paired with the resolved Swift compiler.", configurable = False), attr("xcode_developer_dir", "string", docs = "Pin a specific Xcode developer directory for Swift and the Apple software development kit.", configurable = False)],
     resolver = _swift_package_workspace_resolver, deps = [dep("deps", ["apple_linkable", "apple_test_bundle", "native_linkable"], "First-party Swift package products emitted by native integration discovery.")], providers = ["swift_package_workspace"], capabilities = [capability("build", [])], tools = [tool("swift", ["swift", "swiftc"])], examples = [example("swift-package-workspace-native-project", name = "Swift Package Manager native integration seed", use_when = "Use this when a Swift Package Manager workspace should derive first-party build and test targets from Package.swift.", platforms = ["macos"])], impl = _swift_package_workspace_impl,
 )

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -1538,17 +1538,18 @@ def _xcode_remote_swift_package_infos(ctx, entry_path, project_path, package_ref
             infos.append(info)
     return infos
 
-def _xcode_remote_swift_package_info(ctx, identity, pin, url = ""):
+def _xcode_remote_swift_package_info(ctx, identity, pin, url = "", checkout_root = ".once/xcode-packages"):
     state = pin.get("state") or {}
     revision = state.get("revision") or ""
     if not revision:
         return None
     git = host_which("git")
-    package_dir = ".once/xcode-packages/" + _xcode_sanitized_target_name(identity)
+    package_dir = checkout_root + "/" + _xcode_sanitized_target_name(identity)
     absolute = _xcode_abs(package_dir)
     manifest = absolute + "/Package.swift"
     if not host_file_exists(manifest):
         if not _xcode_host_directory_exists(absolute):
+            host_command([host_which("mkdir"), "-p", _parent_dir(absolute)])
             host_command([git, "clone", "--no-checkout", url or pin.get("location") or "", absolute])
         host_command([git, "-C", absolute, "fetch", "--depth", "1", "origin", revision])
         host_command([git, "-C", absolute, "checkout", "--detach", revision])
@@ -1611,8 +1612,15 @@ def _xcode_swift_package_target_path_is_excluded(root, target_path, excluded, pa
             return True
     return False
 
+def _xcode_swift_package_target_path(target):
+    path = target.get("path") or ""
+    if path:
+        return path
+    directory = "Tests" if (target.get("type") or "") == "test" else "Sources"
+    return directory + "/" + (target.get("name") or "")
+
 def _xcode_swift_package_target_sources(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     root = package_path + "/" if package_path else ""
     excluded = target.get("exclude") or []
     patterns = [root + target_path + "/**/*"]
@@ -1633,7 +1641,7 @@ def _xcode_is_documentation_path(path):
     return ".docc/" in path.lower()
 
 def _xcode_swift_package_target_headers(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     root = package_path + "/" if package_path else ""
     public_headers_path = _xcode_join(root + target_path, target.get("publicHeadersPath") or "include")
     excluded = target.get("exclude") or []
@@ -1649,13 +1657,13 @@ def _xcode_swift_package_target_headers(package_path, target):
     return [path for path in glob([public_headers_path + "/**/*.h"]) if not _xcode_swift_package_target_path_is_excluded(root, target_path, excluded, path)]
 
 def _xcode_swift_package_target_modulemap(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     public_headers_path = _xcode_join(package_path + "/" + target_path, target.get("publicHeadersPath") or "include")
     candidate = public_headers_path + "/module.modulemap"
     return candidate if host_file_exists(_xcode_abs(candidate)) else ""
 
 def _xcode_swift_package_include_dirs(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     include_dir = _xcode_join(package_path + "/" + target_path, target.get("publicHeadersPath") or "include")
     if package_path.startswith(".once/"):
         include_absolute = _xcode_abs(include_dir)
@@ -1667,7 +1675,7 @@ def _xcode_swift_package_include_dirs(package_path, target):
     return []
 
 def _xcode_swift_package_target_header_dirs(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     root = package_path + "/" if package_path else ""
     excluded = target.get("exclude") or []
     if package_path.startswith(".once/"):
@@ -1680,7 +1688,7 @@ def _xcode_swift_package_target_header_dirs(package_path, target):
     return _unique([_parent_dir(header) for header in headers if _parent_dir(header) and not _xcode_swift_package_target_path_is_excluded(root, target_path, excluded, header)])
 
 def _xcode_swift_package_target_datamodels(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     root = package_path + "/" + target_path
     absolute = _xcode_abs(root)
     if not _xcode_host_directory_exists(absolute):
@@ -1728,7 +1736,7 @@ def _xcode_swift_package_resource_bundle_name(package, target):
     return package_name + "_" + target_name + ".bundle"
 
 def _xcode_swift_package_resource_paths(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     root = package_path + "/" if package_path else ""
     paths = []
     for resource in target.get("resources") or []:
@@ -1738,7 +1746,7 @@ def _xcode_swift_package_resource_paths(package_path, target):
     return _unique(paths)
 
 def _xcode_swift_package_structured_resource_paths(package_path, target):
-    target_path = target.get("path") or "Sources/" + (target.get("name") or "")
+    target_path = _xcode_swift_package_target_path(target)
     root = package_path + "/" if package_path else ""
     paths = []
     for resource in target.get("resources") or []:
@@ -2018,33 +2026,39 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
                 resource_paths = _xcode_swift_package_resource_paths(package_path, target)
                 structured_resource_paths = _xcode_swift_package_structured_resource_paths(package_path, target)
                 resource_bundle_name = _xcode_swift_package_resource_bundle_name(package, target) if resource_paths else ""
+                attrs = {
+                    "platform": variant_platform,
+                    "minimum_os": variant["minimum_os"],
+                    "module_name": name,
+                    "sdk_variant": variant["sdk_variant"],
+                    "defines": ["SWIFT_PACKAGE"],
+                    "swift_flags": _xcode_swift_package_name_flags(package) + ["-swift-version", flags["language_mode"]] + flags["swift"],
+                    "clang_flags": ["-std=c++17"] + flags["clang"],
+                    "exported_header_dirs": _xcode_swift_package_include_dirs(package_path, target),
+                    "private_header_dirs": _xcode_swift_package_target_header_dirs(package_path, target),
+                    "prebuild_actions": prebuild_actions,
+                    "resources": resource_paths,
+                    "structured_resources": structured_resource_paths,
+                    "swift_testing": uses_swift_testing,
+                }
+                spec_kind = "apple_library"
+                if target_type == "test":
+                    spec_kind = "apple_test_bundle"
+                else:
+                    attrs["exported_deps"] = dependencies
+                    attrs["swift_flags"] = attrs["swift_flags"] + ["-enable-testing"]
+                    attrs["exported_headers"] = _unique(_xcode_swift_package_target_headers(package_path, target))
+                    attrs["modulemap"] = _xcode_swift_package_target_modulemap(package_path, target)
+                    attrs["enable_modules"] = True
+                    attrs["xctest_support"] = uses_xctest
+                    attrs["resource_bundle_name"] = resource_bundle_name
+                    attrs["resource_bundle_id"] = identity.lower() + "." + name + ".resources" if resource_bundle_name else ""
                 specs.append({
                     "name": variant_id,
-                    "kind": "apple_library",
+                    "kind": spec_kind,
                     "deps": dependencies,
                     "srcs": sources + core_data["sources"],
-                    "attrs": {
-                        "platform": variant_platform,
-                        "minimum_os": variant["minimum_os"],
-                        "module_name": name,
-                        "sdk_variant": variant["sdk_variant"],
-                        "defines": ["SWIFT_PACKAGE"],
-                        "exported_deps": dependencies,
-                        "swift_flags": _xcode_swift_package_name_flags(package) + ["-swift-version", flags["language_mode"]] + flags["swift"],
-                        "clang_flags": ["-std=c++17"] + flags["clang"],
-                        "exported_headers": _unique(_xcode_swift_package_target_headers(package_path, target)),
-                        "exported_header_dirs": _xcode_swift_package_include_dirs(package_path, target),
-                        "private_header_dirs": _xcode_swift_package_target_header_dirs(package_path, target),
-                        "modulemap": _xcode_swift_package_target_modulemap(package_path, target),
-                        "enable_modules": True,
-                        "swift_testing": uses_swift_testing,
-                        "xctest_support": uses_xctest,
-                        "prebuild_actions": prebuild_actions,
-                        "resources": resource_paths,
-                        "structured_resources": structured_resource_paths,
-                        "resource_bundle_name": resource_bundle_name,
-                        "resource_bundle_id": identity.lower() + "." + name + ".resources" if resource_bundle_name else "",
-                    },
+                    "attrs": attrs,
                 })
     return {"specs": specs, "products": product_ids, "modules": module_ids}
 

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -12,6 +12,8 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::process::Command;
 
 #[cfg(unix)]
 use once_frontend::analysis::{AnalysisEngine, AnalysisResult};
@@ -243,76 +245,159 @@ fn swift_package_native_project_loads_without_a_once_manifest() {
 }
 
 #[cfg(target_os = "macos")]
+fn run_git(directory: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(directory)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git command failed");
+}
+
+#[cfg(target_os = "macos")]
+fn local_swift_package(root: &Path) -> (String, String) {
+    let remote = root.join("remote-support");
+    fs::create_dir_all(remote.join("Sources/RemoteSupport")).expect("remote source directory");
+    fs::write(
+        remote.join("Package.swift"),
+        r#"// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "RemoteSupport",
+    products: [.library(name: "RemoteSupport", targets: ["RemoteSupport"])],
+    targets: [.target(name: "RemoteSupport")]
+)
+"#,
+    )
+    .expect("remote package manifest");
+    fs::write(
+        remote.join("Sources/RemoteSupport/RemoteSupport.swift"),
+        "public func remoteValue() -> Int { 42 }\n",
+    )
+    .expect("remote source");
+    for args in [
+        &["init", "--quiet"][..],
+        &["config", "user.email", "once@example.invalid"][..],
+        &["config", "user.name", "Once tests"][..],
+        &["add", "."][..],
+        &["commit", "--quiet", "-m", "initial"][..],
+    ] {
+        run_git(&remote, args);
+    }
+    let revision = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&remote)
+            .output()
+            .expect("read remote revision")
+            .stdout,
+    )
+    .expect("remote revision is utf-8")
+    .trim()
+    .to_string();
+    (format!("file://{}", remote.display()), revision)
+}
+
+#[cfg(target_os = "macos")]
 #[test]
-fn swift_package_native_project_defers_remote_packages_until_build() {
+fn swift_package_native_project_lowers_remote_packages_directly() {
     let tmp = TempDir::new().expect("tempdir");
+    let (remote_url, revision) = local_swift_package(tmp.path());
+
     fs::create_dir_all(tmp.path().join("Sources/App")).expect("source directory");
+    fs::create_dir_all(tmp.path().join("Tests/AppTests")).expect("test source directory");
     fs::write(
         tmp.path().join("Package.swift"),
-        r#"// swift-tools-version: 6.0
+        format!(
+            r#"// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
     name: "LazyRemote",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+        .package(url: "{remote_url}", exact: "1.0.0"),
     ],
     targets: [
         .target(name: "App", dependencies: [
-            .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            .product(name: "RemoteSupport", package: "remote-support"),
         ]),
+        .testTarget(name: "AppTests", dependencies: ["App"]),
     ]
 )
-"#,
+"#
+        ),
     )
     .expect("package manifest");
     fs::write(
         tmp.path().join("Package.resolved"),
-        r#"{
+        format!(
+            r#"{{
   "version": 3,
   "pins": [
-    {
-      "identity": "swift-argument-parser",
+    {{
+      "identity": "remote-support",
       "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-argument-parser.git",
-      "state": {
-        "revision": "d3f6f4d8adfda4094733522fe7d4d0df8d67dbe0",
-        "version": "1.5.0"
-      }
-    }
+      "location": "{remote_url}",
+      "state": {{
+        "revision": "{revision}",
+        "version": "1.0.0"
+      }}
+    }}
   ]
-}
-"#,
+}}
+"#
+        ),
     )
     .expect("package lock");
     fs::write(
         tmp.path().join("Sources/App/App.swift"),
-        "import ArgumentParser\n",
+        "import RemoteSupport\n",
     )
     .expect("source file");
+    fs::write(
+        tmp.path().join("Tests/AppTests/AppTests.swift"),
+        "import XCTest\n@testable import App\n",
+    )
+    .expect("test source file");
 
     let graph = once_frontend::load_graph_workspace(tmp.path())
-        .expect("native graph loads without fetching remote packages");
+        .expect("native graph loads with a locked remote package");
     assert!(
         !tmp.path().join(".build").exists(),
-        "graph loading must not fetch remote Swift packages"
+        "graph loading must not create Swift Package Manager build state"
+    );
+    assert!(
+        tmp.path()
+            .join(".once/swift-package-packages/remote-support/Package.swift")
+            .exists(),
+        "the pinned remote source must be materialized for direct compilation"
+    );
+    assert!(
+        !graph
+            .iter()
+            .any(|target| target.kind == "swift_package_dependencies"),
+        "native package lowering must not delegate compilation to Swift Package Manager"
     );
     let remote = graph
         .iter()
-        .find(|target| target.label.id == "SwiftPackage_LazyRemote_RemoteDependencies")
-        .expect("lazy remote dependency target");
-    assert_eq!(remote.kind, "swift_package_dependencies");
-    assert_eq!(
-        remote.attrs.get("_lazy_resolution"),
-        Some(&AttrValue::Bool(true))
-    );
+        .find(|target| {
+            target.kind == "apple_library"
+                && target.attrs.get("module_name")
+                    == Some(&AttrValue::String("RemoteSupport".to_string()))
+        })
+        .expect("directly lowered remote library");
     let app = graph
         .iter()
         .find(|target| target.label.id == "SwiftPackage_LazyRemote_App")
         .expect("first-party app target");
-    assert!(app
-        .deps
-        .contains(&"SwiftPackage_LazyRemote_RemoteDependencies".to_string()));
+    assert!(app.deps.contains(&remote.label.id));
+    let tests = graph
+        .iter()
+        .find(|target| target.label.id == "SwiftPackage_LazyRemote_AppTests")
+        .expect("directly lowered test bundle");
+    assert_eq!(tests.kind, "apple_test_bundle");
+    assert!(tests.deps.contains(&app.label.id));
 }
 
 #[cfg(unix)]

--- a/web/priv/docs/guide/graph/swift-packages.md
+++ b/web/priv/docs/guide/graph/swift-packages.md
@@ -37,9 +37,11 @@ only when it should be reviewed in `once.toml`:
 once native init swift_package
 ```
 
-By default, native package lowering does not fetch remote dependencies during
-graph loading. See [`swift_package_workspace`](/reference/prelude/swift_package_workspace)
-for its complete contract.
+For locked source-control dependencies, native package lowering materializes
+the pinned sources during graph loading, then compiles them directly through
+Once's Apple target kinds. See
+[`swift_package_workspace`](/reference/prelude/swift_package_workspace) for
+its complete contract.
 
 When the Xcode workspace resolver lowers package sources into Apple targets,
 compiler language and access-control flags follow the manifest tools version.
@@ -63,11 +65,11 @@ compiler, software development kit, linker, and code-signing path work.
 
 ## Packages With Remote Dependencies
 
-Commit `Package.resolved` with `Package.swift`. Native discovery reads those
-files locally and never downloads packages. When a build first needs a locked
-remote product, Once fetches and builds it as a dependency action. Later builds
-reuse that action from the cache while the manifest, lock file, and Swift
-toolchain remain unchanged.
+Commit `Package.resolved` with `Package.swift`. Native package lowering uses
+the lockfile to materialize each source-control dependency at its pinned
+revision. It then derives and compiles the dependency targets directly, so
+Swift Package Manager does not build a separate dependency graph. Registry
+dependencies are not supported by this native path yet.
 
 The ordinary workflow stays the same:
 

--- a/web/priv/docs/reference/prelude/swift_package_workspace.md
+++ b/web/priv/docs/reference/prelude/swift_package_workspace.md
@@ -15,10 +15,12 @@ without `once.toml` can therefore query and build its first-party package
 targets directly. Discovery skips generated package-manager state such as
 `.build` and `.swiftpm`.
 
-Remote package metadata is not fetched during graph loading. When a first-party
-target needs a product from a locked remote package, the resolver adds a
-dependency action that fetches and builds that product only when a build needs
-it. The action is keyed by the package manifest, lock file, and Swift toolchain.
+For locked source-control dependencies, the resolver materializes the pinned
+sources and lowers their package targets into the same Apple target kinds.
+Once compiles those targets directly with the selected Swift compiler. Swift
+Package Manager supplies manifest and lockfile metadata, but does not build
+the dependency products. Registry dependencies are not supported by native
+package lowering yet.
 
 ## Attributes
 


### PR DESCRIPTION
## What changed

- Materialize source-control dependencies pinned in `Package.resolved` and lower them into direct Apple targets.
- Lower package test targets as test bundles and enable testable imports for library targets.
- Add hermetic coverage for a locked remote dependency and its test bundle.
- Update the native Swift package guide and reference.

## Why

The native Swift package integration previously delegated remote dependency builds to a separate `swift build` action. This change keeps compilation in Once's build graph while using [Swift Package Manager](https://www.swift.org/documentation/package-manager/) only to read package metadata.

## Approach

Once materializes each locked source-control package at its pinned revision, then derives its targets alongside first-party targets. The existing Apple target kinds compile the resulting graph directly. Registry dependencies report that they are not supported by this native path yet.

## Impact

Projects with locked source-control dependencies can build and test through Once without a separate Swift Package Manager build graph. SwiftNIO's core target builds, and its core test target runs successfully.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo clippy -p once-frontend --all-targets -- -D warnings`
- `mise exec -- cargo test -p once-frontend --test examples swift_package_native_project`
- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo build -p once-cli`
- Built the SwiftNIO core target and ran its core test target: 684 passing, none failing.
