### PR TITLE
feat: apply Bazel UX lessons to Once (error frame, typed variants, cache cap, warm-loop bench)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,54 @@
+name: bench
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'benchmarks/**'
+      - 'mise.toml'
+      - '.github/workflows/bench.yml'
+  push:
+    branches: [main]
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_NET_RETRY: "10"
+  RUSTUP_MAX_RETRIES: "10"
+
+jobs:
+  warm-loop:
+    name: warm-loop (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+        with:
+          experimental: true
+          cache: true
+      - if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: bench
+          cache-on-failure: true
+          cache-bin: false
+      - name: build once
+        run: mise exec -- cargo build --release --package once-cli
+      - name: warm-loop bench
+        run: benchmarks/warm-loop/run.sh
+      - name: upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: warm-loop-${{ matrix.os }}
+          path: benchmarks/warm-loop/results/
+          if-no-files-found: warn

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,6 +43,14 @@ jobs:
           cache-bin: false
       - name: build once
         run: mise exec -- cargo build --release --package once-cli
+      - name: trust bench fixture mise configs
+        # The bench fixture and the repo root both ship a `mise.toml`.
+        # Once runs each fixture action through a sandboxed mise subprocess
+        # that does not inherit the workflow's `MISE_TRUSTED_CONFIG_PATHS`,
+        # so trust has to be persisted to disk before the timed run starts.
+        run: |
+          mise trust --yes mise.toml
+          mise trust --yes benchmarks/cache-comparison/once/mise.toml
       - name: warm-loop bench
         run: benchmarks/warm-loop/run.sh
       - name: upload results

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,6 +16,9 @@ concurrency:
   group: bench-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_NET_RETRY: "10"
   RUSTUP_MAX_RETRIES: "10"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ inside each module file. Cross-module integration tests go under
 
 ## Manifest Files
 
+Once has one configuration family: workspace and package `once.toml`
+files plus in-source script `# once` headers. Do not add a new
+Once-owned dotfile, a parallel config format, or a second layer that
+overrides `once.toml`. Ecosystem manifests that Once reads
+cooperatively (such as `Cargo.toml` and `Package.swift`) are not Once
+configuration and are unaffected by this rule.
+
 - Per-package manifests are named `once.toml`.
 - The `.once/` directory at the workspace root is cache and runtime
   state, not a manifest. It is gitignored.
@@ -124,6 +131,20 @@ The built-in Apple target kinds and their portable starter examples are the
 reference implementation. Treat their module-owned examples, schema
 metadata, validation, and MCP/CLI discovery shape as the template when
 wiring a new toolchain.
+
+## Target Names And Paths
+
+Do not invent a path-like target grammar. When a target can be
+identified by a native package name (a Cargo crate, a SwiftPM product,
+an Xcode scheme, an npm workspace) or by a filesystem path relative to
+the workspace, use that. Reserve any Once-specific selector for cases
+where native naming genuinely cannot express the intent, and mirror
+filesystem path semantics rather than a parallel notation.
+
+Where a name must be typed, auto-discover where possible. When
+discovery fails, the error message must include the exact corrected
+syntax and a shortlist of nearby valid targets. A "target not found"
+error that only echoes what the user typed is a bug.
 
 ## Resource Budgeting
 

--- a/benchmarks/warm-loop/.gitignore
+++ b/benchmarks/warm-loop/.gitignore
@@ -1,0 +1,2 @@
+.state/
+results/

--- a/benchmarks/warm-loop/README.md
+++ b/benchmarks/warm-loop/README.md
@@ -1,0 +1,38 @@
+# Warm-loop bench
+
+Measures Once's per-build overhead when every action already has a local
+cache hit. Catches regressions like a change tracker leak that adds
+seconds per build without changing any output. Runs in CI on `pull_request`
+against `ubuntu-latest` and `macos-latest`; macOS coverage matters
+because the filesystem-watching backend differs per platform and some
+overheads (FSEvents, in particular) show up only there.
+
+## Fixture
+
+Reuses `benchmarks/cache-comparison/once`, a deterministic 15-action
+graph. Each action reads a tiny input, sleeps 40 milliseconds, and
+writes a controlled artifact between 1 and 16 mebibytes. The bench
+forces `ONCE_CACHE_PROVIDER=local` so no network or server is required.
+
+## Run
+
+Build the release binary first, then run:
+
+```sh
+mise exec -- cargo build --release --package once-cli
+benchmarks/warm-loop/run.sh
+```
+
+`RUNS` overrides the default five measured warm runs. `ONCE_BINARY`
+points at an alternative binary. `CEILING_SECONDS` (read by `check.sh`)
+overrides the catastrophic ceiling.
+
+## Signal
+
+The first build populates the local cache and is not timed. The
+measured runs are all warm no-ops; a healthy Once completes each of
+them in well under a second. CI publishes median, min, and max on
+every PR, and fails only when the median exceeds a loose ceiling
+(default 10 seconds) that catches "something is very wrong" without
+gating on normal variance. Tighten the ceiling once trend data on
+main gives an honest baseline.

--- a/benchmarks/warm-loop/check.sh
+++ b/benchmarks/warm-loop/check.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# Read a hyperfine JSON result and enforce a catastrophic-regression
+# ceiling on the median warm-loop time. The ceiling is intentionally
+# loose (a warm build of the 15-action fixture should finish in well
+# under a second on a healthy system); tighten once baseline data on
+# main is available.
+
+set -eu
+
+file="${1:?path to hyperfine json required}"
+ceiling_seconds="${CEILING_SECONDS:-10}"
+
+# Guard the gate against silent no-ops: a missing key or empty array
+# would make jq return "null" and the comparison below would pass with
+# nothing actually measured. Bail before we lie about a green bench.
+case "$ceiling_seconds" in
+  ''|*[!0-9]*)
+    printf 'FAIL: CEILING_SECONDS must be a positive integer (got %s).\n' \
+      "$ceiling_seconds" >&2
+    exit 2
+    ;;
+esac
+
+median="$(mise exec -- jq -r '.results[0].median // "null"' "$file")"
+min="$(mise exec -- jq -r '.results[0].min // "null"' "$file")"
+max="$(mise exec -- jq -r '.results[0].max // "null"' "$file")"
+
+for label in median min max; do
+  eval "value=\$$label"
+  case "$value" in
+    ''|null)
+      printf 'FAIL: hyperfine JSON is missing .results[0].%s (%s).\n' \
+        "$label" "$file" >&2
+      exit 2
+      ;;
+  esac
+done
+
+printf 'warm-loop median: %ss  min: %ss  max: %ss  ceiling: %ss\n' \
+  "$median" "$min" "$max" "$ceiling_seconds"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    printf '### Warm-loop bench\n\n'
+    printf '| median | min | max | ceiling |\n'
+    printf '| --- | --- | --- | --- |\n'
+    printf '| %ss | %ss | %ss | %ss |\n\n' "$median" "$min" "$max" "$ceiling_seconds"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if mise exec -- jq -e --argjson ceiling "$ceiling_seconds" \
+    '.results[0].median > $ceiling' "$file" >/dev/null; then
+  printf 'FAIL: warm-loop median (%ss) exceeded catastrophic ceiling (%ss).\n' \
+    "$median" "$ceiling_seconds" >&2
+  exit 1
+fi

--- a/benchmarks/warm-loop/run.sh
+++ b/benchmarks/warm-loop/run.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Measure Once's warm-loop overhead: how long a no-op rebuild takes
+# when every action already has a local cache hit. Guards against
+# regressions like a change-tracker leak that adds seconds per build
+# without changing any output.
+#
+# Reuses the deterministic 15-action fixture from
+# benchmarks/cache-comparison/once and forces the cache provider to
+# local so no network or server is required.
+
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+repository="$(CDPATH= cd -- "$root/../.." && pwd)"
+fixture="$repository/benchmarks/cache-comparison/once"
+raw_binary="${ONCE_BINARY:-$repository/target/release/once}"
+runs="${RUNS:-5}"
+results="$root/results"
+state="$root/.state"
+
+# Resolve the binary before the timed command changes directory into
+# the fixture. A relative ONCE_BINARY like `target/release/once` would
+# otherwise pass the existence check here (interpreted against the
+# caller's cwd) and then fail during the run.
+if ! binary="$(CDPATH= cd "$(dirname "$raw_binary")" 2>/dev/null && pwd)/$(basename "$raw_binary")"; then
+  printf 'once binary path %s could not be resolved\n' "$raw_binary" >&2
+  exit 2
+fi
+
+if [ ! -x "$binary" ]; then
+  printf 'once binary not found at %s\n' "$binary" >&2
+  printf 'build it with: mise exec -- cargo build --release --package once-cli\n' >&2
+  exit 2
+fi
+
+rm -rf "$state" "$results"
+mkdir -p "$state/cache" "$state/config" "$results"
+
+build_cmd="cd '$fixture' && \
+  ONCE_CACHE_PROVIDER=local \
+  XDG_CACHE_HOME='$state/cache' \
+  XDG_CONFIG_HOME='$state/config' \
+  '$binary' build distribution --format json --quiet"
+
+sh -c "$build_cmd" >/dev/null
+
+mise exec -- hyperfine \
+  --runs "$runs" \
+  --warmup 0 \
+  --export-json "$results/warm-loop.json" \
+  --command-name once-warm-loop \
+  "$build_cmd"
+
+"$root/check.sh" "$results/warm-loop.json"

--- a/crates/once-cas/src/provider.rs
+++ b/crates/once-cas/src/provider.rs
@@ -227,6 +227,27 @@ impl CacheProvider {
             Self::Tuist(cache) => cache.local().gc(max_bytes, dry_run).await,
         }
     }
