### PR TITLE
fix: resolve copied framework dependencies

### DIFF
--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -2159,14 +2159,15 @@ def _xcode_framework_product_dependencies(objects, target, name_to_id):
                 names.append(dependency)
     return names
 
-def _xcode_framework_xcframework_dependencies(objects, target, file_paths, xcframework_names):
+def _xcode_xcframework_dependencies(objects, target, file_paths, xcframework_names):
     # A prebuilt XCFramework has no PBXTargetDependency. Its ownership is
-    # expressed by the target's Frameworks build phase, so recover the graph
-    # edge from that phase instead of guessing from the bundle path.
+    # expressed by a build phase, including custom Copy Files phases used for
+    # static XCFramework dependencies, so recover the graph edge from the
+    # phase instead of guessing from the bundle path.
     dependencies = []
     for phase_id in target.get("buildPhases") or []:
         phase = objects.get(phase_id) or {}
-        if phase.get("isa") != "PBXFrameworksBuildPhase":
+        if phase.get("isa") not in ["PBXFrameworksBuildPhase", "PBXCopyFilesBuildPhase"]:
             continue
         for build_file_id in phase.get("files") or []:
             build_file = objects.get(build_file_id) or {}
@@ -2993,7 +2994,7 @@ def _xcode_workspace_resolver(ctx):
             spec = _xcode_lower_target(ctx, objects, target, project_settings, name_to_id, dep_closure, configuration, file_paths, project_dir, path_maps, test_plan_settings)
             if spec == None:
                 continue
-            for dependency in _xcode_framework_xcframework_dependencies(objects, target, file_paths, xcframework_names):
+            for dependency in _xcode_xcframework_dependencies(objects, target, file_paths, xcframework_names):
                 spec["deps"] = _unique(spec["deps"] + ["./" + dependency])
             for product in per_target_products[target.get("name") or ""]:
                 identity = product.get("package_identity") or ""

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -15871,8 +15871,49 @@ fn prelude_xcode_recovers_xcframework_dependencies_from_copy_files_phase() {
             "sourceTree": "<group>"
         },
         "BUILD": {"isa": "PBXBuildFile", "fileRef": "DEPENDENCY"},
-        "COPY_XCFRAMEWORK": {"isa": "PBXCopyFilesBuildPhase", "files": ["BUILD"]},
+        "COPY_XCFRAMEWORK": {
+            "isa": "PBXCopyFilesBuildPhase",
+            "dstPath": "_StaticXCFrameworkDependencies/Feature",
+            "dstSubfolderSpec": 16,
+            "files": ["BUILD"]
+        },
         "FEATURE": {"isa": "PBXNativeTarget", "buildPhases": ["COPY_XCFRAMEWORK"]},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+objects = json_decode({objects:?})
