### PR TITLE
fix(xcode): normalize header search paths

### DIFF
--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -2448,7 +2448,7 @@ def _xcode_header_search_dirs(settings, subs):
             if resolved and resolved != "$(inherited)" and not resolved.startswith("$("):
                 if not resolved.startswith("/") and project_dir and resolved != project_dir and not resolved.startswith(project_dir + "/"):
                     resolved = _xcode_join(project_dir, resolved)
-                paths.append(resolved)
+                paths.append(_xcode_normalize_path(resolved))
     return _unique(paths)
 
 def _xcode_auxiliary_modulemaps(settings, subs, primary_modulemap):

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -15139,6 +15139,32 @@ result = repr([_xcode_auxiliary_modulemaps(settings, {{}}, ""), attrs["private_h
 }
 
 #[test]
+fn prelude_xcode_normalizes_workspace_header_search_paths() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+ctx = {{"attr": {{"sdk_variant": "simulator"}}}}
+files = {{
+    "source_flags": {{}},
+    "project_header_dirs": [],
+    "sources": [],
+    "headers": [],
+    "exported_headers": [],
+    "frameworks": [],
+}}
+settings = {{"HEADER_SEARCH_PATHS": ["$(SRCROOT)/../../Common/SharedHeaders/include"]}}
+subs = {{"SRCROOT": "Modules/App/ReproApp", "PROJECT_DIR": "Modules/App/ReproApp"}}
+attrs = _xcode_common_attrs(ctx, {{"name": "App"}}, settings, subs, "ios", files)
+result = repr([_xcode_header_search_dirs(settings, subs), attrs["private_header_dirs"], attrs["clang_flags"]])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["Modules/Common/SharedHeaders/include"], ["Modules/Common/SharedHeaders/include"], ["-I", "Modules/Common/SharedHeaders/include"]]"#
+    );
+}
+
+#[test]
 fn prelude_xcode_lowers_native_search_and_link_flags() {
     let prelude = xcode_prelude_source();
     let source = format!(


### PR DESCRIPTION
## What changed

- Normalize expanded Xcode header search paths before recording them as workspace inputs.
- Add regression coverage for a header directory reached through parent-directory path components.

## Why

Projects can place a shared header directory outside an Xcode project's directory while keeping it inside the Once workspace. Those projects should build when their header search path resolves inside the workspace.

## Root cause

The Xcode resolver expanded the project root in a header search path but preserved parent-directory path components. The later workspace file walk rejected that unnormalized input before resolving it.

## Approach

Apply the resolver's existing path normalization after variable expansion and project-directory resolution. This preserves external absolute search paths while producing a clean workspace-relative directory for paths inside the workspace.

## Impact

Xcode targets can use shared headers through paths such as `$(SRCROOT)/../../Common/SharedHeaders/include` when the resolved directory remains inside the workspace.

## Validation

- `mise exec -- cargo test -p once-frontend --test prelude`
- `mise exec -- cargo fmt --all -- --check`
- `/Users/pepicrft/.superconductor/worktrees/fabrik/sc-resonant-fermion-1cac/target/debug/once -C /Users/pepicrft/Downloads/once-header-path-repro build ReproApp`
