### PR TITLE
fix(xcode): build cache-substituted generated workspaces end to end

### DIFF
--- a/crates/once-core/src/directory_blob.rs
+++ b/crates/once-core/src/directory_blob.rs
@@ -541,9 +541,11 @@ fn restore_streamed_directory_file(
     reader: &mut impl Read,
 ) -> Result<()> {
     let mut output =
-        std::fs::File::create(&entry.destination).map_err(|source| Error::RestoreOutput {
-            path: logical_path.to_string(),
-            source,
+        crate::file_blob::create_replacing_readonly(&entry.destination).map_err(|source| {
+            Error::RestoreOutput {
+                path: logical_path.to_string(),
+                source,
+            }
         })?;
     let copied =
         std::io::copy(&mut reader.take(entry.content_len), &mut output).map_err(|source| {

--- a/crates/once-core/src/file_blob.rs
+++ b/crates/once-core/src/file_blob.rs
@@ -13,6 +13,21 @@ use crate::{Error, Result};
 
 pub(crate) const FILE_BLOB_MAGIC: &[u8] = b"once.file.v1\0";
 
+/// Open `abs` for writing, replacing a read-only file left by an earlier
+/// restore. Two actions can declare the same output path with different
+/// content (a linked binary and its re-signed copy); when the first restore
+/// materializes the blob's read-only mode, truncating it in place fails with
+/// a permission error, so fall back to unlinking and recreating the path.
+pub(crate) fn create_replacing_readonly(abs: &Path) -> std::io::Result<std::fs::File> {
+    match std::fs::File::create(abs) {
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied && abs.is_file() => {
+            std::fs::remove_file(abs)?;
+            std::fs::File::create(abs)
+        }
+        result => result,
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn capture_file_blob(path: &Path) -> std::io::Result<Vec<u8>> {
     let metadata = std::fs::metadata(path)?;
@@ -74,7 +89,7 @@ pub(crate) fn restore_file_blob_from_reader(
             source,
         })?;
     }
-    let mut output = std::fs::File::create(abs).map_err(|source| Error::RestoreOutput {
+    let mut output = create_replacing_readonly(abs).map_err(|source| Error::RestoreOutput {
         path: logical_path.to_string(),
         source,
     })?;
@@ -207,5 +222,23 @@ mod tests {
         restore_file_blob_from_reader("restored", &restored, blob.as_slice()).unwrap();
 
         assert_eq!(std::fs::read(restored).unwrap(), bytes);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn restore_replaces_a_read_only_output_left_by_an_earlier_restore() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source");
+        let restored = dir.path().join("restored");
+        std::fs::write(&source, b"signed").unwrap();
+        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let blob = capture_file_blob(&source).unwrap();
+
+        restore_file_blob_from_reader("restored", &restored, blob.as_slice()).unwrap();
+        restore_file_blob_from_reader("restored", &restored, blob.as_slice()).unwrap();
+
+        assert_eq!(std::fs::read(restored).unwrap(), b"signed");
     }
 }

--- a/crates/once-core/src/outputs.rs
+++ b/crates/once-core/src/outputs.rs
@@ -315,9 +315,11 @@ fn restore_legacy_file(rel: &str, abs: &Path, mut blob: impl Read) -> Result<()>
             source,
         })?;
     }
-    let mut file = std::fs::File::create(abs).map_err(|source| Error::RestoreOutput {
-        path: rel.to_string(),
-        source,
+    let mut file = crate::file_blob::create_replacing_readonly(abs).map_err(|source| {
+        Error::RestoreOutput {
+            path: rel.to_string(),
+            source,
+        }
     })?;
     std::io::copy(&mut blob, &mut file).map_err(|source| Error::RestoreOutput {
         path: rel.to_string(),

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -2156,10 +2156,14 @@ def _apple_clang_profile_runtime(platform, sdk_variant, xcode_developer_dir):
     device_suffix, simulator_suffix = suffixes
     suffix = simulator_suffix if sdk_variant == "simulator" and platform != "macos" else device_suffix
     env = {"DEVELOPER_DIR": xcode_developer_dir} if xcode_developer_dir else {}
-    clang = host_command([host_which("xcrun"), "--find", "clang"], env = env).strip()
+    # Resolved fail-soft: a hermetic or mocked toolchain without these lookup
+    # commands simply links without the runtime, as before.
+    swallow = "\"$@\" 2>/dev/null; exit 0"
+    sh = host_which("sh")
+    clang = host_command([sh, "-c", swallow, "clang-lookup", host_which("xcrun"), "--find", "clang"], env = env).strip()
     if not clang:
         return ""
-    resource_dir = host_command([clang, "-print-resource-dir"], env = env).strip()
+    resource_dir = host_command([sh, "-c", swallow, "clang-resource-dir", clang, "-print-resource-dir"], env = env).strip()
     if not resource_dir:
         return ""
     path = resource_dir + "/lib/darwin/libclang_rt.profile_" + suffix + ".a"

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -723,11 +723,44 @@ def _validate_apple_native_deps(deps, consumer_label):
         label = dep.get("label_id") or "dependency"
         fail(consumer_label + ": Rust library dep `" + label + "` has crate_type `" + crate_type + "` and does not provide an Apple static library; set crate_type = \"staticlib\" for Apple consumers")
 
+def _apple_binary_swift_plugin_dep(ctx):
+    descriptors = []
+    index = 0
+    for descriptor in ctx["attr"].get("binary_swift_plugins") or []:
+        separator = descriptor.find("#")
+        if separator <= 0 or separator == len(descriptor) - 1:
+            fail(ctx["label"]["id"] + ": binary Swift plugin `" + descriptor + "` must use the `<executable>#<module>` form")
+        source = descriptor[:separator]
+        module_name = descriptor[separator + 1:]
+        executable = ""
+        if source.startswith("/"):
+            if not host_file_exists(source):
+                fail(ctx["label"]["id"] + ": binary Swift plugin executable does not exist: " + source)
+            source_dir = _parent_dir(source)
+            if not source_dir or source_dir == "/":
+                fail(ctx["label"]["id"] + ": binary Swift plugin executable must be inside a host directory: " + source)
+            snapshot = declare_output("binary-swift-plugins/" + str(index))
+            materialize_host_tree(source_dir, snapshot)
+            executable = snapshot + "/" + _basename(source)
+        else:
+            executable = _package_relative(ctx, source)
+        descriptors.append(executable + "#" + module_name)
+        index += 1
+    if not descriptors:
+        return None
+    return {
+        "label_id": ctx["label"]["id"] + "#binary-swift-plugins",
+        "transitive_plugin_executables": descriptors,
+    }
+
 def _apple_native_deps(ctx):
     out = []
     materialized = {}
     for dep in ctx["deps"]:
         out.append(_apple_materialize_native_dep(ctx, dep, materialized))
+    binary_swift_plugins = _apple_binary_swift_plugin_dep(ctx)
+    if binary_swift_plugins != None:
+        out.append(binary_swift_plugins)
     return out
 
 # A select-shape attribute value is a dict with exactly one `select`
@@ -2101,6 +2134,37 @@ def _apple_library_impl(ctx):
         "transitive_resource_bundles": transitive_resource_bundles,
     }
 
+_APPLE_PROFILE_RUNTIME_SUFFIXES = {
+    "ios": ("ios", "iossim"),
+    "macos": ("osx", "osx"),
+    "tvos": ("tvos", "tvossim"),
+    "watchos": ("watchos", "watchossim"),
+    "visionos": ("xros", "xrossim"),
+    "xros": ("xros", "xrossim"),
+}
+
+def _apple_clang_profile_runtime(platform, sdk_variant, xcode_developer_dir):
+    # Vendor archives sometimes ship profile-instrumented objects whose strong
+    # `___llvm_profile_runtime` reference the compiler driver only satisfies
+    # under instrumentation flags. Appending the toolchain's profile runtime
+    # as a lazy archive keeps such members linkable and is inert otherwise:
+    # no runtime member is loaded unless an instrumented object was already
+    # pulled into the link.
+    suffixes = _APPLE_PROFILE_RUNTIME_SUFFIXES.get(platform)
+    if not suffixes:
+        return ""
+    device_suffix, simulator_suffix = suffixes
+    suffix = simulator_suffix if sdk_variant == "simulator" and platform != "macos" else device_suffix
+    env = {"DEVELOPER_DIR": xcode_developer_dir} if xcode_developer_dir else {}
+    clang = host_command([host_which("xcrun"), "--find", "clang"], env = env).strip()
+    if not clang:
+        return ""
+    resource_dir = host_command([clang, "-print-resource-dir"], env = env).strip()
+    if not resource_dir:
+        return ""
+    path = resource_dir + "/lib/darwin/libclang_rt.profile_" + suffix + ".a"
+    return path if host_path_exists(path) else ""
+
 def _apple_xcframework_platform(platform):
     if platform == "macos" or platform == "macosx":
         return "macos"
@@ -2166,12 +2230,20 @@ def _apple_xcframework_import_impl(ctx):
         binary_path = library_path + "/" + _basename(library_path).replace(".framework", "") if library_path.endswith(".framework") else library_path
     binary = slice_path + "/" + binary_path
     absolute_slice = workspace_root() + "/" + slice_path
-    files = [path[len(workspace_root()) + 1:] for path in host_command([host_which("find"), absolute_slice, "-type", "f"]).split("\n") if path]
+    files = [path[len(workspace_root()) + 1:] for path in host_command([host_which("find"), "-L", absolute_slice, "-type", "f"]).split("\n") if path]
     is_framework = library_path.endswith(".framework")
     expected_binary = binary if is_framework else library
     if not files or expected_binary not in files:
         fail(ctx["label"]["id"] + ": selected XCFramework slice is missing `" + library + "`")
     linkage = "static" if library_path.endswith(".a") or "current ar archive" in host_command([host_which("file"), workspace_root() + "/" + binary]) else "dynamic"
+    deps = _apple_native_deps(ctx)
+    # Dependency edges on an imported XCFramework are inferred (a prebuilt
+    # Swift module requires other prebuilt modules to load). They make the
+    # dependency's modules visible to consumers at compile time, including the
+    # framework bundles that carry search directories and autolink
+    # suppression, but they are not link edges: archives, SDK libraries, and
+    # linker options stay own-only so the generated project's build phases
+    # remain the only source of link inputs.
     if not is_framework:
         headers_path = selected.get("HeadersPath") or ""
         headers_dir = slice_path + "/" + headers_path if headers_path else ""
@@ -2184,19 +2256,21 @@ def _apple_xcframework_import_impl(ctx):
                 if path.endswith(".modulemap"):
                     modulemaps.append(path)
         module_name = attrs.get("module_name") or _apple_xcframework_module_name(modulemaps, _apple_xcframework_static_library_name(library_path))
+        transitive_framework_bundles = _apple_collect_runtime_framework_bundles(deps)
         return {
             "label_id": ctx["label"]["id"],
             "framework_path": library,
             "framework_module_name": module_name,
             "framework_files": files,
-            "transitive_exported_header_dirs": [headers_dir] if headers_dir else [],
-            "transitive_modulemaps": modulemaps,
+            "transitive_swiftmodule_dirs": _collect_transitive(deps, "transitive_swiftmodule_dirs", []),
+            "transitive_exported_header_dirs": _collect_transitive(deps, "transitive_exported_header_dirs", [headers_dir] if headers_dir else []),
+            "transitive_modulemaps": _collect_transitive(deps, "transitive_modulemaps", modulemaps),
             "transitive_archives": [binary] if linkage == "static" else [],
-            "transitive_framework_search_dirs": [],
-            "transitive_framework_files": files,
-            "transitive_link_framework_bundles": [],
-            "transitive_framework_bundles": [],
-            "transitive_frameworks": [],
+            "transitive_framework_search_dirs": _collect_transitive(deps, "transitive_framework_search_dirs", []),
+            "transitive_framework_files": _collect_transitive(deps, "transitive_framework_files", files),
+            "transitive_link_framework_bundles": _apple_collect_link_framework_bundles(deps),
+            "transitive_framework_bundles": transitive_framework_bundles,
+            "transitive_frameworks": _apple_framework_bundle_paths(transitive_framework_bundles),
             "transitive_sdk_frameworks": [],
             "transitive_weak_sdk_frameworks": [],
             "transitive_sdk_dylibs": [],
@@ -2205,16 +2279,21 @@ def _apple_xcframework_import_impl(ctx):
     module_name = attrs.get("module_name") or _basename(library_path).replace(".framework", "")
     own_bundle = _apple_framework_bundle(library, module_name, files, ctx["label"]["id"])
     own_bundle["linkage"] = linkage
+    transitive_framework_bundles = _apple_collect_runtime_framework_bundles(deps, [] if linkage == "static" else [own_bundle])
     return {
         "label_id": ctx["label"]["id"],
         "framework_path": library,
         "framework_module_name": module_name,
         "framework_files": files,
-        "transitive_swiftmodule_dirs": [],
+        "transitive_swiftmodule_dirs": _collect_transitive(deps, "transitive_swiftmodule_dirs", []),
+        "transitive_exported_header_dirs": _collect_transitive(deps, "transitive_exported_header_dirs", []),
+        "transitive_modulemaps": _collect_transitive(deps, "transitive_modulemaps", []),
         "transitive_archives": [binary] if linkage == "static" else [],
-        "transitive_link_framework_bundles": [own_bundle],
-        "transitive_framework_bundles": [] if linkage == "static" else [own_bundle],
-        "transitive_frameworks": [] if linkage == "static" else [library],
+        "transitive_framework_search_dirs": _collect_transitive(deps, "transitive_framework_search_dirs", []),
+        "transitive_framework_files": _collect_transitive(deps, "transitive_framework_files", []),
+        "transitive_link_framework_bundles": _apple_collect_link_framework_bundles(deps, [own_bundle]),
+        "transitive_framework_bundles": transitive_framework_bundles,
+        "transitive_frameworks": _apple_framework_bundle_paths(transitive_framework_bundles),
         "transitive_sdk_frameworks": [],
         "transitive_weak_sdk_frameworks": [],
         "transitive_sdk_dylibs": [],
@@ -3168,6 +3247,13 @@ def _apple_framework_impl(ctx):
     sdk_dylibs_attr = attrs.get("sdk_dylibs") or []
     linkopts = attrs.get("linkopts") or []
     swift_flags = attrs.get("swift_flags") or []
+    private_header_dirs = []
+    for header_dir in (attrs.get("exported_header_dirs") or []) + (attrs.get("private_header_dirs") or []):
+        resolved_header_dir = _package_relative(ctx, header_dir)
+        absolute_header_dir = resolved_header_dir if resolved_header_dir.startswith("/") else workspace_root() + "/" + resolved_header_dir
+        if resolved_header_dir and host_path_exists(absolute_header_dir) and resolved_header_dir not in private_header_dirs:
+            private_header_dirs.append(resolved_header_dir)
+    private_header_files = _apple_header_inputs(ctx, private_header_dirs)
 
     all_srcs = glob(ctx["srcs"])
     swift_srcs = _filter_swift_sources(all_srcs)
@@ -3232,6 +3318,8 @@ def _apple_framework_impl(ctx):
         swift_argv.extend(["-I", d])
     for hdir in compile_header_dirs:
         swift_argv.extend(["-Xcc", "-I", "-Xcc", hdir])
+    for hdir in private_header_dirs:
+        swift_argv.extend(["-Xcc", "-I", "-Xcc", hdir])
     for mmap in dep_modulemaps:
         swift_argv.extend(["-Xcc", "-fmodule-map-file=" + mmap])
     for hmap in dep_hmaps:
@@ -3274,6 +3362,9 @@ def _apple_framework_impl(ctx):
     for overlay in dep_vfs_overlays:
         if overlay not in swift_inputs:
             swift_inputs.append(overlay)
+    for header in private_header_files:
+        if header not in swift_inputs:
+            swift_inputs.append(header)
     for plugin_input in _apple_swift_plugin_inputs(plugin_dylibs, plugin_executables):
         if plugin_input not in swift_inputs:
             swift_inputs.append(plugin_input)
@@ -3351,6 +3442,8 @@ def _apple_framework_impl(ctx):
         "transitive_swiftmodule_dirs": transitive_swiftmodule_dirs,
         "transitive_archives": [],
         "absorbed_static_archives": absorbed_static_archives,
+        "transitive_framework_search_dirs": framework_search_dirs,
+        "transitive_framework_files": dep_framework_files,
         "transitive_link_framework_bundles": transitive_link_framework_bundles,
         "transitive_framework_bundles": transitive_framework_bundles,
         "transitive_frameworks": _apple_framework_bundle_paths(transitive_framework_bundles),
@@ -3916,6 +4009,9 @@ def _apple_application_impl(ctx):
     for src in swift_srcs:
         swift_argv.append(src)
     _apple_append_archives(swift_argv, dep_archives, alwayslink_archives)
+    profile_runtime = _apple_clang_profile_runtime(platform, sdk_variant, xcode_developer_dir)
+    if profile_runtime:
+        swift_argv.append(profile_runtime)
 
     swift_inputs = list(swift_srcs)
     if embeds_simulator_entitlements:
@@ -5819,6 +5915,7 @@ apple_library = target_kind(
         attr("sdk_dylibs", "list<string>", default = "[]", docs = "Apple SDK dynamic libraries linked by name"),
         attr("linkopts", "list<string>", default = "[]", docs = "Extra linker flags, propagated transitively to consumers"),
         attr("swift_flags", "list<string>", default = "[]", docs = "Extra Swift compiler flags"),
+        attr("binary_swift_plugins", "list<string>", default = "[]", docs = "Prebuilt Swift macro executables in `<executable>#<module>` form", configurable = False),
         attr("clang_flags", "list<string>", default = "[]", docs = "Extra Clang compiler flags"),
         attr("per_source_clang_flags", "map<string,string>", default = "{}", docs = "[JavaScript Object Notation (JSON)](https://www.json.org/json-en.html)-encoded Clang flag lists keyed by source path", configurable = False),
         attr("defines", "list<string>", default = "[]", docs = "`-D` conditions shared by Swift and Clang for compatibility"),
@@ -5911,6 +6008,7 @@ apple_framework = target_kind(
         attr("sdk_dylibs", "list<string>", default = "[]", docs = "Apple SDK dynamic libraries linked by name"),
         attr("linkopts", "list<string>", default = "[]", docs = "Extra linker flags"),
         attr("swift_flags", "list<string>", default = "[]", docs = "Extra Swift compiler flags"),
+        attr("binary_swift_plugins", "list<string>", default = "[]", docs = "Prebuilt Swift macro executables in `<executable>#<module>` form", configurable = False),
         attr("clang_flags", "list<string>", default = "[]", docs = "Extra Clang compiler flags"),
         attr("per_source_clang_flags", "map<string,string>", default = "{}", docs = "[JavaScript Object Notation (JSON)](https://www.json.org/json-en.html)-encoded Clang flag lists keyed by source path", configurable = False),
         attr("defines", "list<string>", default = "[]", docs = "Conditional compilation definitions shared by Swift and Clang for compatibility"),
@@ -5976,6 +6074,7 @@ apple_application = target_kind(
         attr("sdk_dylibs", "list<string>", default = "[]", docs = "Apple SDK dynamic libraries linked by name"),
         attr("linkopts", "list<string>", default = "[]", docs = "Extra linker flags"),
         attr("swift_flags", "list<string>", default = "[]", docs = "Extra Swift compiler flags"),
+        attr("binary_swift_plugins", "list<string>", default = "[]", docs = "Prebuilt Swift macro executables in `<executable>#<module>` form", configurable = False),
         attr("clang_flags", "list<string>", default = "[]", docs = "Extra Clang compiler flags applied to C, C++, Objective-C, and Objective-C++ sources"),
         attr("per_source_clang_flags", "map<string,string>", default = "{}", docs = "JSON-encoded Clang compiler flag lists keyed by source path"),
         attr("defines", "list<string>", default = "[]", docs = "Conditional compilation definitions shared by Swift and Clang for compatibility"),
@@ -6091,6 +6190,7 @@ apple_test_bundle = target_kind(
         attr("sdk_dylibs", "list<string>", default = "[]", docs = "Apple software development kit dynamic libraries linked by name"),
         attr("linkopts", "list<string>", default = "[]", docs = "Extra linker flags"),
         attr("swift_flags", "list<string>", default = "[]", docs = "Extra Swift compiler flags"),
+        attr("binary_swift_plugins", "list<string>", default = "[]", docs = "Prebuilt Swift macro executables in `<executable>#<module>` form", configurable = False),
         attr("clang_flags", "list<string>", default = "[]", docs = "Extra Clang compiler flags applied to C, C++, Objective-C, and Objective-C++ test sources"),
         attr("per_source_clang_flags", "map<string,string>", default = "{}", docs = "JSON-encoded Clang compiler flag lists keyed by test source path"),
         attr("defines", "list<string>", default = "[]", docs = "Conditional compilation definitions shared by Swift and Clang for compatibility"),

--- a/crates/once-frontend/prelude/swift_package.star
+++ b/crates/once-frontend/prelude/swift_package.star
@@ -16,9 +16,12 @@ def _swift_package_workspace_resolver(ctx):
     graph = _xcode_local_swift_package_specs(ctx, packages, attrs.get("platform") or "macos", attrs.get("minimum_os") or "13.0", attrs.get("sdk_variant") or "simulator")
     roots = []
     for product in info.get("products") or []:
-        target_id = graph["products"].get(package["identity"] + "\x1f" + (product.get("name") or ""))
-        if target_id and target_id not in roots:
-            roots.append(target_id)
+        target_ids = graph["products"].get(package["identity"] + "\x1f" + (product.get("name") or ""))
+        if target_ids and type(target_ids) != "list":
+            target_ids = [target_ids]
+        for target_id in target_ids or []:
+            if target_id not in roots:
+                roots.append(target_id)
     return {"targets": graph["specs"], "roots": roots}
 
 def _swift_package_remote_infos(ctx):

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -1842,9 +1842,13 @@ def _xcode_swift_package_dependencies(target, identity, target_ids, product_ids,
             if key == "product" and len(values) > 1 and type(values[1]) == "string" and values[1]:
                 package_identity = values[1]
             name = values[0]
-            dep_id = target_ids.get(package_identity + "\x1f" + name) or target_ids.get(package_identity.lower() + "\x1f" + name) or product_ids.get(package_identity + "\x1f" + name) or product_ids.get(package_identity.lower() + "\x1f" + name) or product_ids.get(name)
-            if dep_id and dep_id not in deps:
-                deps.append("./" + dep_id)
+            dependency_ids = target_ids.get(package_identity + "\x1f" + name) or target_ids.get(package_identity.lower() + "\x1f" + name) or product_ids.get(package_identity + "\x1f" + name) or product_ids.get(package_identity.lower() + "\x1f" + name) or product_ids.get(name)
+            if dependency_ids and type(dependency_ids) != "list":
+                dependency_ids = [dependency_ids]
+            if dependency_ids:
+                for dep_id in dependency_ids:
+                    if dep_id and "./" + dep_id not in deps:
+                        deps.append("./" + dep_id)
             elif lazy_dependency and lazy_products.get(package_identity.lower() + "\x1f" + name) and "./" + lazy_dependency not in deps:
                 deps.append("./" + lazy_dependency)
     return deps
@@ -1929,9 +1933,8 @@ def _xcode_swift_package_target_flags(target, platform, default_language_mode):
     }
 
 def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant, lazy_products = {}, lazy_dependency = "", target_prefix = "SwiftPackage"):
-    # Lower source package targets as ordinary Apple libraries. Products merely
-    # name one or more targets, so consumers depend on the product's primary
-    # target while that target keeps its declared package dependencies.
+    # Lower source package targets as ordinary Apple libraries. Products group
+    # one or more targets, so consumers receive the complete product closure.
     target_ids = {}
     product_ids = {}
     host_target_ids = {}
@@ -1953,8 +1956,17 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
             targets = product.get("targets") or []
             if targets:
                 product_name = product.get("name") or ""
-                product_id = target_ids.get(identity + "\x1f" + targets[0]) or ""
-                host_product_id = host_target_ids.get(identity + "\x1f" + targets[0]) or ""
+                product_target_ids = []
+                host_product_target_ids = []
+                for target_name in targets:
+                    product_target_id = target_ids.get(identity + "\x1f" + target_name) or ""
+                    if product_target_id and product_target_id not in product_target_ids:
+                        product_target_ids.append(product_target_id)
+                    host_product_target_id = host_target_ids.get(identity + "\x1f" + target_name) or ""
+                    if host_product_target_id and host_product_target_id not in host_product_target_ids:
+                        host_product_target_ids.append(host_product_target_id)
+                product_id = product_target_ids[0] if len(product_target_ids) == 1 else product_target_ids
+                host_product_id = host_product_target_ids[0] if len(host_product_target_ids) == 1 else host_product_target_ids
                 product_ids[identity + "\x1f" + product_name] = product_id
                 product_ids[identity.lower() + "\x1f" + product_name] = product_id
                 product_ids[product_name] = product_id
@@ -3385,14 +3397,19 @@ def _xcode_workspace_resolver(ctx):
                 spec["deps"] = _unique(spec["deps"] + ["./" + dependency])
             for product in per_target_products[target.get("name") or ""]:
                 identity = product.get("package_identity") or ""
-                dep_id = package_graph["products"].get(identity + "\x1f" + product["name"]) or package_graph["products"].get(product["name"])
-                if dep_id:
+                dep_ids = package_graph["products"].get(identity + "\x1f" + product["name"]) or package_graph["products"].get(product["name"])
+                if dep_ids and type(dep_ids) != "list":
+                    dep_ids = [dep_ids]
+                for dep_id in dep_ids or []:
                     spec["deps"] = _unique(spec["deps"] + ["./" + dep_id])
             dependency_modules = _unique(_xcode_swift_imports(spec["srcs"]) + _xcode_disabled_autolink_modules(spec["attrs"].get("swift_flags") or []))
             for module in dependency_modules:
-                dep_id = name_to_id.get(module) or package_graph["products"].get(module) or package_graph["modules"].get(module) or xcframework_modules.get(_xcode_product_dependency_key(module))
-                if dep_id and dep_id != spec["name"]:
-                    spec["deps"] = _unique(spec["deps"] + ["./" + dep_id])
+                dep_ids = name_to_id.get(module) or package_graph["products"].get(module) or package_graph["modules"].get(module) or xcframework_modules.get(_xcode_product_dependency_key(module))
+                if dep_ids and type(dep_ids) != "list":
+                    dep_ids = [dep_ids]
+                for dep_id in dep_ids or []:
+                    if dep_id != spec["name"]:
+                        spec["deps"] = _unique(spec["deps"] + ["./" + dep_id])
             if spec["kind"] == "apple_library":
                 spec["attrs"]["exported_deps"] = list(spec["deps"])
             all_specs.append(spec)

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -156,6 +156,8 @@ def _xcode_read_pbxproj(ctx, project_path):
 _XCODE_LIST_SETTINGS = {
     "GCC_PREPROCESSOR_DEFINITIONS": True,
     "SWIFT_ACTIVE_COMPILATION_CONDITIONS": True,
+    "SWIFT_INCLUDE_PATHS": True,
+    "SWIFT_LOAD_BINARY_MACROS": True,
     "OTHER_SWIFT_FLAGS": True,
     "OTHER_LDFLAGS": True,
     "OTHER_CFLAGS": True,
@@ -185,6 +187,7 @@ _XCODE_LINKER_OPTION_ARITY = {
     "-undefined": 1,
     "-unexported_symbols_list": 1,
     "-weak_framework": 1,
+    "-weak_library": 1,
 }
 
 def _xcode_setting_to_list(value):
@@ -883,7 +886,24 @@ def _xcode_synced_group_files(ctx, objects, target, project_dir, path_maps):
         "intent_definitions": _unique(buckets["intent_definitions"]),
     }
 
-def _xcode_classic_phase_files(ctx, objects, target, file_paths):
+def _xcode_build_file_matches_platform(build_file, platform):
+    # A PBXBuildFile can be scoped to platforms (for example an AppKit link
+    # entry filtered to macOS in a multi-platform target). An entry with
+    # filters belongs to the build only when the current platform is listed.
+    filters = build_file.get("platformFilters") or []
+    single = build_file.get("platformFilter") or ""
+    if single and single not in filters:
+        filters = filters + [single]
+    if not filters or not platform:
+        return True
+    aliases = {"xros": "visionos"}
+    wanted = aliases.get(platform) or platform
+    for token in filters:
+        if (aliases.get(token) or token) == wanted:
+            return True
+    return False
+
+def _xcode_classic_phase_files(ctx, objects, target, file_paths, platform = ""):
     # Classic projects list PBXBuildFile entries per phase. Resolve each back
     # to its PBXFileReference's full package-relative path (through the group
     # tree), falling back to the leaf path when the reference is not rooted in
@@ -896,12 +916,15 @@ def _xcode_classic_phase_files(ctx, objects, target, file_paths):
     asset_catalogs = []
     intent_definitions = []
     frameworks = []
+    sdk_dylibs = []
     source_flags = {}
     for phase_id in target.get("buildPhases") or []:
         phase = objects.get(phase_id) or {}
         isa = phase.get("isa") or ""
         for build_file_id in phase.get("files") or []:
             build_file = objects.get(build_file_id) or {}
+            if not _xcode_build_file_matches_platform(build_file, platform):
+                continue
             file_ref_id = build_file.get("fileRef")
             file_ref = objects.get(file_ref_id) or {}
             if isa == "PBXSourcesBuildPhase" and file_ref.get("isa") == "PBXVariantGroup":
@@ -972,6 +995,12 @@ def _xcode_classic_phase_files(ctx, objects, target, file_paths):
                 name = file_ref.get("name") or _basename(path)
                 if _ends_with(name, ".framework"):
                     frameworks.append(name[:len(name) - len(".framework")])
+                elif _ends_with(name, ".tbd"):
+                    dylib = name[:len(name) - len(".tbd")]
+                    if dylib.startswith("lib"):
+                        dylib = dylib[len("lib"):]
+                    if dylib:
+                        sdk_dylibs.append(dylib)
     return {
         "sources": _unique(sources),
         "headers": _unique(headers),
@@ -981,11 +1010,12 @@ def _xcode_classic_phase_files(ctx, objects, target, file_paths):
         "asset_catalogs": _unique(asset_catalogs),
         "intent_definitions": _unique(intent_definitions),
         "frameworks": _unique(frameworks),
+        "sdk_dylibs": _unique(sdk_dylibs),
         "source_flags": source_flags,
     }
 
-def _xcode_target_files(ctx, objects, target, file_paths, project_dir, path_maps):
-    classic = _xcode_classic_phase_files(ctx, objects, target, file_paths)
+def _xcode_target_files(ctx, objects, target, file_paths, project_dir, path_maps, platform = ""):
+    classic = _xcode_classic_phase_files(ctx, objects, target, file_paths, platform)
     synced = _xcode_synced_group_files(ctx, objects, target, project_dir, path_maps)
     project_header_dirs = []
     for path in file_paths.values():
@@ -1000,6 +1030,7 @@ def _xcode_target_files(ctx, objects, target, file_paths, project_dir, path_maps
         "asset_catalogs": _unique(classic["asset_catalogs"] + synced["asset_catalogs"]),
         "intent_definitions": _unique(classic["intent_definitions"] + synced["intent_definitions"]),
         "frameworks": classic["frameworks"],
+        "sdk_dylibs": classic["sdk_dylibs"],
         "source_flags": classic["source_flags"],
         "project_header_dirs": _unique(project_header_dirs),
     }
@@ -2135,6 +2166,23 @@ def _xcode_product_dependency_key(name):
             value = value[:len(value) - len(suffix)]
     return value.replace("_", "-").lower()
 
+def _xcode_realpath(path):
+    absolute = _xcode_abs(path)
+    if not host_path_exists(absolute):
+        return ""
+    return host_command([host_which("realpath"), absolute]).strip()
+
+def _xcode_xcframework_name_map(specs):
+    names = {}
+    for spec in specs:
+        bundle = spec["attrs"]["bundle"]
+        name = spec["name"]
+        names[bundle] = name
+        resolved = _xcode_realpath(bundle)
+        if resolved and resolved not in names:
+            names[resolved] = name
+    return names
+
 def _xcode_framework_product_dependencies(objects, target, name_to_id):
     # Package and pod integration commonly link a target only through a
     # BUILT_PRODUCTS_DIR framework reference. Recover the target edge from the
@@ -2177,10 +2225,279 @@ def _xcode_xcframework_dependencies(objects, target, file_paths, xcframework_nam
             bundle = _xcode_workspace_relative(bundle)
             if not _ends_with(bundle, ".xcframework"):
                 continue
-            dependency = xcframework_names.get(bundle) or ""
+            dependency = xcframework_names.get(bundle) or xcframework_names.get(_xcode_realpath(bundle)) or ""
             if dependency and dependency not in dependencies:
                 dependencies.append(dependency)
     return dependencies
+
+def _xcode_xcframework_module_map(objects, file_paths, xcframework_names):
+    modules = {}
+    for file_ref_id, file_ref in objects.items():
+        if file_ref.get("isa") != "PBXFileReference":
+            continue
+        bundle = file_paths.get(file_ref_id) or _xcode_file_ref_path({}, file_ref)
+        bundle = _xcode_workspace_relative(bundle)
+        if not _ends_with(bundle, ".xcframework"):
+            continue
+        dependency = xcframework_names.get(bundle) or xcframework_names.get(_xcode_realpath(bundle)) or ""
+        if not dependency:
+            continue
+        name = file_ref.get("name") or _basename(bundle)
+        if _ends_with(name, ".xcframework"):
+            name = name[:len(name) - len(".xcframework")]
+        key = _xcode_product_dependency_key(name)
+        if key and key not in modules:
+            modules[key] = dependency
+    return modules
+
+def _xcode_xcframework_dependency_ids(spec_name, module_symbols, module_targets):
+    dependencies = []
+    for symbol in module_symbols:
+        dependency = module_targets.get(_xcode_product_dependency_key(symbol.strip())) or ""
+        if dependency and dependency != spec_name and dependency not in dependencies:
+            dependencies.append(dependency)
+    return dependencies
+
+def _xcode_xcframework_reaches_dependency(start, target, specs):
+    pending = [start]
+    seen = {}
+    for index in range(len(specs)):
+        if index >= len(pending):
+            break
+        current = pending[index]
+        if current == target:
+            return True
+        if current in seen:
+            continue
+        seen[current] = True
+        spec = specs.get(current) or {}
+        for dependency in spec.get("deps") or []:
+            dependency_name = dependency[2:] if dependency.startswith("./") else dependency
+            if dependency_name not in seen and dependency_name not in pending:
+                pending.append(dependency_name)
+    return False
+
+def _xcode_acyclic_xcframework_dependencies(spec_name, dependencies, specs):
+    return [
+        dependency
+        for dependency in dependencies
+        if not _xcode_xcframework_reaches_dependency(dependency, spec_name, specs)
+    ]
+
+def _xcode_xcframework_selected_slice(spec):
+    attrs = spec.get("attrs") or {}
+    bundle = attrs.get("bundle") or ""
+    if not bundle:
+        return ""
+    absolute_info = _xcode_abs(bundle + "/Info.plist")
+    if not host_file_exists(absolute_info):
+        return ""
+    data = json_decode(host_command(["plutil", "-convert", "json", "-o", "-", absolute_info]))
+    platform = attrs.get("platform") or ""
+    wanted_platform = {
+        "visionos": "xros",
+        "xros": "xros",
+    }.get(platform) or platform
+    sdk_variant = attrs.get("sdk_variant") or "simulator"
+    wanted_variant = "simulator" if sdk_variant == "simulator" and wanted_platform != "macos" else ""
+    wanted_arch = attrs.get("arch") or host_arch()
+    for library in data.get("AvailableLibraries") or []:
+        if library.get("SupportedPlatform") != wanted_platform:
+            continue
+        if (library.get("SupportedPlatformVariant") or "") != wanted_variant:
+            continue
+        if wanted_arch not in (library.get("SupportedArchitectures") or []):
+            continue
+        return _xcode_abs(bundle + "/" + library["LibraryIdentifier"])
+    return ""
+
+def _xcode_xcframework_selected_swiftmodules(spec):
+    absolute_slice = _xcode_xcframework_selected_slice(spec)
+    if not absolute_slice:
+        return []
+    return [
+        path
+        for path in host_command([host_which("find"), "-L", absolute_slice, "-type", "f", "-name", "*.swiftmodule"]).split("\n")
+        if path
+    ]
+
+def _xcode_xcframework_selected_swiftinterfaces(spec):
+    absolute_slice = _xcode_xcframework_selected_slice(spec)
+    if not absolute_slice:
+        return []
+    return [
+        path
+        for path in host_command([host_which("find"), "-L", absolute_slice, "-type", "f", "-name", "*.swiftinterface"]).split("\n")
+        if path
+    ]
+
+_XCODE_IMPORT_KIND_KEYWORDS = ["struct", "class", "enum", "protocol", "typealias", "func", "var", "let", "actor"]
+
+def _xcode_swiftinterface_imports(text):
+    # A textual interface lists the module's imports verbatim, optionally
+    # prefixed by attributes (`@_exported`, `@preconcurrency`, ...) and
+    # optionally scoped (`import struct Foo.Bar`).
+    names = []
+    for line in text.split("\n"):
+        stripped = line.strip()
+        for _ in range(4):
+            if not stripped.startswith("@"):
+                break
+            space = stripped.find(" ")
+            stripped = stripped[space + 1:].strip() if space >= 0 else ""
+        if not stripped.startswith("import "):
+            continue
+        rest = stripped[len("import "):].strip()
+        first = rest.split(" ")[0]
+        if first in _XCODE_IMPORT_KIND_KEYWORDS:
+            rest = rest[len(first):].strip()
+        module = rest.split(" ")[0].split(".")[0].split(";")[0]
+        if module and _xcode_probe_module_name(module) and module not in names:
+            names.append(module)
+    return names
+
+_XCODE_PROBE_SDKS = {
+    "ios": ("iphoneos", "iphonesimulator", "ios"),
+    "macos": ("macosx", "macosx", "macos"),
+    "tvos": ("appletvos", "appletvsimulator", "tvos"),
+    "watchos": ("watchos", "watchsimulator", "watchos"),
+    "visionos": ("xros", "xrsimulator", "xros"),
+    "xros": ("xros", "xrsimulator", "xros"),
+}
+
+def _xcode_probe_module_name(name):
+    for ch in name.elems():
+        if not (ch.isalnum() or ch == "_"):
+            return False
+    return len(name) > 0
+
+def _xcode_probe_missing_modules(output):
+    names = []
+    for line in output.split("\n"):
+        index = line.find("missing required module")
+        if index < 0:
+            continue
+        pieces = line[index:].split("'")
+        for position in range(1, len(pieces), 2):
+            name = pieces[position]
+            if name and name not in names:
+                names.append(name)
+    return names
+
+def _xcode_xcframework_serialized_imports(spec, module_files):
+    # A prebuilt Swift module records its exact import list, and loading it
+    # with the compiler reports every required module that the probe SDK and
+    # search paths cannot resolve. Those unresolved names are precisely the
+    # non-SDK requirement edges of this XCFramework, so no symbol scan is
+    # involved and false candidates cannot appear.
+    absolute_slice = _xcode_xcframework_selected_slice(spec)
+    if not absolute_slice:
+        return []
+    interface_imports = []
+    interface_files = _xcode_xcframework_selected_swiftinterfaces(spec)
+    if interface_files:
+        text = host_command(
+            [host_which("sh"), "-c", "cat \"$@\" 2>/dev/null; exit 0", "swift-interface-read"] + interface_files,
+        )
+        interface_imports = _xcode_swiftinterface_imports(text)
+    if not module_files:
+        return interface_imports
+    attrs = spec.get("attrs") or {}
+    sdk_names = _XCODE_PROBE_SDKS.get(attrs.get("platform") or "ios")
+    if not sdk_names:
+        return []
+    device_sdk, simulator_sdk, triple_os = sdk_names
+    sdk_variant = attrs.get("sdk_variant") or "simulator"
+    simulator = sdk_variant == "simulator" and triple_os != "macos"
+    sdk_name = simulator_sdk if simulator else device_sdk
+    xcrun = host_which("xcrun")
+    sdk_path = host_command([xcrun, "--sdk", sdk_name, "--show-sdk-path"]).strip()
+    sdk_version = host_command([xcrun, "--sdk", sdk_name, "--show-sdk-version"]).strip()
+    if not sdk_path or not sdk_version:
+        return []
+    arch = attrs.get("arch") or host_arch()
+    target = arch + "-apple-" + triple_os + sdk_version + ("-simulator" if simulator else "")
+    include_dirs = []
+    module_names = []
+    for path in module_files:
+        parts = path.split("/")
+        if len(parts) < 2:
+            continue
+        parent = parts[-2]
+        if _ends_with(parent, ".swiftmodule"):
+            module_name = parent[:len(parent) - len(".swiftmodule")]
+            include_dir = "/".join(parts[:-2])
+        else:
+            module_name = parts[-1][:len(parts[-1]) - len(".swiftmodule")]
+            include_dir = "/".join(parts[:-1])
+        if module_name and module_name not in module_names:
+            module_names.append(module_name)
+        if include_dir and include_dir not in include_dirs:
+            include_dirs.append(include_dir)
+    imports = list(interface_imports)
+    for module_name in module_names:
+        if not _xcode_probe_module_name(module_name):
+            continue
+        argv = [
+            host_which("sh"),
+            "-c",
+            "module=\"$1\"; shift; printf 'import %s\\n' \"$module\" | \"$@\" 2>&1; exit 0",
+            "swift-import-probe",
+            module_name,
+            host_which("swiftc"),
+            "-typecheck",
+            "-",
+            "-sdk",
+            sdk_path,
+            "-target",
+            target,
+            "-F",
+            absolute_slice,
+        ]
+        for include_dir in include_dirs:
+            argv += ["-I", include_dir]
+        for name in _xcode_probe_missing_modules(host_command(argv)):
+            if name not in imports:
+                imports.append(name)
+    return imports
+
+def _xcode_attach_xcframework_module_dependencies(specs, module_targets):
+    xcframeworks = {
+        spec["name"]: spec
+        for spec in specs
+        if spec.get("kind") == "apple_xcframework_import"
+    }
+    pending = []
+    for spec in specs:
+        if spec.get("kind") == "apple_xcframework_import":
+            continue
+        for dependency in spec.get("deps") or []:
+            dependency_name = dependency[2:] if dependency.startswith("./") else dependency
+            if dependency_name in xcframeworks and dependency_name not in pending:
+                pending.append(dependency_name)
+    seen = {}
+    import_cache = {}
+    for index in range(len(xcframeworks)):
+        if index >= len(pending):
+            break
+        spec_name = pending[index]
+        if spec_name in seen:
+            continue
+        seen[spec_name] = True
+        spec = xcframeworks[spec_name]
+        bundle = (spec.get("attrs") or {}).get("bundle") or ""
+        cache_key = _xcode_realpath(bundle) or bundle
+        serialized_imports = import_cache.get(cache_key)
+        if serialized_imports == None:
+            module_files = _xcode_xcframework_selected_swiftmodules(spec)
+            serialized_imports = _xcode_xcframework_serialized_imports(spec, module_files)
+            import_cache[cache_key] = serialized_imports
+        candidate_dependencies = _xcode_xcframework_dependency_ids(spec_name, serialized_imports, module_targets)
+        dependencies = _xcode_acyclic_xcframework_dependencies(spec_name, candidate_dependencies, xcframeworks)
+        spec["deps"] = _unique((spec.get("deps") or []) + ["./" + dependency for dependency in dependencies])
+        for dependency in dependencies:
+            if dependency in xcframeworks and dependency not in seen and dependency not in pending:
+                pending.append(dependency)
 
 def _xcode_sanitized_target_name(name):
     out = []
@@ -2246,6 +2563,15 @@ def _xcode_is_extension_product(product_type):
     # `com.apple.product-type.app-extension.messages-sticker-pack` and
     # `com.apple.product-type.app-extension.intents-service`.
     return product_type.startswith("com.apple.product-type.app-extension.")
+
+def _xcode_framework_is_static(settings, product_type):
+    # Xcode models a static framework either through the dedicated product
+    # type or through `MACH_O_TYPE = staticlib` on a regular framework target.
+    # Both build an archive: nothing is linked at this node, so lower them
+    # through the static library path.
+    if product_type == "com.apple.product-type.framework.static":
+        return True
+    return _xcode_scalar(settings.get("MACH_O_TYPE")) == "staticlib"
 
 def _xcode_effective_platform(settings, project_settings):
     # Prefer `SDKROOT`, then infer from whichever deployment-target setting or
@@ -2343,7 +2669,36 @@ def _xcode_swift_flags(settings, subs):
     for flag in raw:
         resolved = _xcode_resolve_vars(flag, subs)
         out.append(resolved)
-    return _xcode_clean_flags(out)
+    flags = _xcode_clean_flags(out)
+    # `SWIFT_INCLUDE_PATHS` names directories searched for binary Swift
+    # modules (for example prebuilt static-library XCFramework slices), which
+    # Xcode forwards to the compiler as `-I`.
+    for path in _xcode_setting_to_list(settings.get("SWIFT_INCLUDE_PATHS")):
+        resolved = _xcode_resolve_vars(path, subs)
+        if resolved and "$(" not in resolved:
+            flags.extend(["-I", resolved])
+    return flags
+
+def _xcode_binary_swift_plugins(settings, subs):
+    out = []
+    for descriptor in _xcode_setting_to_list(settings.get("SWIFT_LOAD_BINARY_MACROS")):
+        resolved = _xcode_resolve_vars(descriptor, subs).replace('"', "")
+        if resolved and resolved != "$(inherited)" and not resolved.startswith("$("):
+            out.append(resolved)
+    return _unique(out)
+
+def _xcode_disabled_autolink_modules(flags):
+    modules = []
+    for index in range(len(flags)):
+        if flags[index] != "-Xfrontend" or index + 3 >= len(flags):
+            continue
+        option = flags[index + 1]
+        if option not in ["-disable-autolink-framework", "-disable-autolink-library"] or flags[index + 2] != "-Xfrontend":
+            continue
+        module = flags[index + 3]
+        if module and module not in modules:
+            modules.append(module)
+    return modules
 
 def _xcode_swift_feature_name(setting_suffix):
     overrides = {
@@ -2396,6 +2751,9 @@ def _xcode_swift_language_flags(settings):
             flags.extend(["-swift-version", "4.2"])
         elif major in ["4", "5", "6"]:
             flags.extend(["-swift-version", major])
+    package_name = _xcode_scalar(settings.get("SWIFT_PACKAGE_NAME"))
+    if package_name:
+        flags.extend(["-package-name", package_name])
     if _xcode_scalar(settings.get("SWIFT_DEFAULT_ACTOR_ISOLATION")) == "MainActor":
         flags.extend(["-default-isolation", "MainActor"])
     if _xcode_scalar(settings.get("SWIFT_APPROACHABLE_CONCURRENCY")).upper() == "YES":
@@ -2497,6 +2855,11 @@ def _xcode_linkopts(settings, subs):
         resolved = _xcode_resolve_vars(flag, subs)
         if resolved and resolved != "$(inherited)" and not resolved.startswith("$("):
             resolved_flags.append(resolved)
+        else:
+            # Keep one placeholder per source token so an unresolved argument
+            # cannot be removed from the middle of an arity-bearing linker
+            # option and make that option consume the next unrelated flag.
+            resolved_flags.append("")
     flags = []
     skip_remaining = 0
     for index in range(len(resolved_flags)):
@@ -2504,8 +2867,12 @@ def _xcode_linkopts(settings, subs):
             skip_remaining -= 1
             continue
         resolved = resolved_flags[index]
+        if not resolved:
+            continue
         if resolved == "-Xlinker" and index + 1 < len(resolved_flags):
-            flags.extend([resolved, resolved_flags[index + 1]])
+            argument = resolved_flags[index + 1]
+            if argument:
+                flags.extend([resolved, argument])
             skip_remaining = 1
             continue
         if resolved == "-fprofile-instr-generate":
@@ -2516,11 +2883,16 @@ def _xcode_linkopts(settings, subs):
             continue
         arity = _XCODE_LINKER_OPTION_ARITY.get(resolved)
         if arity != None:
-            flags.extend(["-Xlinker", resolved])
+            arguments = []
             for offset in range(arity):
                 argument_index = index + offset + 1
-                if argument_index < len(resolved_flags):
-                    flags.extend(["-Xlinker", resolved_flags[argument_index]])
+                argument = resolved_flags[argument_index] if argument_index < len(resolved_flags) else ""
+                if argument:
+                    arguments.append(argument)
+            if len(arguments) == arity:
+                flags.extend(["-Xlinker", resolved])
+                for argument in arguments:
+                    flags.extend(["-Xlinker", argument])
             skip_remaining = arity
             continue
         if resolved.startswith("-Wl,"):
@@ -2532,6 +2904,12 @@ def _xcode_linkopts(settings, subs):
             flags.extend(["-Xlinker", resolved])
             continue
         flags.append(resolved)
+    # Dead-code stripping is part of the link contract, not an optimization
+    # detail: with it the linker demotes duplicate definitions among lazily
+    # loaded archive members to warnings and strips the redundant copy, which
+    # multi-copy vendor payloads rely on to link at all.
+    if _xcode_scalar(settings.get("DEAD_CODE_STRIPPING")).upper() == "YES":
+        flags.extend(["-Xlinker", "-dead_strip"])
     return flags
 
 def _xcode_sdk_frameworks(settings, file_frameworks):
@@ -2572,6 +2950,9 @@ def _xcode_common_attrs(ctx, target, settings, subs, platform, files):
     swift_flags = _xcode_swift_flags(settings, subs) + _xcode_swift_language_flags(settings) + _xcode_swift_compilation_flags(settings)
     if swift_flags:
         attrs["swift_flags"] = swift_flags
+    binary_swift_plugins = _xcode_binary_swift_plugins(settings, subs)
+    if binary_swift_plugins:
+        attrs["binary_swift_plugins"] = binary_swift_plugins
     clang_flags = _xcode_clang_flags(settings, subs)
     if clang_flags:
         attrs["clang_flags"] = clang_flags
@@ -2614,6 +2995,9 @@ def _xcode_common_attrs(ctx, target, settings, subs, platform, files):
     sdk_frameworks = _xcode_sdk_frameworks(settings, files["frameworks"])
     if sdk_frameworks:
         attrs["sdk_frameworks"] = sdk_frameworks
+    sdk_dylibs = files.get("sdk_dylibs") or []
+    if sdk_dylibs:
+        attrs["sdk_dylibs"] = sdk_dylibs
     developer_dir = ctx["attr"].get("xcode_developer_dir")
     if developer_dir:
         attrs["xcode_developer_dir"] = developer_dir
@@ -2943,6 +3327,7 @@ def _xcode_workspace_resolver(ctx):
     # Pass two: lower every project's native targets, resolving dependencies and
     # test hosts against the workspace-wide name map.
     all_specs = []
+    all_xcframework_modules = {}
     test_plan_settings = _xcode_test_plan_settings(ctx)
     for project in projects:
         objects = project["objects"]
@@ -2985,10 +3370,12 @@ def _xcode_workspace_resolver(ctx):
             target_prefix = "XcodePackage_" + _xcode_sanitized_target_name(ctx["label"]["id"]),
         )
         xcframework_specs = _xcode_workspace_xcframework_specs(ctx, package_platform, ctx["attr"].get("sdk_variant") or "simulator")
-        xcframework_names = {
-            spec["attrs"]["bundle"]: spec["name"]
-            for spec in xcframework_specs
-        }
+        xcframework_names = _xcode_xcframework_name_map(xcframework_specs)
+        _xcode_register_absolute_xcframework_refs(objects, xcframework_specs, xcframework_names, package_platform, ctx["attr"].get("sdk_variant") or "simulator")
+        xcframework_modules = _xcode_xcframework_module_map(objects, file_paths, xcframework_names)
+        for module, dependency in xcframework_modules.items():
+            if module not in all_xcframework_modules:
+                all_xcframework_modules[module] = dependency
 
         for target in native_targets:
             spec = _xcode_lower_target(ctx, objects, target, project_settings, name_to_id, dep_closure, configuration, file_paths, project_dir, path_maps, test_plan_settings)
@@ -3001,8 +3388,9 @@ def _xcode_workspace_resolver(ctx):
                 dep_id = package_graph["products"].get(identity + "\x1f" + product["name"]) or package_graph["products"].get(product["name"])
                 if dep_id:
                     spec["deps"] = _unique(spec["deps"] + ["./" + dep_id])
-            for module in _xcode_swift_imports(spec["srcs"]):
-                dep_id = name_to_id.get(module) or package_graph["products"].get(module) or package_graph["modules"].get(module)
+            dependency_modules = _unique(_xcode_swift_imports(spec["srcs"]) + _xcode_disabled_autolink_modules(spec["attrs"].get("swift_flags") or []))
+            for module in dependency_modules:
+                dep_id = name_to_id.get(module) or package_graph["products"].get(module) or package_graph["modules"].get(module) or xcframework_modules.get(_xcode_product_dependency_key(module))
                 if dep_id and dep_id != spec["name"]:
                     spec["deps"] = _unique(spec["deps"] + ["./" + dep_id])
             if spec["kind"] == "apple_library":
@@ -3019,6 +3407,8 @@ def _xcode_workspace_resolver(ctx):
             continue
         seen_ids[spec["name"]] = True
         specs.append(spec)
+
+    _xcode_attach_xcframework_module_dependencies(specs, all_xcframework_modules)
 
     # Drop dependency edges to targets that were not emitted (for example a
     # resource-only extension, or a pod linked only through an xcconfig), so no
@@ -3079,6 +3469,71 @@ def _xcode_workspace_xcframework_specs(ctx, platform, sdk_variant):
             },
         })
     return specs
+
+def _xcode_absolute_xcframework_refs(objects):
+    refs = []
+    root = _xcode_workspace_root()
+    for obj in objects.values():
+        if type(obj) != "dict" or obj.get("isa") != "PBXFileReference":
+            continue
+        path = obj.get("path") or ""
+        if not path.startswith("/") or not _ends_with(path, ".xcframework"):
+            continue
+        if root and path.startswith(root):
+            continue
+        if path not in refs:
+            refs.append(path)
+    return refs
+
+def _xcode_register_absolute_xcframework_refs(objects, xcframework_specs, xcframework_names, platform, sdk_variant):
+    # A generated project may reference a prebuilt XCFramework by an absolute
+    # path outside the workspace (for example a per-target artifact cache
+    # entry that has no workspace symlink). The workspace scan cannot discover
+    # those bundles, and action inputs must stay workspace-relative, so bridge
+    # each referenced bundle through a workspace alias symlink — the same
+    # shape as the generator's own derived search-path symlinks — and
+    # register the alias as an import spec.
+    for source in _xcode_absolute_xcframework_refs(objects):
+        if source in xcframework_names:
+            continue
+        if not host_file_exists(source + "/Info.plist"):
+            continue
+        resolved = _xcode_realpath(source) or source
+        existing = xcframework_names.get(resolved) or ""
+        if existing:
+            xcframework_names[source] = existing
+            continue
+        alias_dir = ".once/xcframework-refs/" + _xcode_sanitized_target_name(_parent_dir(source))
+        alias = alias_dir + "/" + _basename(source)
+        absolute_alias = _xcode_abs(alias)
+        if not host_path_exists(absolute_alias):
+            host_command([
+                host_which("sh"),
+                "-c",
+                "mkdir -p \"$1\" && ln -sfn \"$2\" \"$3\"",
+                "xcframework-alias",
+                _xcode_abs(alias_dir),
+                source,
+                absolute_alias,
+            ])
+            if not host_path_exists(absolute_alias):
+                continue
+        name = "XCFramework_" + _xcode_sanitized_target_name(alias)
+        xcframework_specs.append({
+            "name": name,
+            "kind": "apple_xcframework_import",
+            "deps": [],
+            "srcs": [],
+            "attrs": {
+                "bundle": alias,
+                "platform": platform,
+                "sdk_variant": sdk_variant,
+            },
+        })
+        xcframework_names[source] = name
+        xcframework_names[alias] = name
+        if resolved not in xcframework_names:
+            xcframework_names[resolved] = name
 
 def _xcode_transitive_deps(objects, target, name_to_id, native_by_name, seen = None):
     seen = seen or {}
@@ -3146,7 +3601,7 @@ def _xcode_lower_target(ctx, objects, target, project_settings, name_to_id, dep_
         subs["UNLOCALIZED_RESOURCES_FOLDER_PATH"] = wrapper_name
         subs["EXECUTABLE_NAME"] = product_name_seed
 
-    files = _xcode_target_files(ctx, objects, target, file_paths, project_dir, path_maps)
+    files = _xcode_target_files(ctx, objects, target, file_paths, project_dir, path_maps, platform)
     shell_scripts = _xcode_shell_script_phases(ctx, objects, target, subs, project_dir, target_name)
     files["resources"] = _unique(files["resources"] + shell_scripts["resource_inputs"])
     files["structured_resources"] = _unique(files["structured_resources"] + shell_scripts["structured_resource_inputs"])
@@ -3174,7 +3629,7 @@ def _xcode_lower_target(ctx, objects, target, project_settings, name_to_id, dep_
             attrs["application_extension"] = True
     elif kind == "framework":
         attrs, product_name = _xcode_library_attrs(ctx, target, settings, subs, platform, files)
-        if product_type == "com.apple.product-type.framework":
+        if product_type == "com.apple.product-type.framework" and not _xcode_framework_is_static(settings, product_type):
             attrs["product_name"] = product_name
             attrs["bundle_id"] = _xcode_bundle_id(settings, subs, product_name)
             if files["resources"]:

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -245,6 +245,52 @@ fn swift_package_native_project_loads_without_a_once_manifest() {
 }
 
 #[cfg(target_os = "macos")]
+#[test]
+fn swift_package_workspace_keeps_all_targets_of_a_library_product() {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join("Sources/First")).expect("first source directory");
+    fs::create_dir_all(tmp.path().join("Sources/Second")).expect("second source directory");
+    fs::write(
+        tmp.path().join("Package.swift"),
+        r#"// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MultiProduct",
+    products: [.library(name: "MultiProduct", targets: ["First", "Second"])],
+    targets: [.target(name: "First"), .target(name: "Second")]
+)
+"#,
+    )
+    .expect("package manifest");
+    fs::write(
+        tmp.path().join("Sources/First/First.swift"),
+        "public func first() {}\n",
+    )
+    .expect("first source");
+    fs::write(
+        tmp.path().join("Sources/Second/Second.swift"),
+        "public func second() {}\n",
+    )
+    .expect("second source");
+
+    let graph = once_frontend::load_graph_workspace(tmp.path())
+        .expect("Swift package workspace with a multi-target product loads");
+    let workspace = graph
+        .iter()
+        .find(|target| target.label.id == "swift_package")
+        .expect("Swift package workspace target");
+
+    assert_eq!(
+        workspace.deps,
+        vec![
+            "SwiftPackage_MultiProduct_First",
+            "SwiftPackage_MultiProduct_Second",
+        ]
+    );
+}
+
+#[cfg(target_os = "macos")]
 fn run_git(directory: &Path, args: &[&str]) {
     let status = Command::new("git")
         .args(args)

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -6940,6 +6940,8 @@ def host_command(argv, env = None, merge_stderr = None):
         return "/sdks/iPhoneSimulator.sdk\n"
     if "--version" in argv:
         return "Swift version test\n"
+    if "-print-resource-dir" in argv:
+        return "/toolchain/resource\n"
     fail("unexpected host_command: " + str(argv))
 
 ctx = {{
@@ -7306,6 +7308,8 @@ def host_command(argv, env = None, merge_stderr = None):
         return "/sdks/iPhoneSimulator.sdk\n"
     if "--version" in argv:
         return "Swift version test\n"
+    if "-print-resource-dir" in argv:
+        return "/toolchain/resource\n"
     fail("unexpected host_command: " + str(argv))
 
 ctx = {{
@@ -7527,6 +7531,209 @@ fn prelude_apple_thinned_package_rejects_multiple_applications() {
     clippy::too_many_lines,
     reason = "the inline Starlark fixture keeps this provider contract in one test"
 )]
+fn prelude_apple_swift_framework_uses_private_header_search_paths() {
+    let prelude = all_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let sources = workspace.path().join("framework/Sources");
+    let headers = workspace.path().join("framework/Vendor/include/yoga");
+    std::fs::create_dir_all(&sources).unwrap();
+    std::fs::create_dir_all(&headers).unwrap();
+    std::fs::write(sources.join("Plugin.swift"), "public struct Plugin {}\n").unwrap();
+    std::fs::write(headers.join("YGEnums.h"), "typedef int YGEnum;\n").unwrap();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    if name == "codesign":
+        return "/usr/bin/codesign"
+    if name == "find":
+        return "/usr/bin/find"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None, merge_stderr = None):
+    if argv[0] == "/usr/bin/find":
+        return "framework/Vendor/include/yoga/YGEnums.h\n"
+    if "--find" in argv:
+        return "/toolchain/" + argv[len(argv) - 1] + "\n"
+    if "--show-sdk-path" in argv:
+        return "/sdks/iPhoneSimulator.sdk\n"
+    if "--version" in argv:
+        return "Swift version test\n"
+    if "-print-resource-dir" in argv:
+        return "/toolchain/resource\n"
+    fail("unexpected host_command: " + str(argv))
+
+ctx = {{
+    "label": {{
+        "package": "framework",
+        "name": "Plugin",
+        "id": "framework/Plugin",
+    }},
+    "attr": {{
+        "platform": "ios",
+        "bundle_id": "dev.once.Plugin",
+        "minimum_os": "17.0",
+        "sdk_variant": "simulator",
+        "private_header_dirs": ["Vendor/include"],
+    }},
+    "deps": [{{
+        "label_id": "vendor/Binary",
+        "transitive_link_framework_bundles": [{{
+            "path": ".once/vendor/Binary.framework",
+            "module_name": "Binary",
+            "files": [".once/vendor/Binary.framework/Binary"],
+            "label_id": "vendor/Binary",
+            "linkage": "static",
+        }}],
+        "transitive_framework_bundles": [],
+    }}],
+    "srcs": ["Sources/**/*.swift"],
+    "build_dir": ".once/out/framework/Plugin",
+    "capability": "build",
+}}
+provider = _apple_framework_impl(ctx)
+result = repr([
+    provider["framework_path"],
+    provider.get("transitive_framework_search_dirs") or [],
+    provider.get("transitive_framework_files") or [],
+])
+"#
+    );
+    let store = store_for(workspace.path(), "framework");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(
+        out.unwrap(),
+        r#"[".once/out/framework/Plugin/Plugin.framework", [".once/vendor"], [".once/vendor/Binary.framework/Binary"]]"#
+    );
+    let compile = action_by_identifier(&store, "apple_framework_compile_Plugin");
+    assert!(compile
+        .argv
+        .windows(4)
+        .any(|args| { args == ["-Xcc", "-I", "-Xcc", "framework/Vendor/include"] }));
+    assert!(action_has_input_suffix(
+        compile,
+        "framework/Vendor/include/yoga/YGEnums.h"
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the inline Starlark fixture keeps this provider contract in one test"
+)]
+fn prelude_xcode_framework_loads_prebuilt_swift_macro_executables() {
+    let prelude = xcode_prelude_source();
+    let workspace = TempDir::new().unwrap();
+    let sources = workspace.path().join("framework/Sources");
+    std::fs::create_dir_all(&sources).unwrap();
+    std::fs::write(sources.join("Plugin.swift"), "public struct Plugin {}\n").unwrap();
+
+    let macro_cache = TempDir::new().unwrap();
+    let macro_path = macro_cache.path().join("FixtureMacros.macro");
+    std::fs::write(&macro_path, "fixture macro executable\n").unwrap();
+
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    if name == "xcrun":
+        return "/usr/bin/xcrun"
+    if name == "codesign":
+        return "/usr/bin/codesign"
+    if name == "find":
+        return "/usr/bin/find"
+    fail("unexpected host_which: " + name)
+
+def host_command(argv, env = None, merge_stderr = None):
+    if argv[0] == "/usr/bin/find":
+        return ""
+    if "--find" in argv:
+        return "/toolchain/" + argv[len(argv) - 1] + "\n"
+    if "--show-sdk-path" in argv:
+        return "/sdks/iPhoneSimulator.sdk\n"
+    if "--version" in argv:
+        return "Swift version test\n"
+    if "-print-resource-dir" in argv:
+        return "/toolchain/resource\n"
+    fail("unexpected host_command: " + str(argv))
+
+files = {{
+    "source_flags": {{}},
+    "project_header_dirs": [],
+    "sources": ["framework/Sources/Plugin.swift"],
+    "headers": [],
+    "exported_headers": [],
+    "frameworks": [],
+}}
+attrs = _xcode_common_attrs(
+    {{"attr": {{"sdk_variant": "simulator"}}}},
+    {{"name": "Plugin"}},
+    {{"SWIFT_LOAD_BINARY_MACROS": [{macro_descriptor:?}]}},
+    {{}},
+    "ios",
+    files,
+)
+attrs["bundle_id"] = "dev.once.Plugin"
+attrs["minimum_os"] = "17.0"
+ctx = {{
+    "label": {{
+        "package": "framework",
+        "name": "Plugin",
+        "id": "framework/Plugin",
+    }},
+    "attr": attrs,
+    "deps": [],
+    "srcs": ["Sources/**/*.swift"],
+    "build_dir": ".once/out/framework/Plugin",
+    "capability": "build",
+}}
+provider = _apple_framework_impl(ctx)
+result = repr(provider["framework_path"])
+"#,
+        macro_descriptor = format!("{}#FixtureMacros", macro_path.display()),
+    );
+    let store = store_for(workspace.path(), "framework");
+
+    let (store, out) = with_active_store(store, || eval_prelude_source_to_repr(source));
+
+    assert_eq!(
+        out.unwrap(),
+        r#"".once/out/framework/Plugin/Plugin.framework""#
+    );
+    let compile = action_by_identifier(&store, "apple_framework_compile_Plugin");
+    let staged_macro = ".once/out/framework/binary-swift-plugins/0/FixtureMacros.macro";
+    assert!(
+        compile.argv.windows(4).any(|args| {
+            args == [
+                "-Xfrontend",
+                "-load-plugin-executable",
+                "-Xfrontend",
+                &format!("{staged_macro}#FixtureMacros"),
+            ]
+        }),
+        "{:?}",
+        compile.argv
+    );
+    assert!(action_has_input_suffix(compile, staged_macro));
+    assert!(store.actions.iter().any(|action| {
+        matches!(
+            action.operation,
+            Some(DeclaredActionOperation::MaterializeHostTree { ref source, ref destination, .. })
+                if source == macro_cache.path().to_string_lossy().as_ref()
+                    && destination == ".once/out/framework/binary-swift-plugins/0"
+        )
+    }));
+}
+
+#[cfg(unix)]
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the inline Starlark fixture keeps this provider contract in one test"
+)]
 fn prelude_apple_framework_stops_static_links_and_propagates_runtime_frameworks() {
     let prelude = all_prelude_source();
     let workspace = TempDir::new().unwrap();
@@ -7560,6 +7767,8 @@ def host_command(argv, env = None, merge_stderr = None):
         return "/sdks/iPhoneSimulator.sdk\n"
     if "--version" in argv:
         return "Swift version test\n"
+    if "-print-resource-dir" in argv:
+        return "/toolchain/resource\n"
     fail("unexpected host_command: " + str(argv))
 
 support = {{
@@ -14776,6 +14985,200 @@ result = repr(_collect_dep_compile_inputs(deps, "build")[5])
     );
 }
 
+#[test]
+fn prelude_apple_resolves_clang_profile_runtime_archive() {
+    let prelude = apple_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def host_which(name):
+    return "/usr/bin/" + name
+
+def host_path_exists(path):
+    return path.endswith(".a")
+
+def host_command(argv, env = None, merge_stderr = None):
+    if argv[1] == "--find":
+        return "/toolchain/usr/bin/clang\n"
+    if argv[1] == "-print-resource-dir":
+        return "/toolchain/usr/lib/clang/21\n"
+    fail("unexpected host command: " + str(argv))
+
+result = repr([
+    _apple_clang_profile_runtime("ios", "simulator", ""),
+    _apple_clang_profile_runtime("ios", "device", ""),
+    _apple_clang_profile_runtime("macos", "simulator", ""),
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["/toolchain/usr/lib/clang/21/lib/darwin/libclang_rt.profile_iossim.a", "/toolchain/usr/lib/clang/21/lib/darwin/libclang_rt.profile_ios.a", "/toolchain/usr/lib/clang/21/lib/darwin/libclang_rt.profile_osx.a"]"#
+    );
+}
+
+#[test]
+fn prelude_apple_xcframework_import_keeps_dependency_link_data_compile_only() {
+    // An inferred prebuilt-module dependency edge must make the dependency's
+    // modules loadable by consumers (search dirs, module files, autolink
+    // suppression through the propagated framework bundles) without turning
+    // the dependency into a link input. Archives, SDK libraries, and linker
+    // options stay own-only; the generated project's build phases remain the
+    // only source of link edges.
+    let prelude = apple_prelude_source();
+    let available_libraries = serde_json::json!({
+        "AvailableLibraries": [{
+            "LibraryIdentifier": "ios-arm64-simulator",
+            "LibraryPath": "Primary.framework",
+            "BinaryPath": "Primary.framework/Primary",
+            "SupportedArchitectures": ["arm64"],
+            "SupportedPlatform": "ios",
+            "SupportedPlatformVariant": "simulator",
+        }],
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+def host_arch():
+    return "arm64"
+
+def host_file_exists(path):
+    return path == "/workspace/Primary.xcframework/Info.plist"
+
+def host_which(name):
+    return name
+
+def host_command(argv, env = None, merge_stderr = None):
+    if argv[0] == "plutil":
+        return {available_libraries:?}
+    if argv[0] == "find":
+        return "/workspace/Primary.xcframework/ios-arm64-simulator/Primary.framework/Primary\n/workspace/Primary.xcframework/ios-arm64-simulator/Primary.framework/Modules/Primary.swiftmodule/arm64-apple-ios-simulator.swiftmodule\n"
+    if argv[0] == "file":
+        return "current ar archive\n"
+    fail("unexpected host_command: " + str(argv))
+
+support = {{
+    "path": "Cache/Support.xcframework/ios-arm64-simulator/Support.framework",
+    "module_name": "Support",
+    "files": [
+        "Cache/Support.xcframework/ios-arm64-simulator/Support.framework/Support",
+        "Cache/Support.xcframework/ios-arm64-simulator/Support.framework/Modules/Support.swiftmodule/arm64-apple-ios-simulator.swiftmodule",
+    ],
+    "label_id": "Support",
+    "linkage": "static",
+}}
+ctx = {{
+    "label": {{"package": "", "name": "Primary", "id": "Primary"}},
+    "attr": {{
+        "bundle": "Primary.xcframework",
+        "platform": "ios",
+        "sdk_variant": "simulator",
+    }},
+    "configuration": {{"tokens": []}},
+    "deps": [{{
+        "label_id": "Support",
+        "transitive_swiftmodule_dirs": [".once/out/Support"],
+        "transitive_archives": ["Cache/Support.xcframework/ios-arm64-simulator/Support.framework/Support"],
+        "transitive_link_framework_bundles": [support],
+        "transitive_framework_bundles": [],
+        "transitive_sdk_frameworks": ["UIKit"],
+        "transitive_linkopts": ["-ObjC"],
+    }}],
+    "srcs": [],
+    "build_dir": ".once/out/Primary",
+    "capability": "build",
+}}
+provider = _apple_xcframework_import_impl(ctx)
+result = repr([
+    provider["transitive_archives"],
+    [bundle["module_name"] for bundle in provider["transitive_link_framework_bundles"]],
+    provider["transitive_framework_bundles"],
+    provider["transitive_sdk_frameworks"],
+    provider["transitive_linkopts"],
+    provider["transitive_swiftmodule_dirs"],
+    provider["transitive_framework_search_dirs"],
+    provider["transitive_framework_files"],
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["Primary.xcframework/ios-arm64-simulator/Primary.framework/Primary"], ["Primary", "Support"], [], [], [], [".once/out/Support"], [], []]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_registers_absolute_xcframework_refs_via_workspace_alias() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "EXTERNAL": {"isa": "PBXFileReference", "lastKnownFileType": "wrapper.xcframework", "name": "External.xcframework", "path": "/ext/cache/hash/External.xcframework", "sourceTree": "<absolute>"},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+created = {{}}
+
+def host_path_exists(path):
+    return path in created
+
+def host_file_exists(path):
+    return path == "/ext/cache/hash/External.xcframework/Info.plist"
+
+def host_which(name):
+    return name
+
+def host_command(argv, env = None, cwd = None, merge_stderr = None):
+    if argv[0] == "sh":
+        created[argv[6]] = True
+        return ""
+    fail("unexpected host command: " + str(argv))
+
+objects = json_decode({objects:?})
+specs = []
+names = {{}}
+_xcode_register_absolute_xcframework_refs(objects, specs, names, "ios", "simulator")
+result = repr([
+    [spec["attrs"]["bundle"] for spec in specs],
+    names.get("/ext/cache/hash/External.xcframework"),
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[[".once/xcframework-refs/_ext_cache_hash/External.xcframework"], "XCFramework_.once_xcframework-refs__ext_cache_hash_External.xcframework"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_collects_absolute_xcframework_file_references() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "EXTERNAL": {"isa": "PBXFileReference", "lastKnownFileType": "wrapper.xcframework", "name": "External.xcframework", "path": "/ext/cache/hash/External.xcframework", "sourceTree": "<absolute>"},
+        "INTERNAL": {"isa": "PBXFileReference", "lastKnownFileType": "wrapper.xcframework", "name": "Internal.xcframework", "path": "/workspace/Vendor/Internal.xcframework", "sourceTree": "<absolute>"},
+        "RELATIVE": {"isa": "PBXFileReference", "lastKnownFileType": "wrapper.xcframework", "path": "Vendor/Relative.xcframework", "sourceTree": "<group>"},
+        "OTHER": {"isa": "PBXFileReference", "path": "/ext/cache/libz.tbd", "sourceTree": "<absolute>"},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+objects = json_decode({objects:?})
+result = repr(_xcode_absolute_xcframework_refs(objects))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["/ext/cache/hash/External.xcframework"]"#
+    );
+}
+
 #[allow(clippy::too_many_lines)]
 #[test]
 fn prelude_apple_xcframework_import_exposes_static_clang_module_to_swift() {
@@ -15181,6 +15584,23 @@ result = repr([_xcode_clang_flags(settings, subs), _xcode_linkopts(settings, sub
     assert_eq!(
         eval_prelude_source_to_repr(source).unwrap(),
         r#"[["-DSQLITE_HAS_CODEC", "-I", "/Pods/SQLCipher"], ["-Xlinker", "-ObjC", "-profile-generate", "-Xlinker", "-no_application_extension"]]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_drops_linker_option_groups_with_unresolved_arguments() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+settings = {{
+    "OTHER_LDFLAGS": "$(inherited) -weak_library \"$(BUILT_PRODUCTS_DIR)/Optional.framework/Optional\" -ObjC",
+}}
+result = repr(_xcode_linkopts(settings, {{}}))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["-Xlinker", "-ObjC"]"#
     );
 }
 
@@ -15894,6 +16314,431 @@ result = repr(_xcode_xcframework_dependencies(
     assert_eq!(
         eval_prelude_source_to_repr(source).unwrap(),
         r#"["XCFramework_Vendor_DependencyModule.xcframework"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_recovers_xcframework_dependencies_through_workspace_symlink() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "DEPENDENCY": {
+            "isa": "PBXFileReference",
+            "path": "/cache/hash/DependencyModule.xcframework",
+            "sourceTree": "<absolute>"
+        },
+        "BUILD": {"isa": "PBXBuildFile", "fileRef": "DEPENDENCY"},
+        "COPY_XCFRAMEWORK": {
+            "isa": "PBXCopyFilesBuildPhase",
+            "dstPath": "_StaticXCFrameworkDependencies/Feature",
+            "dstSubfolderSpec": 16,
+            "files": ["BUILD"]
+        },
+        "FEATURE": {"isa": "PBXNativeTarget", "buildPhases": ["COPY_XCFRAMEWORK"]},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+def host_path_exists(path):
+    return True
+
+def host_which(name):
+    return "/usr/bin/" + name
+
+def host_command(argv, env = None, merge_stderr = None):
+    if argv[0] == "/usr/bin/realpath":
+        if argv[1] == "/workspace/Derived/FrameworkSearchPaths/DependencyModule.xcframework":
+            return "/cache/hash/DependencyModule.xcframework\n"
+        return argv[1] + "\n"
+    fail("unexpected host command: " + str(argv))
+
+objects = json_decode({objects:?})
+specs = [{{
+    "name": "XCFramework_Derived_FrameworkSearchPaths_DependencyModule.xcframework",
+    "attrs": {{"bundle": "Derived/FrameworkSearchPaths/DependencyModule.xcframework"}},
+}}]
+result = repr(_xcode_xcframework_dependencies(
+    objects,
+    objects["FEATURE"],
+    {{"DEPENDENCY": "/cache/hash/DependencyModule.xcframework"}},
+    _xcode_xcframework_name_map(specs),
+))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["XCFramework_Derived_FrameworkSearchPaths_DependencyModule.xcframework"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_matches_imported_modules_to_cached_xcframework_references() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "DEPENDENCY": {
+            "isa": "PBXFileReference",
+            "name": "Dependency-Module.xcframework",
+            "path": "/cache/hash/Dependency-Module.xcframework",
+            "sourceTree": "<absolute>"
+        },
+        "UNRELATED": {
+            "isa": "PBXFileReference",
+            "name": "Unrelated.framework",
+            "path": "/cache/hash/Unrelated.framework",
+            "sourceTree": "<absolute>"
+        },
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+objects = json_decode({objects:?})
+modules = _xcode_xcframework_module_map(
+    objects,
+    {{"DEPENDENCY": "/cache/hash/Dependency-Module.xcframework"}},
+    {{"/cache/hash/Dependency-Module.xcframework": "XCFramework_Dependency_Module"}},
+)
+result = repr([
+    modules.get(_xcode_product_dependency_key("Dependency_Module")),
+    modules.get(_xcode_product_dependency_key("Unrelated")),
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["XCFramework_Dependency_Module", None]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_recovers_transitive_modules_from_disabled_autolink_flags() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+modules = _xcode_disabled_autolink_modules([
+    "-Xfrontend", "-disable-autolink-framework", "-Xfrontend", "Dependency_Module",
+    "-Xfrontend", "-disable-autolink-library", "-Xfrontend", "SupportLibrary",
+    "-enable-upcoming-feature", "MemberImportVisibility",
+])
+cached = {{
+    _xcode_product_dependency_key("Dependency-Module"): "XCFramework_Dependency_Module",
+    _xcode_product_dependency_key("SupportLibrary"): "XCFramework_SupportLibrary",
+}}
+result = repr([cached.get(_xcode_product_dependency_key(module)) for module in modules])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["XCFramework_Dependency_Module", "XCFramework_SupportLibrary"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_recovers_dependencies_from_prebuilt_swiftmodule_symbols() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+cached = {{
+    _xcode_product_dependency_key("PrimaryModule"): "XCFramework_Primary",
+    _xcode_product_dependency_key("Support_Module"): "XCFramework_Support",
+}}
+result = repr(_xcode_xcframework_dependency_ids(
+    "XCFramework_Primary",
+    ["PrimaryModule", "Support_Module", "unrelated_symbol"],
+    cached,
+))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["XCFramework_Support"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_rejects_prebuilt_dependency_edges_that_close_a_cycle() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+specs = {{
+    "Primary": {{"name": "Primary", "deps": ["./Support"]}},
+    "Support": {{"name": "Support", "deps": []}},
+    "Leaf": {{"name": "Leaf", "deps": []}},
+}}
+result = repr(_xcode_acyclic_xcframework_dependencies(
+    "Support",
+    ["Primary", "Leaf"],
+    specs,
+))
+"#
+    );
+    assert_eq!(eval_prelude_source_to_repr(source).unwrap(), r#"["Leaf"]"#);
+}
+
+#[test]
+fn prelude_xcode_attaches_xcframework_dependencies_from_serialized_imports() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+def host_path_exists(path):
+    return True
+
+def host_file_exists(path):
+    return True
+
+def host_arch():
+    return "arm64"
+
+def host_which(name):
+    return "/usr/bin/" + name
+
+def host_command(argv, env = None, cwd = None, merge_stderr = None):
+    tool = argv[0].split("/")[-1]
+    if tool == "realpath":
+        return argv[1] + "\n"
+    if tool == "plutil":
+        return '{{"AvailableLibraries": [{{"LibraryIdentifier": "ios-arm64-simulator", "SupportedPlatform": "ios", "SupportedPlatformVariant": "simulator", "SupportedArchitectures": ["arm64"]}}]}}'
+    if tool == "find":
+        if argv[-1] == "*.swiftinterface":
+            return ""
+        root = argv[2]
+        name = "ModuleA" if root.find("ModuleA.xcframework") >= 0 else "ModuleB"
+        return root + "/" + name + ".framework/Modules/" + name + ".swiftmodule/arm64-apple-ios-simulator.swiftmodule\n"
+    if tool == "xcrun":
+        if "--show-sdk-path" in argv:
+            return "/SDKs/iPhoneSimulator.sdk\n"
+        return "26.0\n"
+    if tool == "strings":
+        # Symbol noise: ModuleB's binary mentions ModuleA even though the
+        # serialized imports of ModuleB do not include it.
+        polluted = argv[1].find("ModuleB.xcframework") >= 0
+        return "ModuleA\nnoise\n" if polluted else "ModuleB\nnoise\n"
+    if tool == "sh":
+        if argv[4] == "ModuleA":
+            return "<stdin>:1:8: error: missing required modules: 'Foundation', 'ModuleB'\n"
+        return ""
+    fail("unexpected host command: " + str(argv))
+
+specs = [
+    {{"name": "App", "kind": "apple_application", "deps": ["./XCF_B", "./XCF_A"], "attrs": {{}}}},
+    {{"name": "XCF_A", "kind": "apple_xcframework_import", "deps": [], "attrs": {{"bundle": "Vendor/ModuleA.xcframework", "platform": "ios", "sdk_variant": "simulator", "arch": "arm64"}}}},
+    {{"name": "XCF_B", "kind": "apple_xcframework_import", "deps": [], "attrs": {{"bundle": "Vendor/ModuleB.xcframework", "platform": "ios", "sdk_variant": "simulator", "arch": "arm64"}}}},
+]
+module_targets = {{
+    _xcode_product_dependency_key("ModuleA"): "XCF_A",
+    _xcode_product_dependency_key("ModuleB"): "XCF_B",
+}}
+_xcode_attach_xcframework_module_dependencies(specs, module_targets)
+result = repr([specs[1]["deps"], specs[2]["deps"]])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["./XCF_B"], []]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_lowers_swift_package_name_setting() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+result = repr(_xcode_swift_language_flags({{"SWIFT_VERSION": "5.0", "SWIFT_PACKAGE_NAME": "PrimaryFeature"}}))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["-swift-version", "5", "-package-name", "PrimaryFeature"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_lowers_dead_code_stripping_setting() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+result = repr([
+    _xcode_linkopts({{"OTHER_LDFLAGS": "-ObjC", "DEAD_CODE_STRIPPING": "YES"}}, {{}}),
+    _xcode_linkopts({{"OTHER_LDFLAGS": "-ObjC"}}, {{}}),
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["-Xlinker", "-ObjC", "-Xlinker", "-dead_strip"], ["-Xlinker", "-ObjC"]]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_lowers_swift_include_paths_setting() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+settings = {{
+    "OTHER_SWIFT_FLAGS": "-DX",
+    "SWIFT_INCLUDE_PATHS": ["$(inherited)", "$(SRCROOT)/../Vendor/Lib.xcframework/ios-arm64"],
+}}
+result = repr(_xcode_swift_flags(settings, {{"SRCROOT": "Modules/App"}}))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["-DX", "-I", "Modules/App/../Vendor/Lib.xcframework/ios-arm64"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_skips_platform_filtered_build_files() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "APPKIT": {"isa": "PBXFileReference", "name": "AppKit.framework", "path": "System/Library/Frameworks/AppKit.framework", "sourceTree": "DEVELOPER_DIR"},
+        "UIKIT": {"isa": "PBXFileReference", "name": "UIKit.framework", "path": "System/Library/Frameworks/UIKit.framework", "sourceTree": "SDKROOT"},
+        "APPKIT_BUILD": {"isa": "PBXBuildFile", "fileRef": "APPKIT", "platformFilters": ["macos"]},
+        "UIKIT_BUILD": {"isa": "PBXBuildFile", "fileRef": "UIKIT"},
+        "FRAMEWORKS": {"isa": "PBXFrameworksBuildPhase", "files": ["APPKIT_BUILD", "UIKIT_BUILD"]},
+        "TARGET": {"isa": "PBXNativeTarget", "buildPhases": ["FRAMEWORKS"]},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+objects = json_decode({objects:?})
+ios = _xcode_classic_phase_files({{}}, objects, objects["TARGET"], {{}}, "ios")["frameworks"]
+macos = _xcode_classic_phase_files({{}}, objects, objects["TARGET"], {{}}, "macos")["frameworks"]
+result = repr([ios, macos])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["UIKit"], ["AppKit", "UIKit"]]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_classifies_tbd_frameworks_phase_files_as_sdk_dylibs() {
+    let prelude = xcode_prelude_source();
+    let objects = serde_json::json!({
+        "UIKIT": {"isa": "PBXFileReference", "name": "UIKit.framework", "path": "System/Library/Frameworks/UIKit.framework", "sourceTree": "SDKROOT"},
+        "RESOLV": {"isa": "PBXFileReference", "name": "libresolv.tbd", "path": "Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libresolv.tbd", "sourceTree": "DEVELOPER_DIR"},
+        "UIKIT_BUILD": {"isa": "PBXBuildFile", "fileRef": "UIKIT"},
+        "RESOLV_BUILD": {"isa": "PBXBuildFile", "fileRef": "RESOLV"},
+        "FRAMEWORKS": {"isa": "PBXFrameworksBuildPhase", "files": ["UIKIT_BUILD", "RESOLV_BUILD"]},
+        "TARGET": {"isa": "PBXNativeTarget", "buildPhases": ["FRAMEWORKS"]},
+    })
+    .to_string();
+    let source = format!(
+        r#"{prelude}
+objects = json_decode({objects:?})
+files = _xcode_classic_phase_files({{}}, objects, objects["TARGET"], {{}})
+result = repr([files["frameworks"], files["sdk_dylibs"]])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["UIKit"], ["resolv"]]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_treats_staticlib_mach_o_framework_as_static() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+result = repr([
+    _xcode_framework_is_static({{"MACH_O_TYPE": "staticlib"}}, "com.apple.product-type.framework"),
+    _xcode_framework_is_static({{}}, "com.apple.product-type.framework"),
+    _xcode_framework_is_static({{}}, "com.apple.product-type.framework.static"),
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[True, False, True]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_parses_swiftinterface_imports() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+text = "\n".join([
+    "// swift-interface-format-version: 1.0",
+    "// swift-module-flags: -target arm64-apple-ios14.0-simulator -module-name TensorFlowLite",
+    "import Foundation",
+    "@_exported import TensorFlowLiteC",
+    "@preconcurrency @_implementationOnly import SecretCore",
+    "import struct SwiftShims.Detail",
+    "import Swift",
+    "public class Interpreter {{}}",
+])
+result = repr(_xcode_swiftinterface_imports(text))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["Foundation", "TensorFlowLiteC", "SecretCore", "SwiftShims", "Swift"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_recovers_imports_from_interface_only_xcframework() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+def host_path_exists(path):
+    return True
+
+def host_file_exists(path):
+    return True
+
+def host_arch():
+    return "arm64"
+
+def host_which(name):
+    return "/usr/bin/" + name
+
+def host_command(argv, env = None, cwd = None, merge_stderr = None):
+    tool = argv[0].split("/")[-1]
+    if tool == "plutil":
+        return '{{"AvailableLibraries": [{{"LibraryIdentifier": "ios-arm64_x86_64-simulator", "SupportedPlatform": "ios", "SupportedPlatformVariant": "simulator", "SupportedArchitectures": ["arm64", "x86_64"]}}]}}'
+    if tool == "find":
+        if argv[-1] == "*.swiftmodule":
+            return ""
+        return argv[2] + "/TensorFlowLite.framework/Modules/TensorFlowLite.swiftmodule/arm64.swiftinterface\n"
+    if tool == "sh":
+        return "// swift-module-flags: -module-name TensorFlowLite\nimport Foundation\n@_exported import TensorFlowLiteC\n"
+    fail("unexpected host command: " + str(argv))
+
+spec = {{"name": "XCF_TFL", "kind": "apple_xcframework_import", "deps": [], "attrs": {{"bundle": "Vendor/TensorFlowLite.xcframework", "platform": "ios", "sdk_variant": "simulator", "arch": "arm64"}}}}
+module_files = _xcode_xcframework_selected_swiftmodules(spec)
+result = repr(_xcode_xcframework_serialized_imports(spec, module_files))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["Foundation", "TensorFlowLiteC"]"#
+    );
+}
+
+#[test]
+fn prelude_xcode_probe_parses_aggregated_missing_module_list() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+output = "<stdin>:1:8: error: missing required modules: 'Alpha', 'Beta', 'Gamma', 'Delta'\n  | note\n<stdin>:1:8: error: missing required module 'Extra'\n"
+result = repr(_xcode_probe_missing_modules(output))
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"["Alpha", "Beta", "Gamma", "Delta", "Extra"]"#
     );
 }
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -16690,7 +16690,7 @@ result = repr([
     );
     assert_eq!(
         eval_prelude_source_to_repr(source).unwrap(),
-        r#"[True, False, True]"#
+        r"[True, False, True]"
     );
 }
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -6931,6 +6931,8 @@ def host_which(name):
         return "/usr/bin/xcrun"
     if name == "codesign":
         return "/usr/bin/codesign"
+    if name == "sh":
+        return "/bin/sh"
     fail("unexpected host_which: " + name)
 
 def host_command(argv, env = None, merge_stderr = None):
@@ -7299,6 +7301,8 @@ def host_which(name):
         return "/usr/bin/xcrun"
     if name == "codesign":
         return "/usr/bin/codesign"
+    if name == "sh":
+        return "/bin/sh"
     fail("unexpected host_which: " + name)
 
 def host_command(argv, env = None, merge_stderr = None):
@@ -14997,9 +15001,9 @@ def host_path_exists(path):
     return path.endswith(".a")
 
 def host_command(argv, env = None, merge_stderr = None):
-    if argv[1] == "--find":
+    if "--find" in argv:
         return "/toolchain/usr/bin/clang\n"
-    if argv[1] == "-print-resource-dir":
+    if "-print-resource-dir" in argv:
         return "/toolchain/usr/lib/clang/21\n"
     fail("unexpected host command: " + str(argv))
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -14591,6 +14591,36 @@ result = repr([
 }
 
 #[test]
+fn prelude_xcode_preserves_every_target_in_a_package_product() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+infos = [{{
+    "identity": "FixtureShared",
+    "path": "Packages/Shared",
+    "info": {{
+        "products": [{{"name": "Shared", "targets": ["Core", "Extras"]}}],
+        "targets": [
+            {{"name": "Core", "type": "regular", "dependencies": [], "exclude": [], "settings": []}},
+            {{"name": "Extras", "type": "regular", "dependencies": [], "exclude": [], "settings": []}},
+        ],
+    }},
+}}]
+graph = _xcode_local_swift_package_specs({{}}, infos, "macos", "13.0", "simulator")
+consumer = {{"dependencies": [{{"product": ["Shared", "FixtureShared", None, None]}}]}}
+result = repr([
+    graph["products"]["FixtureShared\x1fShared"],
+    _xcode_swift_package_dependencies(consumer, "Consumer", {{}}, graph["products"], "macos"),
+])
+"#
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["SwiftPackage_FixtureShared_Core", "SwiftPackage_FixtureShared_Extras"], ["./SwiftPackage_FixtureShared_Core", "./SwiftPackage_FixtureShared_Extras"]]"#
+    );
+}
+
+#[test]
 fn prelude_xcode_lowers_binary_package_artifacts_to_cached_dependencies() {
     let prelude = xcode_prelude_source();
     let source = format!(

--- a/fixtures/xcode_prebuilt_cache_app/Client.xcodeproj/project.pbxproj
+++ b/fixtures/xcode_prebuilt_cache_app/Client.xcodeproj/project.pbxproj
@@ -1,0 +1,73 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {};
+	objectVersion = 56;
+	objects = {
+		ROOT = {isa = PBXProject; buildConfigurationList = PROJECT_CONFIGS; mainGroup = GROUP; targets = (CLIENT, FEATURE_KIT, SHARED_KIT, CLIENT_TESTS); };
+		PROJECT_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (PROJECT_DEBUG); defaultConfigurationName = Debug; };
+		PROJECT_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {SDKROOT = iphoneos; IPHONEOS_DEPLOYMENT_TARGET = 15.0; TARGETED_DEVICE_FAMILY = "1,2"; SWIFT_VERSION = 5.0; }; };
+
+		GROUP = {isa = PBXGroup; children = (CLIENT_FILE, FEATURE_KIT_FILE, SHARED_KIT_FILE, CLIENT_TESTS_FILE, VENDOR_UI_REF, VENDOR_CORE_REF, VENDOR_ENGINE_REF, VENDOR_TEXT_REF, VENDOR_DATA_REF, VENDOR_REMOTE_REF, RESOLV_REF, APPKIT_REF, FEATURE_KIT_PRODUCT, SHARED_KIT_PRODUCT); sourceTree = "<group>"; };
+
+		VENDOR_UI_REF = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VendorUI.xcframework; path = Vendor/VendorUI.xcframework; sourceTree = "<group>"; };
+		VENDOR_CORE_REF = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VendorCore.xcframework; path = Vendor/VendorCore.xcframework; sourceTree = "<group>"; };
+		VENDOR_ENGINE_REF = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VendorEngine.xcframework; path = Vendor/VendorEngine.xcframework; sourceTree = "<group>"; };
+		VENDOR_TEXT_REF = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VendorText.xcframework; path = Vendor/VendorText.xcframework; sourceTree = "<group>"; };
+		VENDOR_DATA_REF = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VendorData.xcframework; path = Vendor/VendorData.xcframework; sourceTree = "<group>"; };
+		VENDOR_REMOTE_REF = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VendorRemote.xcframework; path = "__REMOTE_VENDOR_DIR__/VendorRemote.xcframework"; sourceTree = "<absolute>"; };
+		RESOLV_REF = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
+		APPKIT_REF = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		FEATURE_KIT_PRODUCT = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FeatureKit.framework; path = FeatureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		SHARED_KIT_PRODUCT = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SharedKit.framework; path = SharedKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+
+		SHARED_KIT_FILE = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedKit/Sources/SharedKit.swift; sourceTree = "<group>"; };
+		SHARED_KIT_BUILD = {isa = PBXBuildFile; fileRef = SHARED_KIT_FILE; };
+		SHARED_KIT_SOURCES = {isa = PBXSourcesBuildPhase; files = (SHARED_KIT_BUILD); };
+		SHARED_KIT_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (SHARED_KIT_DEBUG); defaultConfigurationName = Debug; };
+		SHARED_KIT_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {SDKROOT = iphoneos; IPHONEOS_DEPLOYMENT_TARGET = 15.0; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; MACH_O_TYPE = staticlib; SWIFT_PACKAGE_NAME = ClientPackage; }; };
+		SHARED_KIT = {isa = PBXNativeTarget; buildConfigurationList = SHARED_KIT_CONFIGS; buildPhases = (SHARED_KIT_SOURCES); name = SharedKit; productType = "com.apple.product-type.framework"; productName = SharedKit; };
+
+		FEATURE_KIT_FILE = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureKit/Sources/FeatureKit.swift; sourceTree = "<group>"; };
+		FEATURE_KIT_BUILD = {isa = PBXBuildFile; fileRef = FEATURE_KIT_FILE; };
+		FEATURE_KIT_SOURCES = {isa = PBXSourcesBuildPhase; files = (FEATURE_KIT_BUILD); };
+		FEATURE_KIT_SHARED_BUILD = {isa = PBXBuildFile; fileRef = SHARED_KIT_PRODUCT; };
+		FEATURE_KIT_FRAMEWORKS = {isa = PBXFrameworksBuildPhase; files = (FEATURE_KIT_SHARED_BUILD); };
+		FEATURE_KIT_UI_CP = {isa = PBXBuildFile; fileRef = VENDOR_UI_REF; };
+		FEATURE_KIT_TEXT_CP = {isa = PBXBuildFile; fileRef = VENDOR_TEXT_REF; };
+		FEATURE_KIT_COPY_XCFRAMEWORKS = {isa = PBXCopyFilesBuildPhase; dstPath = "_StaticXCFrameworkDependencies/FeatureKit"; dstSubfolderSpec = 16; files = (FEATURE_KIT_UI_CP, FEATURE_KIT_TEXT_CP); };
+		FEATURE_KIT_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (FEATURE_KIT_DEBUG); defaultConfigurationName = Debug; };
+		FEATURE_KIT_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {SDKROOT = iphoneos; IPHONEOS_DEPLOYMENT_TARGET = 15.0; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; MACH_O_TYPE = staticlib; SWIFT_PACKAGE_NAME = ClientPackage; }; };
+		FEATURE_KIT_DEP_SHARED = {isa = PBXTargetDependency; target = SHARED_KIT; };
+		FEATURE_KIT = {isa = PBXNativeTarget; buildConfigurationList = FEATURE_KIT_CONFIGS; buildPhases = (FEATURE_KIT_SOURCES, FEATURE_KIT_FRAMEWORKS, FEATURE_KIT_COPY_XCFRAMEWORKS); dependencies = (FEATURE_KIT_DEP_SHARED); name = FeatureKit; productType = "com.apple.product-type.framework"; productName = FeatureKit; };
+
+		CLIENT_FILE = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client/Sources/main.swift; sourceTree = "<group>"; };
+		CLIENT_BUILD = {isa = PBXBuildFile; fileRef = CLIENT_FILE; };
+		CLIENT_SOURCES = {isa = PBXSourcesBuildPhase; files = (CLIENT_BUILD); };
+		CLIENT_FEATURE_BUILD = {isa = PBXBuildFile; fileRef = FEATURE_KIT_PRODUCT; };
+		CLIENT_SHARED_BUILD = {isa = PBXBuildFile; fileRef = SHARED_KIT_PRODUCT; };
+		CLIENT_UI_BUILD = {isa = PBXBuildFile; fileRef = VENDOR_UI_REF; };
+		CLIENT_CORE_BUILD = {isa = PBXBuildFile; fileRef = VENDOR_CORE_REF; };
+		CLIENT_TEXT_BUILD = {isa = PBXBuildFile; fileRef = VENDOR_TEXT_REF; };
+		CLIENT_ENGINE_BUILD = {isa = PBXBuildFile; fileRef = VENDOR_ENGINE_REF; };
+		CLIENT_DATA_BUILD = {isa = PBXBuildFile; fileRef = VENDOR_DATA_REF; };
+		CLIENT_REMOTE_BUILD = {isa = PBXBuildFile; fileRef = VENDOR_REMOTE_REF; };
+		CLIENT_RESOLV_BUILD = {isa = PBXBuildFile; fileRef = RESOLV_REF; };
+		CLIENT_APPKIT_BUILD = {isa = PBXBuildFile; fileRef = APPKIT_REF; platformFilters = (macos, ); };
+		CLIENT_FRAMEWORKS = {isa = PBXFrameworksBuildPhase; files = (CLIENT_FEATURE_BUILD, CLIENT_SHARED_BUILD, CLIENT_UI_BUILD, CLIENT_CORE_BUILD, CLIENT_TEXT_BUILD, CLIENT_ENGINE_BUILD, CLIENT_DATA_BUILD, CLIENT_REMOTE_BUILD, CLIENT_RESOLV_BUILD, CLIENT_APPKIT_BUILD); };
+		CLIENT_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (CLIENT_DEBUG); defaultConfigurationName = Debug; };
+		CLIENT_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {SDKROOT = iphoneos; IPHONEOS_DEPLOYMENT_TARGET = 15.0; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; DEAD_CODE_STRIPPING = YES; OTHER_LDFLAGS = "$(inherited) -ObjC"; SWIFT_INCLUDE_PATHS = ("$(inherited)", "Vendor/VendorData.xcframework/ios-arm64_x86_64-simulator"); }; };
+		CLIENT_DEP_FEATURE = {isa = PBXTargetDependency; target = FEATURE_KIT; };
+		CLIENT_DEP_SHARED = {isa = PBXTargetDependency; target = SHARED_KIT; };
+		CLIENT = {isa = PBXNativeTarget; buildConfigurationList = CLIENT_CONFIGS; buildPhases = (CLIENT_SOURCES, CLIENT_FRAMEWORKS); dependencies = (CLIENT_DEP_FEATURE, CLIENT_DEP_SHARED); name = Client; productType = "com.apple.product-type.application"; productName = Client; };
+
+		CLIENT_TESTS_FILE = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTests/Sources/ClientTests.swift; sourceTree = "<group>"; };
+		CLIENT_TESTS_BUILD = {isa = PBXBuildFile; fileRef = CLIENT_TESTS_FILE; };
+		CLIENT_TESTS_SOURCES = {isa = PBXSourcesBuildPhase; files = (CLIENT_TESTS_BUILD); };
+		CLIENT_TESTS_CONFIGS = {isa = XCConfigurationList; buildConfigurations = (CLIENT_TESTS_DEBUG); defaultConfigurationName = Debug; };
+		CLIENT_TESTS_DEBUG = {isa = XCBuildConfiguration; name = Debug; buildSettings = {SDKROOT = iphoneos; IPHONEOS_DEPLOYMENT_TARGET = 15.0; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client"; }; };
+		CLIENT_TESTS_DEP_CLIENT = {isa = PBXTargetDependency; target = CLIENT; };
+		CLIENT_TESTS = {isa = PBXNativeTarget; buildConfigurationList = CLIENT_TESTS_CONFIGS; buildPhases = (CLIENT_TESTS_SOURCES); dependencies = (CLIENT_TESTS_DEP_CLIENT); name = ClientTests; productType = "com.apple.product-type.bundle.unit-test"; productName = ClientTests; };
+	};
+	rootObject = ROOT;
+}

--- a/fixtures/xcode_prebuilt_cache_app/Client/Sources/main.swift
+++ b/fixtures/xcode_prebuilt_cache_app/Client/Sources/main.swift
@@ -1,12 +1,23 @@
 import FeatureKit
+import UIKit
 import VendorData
 import VendorEngine
 import VendorRemote
 
-// `engineNew()` loads the standalone engine archive member while the UI
-// archive already carries an older copy of the same engine: their common
-// symbols only coexist because DEAD_CODE_STRIPPING demotes the duplicates.
-// `dataValue()` resolves through SWIFT_INCLUDE_PATHS; `remoteValue()` through
-// an absolute out-of-workspace XCFramework reference.
-let total = runFeature() + engineNew() + dataValue() + remoteValue()
-print("client total: \(total)")
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        // `engineNew()` loads the standalone engine archive member while the
+        // UI archive already carries an older copy of the same engine: their
+        // common symbols only coexist because DEAD_CODE_STRIPPING demotes the
+        // duplicates. `dataValue()` resolves through SWIFT_INCLUDE_PATHS;
+        // `remoteValue()` through an absolute out-of-workspace reference.
+        let total = runFeature() + engineNew() + dataValue() + remoteValue()
+        print("client total: \(total)")
+        return true
+    }
+}
+
+UIApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil, NSStringFromClass(AppDelegate.self))

--- a/fixtures/xcode_prebuilt_cache_app/Client/Sources/main.swift
+++ b/fixtures/xcode_prebuilt_cache_app/Client/Sources/main.swift
@@ -1,0 +1,12 @@
+import FeatureKit
+import VendorData
+import VendorEngine
+import VendorRemote
+
+// `engineNew()` loads the standalone engine archive member while the UI
+// archive already carries an older copy of the same engine: their common
+// symbols only coexist because DEAD_CODE_STRIPPING demotes the duplicates.
+// `dataValue()` resolves through SWIFT_INCLUDE_PATHS; `remoteValue()` through
+// an absolute out-of-workspace XCFramework reference.
+let total = runFeature() + engineNew() + dataValue() + remoteValue()
+print("client total: \(total)")

--- a/fixtures/xcode_prebuilt_cache_app/ClientTests/Sources/ClientTests.swift
+++ b/fixtures/xcode_prebuilt_cache_app/ClientTests/Sources/ClientTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class ClientTests: XCTestCase {
+    func testClientLaunches() {
+        XCTAssertTrue(true)
+    }
+}

--- a/fixtures/xcode_prebuilt_cache_app/FeatureKit/Sources/FeatureKit.swift
+++ b/fixtures/xcode_prebuilt_cache_app/FeatureKit/Sources/FeatureKit.swift
@@ -1,0 +1,16 @@
+import SharedKit
+import VendorText
+import VendorUI
+
+// `SharedModel` is package-visible: this only compiles when both SharedKit and
+// FeatureKit receive the same `-package-name` from SWIFT_PACKAGE_NAME.
+package func featurePackageValue() -> Int {
+    SharedModel().value
+}
+
+public func runFeature() -> Int {
+    // `render()` pulls the vendor UI archive (and, through its serialized
+    // imports, VendorCore); `textValue()` comes from an interface-only
+    // XCFramework whose textual interface imports VendorCore.
+    render() + textValue() + featurePackageValue()
+}

--- a/fixtures/xcode_prebuilt_cache_app/SharedKit/Sources/SharedKit.swift
+++ b/fixtures/xcode_prebuilt_cache_app/SharedKit/Sources/SharedKit.swift
@@ -1,0 +1,11 @@
+// Declares package-visible API. Consumers inside the same package need the
+// matching `-package-name` compiler flag, lowered from SWIFT_PACKAGE_NAME.
+package struct SharedModel {
+    package var value = 7
+
+    package init() {}
+}
+
+public func sharedDescription() -> String {
+    "shared"
+}

--- a/fixtures/xcode_prebuilt_cache_app/tools/build_vendors.sh
+++ b/fixtures/xcode_prebuilt_cache_app/tools/build_vendors.sh
@@ -1,0 +1,240 @@
+#!/bin/sh
+# Builds the prebuilt vendor XCFrameworks this fixture's generated project
+# references. Binary Swift modules are toolchain-locked, so the bundles are
+# produced at spec time with the host toolchain instead of being checked in.
+#
+# Usage: build_vendors.sh <vendor-dir> <remote-vendor-dir>
+#
+# <vendor-dir>        receives the workspace-relative bundles (Vendor/...)
+# <remote-vendor-dir> receives VendorRemote.xcframework, referenced by the
+#                     project through an absolute out-of-workspace path
+set -eu
+
+VENDOR_DIR="$1"
+REMOTE_DIR="$2"
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+SWIFTC="$(xcrun --sdk iphonesimulator --find swiftc)"
+CLANG="$(xcrun --sdk iphonesimulator --find clang)"
+MIN_OS="15.0"
+ARCHS="arm64 x86_64"
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+xcframework_plist() {
+    # $1 = destination Info.plist, $2 = LibraryPath, $3 = BinaryPath (optional)
+    binary_entry=""
+    if [ -n "${3:-}" ]; then
+        binary_entry="
+            <key>BinaryPath</key>
+            <string>$3</string>"
+    fi
+    cat > "$1" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>AvailableLibraries</key>
+    <array>
+        <dict>$binary_entry
+            <key>LibraryIdentifier</key>
+            <string>ios-arm64_x86_64-simulator</string>
+            <key>LibraryPath</key>
+            <string>$2</string>
+            <key>SupportedArchitectures</key>
+            <array>
+                <string>arm64</string>
+                <string>x86_64</string>
+            </array>
+            <key>SupportedPlatform</key>
+            <string>ios</string>
+            <key>SupportedPlatformVariant</key>
+            <string>simulator</string>
+        </dict>
+    </array>
+    <key>CFBundlePackageType</key>
+    <string>XFWK</string>
+    <key>XCFrameworkFormatVersion</key>
+    <string>1.0</string>
+</dict>
+</plist>
+PLIST
+}
+
+framework_plist() {
+    cat > "$1" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>$2</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.once.fixture.$2</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+</dict>
+</plist>
+PLIST
+}
+
+# build_swift_framework <name> <dest-root> <interface-only: yes/no> <extra swiftc args...>
+# Reads Swift sources from "$SCRATCH/src/<name>" and extra C/ObjC objects from
+# "$SCRATCH/obj/<name>/<arch>" when present.
+build_swift_framework() {
+    name="$1"; dest_root="$2"; interface_only="$3"; shift 3
+    slice="$dest_root/$name.xcframework/ios-arm64_x86_64-simulator"
+    fw="$slice/$name.framework"
+    module_dir="$fw/Modules/$name.swiftmodule"
+    mkdir -p "$module_dir"
+    thin_archives=""
+    for arch in $ARCHS; do
+        out="$SCRATCH/out/$name/$arch"
+        mkdir -p "$out"
+        emit_module_args="-emit-module -emit-module-path $module_dir/$arch-apple-ios-simulator.swiftmodule"
+        if [ "$interface_only" = "yes" ]; then
+            emit_module_args="$emit_module_args -enable-library-evolution -swift-version 5 -emit-module-interface-path $module_dir/$arch-apple-ios-simulator.swiftinterface"
+        fi
+        # shellcheck disable=SC2086
+        "$SWIFTC" -parse-as-library -emit-object \
+            -module-name "$name" \
+            $emit_module_args \
+            -sdk "$SDK" -target "$arch-apple-ios$MIN_OS-simulator" \
+            "$@" \
+            -o "$out/$name.o" \
+            "$SCRATCH/src/$name"/*.swift
+        objects="$out/$name.o"
+        if [ -d "$SCRATCH/obj/$name/$arch" ]; then
+            objects="$objects $(echo "$SCRATCH/obj/$name/$arch"/*.o)"
+        fi
+        # shellcheck disable=SC2086
+        ar crs "$out/lib.a" $objects
+        thin_archives="$thin_archives $out/lib.a"
+    done
+    # shellcheck disable=SC2086
+    lipo -create $thin_archives -output "$fw/$name"
+    if [ "$interface_only" = "yes" ]; then
+        rm -f "$module_dir"/*.swiftmodule "$module_dir"/*.swiftdoc "$module_dir"/*.abi.json
+    fi
+    printf 'framework module %s {\n    export *\n}\n' "$name" > "$fw/Modules/module.modulemap"
+    framework_plist "$fw/Info.plist" "$name"
+    xcframework_plist "$dest_root/$name.xcframework/Info.plist" "$name.framework" "$name.framework/$name"
+}
+
+# build_swift_static_library <name> <dest-root>
+# Library-layout XCFramework: libNAME.a plus a loose swiftmodule directory at
+# the slice root, resolved by consumers through SWIFT_INCLUDE_PATHS.
+build_swift_static_library() {
+    name="$1"; dest_root="$2"
+    slice="$dest_root/$name.xcframework/ios-arm64_x86_64-simulator"
+    module_dir="$slice/$name.swiftmodule"
+    mkdir -p "$module_dir"
+    thin_archives=""
+    for arch in $ARCHS; do
+        out="$SCRATCH/out/$name/$arch"
+        mkdir -p "$out"
+        "$SWIFTC" -parse-as-library -emit-object \
+            -module-name "$name" \
+            -emit-module -emit-module-path "$module_dir/$arch-apple-ios-simulator.swiftmodule" \
+            -sdk "$SDK" -target "$arch-apple-ios$MIN_OS-simulator" \
+            -o "$out/$name.o" \
+            "$SCRATCH/src/$name"/*.swift
+        ar crs "$out/lib.a" "$out/$name.o"
+        thin_archives="$thin_archives $out/lib.a"
+    done
+    # shellcheck disable=SC2086
+    lipo -create $thin_archives -output "$slice/lib$name.a"
+    xcframework_plist "$dest_root/$name.xcframework/Info.plist" "lib$name.a" ""
+}
+
+compile_c_object() {
+    # $1 = module, $2 = source, $3 = object basename, extra args follow
+    module="$1"; source="$2"; object="$3"; shift 3
+    for arch in $ARCHS; do
+        mkdir -p "$SCRATCH/obj/$module/$arch"
+        "$CLANG" -c -isysroot "$SDK" -target "$arch-apple-ios$MIN_OS-simulator" \
+            "$@" -o "$SCRATCH/obj/$module/$arch/$object" "$source"
+    done
+}
+
+mkdir -p "$VENDOR_DIR" "$REMOTE_DIR"
+
+# --- VendorCore: plain Swift static framework with a binary module ---
+mkdir -p "$SCRATCH/src/VendorCore"
+cat > "$SCRATCH/src/VendorCore/VendorCore.swift" <<'SWIFT'
+public func coreValue() -> Int { 3 }
+SWIFT
+build_swift_framework VendorCore "$VENDOR_DIR" no -enable-library-evolution
+
+# --- VendorUI: Swift importing VendorCore, an old engine copy, and a
+#     profile-instrumented Objective-C member that -ObjC will always load ---
+mkdir -p "$SCRATCH/src/VendorUI"
+cat > "$SCRATCH/src/VendorUI/VendorUI.swift" <<'SWIFT'
+import VendorCore
+
+@_silgen_name("engine_old")
+func engineOldSymbol() -> Int32
+
+public func render() -> Int { Int(engineOldSymbol()) + coreValue() }
+SWIFT
+cat > "$SCRATCH/engine_old.c" <<'C'
+int engine_common(void) { return 1; }
+int engine_old(void) { return engine_common() + 1; }
+C
+cat > "$SCRATCH/VendorUITelemetry.m" <<'OBJC'
+#import <Foundation/Foundation.h>
+
+@interface VendorUITelemetry : NSObject
+- (int)beat;
+@end
+
+@implementation VendorUITelemetry
+- (int)beat {
+    return 1;
+}
+@end
+OBJC
+compile_c_object VendorUI "$SCRATCH/engine_old.c" engine_old.o
+compile_c_object VendorUI "$SCRATCH/VendorUITelemetry.m" telemetry.o -fobjc-arc -fprofile-instr-generate
+build_swift_framework VendorUI "$VENDOR_DIR" no \
+    -F "$VENDOR_DIR/VendorCore.xcframework/ios-arm64_x86_64-simulator"
+
+# --- VendorEngine: a newer engine copy sharing symbols with VendorUI's ---
+mkdir -p "$SCRATCH/src/VendorEngine"
+cat > "$SCRATCH/src/VendorEngine/VendorEngine.swift" <<'SWIFT'
+@_silgen_name("engine_new")
+func engineNewSymbol() -> Int32
+
+public func engineNew() -> Int { Int(engineNewSymbol()) }
+SWIFT
+cat > "$SCRATCH/engine_new.c" <<'C'
+int engine_common(void) { return 5; }
+int engine_new(void) { return engine_common() + 2; }
+C
+compile_c_object VendorEngine "$SCRATCH/engine_new.c" engine_new.o
+build_swift_framework VendorEngine "$VENDOR_DIR" no
+
+# --- VendorData: static-library-layout XCFramework (SWIFT_INCLUDE_PATHS) ---
+mkdir -p "$SCRATCH/src/VendorData"
+cat > "$SCRATCH/src/VendorData/VendorData.swift" <<'SWIFT'
+public func dataValue() -> Int { 11 }
+SWIFT
+build_swift_static_library VendorData "$VENDOR_DIR"
+
+# --- VendorText: interface-only framework whose textual interface imports
+#     VendorCore ---
+mkdir -p "$SCRATCH/src/VendorText"
+cat > "$SCRATCH/src/VendorText/VendorText.swift" <<'SWIFT'
+import VendorCore
+
+public func textValue() -> Int { coreValue() + 4 }
+SWIFT
+build_swift_framework VendorText "$VENDOR_DIR" yes \
+    -F "$VENDOR_DIR/VendorCore.xcframework/ios-arm64_x86_64-simulator"
+
+# --- VendorRemote: referenced by an absolute out-of-workspace path ---
+mkdir -p "$SCRATCH/src/VendorRemote"
+cat > "$SCRATCH/src/VendorRemote/VendorRemote.swift" <<'SWIFT'
+public func remoteValue() -> Int { 2 }
+SWIFT
+build_swift_framework VendorRemote "$REMOTE_DIR" no

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -76,6 +76,17 @@ Describe 'apple graph'
     cp -R "$REPO_ROOT/fixtures/xcode_signal_app/." "$WORKSPACE/"
   }
 
+  copy_xcode_prebuilt_cache_app_fixture() {
+    cp -R "$REPO_ROOT/fixtures/xcode_prebuilt_cache_app/." "$WORKSPACE/"
+    REMOTE_VENDOR_DIR="${TMPDIR:-/tmp}/once-remote-vendor-fixture"
+    rm -rf "$REMOTE_VENDOR_DIR"
+    if ! vendor_log="$(sh "$WORKSPACE/tools/build_vendors.sh" "$WORKSPACE/Vendor" "$REMOTE_VENDOR_DIR" 2>&1)"; then
+      printf '%s\n' "$vendor_log" >&2
+      return 1
+    fi
+    sed -i '' "s|__REMOTE_VENDOR_DIR__|$REMOTE_VENDOR_DIR|" "$WORKSPACE/Client.xcodeproj/project.pbxproj"
+  }
+
   create_mock_apple_run_fixture() {
     mkdir -p "$WORKSPACE/bin" "$WORKSPACE/apps/ios/Sources/App"
     cat > "$WORKSPACE/apps/ios/Sources/App/App.swift" <<'SWIFT'
@@ -447,6 +458,47 @@ TOML
     The stdout should include '"name":"SignalNotification","kind":"apple_application"'
     The stdout should include '"name":"SignalCore","kind":"apple_library"'
     The stdout should include '"name":"SignalAppTests","kind":"apple_test_bundle"'
+  End
+
+  It 'builds a cache-substituted style app graph around prebuilt XCFrameworks'
+    Skip if 'apple toolchain unavailable on this host' apple_toolchain_unavailable
+    copy_xcode_prebuilt_cache_app_fixture
+    cat > "$WORKSPACE/once.toml" <<'TOML'
+[[target]]
+name = "ClientWorkspace"
+kind = "xcode_workspace"
+srcs = ["Client.xcodeproj/project.pbxproj"]
+
+[target.attrs]
+project = "Client.xcodeproj"
+TOML
+
+    When call once --format json build ClientWorkspace
+    The status should be success
+    The stdout should include '"target":"ClientWorkspace"'
+    The stdout should include '"status":"completed"'
+    The path "$WORKSPACE/.once/out/Client/Client.app/Client" should be file
+  End
+
+  It 'lists the cache-substituted style targets with their Once kinds'
+    Skip if 'apple toolchain unavailable on this host' apple_toolchain_unavailable
+    copy_xcode_prebuilt_cache_app_fixture
+    cat > "$WORKSPACE/once.toml" <<'TOML'
+[[target]]
+name = "ClientWorkspace"
+kind = "xcode_workspace"
+srcs = ["Client.xcodeproj/project.pbxproj"]
+
+[target.attrs]
+project = "Client.xcodeproj"
+TOML
+
+    When call once --format json query targets
+    The status should be success
+    The stdout should include '"name":"Client","kind":"apple_application"'
+    The stdout should include '"name":"FeatureKit","kind":"apple_library"'
+    The stdout should include '"name":"SharedKit","kind":"apple_library"'
+    The stdout should include '"name":"ClientTests","kind":"apple_test_bundle"'
   End
 
   It 'runs Apple application artifacts through the simulator launch path'

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -480,6 +480,32 @@ TOML
     The path "$WORKSPACE/.once/out/Client/Client.app/Client" should be file
   End
 
+  ios_simulator_unavailable() {
+    xcrun simctl list devices available 2>/dev/null | grep -Eq "iPhone|iPad" && return 1
+    return 0
+  }
+
+  It 'runs the cache-substituted style test bundle on a simulator'
+    Skip if 'apple toolchain unavailable on this host' apple_toolchain_unavailable
+    Skip if 'no iOS simulator available on this host' ios_simulator_unavailable
+    copy_xcode_prebuilt_cache_app_fixture
+    cat > "$WORKSPACE/once.toml" <<'TOML'
+[[target]]
+name = "ClientWorkspace"
+kind = "xcode_workspace"
+srcs = ["Client.xcodeproj/project.pbxproj"]
+
+[target.attrs]
+project = "Client.xcodeproj"
+TOML
+
+    When call once --format json test ClientTests
+    The status should be success
+    The stdout should include '"target":"ClientTests"'
+    The stdout should include '"status":"completed"'
+    The contents of file "$WORKSPACE/.once/out/ClientTests/test/test_results.json" should include '"status":"passed"'
+  End
+
   It 'lists the cache-substituted style targets with their Once kinds'
     Skip if 'apple toolchain unavailable on this host' apple_toolchain_unavailable
     copy_xcode_prebuilt_cache_app_fixture

--- a/spec/apple_spec.sh
+++ b/spec/apple_spec.sh
@@ -77,6 +77,9 @@ Describe 'apple graph'
   }
 
   copy_xcode_prebuilt_cache_app_fixture() {
+    if apple_toolchain_unavailable; then
+      return 0
+    fi
     cp -R "$REPO_ROOT/fixtures/xcode_prebuilt_cache_app/." "$WORKSPACE/"
     REMOTE_VENDOR_DIR="${TMPDIR:-/tmp}/once-remote-vendor-fixture"
     rm -rf "$REMOTE_VENDOR_DIR"


### PR DESCRIPTION
### Summary

I started this work after a generated, cache-substituted Xcode workspace stopped at the first unresolved prebuilt dependency. Each fix exposed the next missing piece of Xcode semantics, and the same build eventually reached a clean application link and a clean warm-cache rebuild.

The main design decision in this PR is to keep inferred dependencies between prebuilt bundles compile-only. Once asks Swift which modules a prebuilt module requires and uses those edges only to make modules visible to consumers. Link inputs continue to come from the Xcode project's declared build phases and linker settings.

This PR also fills the Xcode setting and build-phase gaps encountered along that path, adds an end-to-end fixture for the graph interactions, and fixes cache restoration when an earlier restore left the same output path read-only.

### What changed

| Area | Change |
|---|---|
| XCFramework slice discovery | Follow symlinks when collecting a selected slice so versioned framework binaries are included. |
| Cached bundle identity | Match discovered bundles by canonical path when the pbxproj uses an absolute cache path and the workspace exposes the same bundle through a symlink. |
| Swift and Clang compile inputs | Preserve a Swift framework target's own header search paths, lower `SWIFT_INCLUDE_PATHS`, and keep compile-visible inputs from inferred prebuilt dependencies. |
| Binary Swift macros | Lower `SWIFT_LOAD_BINARY_MACROS`, snapshot absolute host macro directories, and reuse the existing Swift plugin provider path. |
| Linker option parsing | Preserve argument positions while resolving `OTHER_LDFLAGS`, recognize `-weak_library` arity, and drop an entire option group when an argument remains unresolved. |
| Cached dependency recovery | Resolve cached XCFrameworks from build phases, direct Swift imports, generated disabled-autolink flags, serialized Swift module requirements, and textual interfaces. |
| Static framework lowering | Treat regular framework targets with `MACH_O_TYPE = staticlib` as static libraries and lower Frameworks-phase `.tbd` entries to SDK dylibs. |
| Xcode settings | Lower `SWIFT_PACKAGE_NAME` and `DEAD_CODE_STRIPPING` in addition to the Swift include paths above. |
| Project references | Honor `platformFilter` and `platformFilters`, and register absolute out-of-workspace XCFramework references through workspace-relative aliases under `.once/`. |
| Application linking | Add the toolchain profile runtime as a lazy archive when it is available, allowing profile-instrumented vendor members already selected by the link to resolve their runtime hooks. |
| Cached output restore | Replace a read-only file when restoring another cached output to the same path instead of trying to truncate it in place. |

The smaller discovery and setting fixes have focused prelude regressions. The fixture described below covers the interactions that only show up once the whole graph is lowered and linked.

### Dependencies between prebuilt bundles

A prebuilt Swift module can require other prebuilt modules even when the consuming native target does not import them directly. The generated project has authoritative link metadata in its build phases and settings, but in the cases that triggered this work it did not represent that module-level compile visibility as target edges Once could consume.

I first tried matching known module names against `strings` output from binary Swift modules. That failed in both directions. One real module produced 12 candidate edges, 8 of which were false. Those false reverse paths then caused the cycle guard to reject genuine requirements.

I also measured native-symbol matching before dropping symbol heuristics entirely. It produced 438 candidate provider matches across eight referring archives and still covered only six of the eight binaries actually required. No symbol-based dependency inference remains in this branch.

The replacement asks the compiler. Once type-checks a one-line import against the selected bundle slice and the matching SDK, then parses Swift's `missing required modules` diagnostic. In one real case, the probe reported all 46 required non-SDK modules in one invocation. Textual-only bundles provide the same dependency information through their `.swiftinterface` imports. The existing cycle guard remains as a safety check.

### Compile visibility is separate from linking

An earlier version propagated full provider data through those inferred edges. Starting from the leaf's 146 declared XCFramework dependencies, inference reached 859 XCFrameworks, and link data from that expanded graph ended in 28 undefined symbols.

The generated projects showed why. The failing leaf's actual link command had 140 declared force-load inputs, while the referring archives and all eight binaries defining the missing symbols were declared together in the application target's Frameworks phase. They belonged at the application link, not at the leaf.

Inferred prebuilt-module edges now propagate compile-facing module, header, and framework search data, but not archives, SDK libraries, or linker options. Declared Xcode project metadata remains authoritative for linking. After this change the leaf kept exactly its 140 declared force-load inputs, gained zero extras, and the 28-symbol failure disappeared.

### Cached output restore

Warm-cache rebuilding exposed a separate restore failure. A linked binary and its re-signed copy can declare the same output path with different content. When the first cache hit restores a read-only file, the second restore cannot truncate it and fails with `Permission denied`.

The core restore paths now retry that case by unlinking the read-only file and recreating it. A focused core regression covers two restores to the same path.

### End-to-end fixture

`fixtures/xcode_prebuilt_cache_app` keeps the broader graph behavior covered in a small generated-style project. It includes:

* two same-package static frameworks using `MACH_O_TYPE` and `SWIFT_PACKAGE_NAME`
* copy-phase-deferred prebuilt bundles
* a binary Swift module that requires another prebuilt module
* an interface-only prebuilt bundle
* a static-library-layout bundle resolved through `SWIFT_INCLUDE_PATHS`
* an absolute out-of-workspace bundle reference
* a platform-filtered `AppKit` entry and a `libresolv.tbd` entry
* a profile-instrumented Objective-C vendor member
* two vendor archives with overlapping engine symbols that require `-dead_strip` to coexist in this link

The fixture builds its vendor bundles at spec time with the host toolchain so toolchain-locked binary Swift modules are not checked into the repository. Three shell specs build the application, assert the lowered target kinds, and run the hosted test bundle on a simulator.

### Review focus

* The serialized-import probe invokes `swiftc` during analysis once per bundle, with results cached by the command cache. I would appreciate feedback on whether this should be gated or batched.
* Absolute out-of-workspace bundle references are bridged through an idempotent alias symlink under `.once/` during analysis. If that state should be created at a different layer, I can move it.
* The profile runtime is added to application links whenever the matching toolchain archive is available. Because it is a lazy archive, it contributes no members unless an already-selected object references the runtime. I am open to a more explicit way to model this.

### Validation

* `cargo test --workspace`: passed across all 18 suites during branch preparation.
* `cargo test -p once-frontend --test prelude`: 347 passed, 0 failed.
* `cargo test -p once-core`: 205 unit tests and 6 additional tests passed, 0 failed.
* `cargo fmt --all -- --check`: passed.
* `shellspec spec/apple_spec.sh`: 47 examples, 0 failures.
* `once test ClientTests`: the hosted test bundle built, ran on an iOS simulator, and passed 1 of 1 test.
* The originating generated workspace built end to end with the branch's release binary. The application was produced with zero link errors, and a warm-cache rebuild completed cleanly.
