### PR TITLE
feat(xcode): route compatible xcodebuild commands through Once

### DIFF
--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -520,6 +520,17 @@ pub enum Cmd {
         cmd: Option<NativeCmd>,
     },
 
+    /// Accept an Xcode build invocation and use the Once graph when its
+    /// semantics are supported. Other invocations pass through to the system
+    /// Xcode build tool unchanged. Configure this as a mise command wrapper
+    /// to make ordinary `xcodebuild` commands use this compatibility surface.
+    #[usage(name = "xcodebuild")]
+    Compatibility {
+        /// Arguments supplied by the Xcode build invocation.
+        #[usage(trailing_var_arg = true, value_name = "ARG")]
+        argv: Vec<String>,
+    },
+
     /// Expose Once's graph and memory queries to a coding agent.
     ///
     /// Speaks the Model Context Protocol over standard input and output so a
@@ -653,6 +664,7 @@ impl Cmd {
                 }
                 path
             }
+            Self::Compatibility { .. } => vec!["xcodebuild"],
             Self::Runtime { cmd } => {
                 let mut path = vec!["runtime"];
                 if let Some(cmd) = cmd {
@@ -756,6 +768,16 @@ mod tests {
         };
         assert_eq!(target.as_deref(), Some("server/application_dev"));
         assert_eq!(arguments, ["phx.server", "--port", "4001"]);
+    }
+
+    #[test]
+    fn compatibility_accepts_xcodebuild_arguments_after_separator() {
+        let cli = parse(&["once", "xcodebuild", "--", "-showBuildSettings"]);
+
+        let Some(Cmd::Compatibility { argv }) = cli.command else {
+            panic!("expected compatibility command");
+        };
+        assert_eq!(argv, ["-showBuildSettings"]);
     }
 
     #[test]

--- a/crates/once-cli/src/commands/compatibility.rs
+++ b/crates/once-cli/src/commands/compatibility.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::Result;
+use once_core::{ResourceLimits, Xdg};
+
+use crate::cli::Output;
+
+pub async fn run(
+    workspace: &Path,
+    xdg: &Xdg,
+    output: Output,
+    resource_limits: ResourceLimits,
+    argv: Vec<String>,
+) -> Result<ExitCode> {
+    Box::pin(crate::commands::xcodebuild::run(
+        workspace,
+        xdg,
+        output,
+        resource_limits,
+        argv,
+    ))
+    .await
+}

--- a/crates/once-cli/src/commands/mod.rs
+++ b/crates/once-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@
 pub mod auth;
 pub mod cache;
 pub mod change_tracker;
+pub mod compatibility;
 pub mod edit;
 pub mod evidence;
 pub mod exec;
@@ -18,3 +19,4 @@ pub mod surface;
 pub mod test_schedule;
 pub mod toolchain;
 pub mod util;
+pub mod xcodebuild;

--- a/crates/once-cli/src/commands/xcodebuild/invocation.rs
+++ b/crates/once-cli/src/commands/xcodebuild/invocation.rs
@@ -1,0 +1,399 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use once_frontend::GraphTarget;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct Invocation {
+    pub(super) quiet: bool,
+    scheme: String,
+    project: Option<String>,
+}
+
+impl Invocation {
+    pub(super) fn parse(argv: &[String]) -> Option<Self> {
+        let mut parser = Parser::default();
+        let mut index = 0;
+        while let Some(argument) = argv.get(index) {
+            match argument.as_str() {
+                "-project" => {
+                    parser.project = Some(parser.value(argv, &mut index, ProjectKind::Project)?);
+                }
+                "-scheme" => {
+                    parser.scheme = Some(parser.value(argv, &mut index, ProjectKind::Scheme)?);
+                }
+                "-configuration" if !parser.debug_configuration => {
+                    let configuration =
+                        parser.value(argv, &mut index, ProjectKind::Configuration)?;
+                    if configuration != "Debug" {
+                        return None;
+                    }
+                    parser.debug_configuration = true;
+                }
+                "-quiet" if !parser.quiet => parser.quiet = true,
+                "build" if !parser.build => parser.build = true,
+                _ => return None,
+            }
+            index += 1;
+        }
+        parser.finish()
+    }
+
+    pub(super) fn target(&self, graph: &[GraphTarget]) -> Option<String> {
+        let workspaces = graph
+            .iter()
+            .filter(|target| target.kind == "xcode_workspace")
+            .collect::<Vec<_>>();
+        let [workspace] = workspaces.as_slice() else {
+            return None;
+        };
+        if !workspace_uses_debug_configuration(workspace)
+            || !project_matches_workspace(self.project.as_ref(), workspace)
+        {
+            return None;
+        }
+        let reachable = reachable_target_ids(workspace, graph);
+        let matches = graph
+            .iter()
+            .filter(|target| {
+                reachable.contains(&target.label.id)
+                    && target.label.name == self.scheme
+                    && target
+                        .capabilities
+                        .iter()
+                        .any(|capability| capability.name == "build")
+            })
+            .map(|target| target.label.id.clone())
+            .collect::<Vec<_>>();
+        let [target] = matches.as_slice() else {
+            return None;
+        };
+        Some(target.clone())
+    }
+}
+
+#[derive(Default)]
+struct Parser {
+    quiet: bool,
+    build: bool,
+    debug_configuration: bool,
+    project: Option<String>,
+    project_kind: Option<ProjectKind>,
+    scheme: Option<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ProjectKind {
+    Project,
+    Scheme,
+    Configuration,
+}
+
+impl Parser {
+    fn value(&mut self, argv: &[String], index: &mut usize, kind: ProjectKind) -> Option<String> {
+        let value = argv.get(*index + 1)?.clone();
+        if value.starts_with('-') {
+            return None;
+        }
+        match kind {
+            ProjectKind::Project => {
+                if self.project_kind.replace(kind).is_some() {
+                    return None;
+                }
+            }
+            ProjectKind::Scheme => {
+                if self.scheme.replace(value.clone()).is_some() {
+                    return None;
+                }
+            }
+            ProjectKind::Configuration => {}
+        }
+        *index += 1;
+        Some(value)
+    }
+
+    fn finish(self) -> Option<Invocation> {
+        if !self.debug_configuration {
+            return None;
+        }
+        Some(Invocation {
+            quiet: self.quiet,
+            scheme: self.scheme?,
+            project: self.project,
+        })
+    }
+}
+
+fn workspace_uses_debug_configuration(workspace: &GraphTarget) -> bool {
+    workspace
+        .attrs
+        .get("configuration")
+        .and_then(once_frontend::AttrValue::as_str)
+        .is_none_or(|configuration| configuration == "Debug")
+}
+
+fn project_matches_workspace(project: Option<&String>, workspace: &GraphTarget) -> bool {
+    let Some(project) = project else {
+        return true;
+    };
+    let Some(project) = normalized_project_path(project) else {
+        return false;
+    };
+    configured_project(workspace)
+        .or_else(|| project_from_sources(&workspace.srcs))
+        .is_some_and(|candidate| candidate == project)
+}
+
+fn configured_project(workspace: &GraphTarget) -> Option<PathBuf> {
+    workspace
+        .attrs
+        .get("project")
+        .and_then(once_frontend::AttrValue::as_str)
+        .and_then(normalized_project_path)
+}
+
+fn project_from_sources(sources: &[String]) -> Option<PathBuf> {
+    let projects = sources
+        .iter()
+        .filter_map(|source| {
+            let path = Path::new(source);
+            (path
+                .file_name()
+                .is_some_and(|name| name == "project.pbxproj"))
+            .then(|| path.parent())
+            .flatten()
+            .and_then(|path| path.to_str())
+            .and_then(normalized_project_path)
+        })
+        .collect::<BTreeSet<_>>();
+    let projects = projects.into_iter().collect::<Vec<_>>();
+    let [project] = projects.as_slice() else {
+        return None;
+    };
+    Some(project.clone())
+}
+
+fn normalized_project_path(project: &str) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in Path::new(project).components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(path) => normalized.push(path),
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => return None,
+        }
+    }
+    matches!(
+        normalized
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some("xcodeproj")
+    )
+    .then_some(normalized)
+}
+
+fn reachable_target_ids(workspace: &GraphTarget, graph: &[GraphTarget]) -> BTreeSet<String> {
+    let dependencies = graph
+        .iter()
+        .map(|target| {
+            (
+                target.label.id.as_str(),
+                target.dependency_ids().cloned().collect::<Vec<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut pending = workspace.dependency_ids().cloned().collect::<Vec<_>>();
+    let mut reachable = BTreeSet::new();
+    while let Some(target) = pending.pop() {
+        if !reachable.insert(target.clone()) {
+            continue;
+        }
+        if let Some(dependencies) = dependencies.get(target.as_str()) {
+            pending.extend(dependencies.iter().cloned());
+        }
+    }
+    reachable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_frontend::{Capability, TargetLabel};
+
+    fn target(id: &str, kind: &str, deps: &[&str], capabilities: &[&str]) -> GraphTarget {
+        GraphTarget {
+            label: TargetLabel {
+                package: String::new(),
+                name: id.to_string(),
+                id: id.to_string(),
+            },
+            kind: kind.to_string(),
+            deps: deps.iter().map(ToString::to_string).collect(),
+            dependency_edges: BTreeMap::new(),
+            srcs: Vec::new(),
+            visibility: Vec::new(),
+            attrs: BTreeMap::new(),
+            capabilities: capabilities
+                .iter()
+                .map(|name| Capability {
+                    name: (*name).to_string(),
+                    output_groups: Vec::new(),
+                    requires_outputs: Vec::new(),
+                })
+                .collect(),
+            providers: Vec::new(),
+            tools: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn parses_a_debug_scheme_build() {
+        let invocation = Invocation::parse(&arguments(&[
+            "-project",
+            "Client.xcodeproj",
+            "-scheme",
+            "Client",
+            "-configuration",
+            "Debug",
+            "-quiet",
+            "build",
+        ]))
+        .unwrap();
+
+        assert!(invocation.quiet);
+        assert_eq!(invocation.scheme, "Client");
+        assert_eq!(invocation.project.as_deref(), Some("Client.xcodeproj"));
+    }
+
+    #[test]
+    fn rejects_shapes_that_cannot_preserve_xcode_semantics() {
+        for invalid in [
+            ["-scheme", "Client", "test"].as_slice(),
+            ["-scheme", "Client"].as_slice(),
+            ["-scheme", "Client", "-configuration", "Release"].as_slice(),
+            ["-workspace", "Client.xcworkspace", "-scheme", "Client"].as_slice(),
+            [
+                "-scheme",
+                "Client",
+                "-destination",
+                "platform=iOS Simulator",
+            ]
+            .as_slice(),
+            ["-scheme", "Client", "PRODUCT_NAME=Changed"].as_slice(),
+        ] {
+            assert!(Invocation::parse(&arguments(invalid)).is_none());
+        }
+    }
+
+    #[test]
+    fn selects_only_a_reachable_build_target_from_one_xcode_workspace() {
+        let graph = vec![
+            target("xcode", "xcode_workspace", &["Client"], &["build"]),
+            target("Client", "apple_application", &["Library"], &["build"]),
+            target("Library", "apple_library", &[], &["build"]),
+            target("Other", "script", &[], &["build"]),
+        ];
+        let invocation = Invocation::parse(&arguments(&[
+            "-scheme",
+            "Client",
+            "-configuration",
+            "Debug",
+        ]))
+        .unwrap();
+
+        assert_eq!(invocation.target(&graph).as_deref(), Some("Client"));
+    }
+
+    #[test]
+    fn selects_a_project_only_when_it_matches_the_workspace_seed() {
+        let mut workspace = target("xcode", "xcode_workspace", &["Client"], &["build"]);
+        workspace.srcs = vec!["Client.xcodeproj/project.pbxproj".to_string()];
+        let graph = vec![
+            workspace,
+            target("Client", "apple_application", &[], &["build"]),
+        ];
+
+        let matching = Invocation::parse(&arguments(&[
+            "-project",
+            "./Client.xcodeproj",
+            "-scheme",
+            "Client",
+            "-configuration",
+            "Debug",
+        ]))
+        .unwrap();
+        let other = Invocation::parse(&arguments(&[
+            "-project",
+            "Other.xcodeproj",
+            "-scheme",
+            "Client",
+            "-configuration",
+            "Debug",
+        ]))
+        .unwrap();
+
+        assert_eq!(matching.target(&graph).as_deref(), Some("Client"));
+        assert_eq!(other.target(&graph), None);
+    }
+
+    #[test]
+    fn requires_an_unambiguous_project_source() {
+        assert_eq!(
+            project_from_sources(&arguments(&[
+                "Client.xcodeproj/project.pbxproj",
+                "Other.xcodeproj/project.pbxproj",
+            ])),
+            None
+        );
+    }
+
+    #[test]
+    fn requires_one_reachable_target_with_the_scheme_name() {
+        let mut second_client = target("apps/Client", "apple_application", &[], &["build"]);
+        second_client.label.name = "Client".to_string();
+        let graph = vec![
+            target(
+                "xcode",
+                "xcode_workspace",
+                &["Client", "apps/Client"],
+                &["build"],
+            ),
+            target("Client", "apple_application", &[], &["build"]),
+            second_client,
+        ];
+        let invocation = Invocation::parse(&arguments(&[
+            "-scheme",
+            "Client",
+            "-configuration",
+            "Debug",
+        ]))
+        .unwrap();
+
+        assert_eq!(invocation.target(&graph), None);
+    }
+
+    #[test]
+    fn rejects_an_ambiguous_or_unreachable_scheme() {
+        let graph = vec![
+            target("xcode", "xcode_workspace", &["Client"], &["build"]),
+            target("other_xcode", "xcode_workspace", &["Other"], &["build"]),
+            target("Client", "apple_application", &[], &["build"]),
+            target("Other", "apple_application", &[], &["build"]),
+        ];
+        let invocation = Invocation::parse(&arguments(&[
+            "-scheme",
+            "Client",
+            "-configuration",
+            "Debug",
+        ]))
+        .unwrap();
+
+        assert_eq!(invocation.target(&graph), None);
+    }
+}

--- a/crates/once-cli/src/commands/xcodebuild/mod.rs
+++ b/crates/once-cli/src/commands/xcodebuild/mod.rs
@@ -1,0 +1,40 @@
+//! Xcode build compatibility routing.
+
+mod invocation;
+mod passthrough;
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::Result;
+use once_core::{ResourceLimits, SandboxMode, Xdg};
+
+use crate::cli::Output;
+
+pub async fn run(
+    workspace: &Path,
+    xdg: &Xdg,
+    output: Output,
+    resource_limits: ResourceLimits,
+    argv: Vec<String>,
+) -> Result<ExitCode> {
+    let Some(invocation) = invocation::Invocation::parse(&argv) else {
+        return passthrough::run(&argv);
+    };
+    let graph = once_frontend::load_graph_workspace(workspace)?;
+    let Some(target) = invocation.target(&graph) else {
+        return passthrough::run(&argv);
+    };
+    let resolved = crate::commands::graph::resolve_invocation_configuration(workspace, &[])?;
+    let cache = crate::cache_provider::resolve(workspace, xdg)?;
+    crate::commands::graph::build(
+        workspace,
+        &cache,
+        Output::new(output.format, output.quiet || invocation.quiet),
+        &target,
+        SandboxMode::Off,
+        resource_limits,
+        &resolved,
+    )
+    .await
+}

--- a/crates/once-cli/src/commands/xcodebuild/passthrough.rs
+++ b/crates/once-cli/src/commands/xcodebuild/passthrough.rs
@@ -1,0 +1,84 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use anyhow::{bail, Context, Result};
+
+pub(super) fn run(argv: &[String]) -> Result<ExitCode> {
+    let executable = real_xcodebuild()?;
+    let status = Command::new(&executable)
+        .args(argv)
+        .status()
+        .with_context(|| format!("starting {}", executable.display()))?;
+    Ok(ExitCode::from(
+        status
+            .code()
+            .and_then(|code| u8::try_from(code).ok())
+            .unwrap_or(255),
+    ))
+}
+
+fn real_xcodebuild() -> Result<PathBuf> {
+    if let Some(path) = env::var_os("ONCE_XCODEBUILD_PATH").map(PathBuf::from) {
+        if executable(&path) {
+            return Ok(path);
+        }
+        bail!(
+            "ONCE_XCODEBUILD_PATH does not name an executable: {}",
+            path.display()
+        );
+    }
+    let current = env::current_exe()
+        .ok()
+        .and_then(|path| path.canonicalize().ok());
+    for directory in env::var_os("PATH").iter().flat_map(env::split_paths) {
+        let candidate = directory.join("xcodebuild");
+        if !executable(&candidate) || is_current_executable(&candidate, current.as_deref()) {
+            continue;
+        }
+        return Ok(candidate);
+    }
+    bail!("could not find a system xcodebuild outside the Once compatibility wrapper")
+}
+
+fn is_current_executable(candidate: &Path, current: Option<&Path>) -> bool {
+    current.is_some_and(|current| candidate.canonicalize().is_ok_and(|path| path == current))
+}
+
+fn executable(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        path.metadata()
+            .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+    }
+    #[cfg(not(unix))]
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifies_executable_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let executable_path = directory.path().join("xcodebuild");
+        std::fs::write(&executable_path, "").unwrap();
+        assert!(!executable(&executable_path));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(&executable_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&executable_path, permissions).unwrap();
+            assert!(executable(&executable_path));
+        }
+    }
+}

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -218,6 +218,16 @@ async fn run_command(
         }
         Cmd::Edit { cmd } => run_edit_command(workspace, output, cmd).await,
         Cmd::Native { cmd } => run_native_command(workspace, output, cmd).await,
+        Cmd::Compatibility { argv } => {
+            Box::pin(commands::compatibility::run(
+                workspace,
+                xdg,
+                output,
+                resource_limits.clone(),
+                argv,
+            ))
+            .await
+        }
         Cmd::Runtime { cmd } => run_runtime_command(workspace, output, cmd).await,
         Cmd::Mcp {
             workspace: workspace_override,

--- a/spec/xcodebuild_compatibility_spec.sh
+++ b/spec/xcodebuild_compatibility_spec.sh
@@ -1,0 +1,34 @@
+#shellcheck shell=bash
+
+Describe 'xcodebuild compatibility'
+  BeforeEach 'setup_workspace'
+  AfterEach 'cleanup_workspace'
+
+  install_system_xcodebuild() {
+    mkdir -p "$WORKSPACE/tools"
+    cat > "$WORKSPACE/tools/xcodebuild" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*"
+exit "${XCODEBUILD_EXIT_CODE:-0}"
+SH
+    chmod +x "$WORKSPACE/tools/xcodebuild"
+  }
+
+  It 'passes unsupported invocations through without a Once trailer'
+    install_system_xcodebuild
+
+    When call env PATH="$WORKSPACE/tools:$PATH" "$ONCE_BIN" -C "$WORKSPACE" xcodebuild -- -showBuildSettings
+    The status should be success
+    The stdout should equal '-showBuildSettings'
+    The stderr should not include 'cache '
+  End
+
+  It 'preserves the system xcodebuild exit status for unsupported invocations'
+    install_system_xcodebuild
+
+    When call env XCODEBUILD_EXIT_CODE=17 PATH="$WORKSPACE/tools:$PATH" "$ONCE_BIN" -C "$WORKSPACE" xcodebuild -- -showBuildSettings
+    The status should be failure
+    The status should equal 17
+    The stdout should equal '-showBuildSettings'
+  End
+End

--- a/web/priv/docs/guide/graph/apple/xcode.md
+++ b/web/priv/docs/guide/graph/apple/xcode.md
@@ -157,6 +157,45 @@ once test ClientTests
 See [Testing and Scheduling](/guide/graph/testing) for selection and reporting,
 and that target kind's limitations for the test shapes that are supported.
 
+## Keep `xcodebuild` Commands
+
+Once can also sit behind the familiar `xcodebuild` command when a project uses
+[mise](https://mise.jdx.dev/) command wrappers. Add this to the project's
+`mise.toml`, then run `mise reshim` and activate mise in the shell that starts
+the build:
+
+```toml
+[wrappers.xcodebuild]
+command = "once"
+args = ["xcodebuild", "--"]
+```
+
+The wrapper preserves the original arguments. The separator belongs to Once and
+is not passed to Xcode. Once uses the graph for a build
+when it can prove the request is equivalent: one resolved Once Xcode workspace
+seed for a discovered project, a scheme that exactly matches one reachable Once
+build target, an explicit `-configuration Debug` argument, and the default or
+explicit `build` action. An explicit `-project` value must name that discovered
+project. For example:
+
+```sh
+xcodebuild -project Client.xcodeproj -scheme Client -configuration Debug build
+```
+
+For troubleshooting without mise, call the compatibility surface directly and
+put the separator before the Xcode arguments:
+
+```sh
+once xcodebuild -- -project Client.xcodeproj -scheme Client -configuration Debug build
+```
+
+Every other request invokes the system `xcodebuild` with the same arguments and
+exit status. This includes tests, archives, exports, destinations, package
+resolution, custom build settings, workspaces, missing or other configurations,
+help, and version queries. The fallback lets editors, continuous integration,
+and coding agents keep their existing command vocabulary while Once takes over
+only the forms it can model accurately.
+
 ## Work From a Workspace
 
 Point `project` at an `.xcworkspace` to resolve every project the workspace


### PR DESCRIPTION
## What changed

- Added an `once xcodebuild` compatibility surface for wrapper-based Xcode builds.
- Routed only unambiguous Debug builds with a matching project and scheme into the Once graph.
- Preserved native `xcodebuild` behavior for unsupported invocations, including arguments and exit status.
- Documented the mise wrapper configuration and direct troubleshooting form.

## Why

Existing editors, automation, and coding agents already use `xcodebuild`. The compatibility surface lets them keep that command vocabulary while Once handles the build shapes it can model accurately.

## Approach

A mise command wrapper maps `xcodebuild` to `once xcodebuild --`. Once accepts a deliberately narrow request shape: one resolved Xcode workspace seed, one matching reachable target, and an explicit Debug configuration. Every other request resolves the system Xcode build tool after mise removes its own wrapper directories from the process search path.

## Impact

Projects can opt in with a local mise configuration. Build requests that are not modeled, including tests, archives, destinations, custom settings, workspaces, and other configurations, continue through the native tool unchanged.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo test -p once-cli` with 357 passing tests
- `mise exec -- cargo clippy -p once-cli --all-targets -- -D warnings`
- `mise exec -- cargo build --release -p once-cli`
- `mise exec -- shellspec spec/xcodebuild_compatibility_spec.sh`