+result = repr(_xcode_xcframework_dependencies(
+    objects,
+    objects["FEATURE"],
+    {{"DEPENDENCY": "Vendor/DependencyModule.xcframework"}},
+    {{"Vendor/DependencyModule.xcframework": "XCFramework_Vendor_DependencyModule.xcframework"}},
+))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["XCFramework_Vendor_DependencyModule.xcframework"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_recovers_xcframework_dependencies_from_embed_frameworks_copy_files_phase() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "DEPENDENCY": {
+            "isa": "PBXFileReference",
+            "path": "DependencyModule.xcframework",
+            "sourceTree": "<group>"
+        },
+        "BUILD": {"isa": "PBXBuildFile", "fileRef": "DEPENDENCY"},
+        "EMBED_FRAMEWORKS": {
+            "isa": "PBXCopyFilesBuildPhase",
+            "dstPath": "",
+            "dstSubfolderSpec": 10,
+            "files": ["BUILD"]
+        },
+        "FEATURE": {"isa": "PBXNativeTarget", "buildPhases": ["EMBED_FRAMEWORKS"]},
     })
     .to_string();
     let source = format!(

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -15847,7 +15847,38 @@ fn prelude_xcode_recovers_xcframework_dependencies_from_framework_phase() {
     let source = format!(
         r#"{prelude}
 objects = json_decode({objects:?})
-result = repr(_xcode_framework_xcframework_dependencies(
+result = repr(_xcode_xcframework_dependencies(
+    objects,
+    objects["FEATURE"],
+    {{"DEPENDENCY": "Vendor/DependencyModule.xcframework"}},
+    {{"Vendor/DependencyModule.xcframework": "XCFramework_Vendor_DependencyModule.xcframework"}},
+))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["XCFramework_Vendor_DependencyModule.xcframework"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_recovers_xcframework_dependencies_from_copy_files_phase() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "DEPENDENCY": {
+            "isa": "PBXFileReference",
+            "path": "DependencyModule.xcframework",
+            "sourceTree": "<group>"
+        },
+        "BUILD": {"isa": "PBXBuildFile", "fileRef": "DEPENDENCY"},
+        "COPY_XCFRAMEWORK": {"isa": "PBXCopyFilesBuildPhase", "files": ["BUILD"]},
+        "FEATURE": {"isa": "PBXNativeTarget", "buildPhases": ["COPY_XCFRAMEWORK"]},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+objects = json_decode({objects:?})
+result = repr(_xcode_xcframework_dependencies(
     objects,
     objects["FEATURE"],
     {{"DEPENDENCY": "Vendor/DependencyModule.xcframework"}},

--- a/fixtures/xcode_xcframework_import/Feature.xcodeproj/project.pbxproj
+++ b/fixtures/xcode_xcframework_import/Feature.xcodeproj/project.pbxproj
@@ -17,11 +17,11 @@
 		FEATURE_SOURCE_BUILD = {isa = PBXBuildFile; fileRef = FEATURE_SOURCE; };
 		RUST_COMPONENTS_BUILD = {isa = PBXBuildFile; fileRef = RUST_COMPONENTS; };
 		SOURCES = {isa = PBXSourcesBuildPhase; files = (FEATURE_SOURCE_BUILD); };
-		FRAMEWORKS = {isa = PBXFrameworksBuildPhase; files = (RUST_COMPONENTS_BUILD); };
+		COPY_XCFRAMEWORK = {isa = PBXCopyFilesBuildPhase; dstPath = _StaticXCFrameworkDependencies/Feature; dstSubfolderSpec = 16; files = (RUST_COMPONENTS_BUILD); };
 
 		FEATURE_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (FEATURE_DEBUG); defaultConfigurationName = Debug; };
 		FEATURE_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {PRODUCT_NAME = "$(TARGET_NAME)"; PRODUCT_BUNDLE_IDENTIFIER = dev.once.Feature; }; };
-		FEATURE = {isa = PBXNativeTarget; buildConfigurationList = FEATURE_CONFIGS; buildPhases = (SOURCES, FRAMEWORKS); dependencies = (); name = Feature; productName = Feature; productType = "com.apple.product-type.framework"; };
+		FEATURE = {isa = PBXNativeTarget; buildConfigurationList = FEATURE_CONFIGS; buildPhases = (SOURCES, COPY_XCFRAMEWORK); dependencies = (); name = Feature; productName = Feature; productType = "com.apple.product-type.framework"; };
 	};
 	rootObject = PROJECT;
 }

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -304,7 +304,7 @@ SH
     The path "$WORKSPACE/.once/out/Generated/Generated.swift" should be file
   End
 
-  It 'builds a Swift target that imports a linked XCFramework'
+  It 'builds a Swift target that imports an XCFramework from a Copy Files phase'
     Skip if 'apple toolchain unavailable on this host' apple_toolchain_unavailable
     copy_xcode_xcframework_import_fixture
 


### PR DESCRIPTION
## What changed

- Resolve prebuilt framework bundle dependencies from standard Frameworks and Copy Files build phases.
- Add resolver coverage for both the custom static-framework staging phase and the ordinary Embed Frameworks phase, plus an end-to-end regression fixture.

## Why

Some Xcode projects place static framework bundle dependencies in a custom Copy Files phase. Those dependencies must still be available while compiling the consuming target.

## Root cause

The workspace resolver inspected only the standard Frameworks build phase. A framework bundle referenced solely from a Copy Files phase was omitted from the dependency graph, so its module map, headers, and link input never reached compilation.

## Approach

[Swift Build](https://github.com/swiftlang/swift-build/blob/main/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift) discovers prebuilt framework bundles across file-bearing build phases before planning the work. Once now treats Copy Files entries as dependency declarations alongside the standard Frameworks phase. This covers both static-framework staging and ordinary framework embedding without relying on a generated path name.

## Impact

Projects using a Copy Files phase for prebuilt framework bundles now compile through Once without additional configuration.

## Validation

- `mise exec -- cargo test -p once-frontend --test prelude prelude_xcode_ -- --nocapture`
- `mise exec -- cargo build --release -p once-cli`
- `mise exec -- shellspec spec/apple_spec.sh:307 --random none`
- Built `/Users/pepicrft/Downloads/once-static-xcframework-copy-phase-repro` successfully with the release executable.