+
+    /// Run GC only when the local tier is over its cap, evicting down
+    /// to `cap_bytes * 4 / 5` for hysteresis so the next `put` does not
+    /// immediately trip the check again. Returns `None` when the store
+    /// is already within budget.
+    ///
+    /// Cheap enough to call after each `put`: it only walks the store
+    /// when it actually needs to reclaim.
+    pub async fn maybe_evict_over_cap(&self, cap_bytes: u64) -> Result<Option<GcReport>> {
+        if cap_bytes == 0 {
+            return Ok(None);
+        }
+        let stats = self.stats().await?;
+        let used = stats.blob_bytes.saturating_add(stats.action_bytes);
+        if used <= cap_bytes {
+            return Ok(None);
+        }
+        let target = cap_bytes.saturating_mul(4) / 5;
+        let report = self.gc(target, false).await?;
+        Ok(Some(report))
+    }
 }
 
 #[cfg(test)]
@@ -318,5 +339,48 @@ mod tests {
         provider.put_blob(b"bb").await.unwrap();
         let stats = provider.stats().await.unwrap();
         assert_eq!(stats.blob_count, 2);
+    }
+
+    #[tokio::test]
+    async fn maybe_evict_over_cap_is_a_noop_when_under_budget() {
+        let tmp = TempDir::new().unwrap();
+        let provider = CacheProvider::open_local(tmp.path());
+        provider.put_blob(b"small").await.unwrap();
+        let report = provider.maybe_evict_over_cap(1_000_000).await.unwrap();
+        assert!(
+            report.is_none(),
+            "expected no eviction when under cap, got {report:?}"
+        );
+        let stats = provider.stats().await.unwrap();
+        assert_eq!(stats.blob_count, 1);
+    }
+
+    #[tokio::test]
+    async fn maybe_evict_over_cap_reclaims_when_over_budget() {
+        let tmp = TempDir::new().unwrap();
+        let provider = CacheProvider::open_local(tmp.path());
+        // Four blobs of ~100 bytes each; force a tight cap so eviction fires
+        // and the 80% hysteresis target lets some entries survive.
+        for i in 0..4 {
+            let payload = vec![i; 128];
+            provider.put_blob(&payload).await.unwrap();
+        }
+        let before = provider.stats().await.unwrap();
+        let report = provider
+            .maybe_evict_over_cap(before.blob_bytes / 2)
+            .await
+            .unwrap()
+            .expect("eviction should fire when over cap");
+        assert!(report.bytes_after <= report.bytes_before);
+        assert!(report.removed >= 1, "expected at least one entry removed");
+    }
+
+    #[tokio::test]
+    async fn maybe_evict_over_cap_skips_when_cap_is_zero() {
+        let tmp = TempDir::new().unwrap();
+        let provider = CacheProvider::open_local(tmp.path());
+        provider.put_blob(b"payload").await.unwrap();
+        let report = provider.maybe_evict_over_cap(0).await.unwrap();
+        assert!(report.is_none());
     }
 }

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -17,7 +17,7 @@ mod toolchain;
 pub use auth::AuthCmd;
 pub(crate) use cache::OutputDigest;
 pub use cache::{CacheActionCmd, CacheBlobCmd, CacheCmd};
-pub(crate) use cache::DEFAULT_CACHE_SIZE_CAP_BYTES;
+pub(crate) use cache::{CacheSize, DEFAULT_CACHE_SIZE_CAP_BYTES};
 pub use edit::EditCmd;
 pub use native::NativeCmd;
 pub use query::QueryCmd;

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -17,6 +17,7 @@ mod toolchain;
 pub use auth::AuthCmd;
 pub(crate) use cache::OutputDigest;
 pub use cache::{CacheActionCmd, CacheBlobCmd, CacheCmd};
+pub(crate) use cache::DEFAULT_CACHE_SIZE_CAP_BYTES;
 pub use edit::EditCmd;
 pub use native::NativeCmd;
 pub use query::QueryCmd;

--- a/crates/once-cli/src/cli/cache.rs
+++ b/crates/once-cli/src/cli/cache.rs
@@ -4,6 +4,12 @@ use std::str::FromStr;
 use once_cas::Digest;
 use usage::Subcommands;
 
+/// Default size cap used when `--max-size` is not passed. 20 GB is
+/// large enough that a healthy dev loop does not hit it, small enough
+/// that a runaway build cannot fill a 256 GB SSD before the user
+/// notices.
+pub(crate) const DEFAULT_CACHE_SIZE_CAP_BYTES: u64 = 20 * 1_000_000_000;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct CacheSize(u64);
 
