### PR TITLE
fix(xcode): resolve linked framework dependencies

### DIFF
--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -2159,6 +2159,28 @@ def _xcode_framework_product_dependencies(objects, target, name_to_id):
                 names.append(dependency)
     return names
 
+def _xcode_framework_xcframework_dependencies(objects, target, file_paths, xcframework_names):
+    # A prebuilt XCFramework has no PBXTargetDependency. Its ownership is
+    # expressed by the target's Frameworks build phase, so recover the graph
+    # edge from that phase instead of guessing from the bundle path.
+    dependencies = []
+    for phase_id in target.get("buildPhases") or []:
+        phase = objects.get(phase_id) or {}
+        if phase.get("isa") != "PBXFrameworksBuildPhase":
+            continue
+        for build_file_id in phase.get("files") or []:
+            build_file = objects.get(build_file_id) or {}
+            file_ref_id = build_file.get("fileRef")
+            file_ref = objects.get(file_ref_id) or {}
+            bundle = file_paths.get(file_ref_id) or _xcode_file_ref_path({}, file_ref)
+            bundle = _xcode_workspace_relative(bundle)
+            if not _ends_with(bundle, ".xcframework"):
+                continue
+            dependency = xcframework_names.get(bundle) or ""
+            if dependency and dependency not in dependencies:
+                dependencies.append(dependency)
+    return dependencies
+
 def _xcode_sanitized_target_name(name):
     out = []
     for ch in name.elems():
@@ -2962,16 +2984,17 @@ def _xcode_workspace_resolver(ctx):
             target_prefix = "XcodePackage_" + _xcode_sanitized_target_name(ctx["label"]["id"]),
         )
         xcframework_specs = _xcode_workspace_xcframework_specs(ctx, package_platform, ctx["attr"].get("sdk_variant") or "simulator")
+        xcframework_names = {
+            spec["attrs"]["bundle"]: spec["name"]
+            for spec in xcframework_specs
+        }
 
         for target in native_targets:
             spec = _xcode_lower_target(ctx, objects, target, project_settings, name_to_id, dep_closure, configuration, file_paths, project_dir, path_maps, test_plan_settings)
             if spec == None:
                 continue
-            target_name = target.get("name") or ""
-            for xcframework in xcframework_specs:
-                bundle = xcframework["attrs"]["bundle"]
-                if target_name and ("/" + target_name + "/") in ("/" + bundle + "/"):
-                    spec["deps"] = _unique(spec["deps"] + ["./" + xcframework["name"]])
+            for dependency in _xcode_framework_xcframework_dependencies(objects, target, file_paths, xcframework_names):
+                spec["deps"] = _unique(spec["deps"] + ["./" + dependency])
             for product in per_target_products[target.get("name") or ""]:
                 identity = product.get("package_identity") or ""
                 dep_id = package_graph["products"].get(identity + "\x1f" + product["name"]) or package_graph["products"].get(product["name"])

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -15805,6 +15805,37 @@ result = repr(_xcode_framework_product_dependencies(objects, objects["APP"], {{"
 }
 
 #[test]
+fn prelude_xcode_recovers_xcframework_dependencies_from_framework_phase() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "DEPENDENCY": {
+            "isa": "PBXFileReference",
+            "path": "DependencyModule.xcframework",
+            "sourceTree": "<group>"
+        },
+        "BUILD": {"isa": "PBXBuildFile", "fileRef": "DEPENDENCY"},
+        "FRAMEWORKS": {"isa": "PBXFrameworksBuildPhase", "files": ["BUILD"]},
+        "FEATURE": {"isa": "PBXNativeTarget", "buildPhases": ["FRAMEWORKS"]},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+objects = json_decode({objects:?})
+result = repr(_xcode_framework_xcframework_dependencies(
+    objects,
+    objects["FEATURE"],
+    {{"DEPENDENCY": "Vendor/DependencyModule.xcframework"}},
+    {{"Vendor/DependencyModule.xcframework": "XCFramework_Vendor_DependencyModule.xcframework"}},
+))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["XCFramework_Vendor_DependencyModule.xcframework"]"#
+    );
+}
+
+#[test]
 fn prelude_xcode_does_not_treat_built_resource_products_as_sources() {
     let prelude = xcode_prelude_source();
     let objects = serde_json::json!({

--- a/fixtures/xcode_firefox_app/RustComponents.xcframework/ios-arm64_x86_64-simulator/RustComponents.framework/Headers/RustComponents.h
+++ b/fixtures/xcode_firefox_app/RustComponents.xcframework/ios-arm64_x86_64-simulator/RustComponents.framework/Headers/RustComponents.h
@@ -1,0 +1,16 @@
+#ifndef RUST_COMPONENTS_H
+#define RUST_COMPONENTS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *rust_components_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fixtures/xcode_xcframework_import/Feature.xcodeproj/project.pbxproj
+++ b/fixtures/xcode_xcframework_import/Feature.xcodeproj/project.pbxproj
@@ -1,0 +1,27 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {};
+	objectVersion = 56;
+	objects = {
+		PROJECT = {isa = PBXProject; buildConfigurationList = PROJECT_CONFIGS; mainGroup = ROOT; targets = (FEATURE); };
+		PROJECT_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (PROJECT_DEBUG); defaultConfigurationName = Debug; };
+		PROJECT_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {SDKROOT = iphoneos; IPHONEOS_DEPLOYMENT_TARGET = 15.0; SWIFT_VERSION = 5.0; }; };
+
+		ROOT = {isa = PBXGroup; children = (SOURCES_GROUP, VENDOR_GROUP); sourceTree = "<group>"; };
+		SOURCES_GROUP = {isa = PBXGroup; path = Sources/Feature; sourceTree = "<group>"; children = (FEATURE_SOURCE); };
+		VENDOR_GROUP = {isa = PBXGroup; path = Vendor; sourceTree = "<group>"; children = (RUST_COMPONENTS); };
+		FEATURE_SOURCE = {isa = PBXFileReference; path = Feature.swift; sourceTree = "<group>"; };
+		RUST_COMPONENTS = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = RustComponents.xcframework; sourceTree = "<group>"; };
+
+		FEATURE_SOURCE_BUILD = {isa = PBXBuildFile; fileRef = FEATURE_SOURCE; };
+		RUST_COMPONENTS_BUILD = {isa = PBXBuildFile; fileRef = RUST_COMPONENTS; };
+		SOURCES = {isa = PBXSourcesBuildPhase; files = (FEATURE_SOURCE_BUILD); };
+		FRAMEWORKS = {isa = PBXFrameworksBuildPhase; files = (RUST_COMPONENTS_BUILD); };
+
+		FEATURE_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (FEATURE_DEBUG); defaultConfigurationName = Debug; };
+		FEATURE_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {PRODUCT_NAME = "$(TARGET_NAME)"; PRODUCT_BUNDLE_IDENTIFIER = dev.once.Feature; }; };
+		FEATURE = {isa = PBXNativeTarget; buildConfigurationList = FEATURE_CONFIGS; buildPhases = (SOURCES, FRAMEWORKS); dependencies = (); name = Feature; productName = Feature; productType = "com.apple.product-type.framework"; };
+	};
+	rootObject = PROJECT;
+}

