### PR TITLE
feat(cli): add once cargo wrapper for build and test

### DIFF
--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -556,6 +556,17 @@ pub enum Cmd {
         argv: Vec<String>,
     },
 
+    /// Accept a Cargo build or test invocation and use the Once graph when its
+    /// semantics are supported. Other invocations pass through to the system
+    /// Cargo executable unchanged. Configure this as a mise command wrapper to
+    /// make ordinary `cargo` commands use this compatibility surface.
+    #[usage(name = "cargo")]
+    CargoCompatibility {
+        /// Arguments supplied by the Cargo invocation.
+        #[usage(trailing_var_arg = true, value_name = "ARG")]
+        argv: Vec<String>,
+    },
+
     /// Expose Once's graph and memory queries to a coding agent.
     ///
     /// Speaks the Model Context Protocol over standard input and output so a
@@ -597,6 +608,7 @@ pub enum Cmd {
 pub(crate) enum CompatibilityInvocation {
     Xcodebuild(Vec<String>),
     Swift(Vec<String>),
+    Cargo(Vec<String>),
 }
 
 impl Cli {
@@ -653,6 +665,9 @@ impl Cmd {
             Self::PackageCompatibility { argv } => {
                 Some(CompatibilityInvocation::Swift(argv.clone()))
             }
+            Self::CargoCompatibility { argv } => {
+                Some(CompatibilityInvocation::Cargo(argv.clone()))
+            }
             _ => None,
         }
     }
@@ -708,6 +723,7 @@ impl Cmd {
             }
             Self::Compatibility { .. } => vec!["xcodebuild"],
             Self::PackageCompatibility { .. } => vec!["swift"],
+            Self::CargoCompatibility { .. } => vec!["cargo"],
             Self::Runtime { cmd } => {
                 let mut path = vec!["runtime"];
                 if let Some(cmd) = cmd {
@@ -829,6 +845,16 @@ mod tests {
 
         let Some(Cmd::PackageCompatibility { argv }) = cli.command else {
             panic!("expected Swift compatibility command");
+        };
+        assert_eq!(argv, ["build"]);
+    }
+
+    #[test]
+    fn compatibility_accepts_cargo_arguments_after_separator() {
+        let cli = parse(&["once", "cargo", "--", "build"]);
+
+        let Some(Cmd::CargoCompatibility { argv }) = cli.command else {
+            panic!("expected Cargo compatibility command");
         };
         assert_eq!(argv, ["build"]);
     }

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -561,7 +561,7 @@ pub enum Cmd {
     /// Cargo executable unchanged. Configure this as a mise command wrapper to
     /// make ordinary `cargo` commands use this compatibility surface.
     #[usage(name = "cargo")]
-    CargoCompatibility {
+    CrateCompatibility {
         /// Arguments supplied by the Cargo invocation.
         #[usage(trailing_var_arg = true, value_name = "ARG")]
         argv: Vec<String>,
@@ -665,9 +665,7 @@ impl Cmd {
             Self::PackageCompatibility { argv } => {
                 Some(CompatibilityInvocation::Swift(argv.clone()))
             }
-            Self::CargoCompatibility { argv } => {
-                Some(CompatibilityInvocation::Cargo(argv.clone()))
-            }
+            Self::CrateCompatibility { argv } => Some(CompatibilityInvocation::Cargo(argv.clone())),
             _ => None,
         }
     }
@@ -723,7 +721,7 @@ impl Cmd {
             }
             Self::Compatibility { .. } => vec!["xcodebuild"],
             Self::PackageCompatibility { .. } => vec!["swift"],
-            Self::CargoCompatibility { .. } => vec!["cargo"],
+            Self::CrateCompatibility { .. } => vec!["cargo"],
             Self::Runtime { cmd } => {
                 let mut path = vec!["runtime"];
                 if let Some(cmd) = cmd {
@@ -853,7 +851,7 @@ mod tests {
     fn compatibility_accepts_cargo_arguments_after_separator() {
         let cli = parse(&["once", "cargo", "--", "build"]);
 
-        let Some(Cmd::CargoCompatibility { argv }) = cli.command else {
+        let Some(Cmd::CrateCompatibility { argv }) = cli.command else {
             panic!("expected Cargo compatibility command");
         };
         assert_eq!(argv, ["build"]);

--- a/crates/once-cli/src/commands/cargo/invocation.rs
+++ b/crates/once-cli/src/commands/cargo/invocation.rs
@@ -1,0 +1,258 @@
+use once_frontend::GraphTarget;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Command {
+    Build,
+    Test,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct Invocation {
+    pub(super) command: Command,
+    pub(super) quiet: bool,
+}
+
+pub(super) struct NativePackage {
+    pub(super) build_target: String,
+    pub(super) test_targets: Vec<String>,
+}
+
+impl Invocation {
+    pub(super) fn parse(argv: &[String]) -> Option<Self> {
+        let mut parser = Parser::default();
+        let mut index = 0;
+        while let Some(argument) = argv.get(index) {
+            match argument.as_str() {
+                "build" => parser.command(Command::Build)?,
+                "test" => parser.command(Command::Test)?,
+                "-q" | "--quiet" if !parser.quiet => parser.quiet = true,
+                "--manifest-path" => {
+                    let manifest_path = Parser::value(argv, &mut index)?;
+                    if !matches!(manifest_path.as_str(), "Cargo.toml" | "./Cargo.toml")
+                        || !parser.manifest_path()
+                    {
+                        return None;
+                    }
+                }
+                "--offline" | "--frozen" | "--locked" => {}
+                _ => return None,
+            }
+            index += 1;
+        }
+        parser.finish()
+    }
+
+    pub(super) fn package(graph: &[GraphTarget]) -> Option<NativePackage> {
+        let workspaces = graph
+            .iter()
+            .filter(|target| target.kind == "cargo_workspace" && has_capability(target, "build"))
+            .collect::<Vec<_>>();
+        let [workspace] = workspaces.as_slice() else {
+            return None;
+        };
+        let test_targets = graph
+            .iter()
+            .filter(|target| {
+                target.kind == "rust_test"
+                    && has_capability(target, "test")
+                    && is_first_party_target(target, workspace)
+            })
+            .map(|target| target.label.id.clone())
+            .collect();
+        Some(NativePackage {
+            build_target: workspace.label.id.clone(),
+            test_targets,
+        })
+    }
+}
+
+#[derive(Default)]
+struct Parser {
+    command: Option<Command>,
+    manifest_path: bool,
+    quiet: bool,
+}
+
+impl Parser {
+    fn command(&mut self, command: Command) -> Option<()> {
+        self.command.replace(command).is_none().then_some(())
+    }
+
+    fn value(argv: &[String], index: &mut usize) -> Option<String> {
+        let value = argv.get(*index + 1)?.clone();
+        (!value.starts_with('-'))
+            .then_some(value)
+            .inspect(|_| *index += 1)
+    }
+
+    fn manifest_path(&mut self) -> bool {
+        !std::mem::replace(&mut self.manifest_path, true)
+    }
+
+    fn finish(self) -> Option<Invocation> {
+        Some(Invocation {
+            command: self.command?,
+            quiet: self.quiet,
+        })
+    }
+}
+
+fn has_capability(target: &GraphTarget, capability: &str) -> bool {
+    target
+        .capabilities
+        .iter()
+        .any(|candidate| candidate.name == capability)
+}
+
+fn is_first_party_target(target: &GraphTarget, workspace: &GraphTarget) -> bool {
+    let package_prefix = if workspace.label.package.is_empty() {
+        String::new()
+    } else {
+        format!("{}/", workspace.label.package)
+    };
+    target.srcs.iter().any(|source| {
+        source
+            .strip_prefix(&package_prefix)
+            .is_some_and(|source| !source.starts_with(".once/"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use once_frontend::{Capability, TargetLabel};
+
+    fn target(
+        id: &str,
+        package: &str,
+        kind: &str,
+        srcs: &[&str],
+        capabilities: &[&str],
+    ) -> GraphTarget {
+        GraphTarget {
+            label: TargetLabel {
+                package: package.to_string(),
+                name: id.to_string(),
+                id: id.to_string(),
+            },
+            kind: kind.to_string(),
+            deps: Vec::new(),
+            dependency_edges: BTreeMap::new(),
+            srcs: srcs.iter().map(ToString::to_string).collect(),
+            visibility: Vec::new(),
+            attrs: BTreeMap::new(),
+            capabilities: capabilities
+                .iter()
+                .map(|name| Capability {
+                    name: (*name).to_string(),
+                    output_groups: Vec::new(),
+                    requires_outputs: Vec::new(),
+                })
+                .collect(),
+            providers: Vec::new(),
+            tools: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn arguments(values: &[&str]) -> Vec<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn parses_build_and_test_commands() {
+        let build = Invocation::parse(&arguments(&["build"]));
+        let test = Invocation::parse(&arguments(&["-q", "test"]));
+
+        assert_eq!(
+            build,
+            Some(Invocation {
+                command: Command::Build,
+                quiet: false,
+            })
+        );
+        assert_eq!(
+            test,
+            Some(Invocation {
+                command: Command::Test,
+                quiet: true,
+            })
+        );
+    }
+
+    #[test]
+    fn accepts_lockfile_flags_and_workspace_manifest_path() {
+        let build = Invocation::parse(&arguments(&[
+            "build",
+            "--locked",
+            "--manifest-path",
+            "Cargo.toml",
+        ]));
+        assert_eq!(
+            build,
+            Some(Invocation {
+                command: Command::Build,
+                quiet: false,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_requests_that_once_cannot_model() {
+        for invalid in [
+            ["build", "--release"].as_slice(),
+            ["test", "--", "some_test"].as_slice(),
+            ["build", "--features", "extra"].as_slice(),
+            ["build", "-p", "member"].as_slice(),
+            ["build", "--package", "member"].as_slice(),
+            ["build", "--target", "aarch64-unknown-linux-gnu"].as_slice(),
+            ["check"].as_slice(),
+            ["build", "test"].as_slice(),
+            ["build", "--manifest-path", "crates/other/Cargo.toml"].as_slice(),
+        ] {
+            assert!(Invocation::parse(&arguments(invalid)).is_none());
+        }
+    }
+
+    #[test]
+    fn selects_only_first_party_tests_from_one_native_workspace() {
+        let graph = vec![
+            target("cargo", "", "cargo_workspace", &[], &["build"]),
+            target(
+                "cargo_hello_bin_hello_unit_tests",
+                "",
+                "rust_test",
+                &["src/main.rs"],
+                &["build", "test"],
+            ),
+            target(
+                "third_party_serde_unit_tests",
+                "",
+                "rust_test",
+                &[".once/cargo-packages/serde/src/lib.rs"],
+                &["build", "test"],
+            ),
+        ];
+
+        assert!(Invocation::parse(&arguments(&["test"])).is_some());
+        let package = Invocation::package(&graph).unwrap();
+
+        assert_eq!(package.build_target, "cargo");
+        assert_eq!(
+            package.test_targets,
+            ["cargo_hello_bin_hello_unit_tests".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_native_workspaces() {
+        let graph = vec![
+            target("first", "", "cargo_workspace", &[], &["build"]),
+            target("second", "", "cargo_workspace", &[], &["build"]),
+        ];
+        assert!(Invocation::parse(&arguments(&["build"])).is_some());
+        assert!(Invocation::package(&graph).is_none());
+    }
+}

--- a/crates/once-cli/src/commands/cargo/mod.rs
+++ b/crates/once-cli/src/commands/cargo/mod.rs
@@ -1,0 +1,78 @@
+//! Cargo compatibility routing.
+
+mod invocation;
+mod passthrough;
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::Result;
+use once_core::{ResourceLimits, SandboxMode, Xdg};
+
+use crate::cli::Output;
+
+pub async fn run(
+    workspace: &Path,
+    xdg: &Xdg,
+    output: Output,
+    resource_limits: ResourceLimits,
+    argv: Vec<String>,
+) -> Result<ExitCode> {
+    let Some(invocation) = invocation::Invocation::parse(&argv) else {
+        return passthrough::run(&argv);
+    };
+    let graph = once_frontend::load_graph_workspace(workspace)?;
+    let Some(package) = invocation::Invocation::package(&graph) else {
+        return passthrough::run(&argv);
+    };
+    let resolved = crate::commands::graph::resolve_invocation_configuration(workspace, &[])?;
+    let output = Output::new(output.format, output.quiet || invocation.quiet);
+    let cache = crate::cache_provider::resolve(workspace, xdg)?;
+    match invocation.command {
+        invocation::Command::Build => {
+            Box::pin(crate::commands::graph::build(
+                workspace,
+                &cache,
+                output,
+                &package.build_target,
+                SandboxMode::Off,
+                resource_limits,
+                &resolved,
+                false,
+            ))
+            .await
+        }
+        invocation::Command::Test if package.test_targets.is_empty() => {
+            Box::pin(crate::commands::graph::build(
+                workspace,
+                &cache,
+                output,
+                &package.build_target,
+                SandboxMode::Off,
+                resource_limits,
+                &resolved,
+                false,
+            ))
+            .await
+        }
+        invocation::Command::Test => {
+            for target in package.test_targets {
+                let status = crate::commands::graph::test(
+                    workspace,
+                    &cache,
+                    output,
+                    &target,
+                    SandboxMode::Off,
+                    resource_limits.clone(),
+                    &resolved,
+                    false,
+                )
+                .await?;
+                if status != ExitCode::SUCCESS {
+                    return Ok(status);
+                }
+            }
+            Ok(ExitCode::SUCCESS)
+        }
+    }
+}

--- a/crates/once-cli/src/commands/cargo/passthrough.rs
+++ b/crates/once-cli/src/commands/cargo/passthrough.rs
@@ -1,0 +1,7 @@
+use std::process::ExitCode;
+
+use anyhow::Result;
+
+pub(super) fn run(argv: &[String]) -> Result<ExitCode> {
+    crate::commands::compatibility::run_passthrough(argv, "cargo", "ONCE_CARGO_PATH")
+}

--- a/crates/once-cli/src/commands/compatibility.rs
+++ b/crates/once-cli/src/commands/compatibility.rs
@@ -35,6 +35,16 @@ pub async fn run(
             ))
             .await
         }
+        CompatibilityInvocation::Cargo(argv) => {
+            Box::pin(crate::commands::cargo::run(
+                workspace,
+                xdg,
+                output,
+                resource_limits,
+                argv,
+            ))
+            .await
+        }
     }
 }
 

--- a/crates/once-cli/src/commands/mod.rs
+++ b/crates/once-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod auth;
 pub mod cache;
+pub mod cargo;
 pub mod change_tracker;
 pub mod compatibility;
 pub mod edit;

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -249,7 +249,7 @@ async fn run_command(
         Cmd::ChangeTracker => commands::change_tracker::serve(workspace, xdg).await,
         Cmd::Compatibility { .. }
         | Cmd::PackageCompatibility { .. }
-        | Cmd::CargoCompatibility { .. } => {
+        | Cmd::CrateCompatibility { .. } => {
             unreachable!("compatibility commands are routed before command dispatch")
         }
     }

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -247,7 +247,9 @@ async fn run_command(
         }
         Cmd::Reference { out } => crate::reference::generate(&out),
         Cmd::ChangeTracker => commands::change_tracker::serve(workspace, xdg).await,
-        Cmd::Compatibility { .. } | Cmd::PackageCompatibility { .. } => {
+        Cmd::Compatibility { .. }
+        | Cmd::PackageCompatibility { .. }
+        | Cmd::CargoCompatibility { .. } => {
             unreachable!("compatibility commands are routed before command dispatch")
         }
     }

--- a/crates/once-core/src/env/mise_runtime.rs
+++ b/crates/once-core/src/env/mise_runtime.rs
@@ -11,7 +11,7 @@ use crate::Xdg;
 
 use super::mise::ToolEnvError;
 
-pub const MANAGED_MISE_VERSION: &str = "2026.7.5";
+pub const MANAGED_MISE_VERSION: &str = "2026.9.1";
 
 static INSTALL_LOCK: Mutex<()> = Mutex::const_new(());
 
@@ -222,28 +222,28 @@ fn current_asset() -> Result<MiseAsset, ToolEnvError> {
 fn asset_for(operating_system: &str, architecture: &str) -> Option<MiseAsset> {
     match (operating_system, architecture) {
         ("linux", "x86_64") => Some(MiseAsset {
-            filename: "mise-v2026.7.5-linux-x64",
-            sha256: "5f7ab76afdf0780d12edeaa67e908094e9ccf7924cfe203e415c1cfb87bbf778",
+            filename: "mise-v2026.9.1-linux-x64",
+            sha256: "c98423c8470d6dc416d9f7036d0646d8ef5ae92ad9186907f8fcc84cbe7db4ea",
         }),
         ("linux", "aarch64") => Some(MiseAsset {
-            filename: "mise-v2026.7.5-linux-arm64",
-            sha256: "41fcf744050bfa27f9871e2151ac6f44b5ce2741424b3d5282b92becc71e6bc4",
+            filename: "mise-v2026.9.1-linux-arm64",
+            sha256: "0ef0a778eaa8599f3e90a8a0979c9fc3f79922cafb5fa6d39f366d974da33bba",
         }),
         ("macos", "x86_64") => Some(MiseAsset {
-            filename: "mise-v2026.7.5-macos-x64",
-            sha256: "62fe1fe9dbc32c6ce1388ee23df4a0862d3d7f40a6820b40c2f1cbab995dc1d4",
+            filename: "mise-v2026.9.1-macos-x64",
+            sha256: "0718a2aa14a96545a287f77a172d700247bb2d33016e5cf29fce1a05e45ac47a",
         }),
         ("macos", "aarch64") => Some(MiseAsset {
-            filename: "mise-v2026.7.5-macos-arm64",
-            sha256: "a456c65907e8334619d77fa152bdcf9023fddc0daa03d47fbe86d032dbf565b0",
+            filename: "mise-v2026.9.1-macos-arm64",
+            sha256: "3cfbe3295dba1a7e43bd02653517a8cc21135ba91f0635b45c98f1ebecc5513f",
         }),
         ("windows", "x86_64") => Some(MiseAsset {
-            filename: "mise-v2026.7.5-windows-x64.exe",
-            sha256: "1840f167ec8b161598e08b8ede769cf9954c0239b25bb7bdf0b326124b548c32",
+            filename: "mise-v2026.9.1-windows-x64.exe",
+            sha256: "86690787f22ccd55034039cb85bae27b5cba375aefbba5c09dd994487e0df554",
         }),
         ("windows", "aarch64") => Some(MiseAsset {
-            filename: "mise-v2026.7.5-windows-arm64.exe",
-            sha256: "27d3279d9d6a994d910561706f5ca99abcd8a03d38ad15b73ff0b5b3e148e4ea",
+            filename: "mise-v2026.9.1-windows-arm64.exe",
+            sha256: "3912a0fa43705992179867797f7058092ba560c97aa0c03202e4c66c58fdfb45",
         }),
         _ => None,
     }

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -2152,6 +2152,35 @@ def _rust_test_impl(ctx):
     if target and target != host_triple:
         fail(ctx["label"]["id"] + ": rust_test execution supports the host target only; remove `target` or run the cross-compiled test binary with a platform runner")
 
+    # Cargo places a test binary at `target/<profile>/deps/<name>` with its
+    # sibling package binaries at `target/<profile>/<name>`. Integration tests
+    # commonly walk up from `env::current_exe()` to find the binary they
+    # exercise (`parent(current_exe)/../<name>`), so a native path that keeps
+    # the test binary alongside its outputs breaks those tests. Stage the test
+    # under `deps/` and stage each declared bin_exe next to it so the
+    # cargo-shaped `env::current_exe()` walk lands on the real binary.
+    staged_test_binary = declare_output(_rust_declared_output(ctx, "deps/" + _basename(provider["test_binary"])))
+    copy_path(
+        provider["test_binary"],
+        staged_test_binary,
+        inputs = [provider["test_binary"]],
+        identifier = _rust_action_identifier(ctx, "test-stage"),
+    )
+    staged_bin_exe_paths = []
+    for dep in _rust_bin_exe_deps(ctx):
+        binary = dep.get("binary")
+        name = dep.get("binary_name") or dep.get("crate_name")
+        if not binary or not name:
+            continue
+        staged = declare_output(_rust_declared_output(ctx, name + _rust_output_extension("bin", "")))
+        copy_path(
+            binary,
+            staged,
+            inputs = [binary],
+            identifier = _rust_action_identifier(ctx, "test-bin-stage:" + name),
+        )
+        staged_bin_exe_paths.append(staged)
+
     runner_source = declare_output("test/OnceRustTestRunner.rs")
     runner = declare_output("test/once-rust-test-runner" + _rust_output_extension("bin", ""))
     runner_rustc, runner_identity, runner_host_triple = _rustc_toolchain("")
@@ -2169,14 +2198,15 @@ def _rust_test_impl(ctx):
     run_action(
         argv = [
             execution_path(runner),
-            execution_path(provider["test_binary"]),
+            execution_path(staged_test_binary),
             execution_path(results),
             execution_path(log),
             execution_path(native_results),
             ctx["label"]["id"],
         ] + _rust_attr(ctx, "args", []) + _rust_test_filter_args(ctx),
         inputs = _unique(
-            [runner, provider["test_binary"]] +
+            [runner, staged_test_binary] +
+            staged_bin_exe_paths +
             _rust_bin_exe_inputs(ctx) +
             _rust_test_package_inputs(ctx) +
             (provider.get("transitive_data") or [])
@@ -3136,7 +3166,16 @@ def _cargo_workspace_target_kind(target):
         return ""
     if "proc-macro" in kinds or "proc-macro" in crate_types:
         return "proc_macro"
-    if "test" in kinds or "bench" in kinds:
+    # Cargo benches use the nightly-only libtest bench harness by default. A
+    # benchmark crate typically opens with `#![feature(test)]`, which the
+    # stable compiler rejects. `cargo test` on stable simply does not build
+    # benches, so lowering them as rust_test targets makes `once cargo -- test`
+    # fail on projects that plain `cargo test` handles cleanly (ripgrep is the
+    # canonical example). Skip them until Once grows a dedicated bench
+    # capability.
+    if "bench" in kinds:
+        return ""
+    if "test" in kinds:
         return "test"
     if "lib" in kinds or any([crate_type in ["lib", "rlib", "staticlib", "cdylib", "dylib"] for crate_type in crate_types]):
         return "library"

--- a/crates/once-frontend/src/analysis/globals.rs
+++ b/crates/once-frontend/src/analysis/globals.rs
@@ -2204,6 +2204,13 @@ fn collect_glob_matches(
         // would stay valid, and the source would silently never enter the
         // build. Record the absent target as an observed host path so its
         // appearance invalidates what was built without it.
+        //
+        // A symlink whose canonical target already exists but lives outside
+        // the workspace is treated the same way: skip it and record the
+        // observation, so a hybrid project (a Cargo workspace that also runs
+        // Bazel, for instance, leaving `bazel-*` convenience symlinks that
+        // point into the Bazel output tree) loads cleanly instead of failing
+        // the whole graph.
         let canonical = match std::fs::canonicalize(path) {
             Ok(canonical) => canonical,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -2215,15 +2222,17 @@ fn collect_glob_matches(
                     .context(format!("canonicalizing `{}`", path.display())))
             }
         };
-        canonical
-            .strip_prefix(canonical_workspace)
-            .with_context(|| {
-                format!(
-                    "glob result `{}` is outside the workspace `{}`",
-                    canonical.display(),
-                    canonical_workspace.display()
-                )
-            })?;
+        if canonical.strip_prefix(canonical_workspace).is_err() {
+            if metadata.file_type().is_symlink() {
+                observe_absent_link_target(path);
+                continue;
+            }
+            return Err(anyhow!(
+                "glob result `{}` is outside the workspace `{}`",
+                canonical.display(),
+                canonical_workspace.display()
+            ));
+        }
         if !ws_rel.is_empty() {
             out.push(ws_rel);
         }

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -1272,6 +1272,26 @@ fn glob_skips_a_missing_symlink_target_outside_the_workspace() {
 
 #[cfg(unix)]
 #[test]
+fn glob_skips_a_symlink_that_resolves_outside_the_workspace() {
+    let workspace = TempDir::new().unwrap();
+    let external = TempDir::new().unwrap();
+    let package = workspace.path().join("packages/app");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(package.join("app.rs"), "").unwrap();
+    // A hybrid Cargo + Bazel project leaves convenience symlinks like
+    // `bazel-<workspace>` pointing into the Bazel output tree. They exist
+    // and resolve fine, but their targets live outside the Cargo workspace.
+    // The glob should drop them instead of failing the whole graph load.
+    std::fs::create_dir_all(external.path().join("bin")).unwrap();
+    std::os::unix::fs::symlink(external.path(), package.join("bazel-app")).unwrap();
+
+    let matches = expand_globs(workspace.path(), "packages/app", &["**/*".to_string()]).unwrap();
+
+    assert_eq!(matches, vec!["packages/app/app.rs".to_string()]);
+}
+
+#[cfg(unix)]
+#[test]
 fn glob_skips_a_missing_relative_symlink_target_inside_the_workspace() {
     let workspace = TempDir::new().unwrap();
     let package = workspace.path().join("packages/app");
@@ -1364,31 +1384,33 @@ fn glob_normalizes_package_parent_segments_without_losing_the_logical_path() {
     assert_eq!(matches, vec!["shared/value.ex"]);
 }
 
-/// A symlink that resolves outside the workspace must surface as
-/// an error rather than silently leaking external paths into the
-/// returned list. The check rejects honest mistakes; the threat
-/// model assumes a non-adversarial workspace (documented on
-/// `expand_globs`). Windows junctions/symlinks behave similarly
-/// via the same canonicalize call, but get their own test once
-/// Windows CI exists.
+/// A symlink whose canonical target lives outside the workspace is
+/// silently dropped from glob results (and the target is recorded as
+/// an observed host path so its appearance or disappearance still
+/// invalidates cached work). This preserves hybrid layouts such as a
+/// Cargo project that also runs Bazel, which leaves `bazel-*`
+/// convenience symlinks pointing into the Bazel output tree. Windows
+/// junctions and symlinks behave similarly via the same canonicalize
+/// call, but get their own test once Windows CI exists.
 #[cfg(unix)]
 #[test]
-fn glob_rejects_symlink_that_escapes_workspace() {
+fn glob_silently_drops_symlink_that_escapes_workspace() {
     let workspace = TempDir::new().unwrap();
     let external = TempDir::new().unwrap();
     let pkg = workspace.path().join("apps/ios/AppCore");
     std::fs::create_dir_all(&pkg).unwrap();
+    std::fs::write(pkg.join("kept.src"), "").unwrap();
     std::fs::write(external.path().join("stolen.src"), "").unwrap();
     std::os::unix::fs::symlink(external.path().join("stolen.src"), pkg.join("escape.src")).unwrap();
 
-    let err = expand_globs(
+    let matches = expand_globs(
         workspace.path(),
         "apps/ios/AppCore",
-        &["escape.src".to_string()],
+        &["*.src".to_string()],
     )
-    .unwrap_err()
-    .to_string();
-    assert!(err.contains("outside the workspace"), "{err}");
+    .unwrap();
+
+    assert_eq!(matches, vec!["apps/ios/AppCore/kept.src".to_string()]);
 }
 
 #[test]

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -1403,12 +1403,8 @@ fn glob_silently_drops_symlink_that_escapes_workspace() {
     std::fs::write(external.path().join("stolen.src"), "").unwrap();
     std::os::unix::fs::symlink(external.path().join("stolen.src"), pkg.join("escape.src")).unwrap();
 
-    let matches = expand_globs(
-        workspace.path(),
-        "apps/ios/AppCore",
-        &["*.src".to_string()],
-    )
-    .unwrap();
+    let matches =
+        expand_globs(workspace.path(), "apps/ios/AppCore", &["*.src".to_string()]).unwrap();
 
     assert_eq!(matches, vec!["apps/ios/AppCore/kept.src".to_string()]);
 }

--- a/web/priv/docs/guide/graph/rust.md
+++ b/web/priv/docs/guide/graph/rust.md
@@ -144,6 +144,43 @@ Outputs are materialized under `.once/out/<target>/`. The
 [`rust_test` reference](/reference/prelude/rust_test) list their executable,
 log, and test-result outputs.
 
+### Keep Cargo Commands
+
+Once can sit behind the `cargo` command for one native Cargo project or
+workspace. Add this mise wrapper, then run `mise reshim` and activate mise in
+the shell that starts the build:
+
+```toml
+[wrappers.cargo]
+command = "once"
+args = ["cargo", "--"]
+```
+
+Once routes the default debug build and test forms into the native graph:
+
+```sh
+cargo build
+cargo test
+```
+
+`cargo build` builds the workspace seed and its resolved products. `cargo
+test` runs each first-party test target once through Once, excluding tests
+that belong to resolved external crates. `-q` or `--quiet`, `--locked`,
+`--offline`, `--frozen`, and `--manifest-path Cargo.toml` are also supported.
+
+For troubleshooting without mise, call the compatibility surface directly and
+put the separator before the Cargo arguments:
+
+```sh
+once cargo -- test
+```
+
+Every other request, including release builds, feature selection, package
+selection, cross-compilation targets, `cargo check`, `cargo run`, `cargo
+clippy`, and a manifest path outside the workspace root, invokes the system
+`cargo` executable with its original arguments and exit status. This preserves
+Cargo behavior until the request has an exact Once equivalent.
+
 ### Confirm Caching
 
 Run the same build twice without changing an input:


### PR DESCRIPTION
## What changed

- New `once cargo -- <args>` compatibility surface (`crates/once-cli/src/commands/cargo/`) alongside the existing `once xcodebuild` and `once swift` wrappers. When the argv matches a shape Once can model (`cargo build` or `cargo test` on the default profile, with `-q`, `--locked`, `--offline`, `--frozen`, or `--manifest-path Cargo.toml`), the wrapper routes the request to the `cargo_workspace` graph target and to each first-party `rust_test`. Every other invocation passes through to the system `cargo` unchanged.
- Docs update in the [Rust guide](web/priv/docs/guide/graph/rust.md) with the new "Keep Cargo Commands" section and the `[wrappers.cargo]` [mise](https://mise.jdx.dev/) snippet.
- Managed [mise](https://mise.jdx.dev/) bumped from `2026.7.5` to `2026.9.1` so the wrapper example is understood by the bundled runtime and projects pinning `min_version >= 2026.8.16` load cleanly.
- Two design-gap fixes surfaced while validating the wrapper on real projects (details below).

## Why

Users on Cargo projects want the same "put Once behind the tool you already type" experience that already exists for `swift`/`xcodebuild`. Typing `cargo build` and `cargo test` under a mise wrapper should transparently reach Once's cached graph when the request has an exact equivalent, and fall back to the system tool otherwise. This closes that gap and takes the docs snippet from "aspirational" to "runnable" by making sure the bundled toolchain understands the `[wrappers.<tool>]` block.

## Approach

Followed the Swift/Xcode wrapper pattern closely to keep the three compatibility surfaces symmetric:

- `Cmd::CargoCompatibility` and `CompatibilityInvocation::Cargo` in the CLI.
- `commands/cargo/{mod.rs,invocation.rs,passthrough.rs}` — one that parses the invocation, one that dispatches to `commands::graph::build`/`test`, one that shells out to system `cargo` for anything the graph can't model.
- Test-target selection filters `rust_test` targets whose sources sit under the workspace's package prefix (and not under `.once/`), matching how the Swift wrapper isolates first-party test bundles.

Two Once-cargo-integration issues showed up under the wrapper on real projects and got real fixes rather than workarounds:

- **Glob no longer aborts on symlinks that escape the workspace.** A hybrid Cargo + [Bazel](https://bazel.build/) project leaves `bazel-*` convenience symlinks pointing into the Bazel output tree. Previously that made the whole graph load fail with `glob result ... is outside the workspace`. `expand_globs` now silently drops those from the result and records the target as an observed host path, so a later change under it still invalidates cached work.
- **`rust_test` binaries are now staged in a cargo-shaped layout.** Many command-line-interface (CLI) integration tests locate the binary they exercise by walking up from `env::current_exe()` (fd's `find_fd_exe`, ripgrep's `Dir::bin`, the `executable_path` crate used by just). Cargo puts the test binary at `target/<profile>/deps/<test>` with sibling package binaries at `target/<profile>/<bin>`. `_rust_test_impl` now stages the compiled test binary at `<build_dir>/deps/<name>` and each `bin_dep` at `<build_dir>/<bin_name>`, so `parent(current_exe)/../<bin_name>` resolves to the real binary.
- **Cargo benches are no longer lowered as `rust_test` targets.** Bench crates typically open with `#![feature(test)]`, which the stable compiler rejects, and `cargo test` on stable never compiles them. Skipped in `_cargo_workspace_target_kind` until Once grows a bench capability.

## Impact

- Users can add a two-line `[wrappers.cargo]` block to `mise.toml` and keep typing `cargo build`/`cargo test` while the graph handles the ones it understands. Every other Cargo command still works exactly as before.
- Any Cargo project that also uses Bazel (leaving `bazel-*` symlinks in place) can now be loaded by Once without a manual cleanup step.
- Any `rust_test` with `bin_deps` that finds its binary through `env::current_exe()` walks now works out of the box — this is how most CLI integration tests are written.
- The managed-mise bump is a version change users will see in `~/.local/share/once/tools/mise/`. It is downloaded on first use; no manual migration required.

## Validation

`once cargo -- build` and `once cargo -- test` were run end-to-end against a set of well-known Rust projects and this repository:

| Project | Build | Tests through wrapper |
|---|---|---|
| kura (tuist/kura, real Bazel `bazel-*` symlinks left in place) | pass | 355 / 355 pass |
| jdx/mise (workspace, `min_version = "2026.8.16"` intact) | pass | 3313 / 3353 (40 remaining fail identically under plain `cargo test` due to homebrew, network, and `tar --sparse` host dependencies) |
| ripgrep 14.1.1 | pass | 1083 / 1083 pass |
| fd v10.2.0 | pass | 234 / 234 pass |
| just 1.36.0 | pass | 1311 / 1312 pass (one test asserts on `$USER`, which Once's test env clears; unrelated) |
| hyperfine v1.19.0 | fail | build fails inside `borsh 1.5.2` compile because of a pre-existing Once cargo-resolver bug with borsh's `derive` + `schema` feature interaction; `once build cargo` fails the same way, so it's independent of the wrapper. Filing separately. |

Local test suites still green: `cargo test -p once-frontend --lib` (279/279) and `cargo test -p once-cli --bin once` (385/385). The two `--test examples` cases that fail (`every_schema_example_loads_without_diagnostics`, `mix_native_project_lints_in_the_development_environment`) both need `elixir` on `$PATH`; they fail identically on `main` without this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwTnDAwuQowasdmtRvTnW9
