### PR TITLE
ci(release): install libasound2-dev on the Linux release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,11 @@ jobs:
           version: ${{ env.MISE_VERSION }}
           # Restrict to the build tools needed on every matrix host.
           install_args: "rust jq"
+      # libcap-ng-dev links the embedded sandbox provider; libasound2-dev
+      # resolves the ALSA backend that the audio output layer links on
+      # Linux, whether or not sound is used at runtime.
       - if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y binutils build-essential libcap-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y binutils build-essential libcap-ng-dev libasound2-dev
       - name: Cache Rust
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
@@ -166,8 +169,9 @@ jobs:
         with:
           version: ${{ env.MISE_VERSION }}
           install_args: "rust jq"
+      # Same native libraries as the CLI build above.
       - if: startsWith(matrix.runner, 'ubuntu-')
-        run: sudo apt-get update && sudo apt-get install -y binutils build-essential libcap-ng-dev
+        run: sudo apt-get update && sudo apt-get install -y binutils build-essential libcap-ng-dev libasound2-dev
       - name: Cache Rust
         continue-on-error: true
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,12 +212,19 @@ with the same pin.
 ## Native Dependencies
 
 Linux builds need `libcap-ng-dev` because the embedded Microsandbox
-provider links through native KVM support. Install it before running
-workspace builds locally on Linux:
+provider links through native KVM support, and `libasound2-dev` because
+the CLI links the ALSA backend of its audio output layer. The ALSA
+library is a load-time dependency of the resulting binary even when
+sound is never used, so `libasound2` has to be present on Linux hosts
+that run it. Install both before running workspace builds locally on
+Linux:
 
 ```sh
-sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+sudo apt-get update && sudo apt-get install -y libcap-ng-dev libasound2-dev
 ```
+
+Every Linux job that compiles the workspace needs the same two packages,
+release jobs included.
 
 ## Android Toolchain
 

--- a/web/priv/docs/guide/local-execution/sound.md
+++ b/web/priv/docs/guide/local-execution/sound.md
@@ -19,6 +19,15 @@ once --sound exec -- mise install --yes
 When the default audio device is unavailable (headless CI, no audio hardware)
 the flag has no effect and the command runs as if it had not been passed.
 
+On Linux, audio output goes through ALSA, and `once` links against it when it
+loads, whether or not you pass `--sound`. Minimal images such as
+`debian:*-slim` do not ship it, so install `libasound2` there before running
+`once`:
+
+```sh
+apt-get update && apt-get install -y libasound2
+```
+
 ## What You Hear
 
 Each run is one continuous piece of music. It has a beginning, a middle, and


### PR DESCRIPTION
## Why

No release has been cut since 0.51.0. The last four pushes to main either got cancelled by the release concurrency group or, in the case of the most recent one, failed outright: both Linux legs of the release matrix now stop after about two minutes.

The cause is the `--sound` work in #264. It added an audio output layer that links the ALSA backend on Linux, and the PR updated every workflow that compiles the workspace (`once.yml`, `web.yml`, `bench.yml`) plus `web/Dockerfile` to install `libasound2-dev`. `release.yml` was the one that got missed, so the bootstrap build there dies with:

```
error: failed to run custom build command for `alsa-sys v0.3.1`
  Package alsa was not found in the pkg-config search path.
```

Both `Build <linux target>` and `Build SDK libraries <linux target>` hit it, and since `publish` needs the whole `build` matrix, the GitHub release never gets created.

## What this does

Adds `libasound2-dev` to the two `apt-get install` lines in `release.yml`, matching what the other Linux jobs already install, and leaves a comment on each so the pairing with `libcap-ng-dev` is legible next time.

## The part worth a second look

ALSA is a load-time dependency of the Linux binary, not a lazy one. The binary links it when it loads whether or not `--sound` is passed, which is why #264 also had to add `libasound2` to the runner stage of the Dockerfile. That means the Linux artifacts this release publishes will not start on an image that lacks `libasound2`, and minimal bases like `debian:*-slim` do not have it.

I considered handling that here by making the audio dependency optional and building the Linux release without it, but that is a product call about what ships in the Linux binary rather than a CI fix, and it should not be what keeps main from releasing. So this PR only unblocks the pipeline, and documents the requirement in two places: the Native Dependencies section of `AGENTS.md` for anyone building locally, and the sound guide for anyone installing `once` on a slim Linux image.

Happy to follow up with the feature-gate approach if we would rather the Linux artifact stay free of the runtime dependency.

## Verification

The failure and the fix are both in the workflow definition, so this is verified by the release run on main after merge. What I checked here: the failing job logs name `alsa-sys` and its pkg-config probe as the cause; the two edited steps are the only Linux jobs in `release.yml` that compile Rust (`publish`, `publish-sdks` and `notes` run `git-cliff`, `gh` and the package registries, and `build-xcframework` is macOS only); the same package on the same runner family already works in `once.yml`; and the file still parses as YAML.

One unrelated red build on main: the `web` workflow's `check` job failed on a transient apt outage on the self-hosted runner, where `archive.ubuntu.com` was unreachable for six minutes. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpWVDWTcDV1NaWhvWuK3eR