--- a/fixtures/xcode_xcframework_import/Sources/Feature/Feature.swift
+++ b/fixtures/xcode_xcframework_import/Sources/Feature/Feature.swift
@@ -1,0 +1,5 @@
+import RustComponents
+
+public enum Feature {
+    public static let name = "Feature"
+}

--- a/fixtures/xcode_xcframework_import/once.toml
+++ b/fixtures/xcode_xcframework_import/once.toml
@@ -1,0 +1,11 @@
+[[target]]
+name = "feature_workspace"
+kind = "xcode_workspace"
+srcs = [
+  "Feature.xcodeproj/project.pbxproj",
+  "Sources/Feature/**/*.swift",
+  "Vendor/RustComponents.xcframework/Info.plist",
+]
+
+[target.attrs]
+project = "Feature.xcodeproj"

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -62,6 +62,12 @@ Describe 'apple graph'
     cp -R "$REPO_ROOT/fixtures/xcode_firefox_app/." "$WORKSPACE/"
   }
 
+  copy_xcode_xcframework_import_fixture() {
+    cp -R "$REPO_ROOT/fixtures/xcode_xcframework_import/." "$WORKSPACE/"
+    mkdir -p "$WORKSPACE/Vendor"
+    cp -R "$REPO_ROOT/fixtures/xcode_firefox_app/RustComponents.xcframework" "$WORKSPACE/Vendor/"
+  }
+
   copy_xcode_wikipedia_app_fixture() {
     cp -R "$REPO_ROOT/fixtures/xcode_wikipedia_app/." "$WORKSPACE/"
   }
@@ -296,6 +302,17 @@ SH
     The stdout should include '"status":"completed"'
     The path "$WORKSPACE/.once/out/Generated/Generated.swiftmodule" should be file
     The path "$WORKSPACE/.once/out/Generated/Generated.swift" should be file
+  End
+
+  It 'builds a Swift target that imports a linked XCFramework'
+    Skip if 'apple toolchain unavailable on this host' apple_toolchain_unavailable
+    copy_xcode_xcframework_import_fixture
+
+    When call once --format json build Feature
+    The status should be success
+    The stdout should include '"target":"Feature"'
+    The stdout should include '"status":"completed"'
+    The path "$WORKSPACE/.once/out/Feature/Feature.framework/Feature" should be file
   End
 
   It 'lowers a Firefox-style multi-library project from a real .xcodeproj'


### PR DESCRIPTION
## What changed

- Resolve linked prebuilt Xcode framework bundles from each target's Frameworks build phase.
- Add focused unit coverage and a compact local end-to-end fixture that imports a linked framework bundle from Swift.

## Why

Projects can link a framework bundle from `Vendor/` without declaring a native target dependency. Once must preserve that relationship so Swift can import the module during compilation.

## Root cause

The resolver previously attached discovered framework bundles using a target-name path heuristic. A bundle such as `Vendor/DependencyModule.xcframework` did not match its consuming target and its dependency edge was omitted.

## Approach

The resolver now reads framework build-phase file references, resolves the referenced bundle path, and connects the consuming target to the corresponding imported framework target.

## Impact

Swift targets that import a linked prebuilt framework bundle receive its module search path and link input. Existing projects no longer need the bundle path to contain the consuming target name.

## Validation

- `mise exec -- cargo test -p once-frontend prelude_xcode_recovers_xcframework_dependencies_from_framework_phase`
- `target/debug/once -C /Users/pepicrft/Downloads/once-dependency-repro --format json query target FeatureModule`
- `target/debug/once -C /Users/pepicrft/Downloads/once-dependency-repro --format json build FeatureModule`
- Built the compact local framework-import fixture with `target/debug/once`; it completed in about three seconds.
- `mise exec -- cargo fmt --all -- --check`
- `git diff --check`