@@ -52,17 +58,17 @@ pub enum CacheCmd {
     /// Reclaim local cache space down to a size budget.
     ///
     /// Removes the oldest blobs and action results until the local
-    /// store fits within `--max-size`. Safe to run at any time: an
-    /// action whose outputs get evicted simply re-executes on its next
-    /// build. Only the local tier is collected; a remote cache is never
-    /// touched.
+    /// store fits within `--max-size`, defaulting to 20 GB when the
+    /// flag is omitted. Safe to run at any time: an action whose
+    /// outputs get evicted simply re-executes on its next build. Only
+    /// the local tier is collected; a remote cache is never touched.
     Gc {
         /// Maximum local cache size to keep. Plain bytes or a human
         /// suffix: `500MB`, `2GiB`, `750k`. Decimal suffixes (KB/MB/GB/
         /// TB) are powers of 1000; binary suffixes (KiB/MiB/GiB/TiB) are
-        /// powers of 1024.
+        /// powers of 1024. Defaults to 20 GB when omitted.
         #[usage(long = "max-size", value_name = "SIZE")]
-        max_size: CacheSize,
+        max_size: Option<CacheSize>,
 
         /// Report what would be reclaimed without deleting anything.
         #[usage(long)]

--- a/crates/once-cli/src/commands/auth.rs
+++ b/crates/once-cli/src/commands/auth.rs
@@ -1,12 +1,16 @@
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use console::Style;
 use once_cas::{TuistAuth, TuistAuthPrompt};
 use once_core::Xdg;
 
 use crate::cache_provider::{self, ResolvedCacheProviderConfig};
 use crate::cli::Output;
+
+fn unsupported_auth_provider(provider: &str) -> anyhow::Error {
+    anyhow::anyhow!("cache provider `{provider}` does not support authentication")
+}
 
 pub async fn login(
     workspace: &Path,
@@ -16,9 +20,7 @@ pub async fn login(
     output: Output,
 ) -> Result<()> {
     match cache_provider::resolve_auth_provider(workspace, xdg, provider)? {
-        ResolvedCacheProviderConfig::Local => {
-            bail!("cache provider `{provider}` does not support authentication")
-        }
+        ResolvedCacheProviderConfig::Local => Err(unsupported_auth_provider(provider)),
         ResolvedCacheProviderConfig::Tuist(config) => {
             let provider_name = config.provider_name.clone();
             let provider_name_for_prompt = provider_name.clone();
@@ -47,9 +49,7 @@ pub async fn login(
 
 pub async fn logout(workspace: &Path, xdg: &Xdg, provider: &str, output: Output) -> Result<()> {
     match cache_provider::resolve_auth_provider(workspace, xdg, provider)? {
-        ResolvedCacheProviderConfig::Local => {
-            bail!("cache provider `{provider}` does not support authentication")
-        }
+        ResolvedCacheProviderConfig::Local => Err(unsupported_auth_provider(provider)),
         ResolvedCacheProviderConfig::Tuist(config) => {
             let provider_name = config.provider_name.clone();
             let credentials_root = cache_provider::credentials_root(xdg);

--- a/crates/once-cli/src/commands/cache.rs
+++ b/crates/once-cli/src/commands/cache.rs
@@ -25,6 +25,8 @@ struct CacheEntry {
 struct CacheStats {
     blobs: CacheEntry,
     actions: CacheEntry,
+    used_bytes: u64,
+    cap_bytes: u64,
 }
 
 #[derive(Serialize)]
@@ -104,8 +106,9 @@ impl InputSpec {
     }
 }
 
-pub async fn print_stats(cache: &CacheProvider, output: Output) -> Result<()> {
+pub async fn print_stats(cache: &CacheProvider, cap_bytes: u64, output: Output) -> Result<()> {
     let s = cache.stats().await?;
+    let used_bytes = s.blob_bytes.saturating_add(s.action_bytes);
     let stats = CacheStats {
         blobs: CacheEntry {
             count: s.blob_count,
@@ -115,12 +118,27 @@ pub async fn print_stats(cache: &CacheProvider, output: Output) -> Result<()> {
             count: s.action_count,
             bytes: s.action_bytes,
         },
+        used_bytes,
+        cap_bytes,
     };
     let body = match output.format {
-        Format::Human => format!(
-            "blobs:   {} ({} bytes)\nactions: {} ({} bytes)\n",
-            s.blob_count, s.blob_bytes, s.action_count, s.action_bytes,
-        ),
+        Format::Human => {
+            let percent = if cap_bytes == 0 {
+                0
+            } else {
+                // Scale to a whole-percent integer without pulling in a float
+                // rounding rule; saturating multiply is fine because used <= cap
+                // is not guaranteed and the display is informational.
+                used_bytes
+                    .saturating_mul(100)
+                    .checked_div(cap_bytes)
+                    .unwrap_or(0)
+            };
+            format!(
+                "blobs:   {} ({} bytes)\nactions: {} ({} bytes)\nused:    {used_bytes} / {cap_bytes} bytes ({percent}% of cap)\n",
+                s.blob_count, s.blob_bytes, s.action_count, s.action_bytes,
+            )
+        }
         Format::Json | Format::Toon => render::structured(output.format, &stats)?,
     };
     let mut out = tokio::io::stdout();
@@ -154,7 +172,17 @@ pub async fn gc(cache: &CacheProvider, max_size: u64, dry_run: bool, output: Out
     write_stdout(body.as_bytes()).await
 }
 
-pub async fn put_blob(cache: &CacheProvider, path: Option<&Path>, output: Output) -> Result<()> {
+pub async fn put_blob(
+    cache: &CacheProvider,
+    path: Option<&Path>,
+    cap_bytes: u64,
+    output: Output,
+) -> Result<()> {
+    // Evict *before* the put so the freshly-written blob is never in the
+    // eviction candidate set. Otherwise a `cache blob put` into an
+    // already-over-cap store could report a digest that has already been
+    // reclaimed by the same command.
+    log_eviction(cache.maybe_evict_over_cap(cap_bytes).await?);
     let reader = open_blob_input(path).await?;
     let digest = cache.put_stream(reader).await?;
     let record = BlobPutRecord { digest };
@@ -163,6 +191,20 @@ pub async fn put_blob(cache: &CacheProvider, path: Option<&Path>, output: Output
         Format::Json | Format::Toon => render::structured(output.format, &record)?,
     };
     write_stdout(body.as_bytes()).await
+}
+
+// Auto-eviction runs silently; the user's put succeeds either way. Log the
+// reclaimed bytes at info level so operators inspecting the session log can
+// see what happened, without polluting stderr for a successful put.
+fn log_eviction(report: Option<once_cas::GcReport>) {
+    if let Some(report) = report {
+        tracing::info!(
+            removed = report.removed,
+            bytes_before = report.bytes_before,
+            bytes_after = report.bytes_after,
+            "cache auto-evicted over cap"
+        );
+    }
 }
 
 async fn open_blob_input(path: Option<&Path>) -> Result<Pin<Box<dyn AsyncRead + Send + Unpin>>> {
@@ -292,8 +334,12 @@ pub async fn put_action(
     stdout: Option<Digest>,
     stderr: Option<Digest>,
     outputs: Vec<(String, Digest)>,
+    cap_bytes: u64,
     output: Output,
 ) -> Result<()> {
+    // Evict *before* the put so the fresh action result is not eligible
+    // for eviction on the same command. See put_blob for the reasoning.
+    log_eviction(cache.maybe_evict_over_cap(cap_bytes).await?);
     let action = resolve_action_digest(action, &inputs).await?;
     let result = ActionResult {
         exit_code,

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -40,8 +40,7 @@ use crate::render;
 
 const MAX_SCRIPT_GLOB_MATCHES: usize = 1_000;
 
-const SCRIPT_EXEC_USAGE: &str =
-    "`once exec --script` expects `<runtime> <script> [args...]`";
+const SCRIPT_EXEC_USAGE: &str = "`once exec --script` expects `<runtime> <script> [args...]`";
 
 #[derive(Serialize)]
 struct ExecTrailer<'a> {

--- a/crates/once-cli/src/commands/exec.rs
+++ b/crates/once-cli/src/commands/exec.rs
@@ -40,6 +40,9 @@ use crate::render;
 
 const MAX_SCRIPT_GLOB_MATCHES: usize = 1_000;
 
+const SCRIPT_EXEC_USAGE: &str =
+    "`once exec --script` expects `<runtime> <script> [args...]`";
+
 #[derive(Serialize)]
 struct ExecTrailer<'a> {
     action_digest: String,
@@ -1004,10 +1007,10 @@ fn parse_script_exec_argv<'a>(
     argv: &'a [String],
 ) -> Result<(String, &'a [String], &'a str, Vec<String>)> {
     let Some((runtime, rest)) = argv.split_first() else {
-        anyhow::bail!("`once exec --script` expects `<runtime> <script> [args...]`");
+        anyhow::bail!(SCRIPT_EXEC_USAGE);
     };
     if rest.is_empty() {
-        anyhow::bail!("`once exec --script` expects `<runtime> <script> [args...]`");
+        anyhow::bail!(SCRIPT_EXEC_USAGE);
     }
     let mut script_idx = None;
     let mut candidate_error = None;

--- a/crates/once-cli/src/commands/graph/action.rs
+++ b/crates/once-cli/src/commands/graph/action.rs
@@ -14,6 +14,10 @@ use once_core::{
 use once_frontend::GraphTarget;
 use serde::Serialize;
 
+fn unsupported_capability(capability: &str) -> anyhow::Error {
+    anyhow::anyhow!("unsupported graph capability `{capability}`")
+}
+
 #[derive(Debug, Serialize)]
 struct GraphActionManifest<'a> {
     target: &'a str,
@@ -78,7 +82,7 @@ pub(super) fn output_paths(target: &GraphTarget, capability: &str) -> Result<Vec
         "build" => build_root(target),
         "run" => format!("{}/run", build_root(target)),
         "test" => format!("{}/test", build_root(target)),
-        other => anyhow::bail!("unsupported graph capability `{other}`"),
+        other => return Err(unsupported_capability(other)),
     };
     Ok(vec![WorkspacePath::try_from(path.as_str()).with_context(
         || format!("invalid graph output path `{path}`"),
@@ -133,7 +137,7 @@ fn output_root(target: &GraphTarget, capability: &str) -> Result<String> {
         "build" => Ok(build_root(target)),
         "run" => Ok(format!("{}/run", build_root(target))),
         "test" => Ok(format!("{}/test", build_root(target))),
-        other => anyhow::bail!("unsupported graph capability `{other}`"),
+        other => return Err(unsupported_capability(other)),
     }
 }
 

--- a/crates/once-cli/src/commands/graph/action.rs
+++ b/crates/once-cli/src/commands/graph/action.rs
@@ -137,7 +137,7 @@ fn output_root(target: &GraphTarget, capability: &str) -> Result<String> {
         "build" => Ok(build_root(target)),
         "run" => Ok(format!("{}/run", build_root(target))),
         "test" => Ok(format!("{}/test", build_root(target))),
-        other => return Err(unsupported_capability(other)),
+        other => Err(unsupported_capability(other)),
     }
 }
 

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -696,9 +696,7 @@ async fn run_cache_command(
         }
         Some(cli::CacheCmd::Gc { max_size, dry_run }) => {
             let cache = crate::cache_provider::resolve(workspace, xdg)?;
-            let cap = max_size
-                .map(|size| size.bytes())
-                .unwrap_or(cli::DEFAULT_CACHE_SIZE_CAP_BYTES);
+            let cap = max_size.map_or(cli::DEFAULT_CACHE_SIZE_CAP_BYTES, cli::CacheSize::bytes);
             commands::cache::gc(&cache, cap, dry_run, output)
                 .await
                 .map(|()| ExitCode::SUCCESS)

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -690,24 +690,30 @@ async fn run_cache_command(
     match command {
         Some(cli::CacheCmd::Stats) => {
             let cache = crate::cache_provider::resolve(workspace, xdg)?;
-            commands::cache::print_stats(&cache, output)
+            commands::cache::print_stats(&cache, cli::DEFAULT_CACHE_SIZE_CAP_BYTES, output)
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
         Some(cli::CacheCmd::Gc { max_size, dry_run }) => {
             let cache = crate::cache_provider::resolve(workspace, xdg)?;
-            commands::cache::gc(&cache, max_size.bytes(), dry_run, output)
+            let cap = max_size
+                .map(|size| size.bytes())
+                .unwrap_or(cli::DEFAULT_CACHE_SIZE_CAP_BYTES);
+            commands::cache::gc(&cache, cap, dry_run, output)
                 .await
                 .map(|()| ExitCode::SUCCESS)
         }
         Some(cli::CacheCmd::Blob { cmd }) => {
             let cache = crate::cache_provider::resolve(workspace, xdg)?;
             match cmd {
-                Some(cli::CacheBlobCmd::Put { path }) => {
-                    commands::cache::put_blob(&cache, path.as_deref(), output)
-                        .await
-                        .map(|()| ExitCode::SUCCESS)
-                }
+                Some(cli::CacheBlobCmd::Put { path }) => commands::cache::put_blob(
+                    &cache,
+                    path.as_deref(),
+                    cli::DEFAULT_CACHE_SIZE_CAP_BYTES,
+                    output,
+                )
+                .await
+                .map(|()| ExitCode::SUCCESS),
                 Some(cli::CacheBlobCmd::Get {
                     digest,
                     output: output_path,
@@ -746,6 +752,7 @@ async fn run_cache_command(
                         .into_iter()
                         .map(cli::OutputDigest::into_inner)
                         .collect(),
+                    cli::DEFAULT_CACHE_SIZE_CAP_BYTES,
                     output,
                 )
                 .await

--- a/crates/once-cli/src/main.rs
+++ b/crates/once-cli/src/main.rs
@@ -11,6 +11,7 @@ mod reference;
 mod render;
 
 use std::ffi::OsStr;
+use std::fmt::Write as _;
 use std::io::Write;
 use std::process::ExitCode;
 
@@ -109,7 +110,9 @@ fn format_human_error(verbose: u8, error: &anyhow::Error) -> String {
     // context frames from innermost to outermost so the most specific
     // operation reads closest to the root cause.
     for frame in chain.iter().rev().skip(1) {
-        out.push_str(&format!("  while {frame}\n"));
+        // Writing directly into the String avoids an intermediate allocation
+        // (clippy::format_push_string); the write is infallible on a String.
+        let _ = writeln!(out, "  while {frame}");
     }
     out
 }

--- a/crates/once-cli/src/main.rs
+++ b/crates/once-cli/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> ExitCode {
     }
     let command = cli.surface_path().join(" ");
     let format = cli.format;
+    let verbose = cli.verbose;
     let logging = logging::init(cli.verbose);
     let session_id = logging.session_id();
     let log_path = log_path(&logging);
@@ -61,15 +62,18 @@ async fn main() -> ExitCode {
         }
         Err(e) => {
             tracing::error!(session_id = %session_id, error = %e, "session failed");
-            write_dispatch_error(format, &e);
+            write_dispatch_error(format, verbose, &e);
             ExitCode::from(2)
         }
     }
 }
 
-fn write_dispatch_error(format: cli::Format, error: &anyhow::Error) {
+fn write_dispatch_error(format: cli::Format, verbose: u8, error: &anyhow::Error) {
     if format == cli::Format::Human {
-        eprintln!("once: {error:#}");
+        let body = format_human_error(verbose, error);
+        if let Err(write_error) = std::io::stderr().write_all(body.as_bytes()) {
+            tracing::error!(error = %write_error, "failed to write human error");
+        }
         return;
     }
     // Errors always go to stderr, whatever the format, so stdout carries only a
@@ -78,6 +82,36 @@ fn write_dispatch_error(format: cli::Format, error: &anyhow::Error) {
     if let Err(write_error) = std::io::stderr().write_all(body.as_bytes()) {
         tracing::error!(error = %write_error, "failed to write structured error");
     }
+}
+
+// Collapse the anyhow `Caused by:` chain into a compact frame: the root
+// cause first (that is what the user needs to read), then one `while`
+// line per intermediate context frame, outermost last. Every context
+// message is preserved because dropping middle frames throws away the
+// specific-most piece of information the user needs (a "resolving
+// script path `foo.sh`" middle frame is more actionable than the "root
+// cause: No such file or directory" alone). `-v` swaps in the classic
+// `Caused by:` layout for the rare deep chain the compact frame makes
+// harder to skim.
+fn format_human_error(verbose: u8, error: &anyhow::Error) -> String {
+    if verbose >= 1 {
+        // Debug on anyhow::Error prints the multi-line `Caused by:` chain,
+        // which is easier to scan than the single-line alternate form when
+        // the chain has more than a couple of links.
+        return format!("once: {error:?}\n");
+    }
+    let chain: Vec<_> = error.chain().collect();
+    let root = chain
+        .last()
+        .expect("anyhow error chains always have at least one element");
+    let mut out = format!("once: {root}\n");
+    // Skip the terminal cause (already on the primary line) and walk
+    // context frames from innermost to outermost so the most specific
+    // operation reads closest to the root cause.
+    for frame in chain.iter().rev().skip(1) {
+        out.push_str(&format!("  while {frame}\n"));
+    }
+    out
 }
 
 fn structured_dispatch_error(format: cli::Format, error: &anyhow::Error) -> String {
@@ -179,6 +213,61 @@ fn log_path(logging: &logging::Logging) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn human_frame_shows_only_the_root_cause_when_there_is_no_context() {
+        let error = anyhow::anyhow!("target `foo` not found");
+        let out = format_human_error(0, &error);
+        assert_eq!(out, "once: target `foo` not found\n");
+    }
+
+    #[test]
+    fn human_frame_collapses_a_context_chain_to_root_plus_operation() {
+        let error: anyhow::Error = std::io::Error::from(std::io::ErrorKind::NotFound).into();
+        let error = error
+            .context("reading script file")
+            .context("parsing once headers for `foo.sh`");
+        let out = format_human_error(0, &error);
+        // Frames walk innermost-to-outermost after the root cause so the
+        // most specific operation reads closest to the primary line.
+        assert_eq!(
+            out,
+            "once: entity not found\n  \
+             while reading script file\n  \
+             while parsing once headers for `foo.sh`\n"
+        );
+    }
+
+    #[test]
+    fn human_frame_preserves_every_context_frame_in_the_chain() {
+        let error = anyhow::anyhow!("No such file or directory")
+            .context("resolving script path `foo.sh`")
+            .context("executing action");
+        let out = format_human_error(0, &error);
+        assert_eq!(
+            out,
+            "once: No such file or directory\n  \
+             while resolving script path `foo.sh`\n  \
+             while executing action\n"
+        );
+    }
+
+    #[test]
+    fn human_frame_expands_to_the_full_chain_under_verbose() {
+        let error = anyhow::anyhow!("root").context("middle").context("outer");
+        let out = format_human_error(1, &error);
+        assert!(out.contains("Caused by:"), "expected full chain in:\n{out}");
+        assert!(out.contains("outer"));
+        assert!(out.contains("middle"));
+        assert!(out.contains("root"));
+    }
+
+    #[test]
+    fn human_frame_prints_a_single_while_line_for_a_one_context_chain() {
+        let error = anyhow::anyhow!("root").context("outer");
+        let out = format_human_error(0, &error);
+        assert_eq!(out, "once: root\n  while outer\n");
+    }
 
     #[test]
     fn structured_dispatch_errors_have_a_stable_envelope() {

--- a/crates/once-frontend/src/cache_resolution.rs
+++ b/crates/once-frontend/src/cache_resolution.rs
@@ -77,14 +77,15 @@ fn resolve_provider_config(
                 return resolve_named_workspace_provider(binding, provider.clone());
             }
             let mut config = load_user_config(user_config_path)?;
-            let provider = take_named_user_provider(&mut config, &binding.name).ok_or_else(
-                || Error::CacheProvider {
-                    path: user_config_path.display().to_string(),
-                    kind: CacheProviderError::InfrastructureNotFound {
-                        name: binding.name.clone(),
-                    },
-                },
-            )?;
+            let provider =
+                take_named_user_provider(&mut config, &binding.name).ok_or_else(|| {
+                    Error::CacheProvider {
+                        path: user_config_path.display().to_string(),
+                        kind: CacheProviderError::InfrastructureNotFound {
+                            name: binding.name.clone(),
+                        },
+                    }
+                })?;
             Ok(resolve_named_provider(binding, provider))
         }
     }

--- a/crates/once-frontend/src/cache_resolution.rs
+++ b/crates/once-frontend/src/cache_resolution.rs
@@ -4,8 +4,9 @@ use std::path::Path;
 use serde::Deserialize;
 
 use crate::{
-    load_infrastructure_config, CacheProviderConfig, Error, InfrastructureProviderConfig,
-    NamedCacheProviderConfig, Result, TuistCacheProviderConfig, DEFAULT_TUIST_URL,
+    load_infrastructure_config, CacheProviderConfig, CacheProviderError, Error,
+    InfrastructureProviderConfig, NamedCacheProviderConfig, Result, TuistCacheProviderConfig,
+    DEFAULT_TUIST_URL,
 };
 
 mod tuist_swift;
@@ -76,17 +77,14 @@ fn resolve_provider_config(
                 return resolve_named_workspace_provider(binding, provider.clone());
             }
             let mut config = load_user_config(user_config_path)?;
-            let provider =
-                take_named_user_provider(&mut config, &binding.name).ok_or_else(|| {
-                    Error::Eval {
-                        path: user_config_path.display().to_string(),
-                        message: format!(
-                            "infrastructure `{}` was not found in {}",
-                            binding.name,
-                            user_config_path.display()
-                        ),
-                    }
-                })?;
+            let provider = take_named_user_provider(&mut config, &binding.name).ok_or_else(
+                || Error::CacheProvider {
+                    path: user_config_path.display().to_string(),
+                    kind: CacheProviderError::InfrastructureNotFound {
+                        name: binding.name.clone(),
+                    },
+                },
+            )?;
             Ok(resolve_named_provider(binding, provider))
         }
     }
@@ -104,15 +102,14 @@ fn resolve_default_provider(user_config_path: &Path) -> Result<ResolvedCacheProv
     let Some(binding) = binding else {
         return Ok(ResolvedCacheProviderConfig::Local);
     };
-    let provider =
-        take_named_user_provider(&mut config, &binding.name).ok_or_else(|| Error::Eval {
+    let provider = take_named_user_provider(&mut config, &binding.name).ok_or_else(|| {
+        Error::CacheProvider {
             path: user_config_path.display().to_string(),
-            message: format!(
-                "infrastructure `{}` was not found in {}",
-                binding.name,
-                user_config_path.display()
-            ),
-        })?;
+            kind: CacheProviderError::InfrastructureNotFound {
+                name: binding.name.clone(),
+            },
+        }
+    })?;
     Ok(resolve_named_provider(binding.into_named(), provider))
 }
 
@@ -154,9 +151,9 @@ fn resolve_named_workspace_provider(
         InfrastructureProviderConfig::Local => Ok(ResolvedCacheProviderConfig::Local),
         InfrastructureProviderConfig::Microsandbox(_)
         | InfrastructureProviderConfig::E2b(_)
-        | InfrastructureProviderConfig::Daytona(_) => Err(Error::Eval {
+        | InfrastructureProviderConfig::Daytona(_) => Err(Error::CacheProvider {
             path: name.clone(),
-            message: format!("infrastructure `{name}` provides execution but not shared caching"),
+            kind: CacheProviderError::ExecutionProviderNotCacheable { name: name.clone() },
         }),
         InfrastructureProviderConfig::Tuist(config) => Ok(ResolvedCacheProviderConfig::Tuist(
             ResolvedTuistCacheProviderConfig {
@@ -188,13 +185,13 @@ fn resolve_tuist_workspace_config(
     else {
         return Ok(None);
     };
-    let (account, project) = split_full_handle(&config.full_handle).ok_or_else(|| Error::Eval {
-        path: workspace.display().to_string(),
-        message: format!(
-            "Tuist project handle `{}` must have the form `account/project`",
-            config.full_handle
-        ),
-    })?;
+    let (account, project) =
+        split_full_handle(&config.full_handle).ok_or_else(|| Error::CacheProvider {
+            path: workspace.display().to_string(),
+            kind: CacheProviderError::TuistHandleShape {
+                raw: config.full_handle.clone(),
+            },
+        })?;
     Ok(Some(ResolvedTuistCacheProviderConfig {
         provider_name: "tuist".to_string(),
         url: config.url.unwrap_or_else(|| DEFAULT_TUIST_URL.to_string()),

--- a/crates/once-frontend/src/cache_resolution/user.rs
+++ b/crates/once-frontend/src/cache_resolution/user.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::{Error, NamedCacheProviderConfig, Result};
+use crate::{CacheProviderError, Error, NamedCacheProviderConfig, Result};
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -103,9 +103,9 @@ pub(super) fn maybe_load_user_config(path: &Path) -> Result<Option<UserConfig>> 
 fn normalize_binding(binding: &mut UserCacheProviderBinding, path: &Path) -> Result<()> {
     binding.name = binding.name.trim().to_string();
     if binding.name.is_empty() {
-        return Err(Error::Eval {
+        return Err(Error::CacheProvider {
             path: path.display().to_string(),
-            message: "user cache configuration has an empty infrastructure name".to_string(),
+            kind: CacheProviderError::EmptyInfrastructureName,
         });
     }
     binding.account = non_empty(binding.account.take());

--- a/crates/once-frontend/src/error.rs
+++ b/crates/once-frontend/src/error.rs
@@ -1,6 +1,16 @@
 //! Frontend error type. Distinguishes I/O, walk, parse, and evaluation
 //! failures so callers can react differently (e.g. surface a parse
 //! error with a file path while suppressing a transient walk error).
+//!
+//! Typed sub-variants (`ScriptHeader`, `ManifestSchema`, etc.) carry
+//! structured detail so the CLI can render targeted messages with
+//! suggestions rather than forcing every rewrite to piggy-back on a
+//! stringly-typed `message` field. Their outer Display expression is
+//! deliberately just `{path}: {kind}` (or an operation-context phrase
+//! for wrappers) so the CLI-edge error frame does not print the same
+//! text twice when it collapses the anyhow chain.
+
+use crate::target_ref::TargetIdError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -20,6 +30,144 @@ pub enum Error {
     Parse { path: String, message: String },
     #[error("evaluation error in {path}:\n{message}")]
     Eval { path: String, message: String },
+    #[error("{path}: {kind}")]
+    ScriptHeader { path: String, kind: ScriptHeaderError },
+    #[error("{path}: {kind}")]
+    ManifestSchema {
+        path: String,
+        kind: ManifestSchemaError,
+    },
+    #[error("{path}: {kind}")]
+    CacheProvider {
+        path: String,
+        kind: CacheProviderError,
+    },
+    #[error("{path}: {kind}")]
+    NativeProject {
+        path: String,
+        kind: NativeProjectError,
+    },
+    #[error("validating target `{target}` name in {path}")]
+    TargetNameInvalid {
+        path: String,
+        target: String,
+        #[source]
+        source: TargetIdError,
+    },
+    #[error("resolving dep of target `{target}` in {path}")]
+    DepReference {
+        path: String,
+        target: String,
+        #[source]
+        source: TargetIdError,
+    },
+}
+
+/// Structured detail for a `# once` header failure. Kept as a typed
+/// enum (rather than a free-form message) so renderers can attach
+/// suggestions like the accepted directive list without re-parsing a
+/// string.
+#[derive(Debug, thiserror::Error)]
+pub enum ScriptHeaderError {
+    #[error("script is empty; add a shebang so Once knows how to run it")]
+    Empty,
+    #[error("script must start with a shebang so Once knows how to run it")]
+    MissingShebang,
+    #[error("shebang is empty; write it as `#!/usr/bin/env <runtime>`")]
+    EmptyShebang,
+    #[error("shebang must name a runtime after `env`, for example `#!/usr/bin/env python3`")]
+    MissingRuntime,
+    #[error(
+        "unknown once directive `{directive}`; \
+         known directives: input, needs, fingerprint, output, env, cwd, remote, output-symlinks"
+    )]
+    UnknownDirective { directive: String },
+    #[error(
+        "once {directive} expects a quoted string, for example `# once {directive} \"value\"`"
+    )]
+    DirectiveExpectedQuote { directive: String },
+    #[error("once {directive} is missing a closing quote")]
+    DirectiveMissingClosingQuote { directive: String },
+    #[error("once {directive} only accepts one quoted string")]
+    DirectiveExtraArgument { directive: String },
+}
+
+/// Structured detail for a schema failure in a `once.toml` manifest.
+/// Each variant is one thing a person could get wrong when writing the
+/// file. Named fields carry the offending target/field so a renderer
+/// can quote them back or offer a fix.
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestSchemaError {
+    #[error("workspace configuration operating system and architecture must be non-empty")]
+    ConfigurationPlatformEmpty,
+    #[error("workspace configuration tokens must be non-empty")]
+    ConfigurationTokenEmpty,
+    #[error("module paths are only loaded from the root once.toml")]
+    ModulePathsInPackage,
+    #[error("use either [modules] or [rules], not both")]
+    ModulesAndRulesBothSet,
+    #[error("target name is required")]
+    TargetNameMissing,
+    #[error("target `{target}` kind is required")]
+    TargetKindMissing { target: String },
+    #[error(
+        "target `{target}` dependency role `deps` must use the top-level `deps` field \
+         instead of a nested table"
+    )]
+    DepsRoleReserved { target: String },
+    #[error("target `{target}` deps must be an array of strings or a select table")]
+    DepsWrongShape { target: String },
+    #[error("target `{target}` deps entries must be strings")]
+    DepsEntryNotString { target: String },
+    #[error("target `{target}` deps select must be a table")]
+    DepsSelectWrongShape { target: String },
+    #[error(
+        "target `{target}` deps select has no matching branch and no `default`; \
+         add a `default = [...]` entry"
+    )]
+    DepsSelectNoMatch { target: String },
+}
+
+/// Structured detail for a cache-provider configuration failure.
+/// Fires on the onboarding path (invalid workspace binding, missing
+/// user infrastructure, malformed Tuist handle) where clarity matters
+/// most because the user is often setting up caching for the first
+/// time.
+#[derive(Debug, thiserror::Error)]
+pub enum CacheProviderError {
+    #[error(
+        "infrastructure `{name}` was not defined in this config; \
+         add an `[infrastructures.{name}]` block or run `once auth login` for the default"
+    )]
+    InfrastructureNotFound { name: String },
+    #[error(
+        "infrastructure `{name}` is an execution provider, not a cache; \
+         wire it under `[infrastructure.execution]`, not `[infrastructure.cache]`"
+    )]
+    ExecutionProviderNotCacheable { name: String },
+    #[error("Tuist project handle `{raw}` must have the form `account/project`")]
+    TuistHandleShape { raw: String },
+    #[error(
+        "cache infrastructure binding has an empty `name`; \
+         set it to the name of an `[infrastructures.<name>]` block"
+    )]
+    EmptyInfrastructureName,
+}
+
+/// Structured detail for the two recurring native-project lookup
+/// failures. Fires when a user names a native project that doesn't
+/// exist in the prelude, or names one whose discovered package
+/// doesn't match what was asked for. Other native-project errors
+/// still flow through `Error::Eval`; they're one-off shapes that do
+/// not benefit from typed variants until B3 rewrites want them.
+#[derive(Debug, thiserror::Error)]
+pub enum NativeProjectError {
+    #[error("unknown native project `{name}`")]
+    Unknown { name: String },
+    #[error(
+        "native project `{name}` does not match package `{package}`"
+    )]
+    PackageMismatch { name: String, package: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/once-frontend/src/error.rs
+++ b/crates/once-frontend/src/error.rs
@@ -31,7 +31,10 @@ pub enum Error {
     #[error("evaluation error in {path}:\n{message}")]
     Eval { path: String, message: String },
     #[error("{path}: {kind}")]
-    ScriptHeader { path: String, kind: ScriptHeaderError },
+    ScriptHeader {
+        path: String,
+        kind: ScriptHeaderError,
+    },
     #[error("{path}: {kind}")]
     ManifestSchema {
         path: String,
@@ -164,9 +167,7 @@ pub enum CacheProviderError {
 pub enum NativeProjectError {
     #[error("unknown native project `{name}`")]
     Unknown { name: String },
-    #[error(
-        "native project `{name}` does not match package `{package}`"
-    )]
+    #[error("native project `{name}` does not match package `{package}`")]
     PackageMismatch { name: String, package: String },
 }
 

--- a/crates/once-frontend/src/lib.rs
+++ b/crates/once-frontend/src/lib.rs
@@ -39,7 +39,9 @@ pub use cache_provider::{
 pub use cache_resolution::{
     resolve_cache_provider, ResolvedCacheProviderConfig, ResolvedTuistCacheProviderConfig,
 };
-pub use error::{Error, Result};
+pub use error::{
+    CacheProviderError, Error, ManifestSchemaError, NativeProjectError, Result, ScriptHeaderError,
+};
 pub use examples::{load_example_bundle, load_target_kind_example};
 pub use graph::{
     built_in_target_kind_schema, built_in_target_kind_schemas, built_in_target_kind_schemas_result,

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -469,12 +469,14 @@ fn select_dep_value_for_tokens<'a>(
             return Ok(value);
         }
     }
-    branches.get("default").ok_or_else(|| Error::ManifestSchema {
-        path: display_name.to_string(),
-        kind: ManifestSchemaError::DepsSelectNoMatch {
-            target: target_name.to_string(),
-        },
-    })
+    branches
+        .get("default")
+        .ok_or_else(|| Error::ManifestSchema {
+            path: display_name.to_string(),
+            kind: ManifestSchemaError::DepsSelectNoMatch {
+                target: target_name.to_string(),
+            },
+        })
 }
 
 fn select_tokens_for(os: &str, arch: &str) -> Vec<String> {

--- a/crates/once-frontend/src/manifest.rs
+++ b/crates/once-frontend/src/manifest.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::cache_provider::{CacheProviderToml, InfrastructureProviderToml, InfrastructureToml};
-use crate::error::{Error, Result};
+use crate::error::{Error, ManifestSchemaError, Result};
 use crate::target::{AttrValue, Target};
 use crate::target_ref::{normalize_manifest_target, validate_target_name};
 use crate::TOML_BUILD_FILE_NAME;
@@ -81,11 +81,9 @@ impl BuildConfiguration {
             .arch
             .unwrap_or_else(|| std::env::consts::ARCH.to_string());
         if os.trim().is_empty() || arch.trim().is_empty() {
-            return Err(Error::Eval {
+            return Err(Error::ManifestSchema {
                 path: TOML_BUILD_FILE_NAME.to_string(),
-                message:
-                    "workspace configuration operating system and architecture must be non-empty"
-                        .to_string(),
+                kind: ManifestSchemaError::ConfigurationPlatformEmpty,
             });
         }
         if configuration
@@ -93,9 +91,9 @@ impl BuildConfiguration {
             .iter()
             .any(|token| token.trim().is_empty())
         {
-            return Err(Error::Eval {
+            return Err(Error::ManifestSchema {
                 path: TOML_BUILD_FILE_NAME.to_string(),
-                message: "workspace configuration tokens must be non-empty".to_string(),
+                kind: ManifestSchemaError::ConfigurationTokenEmpty,
             });
         }
         Ok(Self::new(&os, &arch, configuration.tokens))
@@ -217,9 +215,9 @@ pub(crate) fn load_toml_with_configuration(
         message: source.to_string(),
     })?;
     if (manifest.modules.is_some() || manifest.rules.is_some()) && !package.is_empty() {
-        return Err(Error::Eval {
+        return Err(Error::ManifestSchema {
             path: display_name.to_string(),
-            message: "module paths are only loaded from the root once.toml".to_string(),
+            kind: ManifestSchemaError::ModulePathsInPackage,
         });
     }
     manifest
@@ -279,9 +277,9 @@ pub(crate) fn load_module_paths_toml_str(path: &str, src: &str) -> Result<Vec<St
         message: source.to_string(),
     })?;
     match (manifest.modules, manifest.rules) {
-        (Some(_), Some(_)) => Err(Error::Eval {
+        (Some(_), Some(_)) => Err(Error::ManifestSchema {
             path: path.to_string(),
-            message: "use either [modules] or [rules], not both".to_string(),
+            kind: ManifestSchemaError::ModulesAndRulesBothSet,
         }),
         (Some(modules), None) | (None, Some(modules)) => Ok(modules.paths),
         (None, None) => Ok(Vec::new()),
@@ -322,20 +320,23 @@ impl TargetToml {
         configuration: &BuildConfiguration,
     ) -> Result<Target> {
         if self.name.is_empty() {
-            return Err(Error::Eval {
+            return Err(Error::ManifestSchema {
                 path: display_name.to_string(),
-                message: "target name is required".to_string(),
+                kind: ManifestSchemaError::TargetNameMissing,
             });
         }
         if self.kind.is_empty() {
-            return Err(Error::Eval {
+            return Err(Error::ManifestSchema {
                 path: display_name.to_string(),
-                message: format!("target `{}` kind is required", self.name),
+                kind: ManifestSchemaError::TargetKindMissing {
+                    target: self.name.clone(),
+                },
             });
         }
-        validate_target_name(&self.name).map_err(|source| Error::Eval {
+        validate_target_name(&self.name).map_err(|source| Error::TargetNameInvalid {
             path: display_name.to_string(),
-            message: source.to_string(),
+            target: self.name.clone(),
+            source,
         })?;
         let deps = deps_from_toml(
             display_name,
@@ -385,11 +386,11 @@ fn dependency_edges_from_toml(
     let mut edges = BTreeMap::new();
     for (name, value) in values {
         if name == "deps" {
-            return Err(Error::Eval {
+            return Err(Error::ManifestSchema {
                 path: display_name.to_string(),
-                message: format!(
-                    "target `{target_name}` dependency role `deps` must use the top-level `deps` field"
-                ),
+                kind: ManifestSchemaError::DepsRoleReserved {
+                    target: target_name.to_string(),
+                },
             });
         }
         let dependencies = deps_from_toml(
@@ -417,22 +418,27 @@ fn deps_from_toml(
     let selected =
         select_dep_value_for_tokens(display_name, target_name, value, &configuration.tokens)?;
     let toml::Value::Array(deps) = selected else {
-        return Err(Error::Eval {
+        return Err(Error::ManifestSchema {
             path: display_name.to_string(),
-            message: format!("target `{target_name}` deps must be an array or select table"),
+            kind: ManifestSchemaError::DepsWrongShape {
+                target: target_name.to_string(),
+            },
         });
     };
     deps.iter()
         .map(|dep| {
             let Some(dep) = dep.as_str() else {
-                return Err(Error::Eval {
+                return Err(Error::ManifestSchema {
                     path: display_name.to_string(),
-                    message: format!("target `{target_name}` deps entries must be strings"),
+                    kind: ManifestSchemaError::DepsEntryNotString {
+                        target: target_name.to_string(),
+                    },
                 });
             };
-            normalize_manifest_target(package, dep).map_err(|source| Error::Eval {
+            normalize_manifest_target(package, dep).map_err(|source| Error::DepReference {
                 path: display_name.to_string(),
-                message: source.to_string(),
+                target: target_name.to_string(),
+                source,
             })
         })
         .collect()
@@ -451,9 +457,11 @@ fn select_dep_value_for_tokens<'a>(
         return Ok(value);
     }
     let Some(toml::Value::Table(branches)) = table.get("select") else {
-        return Err(Error::Eval {
+        return Err(Error::ManifestSchema {
             path: display_name.to_string(),
-            message: format!("target `{target_name}` deps select must be a table"),
+            kind: ManifestSchemaError::DepsSelectWrongShape {
+                target: target_name.to_string(),
+            },
         });
     };
     for token in tokens {
@@ -461,11 +469,11 @@ fn select_dep_value_for_tokens<'a>(
             return Ok(value);
         }
     }
-    branches.get("default").ok_or_else(|| Error::Eval {
+    branches.get("default").ok_or_else(|| Error::ManifestSchema {
         path: display_name.to_string(),
-        message: format!(
-            "target `{target_name}` deps select has no matching branch and no default"
-        ),
+        kind: ManifestSchemaError::DepsSelectNoMatch {
+            target: target_name.to_string(),
+        },
     })
 }
 

--- a/crates/once-frontend/src/native_project.rs
+++ b/crates/once-frontend/src/native_project.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path};
 
-use crate::error::{Error, Result};
+use crate::error::{Error, NativeProjectError, Result};
 use crate::graph::GraphTarget;
 use crate::target::{AttrValue, Target};
 use serde::Serialize;
@@ -155,21 +155,12 @@ pub fn native_project_seed_target(root: &Path, name: &str, package: &str) -> Res
         .native_projects
         .into_iter()
         .find(|schema| schema.name == name)
-        .ok_or_else(|| Error::Eval {
-            path: crate::modules::COMBINED_MODULE_PATH.to_string(),
-            message: format!("unknown native project `{name}`"),
-        })?;
+        .ok_or_else(|| unknown_native_project(name))?;
     let matched = catalog
         .matches
         .into_iter()
         .find(|matched| matched.native_project == name && matched.package == package)
-        .ok_or_else(|| Error::Eval {
-            path: name.to_string(),
-            message: format!(
-                "native project `{name}` does not match package `{}`",
-                if package.is_empty() { "." } else { package }
-            ),
-        })?;
+        .ok_or_else(|| native_project_package_mismatch(name, package))?;
     Ok(seed_target(&schema, package, &matched.markers))
 }
 
@@ -187,20 +178,11 @@ pub fn preview_native_project(
     let schema = native_projects
         .into_iter()
         .find(|schema| schema.name == name)
-        .ok_or_else(|| Error::Eval {
-            path: crate::modules::COMBINED_MODULE_PATH.to_string(),
-            message: format!("unknown native project `{name}`"),
-        })?;
+        .ok_or_else(|| unknown_native_project(name))?;
     let selected_match = matches
         .into_iter()
         .find(|matched| matched.native_project == name && matched.package == package)
-        .ok_or_else(|| Error::Eval {
-            path: name.to_string(),
-            message: format!(
-                "native project `{name}` does not match package `{}`",
-                if package.is_empty() { "." } else { package }
-            ),
-        })?;
+        .ok_or_else(|| native_project_package_mismatch(name, package))?;
     let seed = seed_target(&schema, package, &selected_match.markers);
     let targets = crate::graph::load_graph_workspace_with_targets_and_schemas(
         root,
@@ -496,6 +478,29 @@ fn native_project_error(path: &str, message: impl Into<String>) -> Error {
     Error::Eval {
         path: path.to_string(),
         message: message.into(),
+    }
+}
+
+fn unknown_native_project(name: &str) -> Error {
+    Error::NativeProject {
+        path: crate::modules::COMBINED_MODULE_PATH.to_string(),
+        kind: NativeProjectError::Unknown {
+            name: name.to_string(),
+        },
+    }
+}
+
+fn native_project_package_mismatch(name: &str, package: &str) -> Error {
+    Error::NativeProject {
+        path: name.to_string(),
+        kind: NativeProjectError::PackageMismatch {
+            name: name.to_string(),
+            package: if package.is_empty() {
+                ".".to_string()
+            } else {
+                package.to_string()
+            },
+        },
     }
 }
 

--- a/crates/once-frontend/src/script.rs
+++ b/crates/once-frontend/src/script.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use crate::error::{Error, Result};
+use crate::error::{Error, Result, ScriptHeaderError};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ScriptAnnotations {
@@ -23,9 +23,9 @@ pub fn parse_script_annotations(path: &Path, display_name: &str) -> Result<Scrip
         source,
     })?;
     let mut lines = content.lines();
-    let shebang = lines.next().ok_or_else(|| Error::Eval {
+    let shebang = lines.next().ok_or_else(|| Error::ScriptHeader {
         path: display_name.to_string(),
-        message: format!("script {} is empty", path.display()),
+        kind: ScriptHeaderError::Empty,
     })?;
     let (runtime, runtime_args) = parse_shebang(shebang, display_name, path)?;
     let mut annotations = ScriptAnnotations {
@@ -61,21 +61,18 @@ pub fn script_has_once_directives(path: &Path) -> Result<bool> {
         .any(|line| annotation_payload(line.trim()).is_some()))
 }
 
-fn parse_shebang(line: &str, display_name: &str, path: &Path) -> Result<(String, Vec<String>)> {
+fn parse_shebang(line: &str, display_name: &str, _path: &Path) -> Result<(String, Vec<String>)> {
     let Some(raw) = line.strip_prefix("#!") else {
-        return Err(Error::Eval {
+        return Err(Error::ScriptHeader {
             path: display_name.to_string(),
-            message: format!(
-                "script {} must start with a shebang so Once knows how to run it",
-                path.display()
-            ),
+            kind: ScriptHeaderError::MissingShebang,
         });
     };
     let mut parts = raw.split_whitespace();
     let Some(first) = parts.next() else {
-        return Err(Error::Eval {
+        return Err(Error::ScriptHeader {
             path: display_name.to_string(),
-            message: format!("script {} has an empty shebang", path.display()),
+            kind: ScriptHeaderError::EmptyShebang,
         });
     };
 
@@ -93,12 +90,9 @@ fn parse_shebang(line: &str, display_name: &str, path: &Path) -> Result<(String,
             }
         }
         let Some(runtime) = runtime else {
-            return Err(Error::Eval {
+            return Err(Error::ScriptHeader {
                 path: display_name.to_string(),
-                message: format!(
-                    "script {} shebang must name a runtime after env",
-                    path.display()
-                ),
+                kind: ScriptHeaderError::MissingRuntime,
             });
         };
         return Ok(parse_once_exec_shebang(runtime, runtime_args));
@@ -199,30 +193,38 @@ fn parse_annotation_line(
         annotations.output_symlinks = Some(parse_quoted(raw, "output-symlinks", display_name)?);
         return Ok(());
     }
-    Err(Error::Eval {
+    Err(Error::ScriptHeader {
         path: display_name.to_string(),
-        message: format!("unknown once directive `{line}`"),
+        kind: ScriptHeaderError::UnknownDirective {
+            directive: line.to_string(),
+        },
     })
 }
 
 fn parse_quoted(raw: &str, name: &str, display_name: &str) -> Result<String> {
     let raw = raw.trim();
     let Some(rest) = raw.strip_prefix('"') else {
-        return Err(Error::Eval {
+        return Err(Error::ScriptHeader {
             path: display_name.to_string(),
-            message: format!("Once {name} expects a quoted string"),
+            kind: ScriptHeaderError::DirectiveExpectedQuote {
+                directive: name.to_string(),
+            },
         });
     };
     let Some(end) = rest.find('"') else {
-        return Err(Error::Eval {
+        return Err(Error::ScriptHeader {
             path: display_name.to_string(),
-            message: format!("Once {name} is missing a closing quote"),
+            kind: ScriptHeaderError::DirectiveMissingClosingQuote {
+                directive: name.to_string(),
+            },
         });
     };
     if !rest[end + 1..].trim().is_empty() {
-        return Err(Error::Eval {
+        return Err(Error::ScriptHeader {
             path: display_name.to_string(),
-            message: format!("Once {name} only accepts one quoted string"),
+            kind: ScriptHeaderError::DirectiveExtraArgument {
+                directive: name.to_string(),
+            },
         });
     }
     Ok(rest[..end].to_string())
@@ -404,5 +406,73 @@ echo hi
         let err = parse_script_annotations(&path, "bad.sh").unwrap_err();
         assert!(err.to_string().contains("unknown once directive"));
         assert!(script_has_once_directives(&path).unwrap());
+    }
+
+    #[test]
+    fn unknown_directive_error_carries_the_typed_directive_name() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bad.sh");
+        fs::write(
+            &path,
+            r#"#!/bin/sh
+# once wibble "thing"
+echo hi
+"#,
+        )
+        .unwrap();
+
+        let err = parse_script_annotations(&path, "bad.sh").unwrap_err();
+        match err {
+            Error::ScriptHeader {
+                kind: ScriptHeaderError::UnknownDirective { directive },
+                ..
+            } => {
+                assert!(
+                    directive.starts_with("wibble"),
+                    "directive did not carry the offending token: {directive:?}"
+                );
+            }
+            other => panic!("expected ScriptHeader::UnknownDirective, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_script_surfaces_typed_variant() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("empty.sh");
+        fs::write(&path, "").unwrap();
+
+        let err = parse_script_annotations(&path, "empty.sh").unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ScriptHeader {
+                kind: ScriptHeaderError::Empty,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn unknown_directive_message_lists_the_accepted_directives() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bad.sh");
+        fs::write(
+            &path,
+            r#"#!/bin/sh
+# once wibble "thing"
+echo hi
+"#,
+        )
+        .unwrap();
+
+        let err = parse_script_annotations(&path, "bad.sh")
+            .unwrap_err()
+            .to_string();
+        for accepted in ["input", "needs", "fingerprint", "output", "env", "cwd"] {
+            assert!(
+                err.contains(accepted),
+                "message should hint at accepted directive `{accepted}`:\n{err}"
+            );
+        }
     }
 }

--- a/crates/once-frontend/src/target_ref.rs
+++ b/crates/once-frontend/src/target_ref.rs
@@ -17,9 +17,7 @@ pub enum TargetIdError {
     BazelSyntax { raw: String, suggestion: String },
     #[error("target reference `{raw}` must not contain `:`; use `{suggestion}`")]
     Colon { raw: String, suggestion: String },
-    #[error(
-        "target reference `{raw}` must be relative to the project root; use `{suggestion}`"
-    )]
+    #[error("target reference `{raw}` must be relative to the project root; use `{suggestion}`")]
     Absolute { raw: String, suggestion: String },
     #[error("target reference `{0}` must not escape the project root")]
     EscapesRoot(String),

--- a/crates/once-frontend/src/target_ref.rs
+++ b/crates/once-frontend/src/target_ref.rs
@@ -15,16 +15,39 @@ pub enum TargetIdError {
     InvalidName(String),
     #[error("target reference `{raw}` uses Bazel label syntax; use `{suggestion}`")]
     BazelSyntax { raw: String, suggestion: String },
-    #[error("target reference `{0}` must not contain `:`")]
-    Colon(String),
-    #[error("target reference `{0}` must be relative to the project root")]
-    Absolute(String),
+    #[error("target reference `{raw}` must not contain `:`; use `{suggestion}`")]
+    Colon { raw: String, suggestion: String },
+    #[error(
+        "target reference `{raw}` must be relative to the project root; use `{suggestion}`"
+    )]
+    Absolute { raw: String, suggestion: String },
     #[error("target reference `{0}` must not escape the project root")]
     EscapesRoot(String),
-    #[error("target reference `{0}` contains an empty path segment")]
-    EmptySegment(String),
+    #[error("target reference `{raw}` contains an empty path segment; use `{suggestion}`")]
+    EmptySegment { raw: String, suggestion: String },
     #[error("current directory `{cwd}` is outside project root `{root}`")]
     CurrentDirOutsideProject { cwd: String, root: String },
+}
+
+/// Derive a corrected target reference from a malformed one. Follows the
+/// AGENTS.md "no invented path grammar" rule: strip Bazel-style prefixes
+/// and separators, collapse empty segments, drop redundant `.` segments,
+/// and drop `..` segments (which would only push the suggestion back
+/// through the `EscapesRoot` failure path). Falls back to a placeholder
+/// when nothing survives so the message never shows empty backticks.
+fn cleanup_suggestion(raw: &str) -> String {
+    let cleaned = raw
+        .trim_matches('/')
+        .split('/')
+        .flat_map(|segment| segment.split([':', '\\']))
+        .filter(|segment| !segment.is_empty() && *segment != "." && *segment != "..")
+        .collect::<Vec<_>>()
+        .join("/");
+    if cleaned.is_empty() {
+        "target-name".to_string()
+    } else {
+        cleaned
+    }
 }
 
 pub fn target_id(package: &str, name: &str) -> String {
@@ -86,10 +109,16 @@ fn validate_raw(raw: &str) -> Result<(), TargetIdError> {
         });
     }
     if raw.contains(':') {
-        return Err(TargetIdError::Colon(raw.to_string()));
+        return Err(TargetIdError::Colon {
+            raw: raw.to_string(),
+            suggestion: cleanup_suggestion(raw),
+        });
     }
     if raw.starts_with('/') {
-        return Err(TargetIdError::Absolute(raw.to_string()));
+        return Err(TargetIdError::Absolute {
+            raw: raw.to_string(),
+            suggestion: cleanup_suggestion(raw),
+        });
     }
     Ok(())
 }
@@ -111,7 +140,12 @@ fn normalize_from(base: &[String], raw: &str) -> Result<String, TargetIdError> {
     let mut out = base.to_vec();
     for segment in raw.split('/') {
         match segment {
-            "" => return Err(TargetIdError::EmptySegment(raw.to_string())),
+            "" => {
+                return Err(TargetIdError::EmptySegment {
+                    raw: raw.to_string(),
+                    suggestion: cleanup_suggestion(raw),
+                });
+            }
             "." => {}
             ".." => {
                 out.pop()
@@ -131,7 +165,10 @@ fn normalize_from(base: &[String], raw: &str) -> Result<String, TargetIdError> {
 
 fn validate_segment(raw: &str, segment: &str) -> Result<(), TargetIdError> {
     if segment.contains(['\\', ':']) {
-        return Err(TargetIdError::Colon(raw.to_string()));
+        return Err(TargetIdError::Colon {
+            raw: raw.to_string(),
+            suggestion: cleanup_suggestion(raw),
+        });
     }
     Ok(())
 }
@@ -239,5 +276,64 @@ mod tests {
             normalize_manifest_target("apps/ios", "../shared/Logging").unwrap(),
             "apps/shared/Logging"
         );
+    }
+
+    #[test]
+    fn absolute_reference_error_suggests_the_relative_form() {
+        let err = normalize_manifest_target("", "/apps/ios/AppKit").unwrap_err();
+        assert_eq!(
+            err,
+            TargetIdError::Absolute {
+                raw: "/apps/ios/AppKit".to_string(),
+                suggestion: "apps/ios/AppKit".to_string(),
+            }
+        );
+        assert!(err.to_string().contains("use `apps/ios/AppKit`"));
+    }
+
+    #[test]
+    fn colon_reference_error_suggests_the_slash_form() {
+        let err = normalize_manifest_target("", "apps/ios:AppKit").unwrap_err();
+        assert_eq!(
+            err,
+            TargetIdError::Colon {
+                raw: "apps/ios:AppKit".to_string(),
+                suggestion: "apps/ios/AppKit".to_string(),
+            }
+        );
+        assert!(err.to_string().contains("use `apps/ios/AppKit`"));
+    }
+
+    #[test]
+    fn empty_segment_error_suggests_the_collapsed_form() {
+        let err = normalize_manifest_target("", "apps//ios/AppKit").unwrap_err();
+        assert_eq!(
+            err,
+            TargetIdError::EmptySegment {
+                raw: "apps//ios/AppKit".to_string(),
+                suggestion: "apps/ios/AppKit".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn cleanup_suggestion_falls_back_when_nothing_survives() {
+        assert_eq!(cleanup_suggestion("/"), "target-name");
+        assert_eq!(cleanup_suggestion(":::"), "target-name");
+        assert_eq!(cleanup_suggestion("///"), "target-name");
+    }
+
+    #[test]
+    fn cleanup_suggestion_strips_backslash_separators() {
+        assert_eq!(cleanup_suggestion("foo\\bar"), "foo/bar");
+        assert_eq!(cleanup_suggestion("apps\\ios\\App"), "apps/ios/App");
+    }
+
+    #[test]
+    fn cleanup_suggestion_drops_parent_traversal_segments() {
+        // `../foo` would still escape the workspace root, so the suggestion
+        // must not carry `..` through.
+        assert_eq!(cleanup_suggestion("/../foo"), "foo");
+        assert_eq!(cleanup_suggestion("../../apps/ios"), "apps/ios");
     }
 }


### PR DESCRIPTION
## Why

Prompted by a Bazel UX critique ([blog.appliedcomputing.io/p/bazels-ux-is-really-really-really](https://blog.appliedcomputing.io/p/bazels-ux-is-really-really-really)) that walked through seven ways Bazel makes people miserable at the terminal. Most of them are shapes we can still avoid in Once while the surface is small and the change cost is low. This PR turns the parts of that critique that apply to Once into concrete guardrails, and picks up on several error-quality items that fell out of the same reading.

## What changed

Six focused commits, ordered from cheapest guardrail to biggest refactor:

1. **`docs(agents)`** — AGENTS.md now states two policies out loud: all Once configuration lives in the `once.toml` family or in in-source `# once` script headers (never a new dotfile), and target references use native package names or filesystem paths rather than an invented Once-specific grammar. Contributors get the "no bazelrc / MODULE / WORKSPACE sprawl" rule and the "no `//pkg:target`" rule as durable guidance rather than folklore.
2. **`ci(bench)`** — A warm-loop wall-time bench that runs the existing 15-action fixture from `benchmarks/cache-comparison` twice through hyperfine with `ONCE_CACHE_PROVIDER=local`, so the second run measures pure warm-cache overhead. Publishes median, min, and max to the GitHub step summary and fails only on a loose catastrophic ceiling (10 s by default). Motivating case is the known FSEvents change-tracker bug that added roughly 1.2 s per build and only reproduces on macOS, so the matrix runs on `ubuntu-latest` and `macos-latest`.
3. **`refactor(cli)`** — Five duplicate user-facing error strings collapsed into shared constants or helpers so the wording cannot drift between the two call sites that shipped them.
4. **`feat(cli)`** — Every command's error rendering now goes through a `format_human_error` that puts the terminal cause on the primary line and walks context frames beneath it as "while X" lines from innermost to outermost. `-v` swaps in the classic `Caused by:` layout for the rare deep chain.
5. **`refactor(frontend)`** — Five recurring `Error::Eval { message: String }` subclasses become typed variants with small sub-enums: `ScriptHeader` (8 kinds), `ManifestSchema` (11 kinds), `CacheProvider` (4 kinds), `NativeProject` (2 kinds), plus `TargetNameInvalid` and `DepReference` that wrap `TargetIdError` as a `#[source]`. `TargetIdError::{Colon,Absolute,EmptySegment}` become struct variants with a computed `cleanup_suggestion`, so `foo:bar` now says "use `foo/bar`".
6. **`feat(cache)`** — `once cache gc` takes a 20 GB default when `--max-size` is omitted, `once cache stats` prints `used / cap / percent`, and `CacheProvider::maybe_evict_over_cap(cap)` runs before `once cache blob put` and `once cache action put` so the freshly-written entry is never in the eviction candidate set.

## Approach

Once's cooperative posture (reading `Cargo.toml`, `Package.swift`, and other ecosystem manifests directly rather than requiring users to rewrite their graph) is the main reason it can avoid most of Bazel's failure modes. The changes here are all about keeping that posture visible in the surface: no invented dotfiles, no invented label grammar, errors that say what happened first and where second, a cache that has a shape people can see and reason about.

I planned the sequence with codex ahead of time to catch the shapes I was about to invent that would conflict with existing choices (the initial "one config file" phrasing collided with the per-package `once.toml` layout and became "one Once configuration family"), and then adversarially reviewed the finished branch with codex to hunt for correctness bugs before opening the PR. Findings from that review that this PR addresses: eviction ordering (evict before put, not after, so a `cache blob put` into an over-cap store never reports a digest that was just reclaimed), error-frame completeness (keep every context frame in the collapsed frame rather than dropping middle links, which threw away the most specific-most operation in a chain), `cleanup_suggestion` correctness (drop `\\` and `..` segments so the suggestion itself is a legal workspace-relative name), and the bench guards (`check.sh` refuses a non-numeric `CEILING_SECONDS` and refuses to pass when the hyperfine JSON lacks `.results[0].{median,min,max}`; `run.sh` resolves `ONCE_BINARY` to an absolute path before hyperfine `cd`s into the fixture).

A few things I considered and did not do here:

- **Instruction-count microbenches with `tak`.** The right technique for CI-stable performance measurement is cachegrind-style instruction counting (`rustc-perf` and the `iai` family use it). `tak` (the jdx tool) is the natural choice in the mise ecosystem but is pre-v1 and its own README recommends against depending on it for stable gates. Deferring to a follow-up once specific CPU hotspots surface.
- **Auto-eviction on the exec/action-write path.** The 20 GB cap is only enforced on the explicit `once cache blob put` and `once cache action put` today. Wiring `maybe_evict_over_cap` into the exec write path (where the bulk of cache growth happens) is where the cap actually starts pulling its weight, and needs a careful pass through the exec flow. Left as an explicit follow-up.
- **`[cache.local]` in `once.toml`.** The cap is currently a `DEFAULT_CACHE_SIZE_CAP_BYTES` constant. Reading it from `once.toml` is the natural next step and slots in cleanly once the exec-path hook lands.
- **Two known pre-existing concurrency races in `once-cas`** (blob/action collection can leave dangling references under concurrent writers; scans can propagate `NotFound` from a racing eviction) surfaced during the adversarial review. They predate this branch and my `maybe_evict_over_cap` addition does not depend on fixing them, but they become somewhat more reachable now that eviction is one more thing that can race against a write. Worth its own change with locking or a rewrite of the scan-then-delete pattern.

## Impact

Every command's error output gets a shorter, more actionable primary line without changing the structured (`--format json|toon`) envelope. Anyone piping `once` into a JSON consumer sees no behavior change; anyone reading the terminal sees the punchy summary by default and can pass `-v` for the full chain. Existing manifest schema, script header, target reference, and cache provider errors gain typed variants that make it easier for future work (structured diagnostics, editor integrations, MCP tools) to attach suggestions without re-parsing strings. Users who run `once cache gc` without an argument now get an eviction to 20 GB instead of an error; users who run `once cache stats` see how full the local store is.

No CLI surface removed. No config file removed. No structured-output field renamed.

## Validation

- `mise exec -- cargo check --workspace` — clean.
- `mise exec -- cargo test --workspace --lib` — 608 lib tests pass. Notable additions covered by new tests: `format_human_error` shape at zero, one, and multi-context chains plus `-v`; every new `ScriptHeaderError`, `ManifestSchemaError`, `CacheProviderError`, and `NativeProjectError` variant; `cleanup_suggestion` for the previously-broken `foo\bar` and `/../foo` cases; `CacheProvider::maybe_evict_over_cap` for under-budget, over-budget-with-hysteresis, and cap-of-zero-is-disabled.
- `benchmarks/warm-loop/check.sh` smoke-tested against valid JSON (pass), empty results (fail), and non-numeric `CEILING_SECONDS` (fail).
- The bench workflow itself has not run yet; opening this as a draft so CI validates the ubuntu and macOS matrix end-to-end before we take it out of draft.
