### PR TITLE
feat(cli): render build and test runs through a live terminal reporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,19 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
@@ -2434,6 +2447,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,6 +3556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,10 +3726,11 @@ dependencies = [
  "anyhow",
  "axum",
  "blake3",
- "console",
+ "console 0.16.4",
  "fd-lock",
  "futures",
  "glob",
+ "indicatif",
  "libc",
  "notify",
  "once-cas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.22"
 blake3 = "1"
 usage = { package = "usage-rs", version = "6.4.1" }
 console = "0.16"
+indicatif = "0.17"
 fd-lock = "4"
 futures = "0.3"
 glob = "0.3"

--- a/crates/once-cli/Cargo.toml
+++ b/crates/once-cli/Cargo.toml
@@ -28,6 +28,7 @@ axum.workspace = true
 blake3.workspace = true
 usage.workspace = true
 console.workspace = true
+indicatif.workspace = true
 fd-lock.workspace = true
 glob.workspace = true
 futures.workspace = true

--- a/crates/once-cli/src/bus_events.rs
+++ b/crates/once-cli/src/bus_events.rs
@@ -79,6 +79,42 @@ pub fn target_publishing(bus: &RunEventBus, target_id: &str) {
     });
 }
 
+/// Publish `RunCompleted` for the whole run. Used at the outer run
+/// boundary when the scheduler already published a per-target
+/// `TargetCompleted` for the top-level target and only the terminal
+/// run event is missing.
+pub fn run_completed(bus: &RunEventBus, exit_code: i32) {
+    bus.publish(RunEvent::RunCompleted {
+        at_epoch_ms: now_epoch_ms(),
+        exit_status: exit_code,
+    });
+}
+
+/// Publish `TargetCompleted` for one target with no `RunCompleted`.
+/// Used by the graph scheduler which fires many of these as
+/// dependencies finish; the outer run publishes its own `RunCompleted`
+/// via [`target_finished`] or [`run_completed`].
+pub fn target_completed(
+    bus: &RunEventBus,
+    target_id: &str,
+    duration_ms: u64,
+    was_cached: bool,
+    exit_code: i32,
+) {
+    let result = if exit_code == 0 {
+        TargetResult::Succeeded
+    } else {
+        TargetResult::Failed
+    };
+    bus.publish(RunEvent::TargetCompleted {
+        at_epoch_ms: now_epoch_ms(),
+        target_id: target_id.to_string(),
+        result,
+        was_cached,
+        duration_ms: i64::try_from(duration_ms).unwrap_or(i64::MAX),
+    });
+}
+
 /// Publish `TargetCompleted` for a target that finished (any outcome)
 /// followed by `RunCompleted` for the whole run. The cache label is
 /// interpreted case-insensitively: `hit` maps to `was_cached=true`.

--- a/crates/once-cli/src/bus_events.rs
+++ b/crates/once-cli/src/bus_events.rs
@@ -18,8 +18,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use once_core::{
-    ActionOutputObserver, ActionOutputStream, LogStream, Phase, RunEvent, RunEventBus,
-    TargetResult,
+    ActionOutputObserver, ActionOutputStream, LogStream, Phase, RunEvent, RunEventBus, TargetResult,
 };
 
 /// Publish `RunStarted` and `TargetQueued`. Idempotent from the caller's
@@ -183,7 +182,10 @@ mod tests {
         target_executing(&bus, "//foo:bar");
         target_finished(&bus, "//foo:bar", 10, "miss", 0);
 
-        assert!(matches!(rx.recv().await.unwrap(), RunEvent::RunStarted { at_epoch_ms: 42 }));
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            RunEvent::RunStarted { at_epoch_ms: 42 }
+        ));
         assert!(matches!(
             rx.recv().await.unwrap(),
             RunEvent::TargetQueued { target_id, .. } if target_id == "//foo:bar"
@@ -194,11 +196,18 @@ mod tests {
         ));
         assert!(matches!(
             rx.recv().await.unwrap(),
-            RunEvent::TargetPhase { phase: Phase::Executing, .. }
+            RunEvent::TargetPhase {
+                phase: Phase::Executing,
+                ..
+            }
         ));
         assert!(matches!(
             rx.recv().await.unwrap(),
-            RunEvent::TargetCompleted { result: TargetResult::Succeeded, was_cached: false, .. }
+            RunEvent::TargetCompleted {
+                result: TargetResult::Succeeded,
+                was_cached: false,
+                ..
+            }
         ));
         assert!(matches!(
             rx.recv().await.unwrap(),

--- a/crates/once-cli/src/bus_events.rs
+++ b/crates/once-cli/src/bus_events.rs
@@ -1,0 +1,240 @@
+//! Always-on producers for [`RunEventBus`] events.
+//!
+//! Historically only the `--ui` HTTP dashboard published lifecycle
+//! events onto the bus, so nothing else (a terminal renderer, the RFC
+//! 0008 ingest, an in-process sound module that wants to subscribe)
+//! could observe them. This module provides small helpers that a
+//! command's hot path can call unconditionally to broadcast the same
+//! events the dashboard used to emit, plus a lightweight
+//! [`ActionOutputObserver`] that only pushes `LogChunk` events onto
+//! the bus (with no channel or per-run UI store).
+//!
+//! The UI dashboard still exists; when it is enabled, its
+//! [`Publisher`](crate::commands::ui::Publisher) additionally updates a
+//! rendering store from these events, but the bus emit itself moves
+//! here so it fires whether or not the dashboard is on.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use once_core::{
+    ActionOutputObserver, ActionOutputStream, LogStream, Phase, RunEvent, RunEventBus,
+    TargetResult,
+};
+
+/// Publish `RunStarted` and `TargetQueued`. Idempotent from the caller's
+/// perspective; the bus itself is a broadcast channel that silently
+/// succeeds when nothing is subscribed.
+pub fn run_started(bus: &RunEventBus, target_id: &str, at_epoch_ms: i64) {
+    bus.publish(RunEvent::RunStarted { at_epoch_ms });
+    bus.publish(RunEvent::TargetQueued {
+        at_epoch_ms,
+        target_id: target_id.to_string(),
+    });
+}
+
+pub fn target_cache_checking(bus: &RunEventBus, target_id: &str) {
+    bus.publish(RunEvent::TargetPhase {
+        at_epoch_ms: now_epoch_ms(),
+        target_id: target_id.to_string(),
+        phase: Phase::CacheChecking,
+    });
+}
+
+pub fn target_preparing(bus: &RunEventBus, target_id: &str) {
+    bus.publish(RunEvent::TargetPhase {
+        at_epoch_ms: now_epoch_ms(),
+        target_id: target_id.to_string(),
+        phase: Phase::Preparing,
+    });
+}
+
+/// Fire `TargetStarted` followed by `TargetPhase(Executing)` for a
+/// target that has begun running its action.
+pub fn target_executing(bus: &RunEventBus, target_id: &str) {
+    let at = now_epoch_ms();
+    bus.publish(RunEvent::TargetStarted {
+        at_epoch_ms: at,
+        target_id: target_id.to_string(),
+    });
+    bus.publish(RunEvent::TargetPhase {
+        at_epoch_ms: at,
+        target_id: target_id.to_string(),
+        phase: Phase::Executing,
+    });
+}
+
+pub fn target_capturing(bus: &RunEventBus, target_id: &str) {
+    bus.publish(RunEvent::TargetPhase {
+        at_epoch_ms: now_epoch_ms(),
+        target_id: target_id.to_string(),
+        phase: Phase::Capturing,
+    });
+}
+
+pub fn target_publishing(bus: &RunEventBus, target_id: &str) {
+    bus.publish(RunEvent::TargetPhase {
+        at_epoch_ms: now_epoch_ms(),
+        target_id: target_id.to_string(),
+        phase: Phase::Publishing,
+    });
+}
+
+/// Publish `TargetCompleted` for a target that finished (any outcome)
+/// followed by `RunCompleted` for the whole run. The cache label is
+/// interpreted case-insensitively: `hit` maps to `was_cached=true`.
+pub fn target_finished(
+    bus: &RunEventBus,
+    target_id: &str,
+    duration_ms: u64,
+    cache: &str,
+    exit_code: i32,
+) {
+    let result = if exit_code == 0 {
+        TargetResult::Succeeded
+    } else {
+        TargetResult::Failed
+    };
+    bus.publish(RunEvent::TargetCompleted {
+        at_epoch_ms: now_epoch_ms(),
+        target_id: target_id.to_string(),
+        result,
+        was_cached: cache.eq_ignore_ascii_case("hit"),
+        duration_ms: i64::try_from(duration_ms).unwrap_or(i64::MAX),
+    });
+    bus.publish(RunEvent::RunCompleted {
+        at_epoch_ms: now_epoch_ms(),
+        exit_status: exit_code,
+    });
+}
+
+/// Publish `TargetCompleted{Failed}` and `RunCompleted{1}` for a run
+/// that couldn't even reach the action stage (setup failure).
+pub fn target_failed(bus: &RunEventBus, target_id: &str, duration_ms: u64) {
+    bus.publish(RunEvent::TargetCompleted {
+        at_epoch_ms: now_epoch_ms(),
+        target_id: target_id.to_string(),
+        result: TargetResult::Failed,
+        was_cached: false,
+        duration_ms: i64::try_from(duration_ms).unwrap_or(i64::MAX),
+    });
+    bus.publish(RunEvent::RunCompleted {
+        at_epoch_ms: now_epoch_ms(),
+        exit_status: 1,
+    });
+}
+
+/// A lightweight observer that only publishes `LogChunk` events onto
+/// the bus. Unlike the UI dashboard's observer, it never queues text
+/// into a decoder or channel; the terminal reporter and any other
+/// subscriber decode as they render.
+pub struct BusOutputObserver {
+    bus: RunEventBus,
+    target_id: String,
+}
+
+impl BusOutputObserver {
+    #[must_use]
+    pub fn new(bus: RunEventBus, target_id: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self {
+            bus,
+            target_id: target_id.into(),
+        })
+    }
+}
+
+impl ActionOutputObserver for BusOutputObserver {
+    fn observe(&self, stream: ActionOutputStream, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        self.bus.publish(RunEvent::LogChunk {
+            at_epoch_ms: now_epoch_ms(),
+            target_id: self.target_id.clone(),
+            stream: match stream {
+                ActionOutputStream::Stdout => LogStream::Stdout,
+                ActionOutputStream::Stderr => LogStream::Stderr,
+            },
+            bytes: bytes.to_vec(),
+        });
+    }
+}
+
+fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or_default()
+}
+
+pub fn now_ms() -> i64 {
+    now_epoch_ms()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn helpers_fire_expected_events() {
+        let bus = RunEventBus::new(16);
+        let mut rx = bus.subscribe();
+        run_started(&bus, "//foo:bar", 42);
+        target_executing(&bus, "//foo:bar");
+        target_finished(&bus, "//foo:bar", 10, "miss", 0);
+
+        assert!(matches!(rx.recv().await.unwrap(), RunEvent::RunStarted { at_epoch_ms: 42 }));
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            RunEvent::TargetQueued { target_id, .. } if target_id == "//foo:bar"
+        ));
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            RunEvent::TargetStarted { target_id, .. } if target_id == "//foo:bar"
+        ));
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            RunEvent::TargetPhase { phase: Phase::Executing, .. }
+        ));
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            RunEvent::TargetCompleted { result: TargetResult::Succeeded, was_cached: false, .. }
+        ));
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            RunEvent::RunCompleted { exit_status: 0, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn bus_output_observer_publishes_log_chunks() {
+        let bus = RunEventBus::new(8);
+        let mut rx = bus.subscribe();
+        let observer = BusOutputObserver::new(bus.clone(), "//x:y");
+        observer.observe(ActionOutputStream::Stdout, b"hello");
+
+        match rx.recv().await.unwrap() {
+            RunEvent::LogChunk {
+                target_id,
+                stream,
+                bytes,
+                ..
+            } => {
+                assert_eq!(target_id, "//x:y");
+                assert_eq!(stream, LogStream::Stdout);
+                assert_eq!(bytes, b"hello");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_chunk_is_ignored() {
+        let bus = RunEventBus::new(4);
+        let mut rx = bus.subscribe();
+        let observer = BusOutputObserver::new(bus.clone(), "//x:y");
+        observer.observe(ActionOutputStream::Stdout, b"");
+        // Nothing published; try_recv would immediately error.
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -39,10 +39,22 @@ pub enum Format {
     Toon,
 }
 
+/// When to emit ANSI color escapes in human-mode output. `auto`
+/// respects TTY detection and the standard `NO_COLOR`,
+/// `CLICOLOR_FORCE`, and `TERM=dumb` environment variables; `always`
+/// forces color even when piped; `never` suppresses it entirely.
+#[derive(Copy, Clone, Debug, usage::ValueEnum, Default, PartialEq, Eq)]
+pub enum ColorChoice {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
 /// Output policy passed to command handlers. Bundles the chosen
-/// [`Format`] with the global `--quiet` flag so commands have one
-/// argument to consult instead of two. Cheap to copy; future flags
-/// that affect rendering (e.g. `--no-color`) drop in here.
+/// [`Format`] with the global `--quiet`, `--color`, and `--verbose`
+/// flags so commands have one argument to consult instead of four.
+/// Cheap to copy.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Output {
     pub format: Format,
@@ -50,12 +62,37 @@ pub struct Output {
     /// Errors and the structured
     /// envelope of `--format json`/`toon` are never suppressed.
     pub quiet: bool,
+    /// When and how to emit ANSI color escapes.
+    pub color: ColorChoice,
+    /// Repeat count of the `-v/--verbose` flag. In human mode the
+    /// terminal reporter treats `>=1` as "surface a short tail of
+    /// captured output on every target" and `>=2` as "stream all
+    /// captured output live". Values `>=1` also raise the tracing
+    /// stderr filter (see `logging::init`), which is unchanged.
+    pub verbose: u8,
 }
 
 impl Output {
     #[must_use]
     pub fn new(format: Format, quiet: bool) -> Self {
-        Self { format, quiet }
+        Self {
+            format,
+            quiet,
+            color: ColorChoice::default(),
+            verbose: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn with_color(mut self, color: ColorChoice) -> Self {
+        self.color = color;
+        self
+    }
+
+    #[must_use]
+    pub fn with_verbose(mut self, verbose: u8) -> Self {
+        self.verbose = verbose;
+        self
     }
 
     /// Whether human-mode progress and success trailers should print.
@@ -159,6 +196,12 @@ pub struct Cli {
     /// `-q` flag of common build tools.
     #[usage(short = 'q', long, global = true)]
     pub quiet: bool,
+
+    /// When to emit ANSI color in human-mode output. Defaults to
+    /// `auto`, which honors TTY detection, `NO_COLOR`, `CLICOLOR_FORCE`,
+    /// and `TERM=dumb`.
+    #[usage(long, global = true, value_enum, default = "auto")]
+    pub color: ColorChoice,
 
     /// Play soft procedural pad tones at meaningful moments in a command's
     /// lifecycle: a note when work starts, a note per action as it completes,

--- a/crates/once-cli/src/commands/bazel/mod.rs
+++ b/crates/once-cli/src/commands/bazel/mod.rs
@@ -27,7 +27,9 @@ pub async fn run(
     };
     let resolved = crate::commands::graph::resolve_invocation_configuration(workspace, &[])?;
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
-    let output = Output::new(output.format, output.quiet);
+    let output = Output::new(output.format, output.quiet)
+        .with_color(output.color)
+        .with_verbose(output.verbose);
     match invocation.command {
         invocation::Command::Build => {
             Box::pin(crate::commands::graph::build(

--- a/crates/once-cli/src/commands/cargo/mod.rs
+++ b/crates/once-cli/src/commands/cargo/mod.rs
@@ -26,7 +26,9 @@ pub async fn run(
         return passthrough::run(&argv);
     };
     let resolved = crate::commands::graph::resolve_invocation_configuration(workspace, &[])?;
-    let output = Output::new(output.format, output.quiet || invocation.quiet);
+    let output = Output::new(output.format, output.quiet || invocation.quiet)
+        .with_color(output.color)
+        .with_verbose(output.verbose);
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
     match invocation.command {
         invocation::Command::Build => {

--- a/crates/once-cli/src/commands/graph/analysis.rs
+++ b/crates/once-cli/src/commands/graph/analysis.rs
@@ -190,6 +190,10 @@ pub(super) struct BuildSession {
     target_outcomes: Arc<TargetOutcomes>,
     sandbox: SandboxMode,
     output_observer: Option<Arc<dyn ActionOutputObserver>>,
+    /// Optional per-run event bus so the scheduler can publish
+    /// `TargetStarted` / `TargetCompleted` per graph target while it
+    /// walks the dependency closure.
+    event_bus: Option<once_core::RunEventBus>,
 }
 
 struct Resolution {
@@ -343,6 +347,7 @@ impl BuildSession {
             )),
             sandbox,
             output_observer: None,
+            event_bus: None,
         }
     }
 
@@ -356,6 +361,15 @@ impl BuildSession {
         output_observer: Arc<dyn ActionOutputObserver>,
     ) -> Self {
         self.output_observer = Some(output_observer);
+        self
+    }
+
+    /// Wire the session to publish per-target lifecycle events onto
+    /// the given bus while it schedules dependencies. Without this the
+    /// scheduler is silent per-target and only the outer run's own
+    /// events fire.
+    pub(super) fn with_event_bus(mut self, bus: once_core::RunEventBus) -> Self {
+        self.event_bus = Some(bus);
         self
     }
 
@@ -729,6 +743,7 @@ impl BuildSession {
             sandbox: self.sandbox,
             resources: Arc::clone(&self.resources),
             output_observer: self.output_observer.clone(),
+            event_bus: self.event_bus.clone(),
         }
     }
 
@@ -1110,6 +1125,11 @@ struct BuildContext {
     pub sandbox: SandboxMode,
     pub resources: Arc<ResourcePool>,
     pub output_observer: Option<Arc<dyn ActionOutputObserver>>,
+    /// When set, `build_one` publishes per-target lifecycle events onto
+    /// this bus so the terminal reporter (and other subscribers) can
+    /// render live per-dependency progress rather than only the
+    /// top-level target's phase transitions.
+    pub event_bus: Option<once_core::RunEventBus>,
 }
 
 /// Analyse one target, reusing a stored analysis when its recorded answers
@@ -1199,6 +1219,7 @@ async fn build_one(
         sandbox,
         resources,
         output_observer,
+        event_bus,
     } = context;
     let DependencyInputs {
         providers,
@@ -1209,6 +1230,10 @@ async fn build_one(
 
     ensure_graph_target_valid(&target)?;
     let target_id = target.label.id.clone();
+    let build_started_at = std::time::Instant::now();
+    if let Some(bus) = &event_bus {
+        crate::bus_events::target_executing(bus, &target_id);
+    }
     // Names this build: the same target definition, reached through the same
     // dependency outcomes, analysed by the same code against the same
     // configuration. Computed once and used both to look for a recorded
@@ -1227,6 +1252,18 @@ async fn build_one(
     {
         if let Some(outcome) = target_outcomes.reuse(&target, &key, &changes) {
             target_outcomes.carry_forward(&target_id);
+            if let Some(bus) = &event_bus {
+                let duration_ms =
+                    u64::try_from(build_started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+                let was_cached = matches!(outcome.cache_state, once_core::EvidenceCacheState::Hit);
+                crate::bus_events::target_completed(
+                    bus,
+                    &target_id,
+                    duration_ms,
+                    was_cached,
+                    outcome.result.exit_code,
+                );
+            }
             return Ok((target_id, outcome));
         }
     }
@@ -1291,6 +1328,17 @@ async fn build_one(
         .map(|key| target_outcomes::key(key, &action_digests))
     {
         target_outcomes.record(&target, key, &observations, &declared_inputs, &outcome);
+    }
+    if let Some(bus) = &event_bus {
+        let duration_ms = u64::try_from(build_started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let was_cached = matches!(outcome.cache_state, once_core::EvidenceCacheState::Hit);
+        crate::bus_events::target_completed(
+            bus,
+            &target_id,
+            duration_ms,
+            was_cached,
+            outcome.result.exit_code,
+        );
     }
     Ok((target_id, outcome))
 }

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -245,7 +245,9 @@ pub async fn build(
     .await
     {
         Ok(session) => {
-            let session = session.with_resource_limits(resource_limits);
+            let session = session
+                .with_resource_limits(resource_limits)
+                .with_event_bus(bus.clone());
             match (&live_output, &bus_observer) {
                 (Some(live_output), _) => session.with_output_observer(live_output.observer()),
                 (None, Some(observer)) => session.with_output_observer(observer.clone()),
@@ -433,13 +435,10 @@ pub async fn build(
             )
             .await;
     }
-    bus_events::target_finished(
-        &bus,
-        target_id,
-        duration_ms,
-        &record.cache,
-        record.result.exit_code,
-    );
+    // The scheduler already fired `TargetCompleted` for the top-level
+    // target from `build_one`; publish only the outer `RunCompleted`
+    // here to avoid a duplicate completion line.
+    bus_events::run_completed(&bus, record.result.exit_code);
     write_record(output, &record).await?;
     #[cfg(feature = "events-ingest")]
     if let Some(handle) = event_client.take() {
@@ -696,7 +695,8 @@ pub async fn test_with_filters(
         resolved,
     )
     .await?
-    .with_resource_limits(resource_limits);
+    .with_resource_limits(resource_limits)
+    .with_event_bus(bus.clone());
     let session = match (&live_output, &bus_observer) {
         (Some(live_output), _) => session.with_output_observer(live_output.observer()),
         (None, Some(observer)) => session.with_output_observer(observer.clone()),
@@ -784,13 +784,10 @@ pub async fn test_with_filters(
             )
             .await;
     }
-    bus_events::target_finished(
-        &bus,
-        target_id,
-        duration_ms,
-        &record.cache,
-        record.result.exit_code,
-    );
+    // The scheduler already fired `TargetCompleted` for the top-level
+    // target from `build_one`; publish only the outer `RunCompleted`
+    // here to avoid a duplicate completion line.
+    bus_events::run_completed(&bus, record.result.exit_code);
     write_record(output, &record).await?;
     write_runs_report(workspace, ui_server.as_ref()).await;
     emit_capability_completion_sounds(&record);

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -21,7 +21,7 @@ use std::time::Instant;
 
 use anyhow::{anyhow, Context, Result};
 use once_cas::{CacheProvider, Digest};
-use once_core::{EvidenceCacheState, LintSeverity, ResourceLimits, SandboxMode};
+use once_core::{EvidenceCacheState, LintSeverity, ResourceLimits, RunEventBus, SandboxMode};
 use once_frontend::analysis::AnalysisOptions;
 use once_frontend::GraphTarget;
 
@@ -33,7 +33,35 @@ use self::capability::{
 use self::lint::{
     lint_provider_output_path, persist_lint_results, validate_lint_provider, write_lint_results,
 };
-use crate::cli::Output;
+use crate::bus_events::{self, BusOutputObserver};
+use crate::cli::{ColorChoice, Format, Output};
+use crate::reporter::{ColorMode, ReporterOptions, TerminalReporter, Verbosity};
+
+/// Capacity of the per-run event bus. Sized so a burst of per-target
+/// phase and log events cannot make a slow subscriber drop its own
+/// snapshot updates.
+const EVENT_BUS_CAPACITY: usize = 1024;
+
+fn spawn_reporter(bus: &RunEventBus, output: Output, command_label: &str) -> Option<TerminalReporter> {
+    if output.format != Format::Human || output.quiet {
+        return None;
+    }
+    let options = ReporterOptions {
+        command_label: command_label.to_string(),
+        color: match output.color {
+            ColorChoice::Auto => ColorMode::Auto,
+            ColorChoice::Always => ColorMode::Always,
+            ColorChoice::Never => ColorMode::Never,
+        },
+        verbosity: match output.verbose {
+            0 => Verbosity::Normal,
+            1 => Verbosity::Verbose,
+            _ => Verbosity::ExtraVerbose,
+        },
+        suppress_panel: false,
+    };
+    Some(TerminalReporter::spawn(bus, options))
+}
 
 pub(crate) use configuration::ResolvedConfiguration;
 
@@ -89,6 +117,11 @@ pub async fn build(
     ui: bool,
 ) -> Result<ExitCode> {
     let started_at = Instant::now();
+    let bus = RunEventBus::new(EVENT_BUS_CAPACITY);
+    let command_label = format!("build {target_id}");
+    let reporter = spawn_reporter(&bus, output, &command_label);
+    bus_events::run_started(&bus, target_id, bus_events::now_ms());
+
     let ui_server = if ui {
         Some(crate::commands::ui::UiServer::start().await?)
     } else {
@@ -137,12 +170,21 @@ pub async fn build(
         publisher
             .progress(run_context, "Preparing the Once build graph…\n")
             .await;
-        publisher.target_cache_checking(run_context).await;
     }
+    bus_events::target_cache_checking(&bus, target_id);
     let live_output = publisher
         .as_ref()
         .zip(run_context.as_ref())
         .map(|(publisher, run_context)| publisher.live_output(run_context));
+    // If the UI dashboard is not attached, keep an observer that only
+    // publishes LogChunk events onto the bus so the terminal reporter
+    // (and the ingest client, when the feature is enabled) can still
+    // render captured child output.
+    let bus_observer: Option<std::sync::Arc<dyn once_core::ActionOutputObserver>> = if live_output.is_none() {
+        Some(BusOutputObserver::new(bus.clone(), target_id.to_string()))
+    } else {
+        None
+    };
     let xdg = once_core::Xdg::from_env();
     let stored_receipt =
         build_receipt::read(workspace, target_id, sandbox, &resolved.path_suffix).await;
@@ -165,6 +207,11 @@ pub async fn build(
     )
     .await
     {
+        let duration_ms: u64 = started_at
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
         if let (Some(publisher), Some(run_context)) = (&publisher, &run_context) {
             publisher
                 .progress(run_context, "Reused the previous Once build result.\n")
@@ -173,19 +220,17 @@ pub async fn build(
                 .finished(
                     run_context,
                     &record.action_digest,
-                    started_at
-                        .elapsed()
-                        .as_millis()
-                        .try_into()
-                        .unwrap_or(u64::MAX),
+                    duration_ms,
                     &record.cache,
                     0,
                     None,
                 )
                 .await;
         }
+        bus_events::target_finished(&bus, target_id, duration_ms, &record.cache, 0);
         write_record(output, &record).await?;
         write_runs_report(workspace, ui_server.as_ref()).await;
+        finish_reporter(reporter).await;
         return Ok(ExitCode::SUCCESS);
     }
     let changes = analysis::known_changes(initial_snapshot.as_ref(), digest_position.as_ref());
@@ -196,28 +241,27 @@ pub async fn build(
     {
         Ok(session) => {
             let session = session.with_resource_limits(resource_limits);
-            match &live_output {
-                Some(live_output) => session.with_output_observer(live_output.observer()),
-                None => session,
+            match (&live_output, &bus_observer) {
+                (Some(live_output), _) => session.with_output_observer(live_output.observer()),
+                (None, Some(observer)) => session.with_output_observer(observer.clone()),
+                (None, None) => session,
             }
         }
         Err(error) => {
+            let duration_ms: u64 = started_at
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
             if let (Some(publisher), Some(run_context)) = (&publisher, &run_context) {
                 publisher
                     .progress(run_context, &format!("Build setup failed: {error}\n"))
                     .await;
-                publisher
-                    .failed(
-                        run_context,
-                        started_at
-                            .elapsed()
-                            .as_millis()
-                            .try_into()
-                            .unwrap_or(u64::MAX),
-                    )
-                    .await;
+                publisher.failed(run_context, duration_ms).await;
             }
+            bus_events::target_failed(&bus, target_id, duration_ms);
             write_runs_report(workspace, ui_server.as_ref()).await;
+            finish_reporter(reporter).await;
             return Err(error);
         }
     };
@@ -228,14 +272,19 @@ pub async fn build(
                 "Analysing the Once targets and starting actions…\n",
             )
             .await;
-        publisher.target_preparing(run_context).await;
-        publisher.target_executing(run_context).await;
     }
+    bus_events::target_preparing(&bus, target_id);
+    bus_events::target_executing(&bus, target_id);
     session.with_known_changes(changes);
     let session = session;
     let target = match session.target(target_id) {
         Ok(target) => target,
         Err(error) => {
+            let duration_ms: u64 = started_at
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
             if let Some(live_output) = &live_output {
                 live_output.flush().await;
             }
@@ -243,18 +292,11 @@ pub async fn build(
                 publisher
                     .progress(run_context, &format!("Build setup failed: {error}\n"))
                     .await;
-                publisher
-                    .failed(
-                        run_context,
-                        started_at
-                            .elapsed()
-                            .as_millis()
-                            .try_into()
-                            .unwrap_or(u64::MAX),
-                    )
-                    .await;
+                publisher.failed(run_context, duration_ms).await;
             }
+            bus_events::target_failed(&bus, target_id, duration_ms);
             write_runs_report(workspace, ui_server.as_ref()).await;
+            finish_reporter(reporter).await;
             return Err(error);
         }
     };
@@ -266,6 +308,11 @@ pub async fn build(
             record
         }
         Err(error) => {
+            let duration_ms: u64 = started_at
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
             if let Some(live_output) = &live_output {
                 live_output.flush().await;
             }
@@ -273,18 +320,11 @@ pub async fn build(
                 publisher
                     .progress(run_context, &format!("Build failed: {error}\n"))
                     .await;
-                publisher
-                    .failed(
-                        run_context,
-                        started_at
-                            .elapsed()
-                            .as_millis()
-                            .try_into()
-                            .unwrap_or(u64::MAX),
-                    )
-                    .await;
+                publisher.failed(run_context, duration_ms).await;
             }
+            bus_events::target_failed(&bus, target_id, duration_ms);
             write_runs_report(workspace, ui_server.as_ref()).await;
+            finish_reporter(reporter).await;
             return Err(error);
         }
     };
@@ -295,24 +335,33 @@ pub async fn build(
     // so the fast path can never skip its mandatory work.
     if record.cache_state == EvidenceCacheState::Bypass {
         build_receipt::clear(workspace, target_id, sandbox, &resolved.path_suffix).await;
+        let duration_ms: u64 = started_at
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
         if let (Some(publisher), Some(run_context)) = (&publisher, &run_context) {
             publisher
                 .finished(
                     run_context,
                     &record.action_digest,
-                    started_at
-                        .elapsed()
-                        .as_millis()
-                        .try_into()
-                        .unwrap_or(u64::MAX),
+                    duration_ms,
                     &record.cache,
                     record.result.exit_code,
                     None,
                 )
                 .await;
         }
+        bus_events::target_finished(
+            &bus,
+            target_id,
+            duration_ms,
+            &record.cache,
+            record.result.exit_code,
+        );
         write_record(output, &record).await?;
         write_runs_report(workspace, ui_server.as_ref()).await;
+        finish_reporter(reporter).await;
         return Ok(ExitCode::SUCCESS);
     }
     // Where the journal stands, not where it will stand once the platform has
@@ -360,24 +409,32 @@ pub async fn build(
             .await;
         }
     }
+    let duration_ms: u64 = started_at
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    bus_events::target_capturing(&bus, target_id);
+    bus_events::target_publishing(&bus, target_id);
     if let (Some(publisher), Some(run_context)) = (&publisher, &run_context) {
-        publisher.target_capturing(run_context).await;
-        publisher.target_publishing(run_context).await;
         publisher
             .finished(
                 run_context,
                 &record.action_digest,
-                started_at
-                    .elapsed()
-                    .as_millis()
-                    .try_into()
-                    .unwrap_or(u64::MAX),
+                duration_ms,
                 &record.cache,
                 record.result.exit_code,
                 None,
             )
             .await;
     }
+    bus_events::target_finished(
+        &bus,
+        target_id,
+        duration_ms,
+        &record.cache,
+        record.result.exit_code,
+    );
     write_record(output, &record).await?;
     #[cfg(feature = "events-ingest")]
     if let Some(handle) = event_client.take() {
@@ -387,7 +444,16 @@ pub async fn build(
     }
     write_runs_report(workspace, ui_server.as_ref()).await;
     emit_capability_completion_sounds(&record);
+    finish_reporter(reporter).await;
     Ok(ExitCode::SUCCESS)
+}
+
+/// Await the terminal reporter's shutdown so its final summary lands
+/// before the CLI returns. A no-op when no reporter was spawned.
+async fn finish_reporter(reporter: Option<TerminalReporter>) {
+    if let Some(reporter) = reporter {
+        reporter.finish().await;
+    }
 }
 
 fn emit_capability_completion_sounds(record: &CapabilityRunRecord) {
@@ -535,6 +601,11 @@ pub async fn test_with_filters(
         }
     }
     let started_at = Instant::now();
+    let bus = RunEventBus::new(EVENT_BUS_CAPACITY);
+    let command_label = format!("test {target_id}");
+    let reporter = spawn_reporter(&bus, output, &command_label);
+    bus_events::run_started(&bus, target_id, bus_events::now_ms());
+
     let ui_server = if ui {
         Some(crate::commands::ui::UiServer::start().await?)
     } else {
@@ -566,32 +637,36 @@ pub async fn test_with_filters(
             .progress(run_context, "Preparing the Once test run…\n")
             .await;
     }
+    bus_events::target_cache_checking(&bus, target_id);
     let live_output = publisher
         .as_ref()
         .zip(run_context.as_ref())
         .map(|(publisher, run_context)| publisher.live_output(run_context));
+    let bus_observer: Option<std::sync::Arc<dyn once_core::ActionOutputObserver>> = if live_output.is_none() {
+        Some(BusOutputObserver::new(bus.clone(), target_id.to_string()))
+    } else {
+        None
+    };
     let graph = match once_frontend::load_graph_workspace_with_configuration(
         workspace,
         &resolved.configuration,
     ) {
         Ok(graph) => graph,
         Err(error) => {
+            let duration_ms: u64 = started_at
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
             if let (Some(publisher), Some(run_context)) = (&publisher, &run_context) {
                 publisher
                     .progress(run_context, &format!("Test setup failed: {error}\n"))
                     .await;
-                publisher
-                    .failed(
-                        run_context,
-                        started_at
-                            .elapsed()
-                            .as_millis()
-                            .try_into()
-                            .unwrap_or(u64::MAX),
-                    )
-                    .await;
+                publisher.failed(run_context, duration_ms).await;
             }
+            bus_events::target_failed(&bus, target_id, duration_ms);
             write_runs_report(workspace, ui_server.as_ref()).await;
+            finish_reporter(reporter).await;
             return Err(error).context("loading graph");
         }
     };
@@ -616,15 +691,18 @@ pub async fn test_with_filters(
     )
     .await?
     .with_resource_limits(resource_limits);
-    let session = match &live_output {
-        Some(live_output) => session.with_output_observer(live_output.observer()),
-        None => session,
+    let session = match (&live_output, &bus_observer) {
+        (Some(live_output), _) => session.with_output_observer(live_output.observer()),
+        (None, Some(observer)) => session.with_output_observer(observer.clone()),
+        (None, None) => session,
     };
     if let (Some(publisher), Some(run_context)) = (&publisher, &run_context) {
         publisher
             .progress(run_context, "Running the selected Once test target…\n")
             .await;
     }
+    bus_events::target_preparing(&bus, target_id);
+    bus_events::target_executing(&bus, target_id);
     let target = session.target(target_id)?;
     let test_capability = ensure_capability(target, "test")?;
     if !test_capability.requires_outputs.is_empty()
@@ -681,25 +759,36 @@ pub async fn test_with_filters(
     }
     let test_results =
         load_test_results_for_runs(workspace, target_id, record.test_results.as_deref());
+    let duration_ms: u64 = started_at
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    bus_events::target_capturing(&bus, target_id);
+    bus_events::target_publishing(&bus, target_id);
     if let (Some(publisher), Some(run_context)) = (&publisher, &run_context) {
         publisher
             .finished(
                 run_context,
                 &record.action_digest,
-                started_at
-                    .elapsed()
-                    .as_millis()
-                    .try_into()
-                    .unwrap_or(u64::MAX),
+                duration_ms,
                 &record.cache,
                 record.result.exit_code,
                 test_results,
             )
             .await;
     }
+    bus_events::target_finished(
+        &bus,
+        target_id,
+        duration_ms,
+        &record.cache,
+        record.result.exit_code,
+    );
     write_record(output, &record).await?;
     write_runs_report(workspace, ui_server.as_ref()).await;
     emit_capability_completion_sounds(&record);
+    finish_reporter(reporter).await;
     Ok(ExitCode::SUCCESS)
 }
 

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -42,7 +42,11 @@ use crate::reporter::{ColorMode, ReporterOptions, TerminalReporter, Verbosity};
 /// snapshot updates.
 const EVENT_BUS_CAPACITY: usize = 1024;
 
-fn spawn_reporter(bus: &RunEventBus, output: Output, command_label: &str) -> Option<TerminalReporter> {
+fn spawn_reporter(
+    bus: &RunEventBus,
+    output: Output,
+    command_label: &str,
+) -> Option<TerminalReporter> {
     if output.format != Format::Human || output.quiet {
         return None;
     }
@@ -180,11 +184,12 @@ pub async fn build(
     // publishes LogChunk events onto the bus so the terminal reporter
     // (and the ingest client, when the feature is enabled) can still
     // render captured child output.
-    let bus_observer: Option<std::sync::Arc<dyn once_core::ActionOutputObserver>> = if live_output.is_none() {
-        Some(BusOutputObserver::new(bus.clone(), target_id.to_string()))
-    } else {
-        None
-    };
+    let bus_observer: Option<std::sync::Arc<dyn once_core::ActionOutputObserver>> =
+        if live_output.is_none() {
+            Some(BusOutputObserver::new(bus.clone(), target_id.to_string()))
+        } else {
+            None
+        };
     let xdg = once_core::Xdg::from_env();
     let stored_receipt =
         build_receipt::read(workspace, target_id, sandbox, &resolved.path_suffix).await;
@@ -642,11 +647,12 @@ pub async fn test_with_filters(
         .as_ref()
         .zip(run_context.as_ref())
         .map(|(publisher, run_context)| publisher.live_output(run_context));
-    let bus_observer: Option<std::sync::Arc<dyn once_core::ActionOutputObserver>> = if live_output.is_none() {
-        Some(BusOutputObserver::new(bus.clone(), target_id.to_string()))
-    } else {
-        None
-    };
+    let bus_observer: Option<std::sync::Arc<dyn once_core::ActionOutputObserver>> =
+        if live_output.is_none() {
+            Some(BusOutputObserver::new(bus.clone(), target_id.to_string()))
+        } else {
+            None
+        };
     let graph = match once_frontend::load_graph_workspace_with_configuration(
         workspace,
         &resolved.configuration,

--- a/crates/once-cli/src/commands/swift/mod.rs
+++ b/crates/once-cli/src/commands/swift/mod.rs
@@ -29,7 +29,9 @@ pub async fn run(
         return passthrough::run(&argv);
     };
     let resolved = crate::commands::graph::resolve_invocation_configuration(workspace, &[])?;
-    let output = Output::new(output.format, output.quiet || invocation.quiet);
+    let output = Output::new(output.format, output.quiet || invocation.quiet)
+        .with_color(output.color)
+        .with_verbose(output.verbose);
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
     match invocation.command {
         invocation::Command::Build => {

--- a/crates/once-cli/src/commands/ui.rs
+++ b/crates/once-cli/src/commands/ui.rs
@@ -4,9 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use once_core::{
-    ActionOutputObserver, ActionOutputStream, LogStream, RunEvent, RunEventBus,
-};
+use once_core::{ActionOutputObserver, ActionOutputStream, LogStream, RunEvent, RunEventBus};
 use once_frontend::{AttrValue, BuildConfiguration};
 use serde::Serialize;
 use tokio::sync::{mpsc, oneshot};

--- a/crates/once-cli/src/commands/ui.rs
+++ b/crates/once-cli/src/commands/ui.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use once_core::{
-    ActionOutputObserver, ActionOutputStream, LogStream, Phase, RunEvent, RunEventBus, TargetResult,
+    ActionOutputObserver, ActionOutputStream, LogStream, RunEvent, RunEventBus,
 };
 use once_frontend::{AttrValue, BuildConfiguration};
 use serde::Serialize;
@@ -262,6 +262,9 @@ impl Publisher {
         self.store.event_bus()
     }
 
+    /// Announce that the run started, seeding the UI snapshot store.
+    /// Bus emission for the lifecycle event lives in
+    /// [`crate::bus_events`] so a run without the UI still fires it.
     #[allow(clippy::unused_async)]
     pub async fn started(&self, context: &RunContext) {
         self.store.replace(RunSnapshot {
@@ -284,80 +287,15 @@ impl Publisher {
             static_report_path: None,
             output_byte_count: 0,
         });
-        let bus = self.event_bus();
-        bus.publish(RunEvent::RunStarted {
-            at_epoch_ms: i64::try_from(context.started_at_ms).unwrap_or(i64::MAX),
-        });
-        bus.publish(RunEvent::TargetQueued {
-            at_epoch_ms: i64::try_from(context.started_at_ms).unwrap_or(i64::MAX),
-            target_id: context.target.clone(),
-        });
     }
 
-    /// Announce that the target is doing an action-cache lookup.
-    #[allow(clippy::unused_async)]
-    pub async fn target_cache_checking(&self, context: &RunContext) {
-        self.event_bus().publish(RunEvent::TargetPhase {
-            at_epoch_ms: now_epoch_ms(),
-            target_id: context.target.clone(),
-            phase: Phase::CacheChecking,
-        });
-    }
-
-    /// Announce that the target has moved past cache decision into
-    /// worker allocation, sandbox setup, and input materialization.
-    #[allow(clippy::unused_async)]
-    pub async fn target_preparing(&self, context: &RunContext) {
-        self.event_bus().publish(RunEvent::TargetPhase {
-            at_epoch_ms: now_epoch_ms(),
-            target_id: context.target.clone(),
-            phase: Phase::Preparing,
-        });
-    }
-
-    /// Announce that the target subprocess has finished and outputs
-    /// are being collected and validated.
-    #[allow(clippy::unused_async)]
-    pub async fn target_capturing(&self, context: &RunContext) {
-        self.event_bus().publish(RunEvent::TargetPhase {
-            at_epoch_ms: now_epoch_ms(),
-            target_id: context.target.clone(),
-            phase: Phase::Capturing,
-        });
-    }
-
-    /// Announce that the target has begun executing. Emits
-    /// `TargetStarted` followed by `TargetPhase(Executing)`.
-    #[allow(clippy::unused_async)]
-    pub async fn target_executing(&self, context: &RunContext) {
-        let bus = self.event_bus();
-        let at = now_epoch_ms();
-        bus.publish(RunEvent::TargetStarted {
-            at_epoch_ms: at,
-            target_id: context.target.clone(),
-        });
-        bus.publish(RunEvent::TargetPhase {
-            at_epoch_ms: at,
-            target_id: context.target.clone(),
-            phase: Phase::Executing,
-        });
-    }
-
-    /// Announce that the target has moved into the publishing phase
-    /// (writing outputs and evidence to CAS).
-    #[allow(clippy::unused_async)]
-    pub async fn target_publishing(&self, context: &RunContext) {
-        self.event_bus().publish(RunEvent::TargetPhase {
-            at_epoch_ms: now_epoch_ms(),
-            target_id: context.target.clone(),
-            phase: Phase::Publishing,
-        });
-    }
-
+    /// Update the UI snapshot with the run's terminal state. Bus
+    /// emission of `TargetCompleted` and `RunCompleted` lives in
+    /// [`crate::bus_events`] so it fires whether or not the UI is on.
     #[allow(clippy::unused_async)]
     pub async fn finished(
         &self,
-        context: &RunContext,
+        _context: &RunContext,
         action_digest: &str,
         duration_ms: u64,
         cache: &str,
@@ -377,42 +315,17 @@ impl Publisher {
             run.exit_code = Some(exit_code);
             run.test_results = test_results;
         });
-        let bus = self.event_bus();
-        bus.publish(RunEvent::TargetCompleted {
-            at_epoch_ms: now_epoch_ms(),
-            target_id: context.target.clone(),
-            result: if exit_code == 0 {
-                TargetResult::Succeeded
-            } else {
-                TargetResult::Failed
-            },
-            was_cached: cache.eq_ignore_ascii_case("hit"),
-            duration_ms: i64::try_from(duration_ms).unwrap_or(i64::MAX),
-        });
-        bus.publish(RunEvent::RunCompleted {
-            at_epoch_ms: now_epoch_ms(),
-            exit_status: exit_code,
-        });
     }
 
+    /// Update the UI snapshot with a failure that terminated before the
+    /// action reached the runner. Bus emission of the corresponding
+    /// terminal events lives in [`crate::bus_events`].
     #[allow(clippy::unused_async)]
-    pub async fn failed(&self, context: &RunContext, duration_ms: u64) {
+    pub async fn failed(&self, _context: &RunContext, duration_ms: u64) {
         self.store.update(|run| {
             run.status = "failed".to_string();
             run.duration_ms = Some(duration_ms);
             run.exit_code = Some(1);
-        });
-        let bus = self.event_bus();
-        bus.publish(RunEvent::TargetCompleted {
-            at_epoch_ms: now_epoch_ms(),
-            target_id: context.target.clone(),
-            result: TargetResult::Failed,
-            was_cached: false,
-            duration_ms: i64::try_from(duration_ms).unwrap_or(i64::MAX),
-        });
-        bus.publish(RunEvent::RunCompleted {
-            at_epoch_ms: now_epoch_ms(),
-            exit_status: 1,
         });
     }
 

--- a/crates/once-cli/src/commands/xcodebuild/mod.rs
+++ b/crates/once-cli/src/commands/xcodebuild/mod.rs
@@ -30,7 +30,9 @@ pub async fn run(
     Box::pin(crate::commands::graph::build(
         workspace,
         &cache,
-        Output::new(output.format, output.quiet || invocation.quiet),
+        Output::new(output.format, output.quiet || invocation.quiet)
+            .with_color(output.color)
+            .with_verbose(output.verbose),
         &target,
         SandboxMode::Off,
         resource_limits,

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -10,7 +10,9 @@ use crate::cli::{self, Cli, Cmd, Output};
 use crate::commands;
 
 pub(crate) async fn dispatch(cli: Cli) -> Result<ExitCode> {
-    let output = Output::new(cli.format, cli.quiet);
+    let output = Output::new(cli.format, cli.quiet)
+        .with_color(cli.color)
+        .with_verbose(cli.verbose);
     if cli.list {
         return commands::surface::print(&cli.surface_path(), output)
             .await

--- a/crates/once-cli/src/main.rs
+++ b/crates/once-cli/src/main.rs
@@ -2,6 +2,7 @@
 //! to the verb modules under [`commands`], and propagates the
 //! resulting exit code.
 
+mod bus_events;
 mod cache_provider;
 mod cli;
 mod commands;
@@ -9,6 +10,7 @@ mod dispatch;
 mod logging;
 mod reference;
 mod render;
+mod reporter;
 mod sound;
 
 use std::ffi::OsStr;

--- a/crates/once-cli/src/reporter.rs
+++ b/crates/once-cli/src/reporter.rs
@@ -162,6 +162,12 @@ struct CapturedOutput {
     stderr: Vec<u8>,
 }
 
+/// Function pointer that wraps a string in one of the reporter's
+/// styling roles (green success, red failure, and so on). Aliased here
+/// to keep the completion match arm readable and satisfy
+/// clippy's `type_complexity` lint.
+type StyleFn = fn(String) -> console::StyledObject<String>;
+
 #[derive(Default, Clone, Copy)]
 struct Totals {
     started: usize,
@@ -216,10 +222,15 @@ impl RenderState {
     }
 
     /// Returns `true` when the run is complete and the reporter can stop.
+    ///
+    /// The wildcard arm covers not just future `RunEvent` variants
+    /// (the enum is `#[non_exhaustive]`) but also every variant that
+    /// today is a no-op for the reporter: `RunStarted`, `TargetQueued`,
+    /// and the test-suite/test-case events. Consolidating them keeps
+    /// clippy's `match_same_arms` happy without a target-by-target
+    /// list of `=> false` branches.
     fn handle_event(&mut self, event: RunEvent) -> bool {
         match event {
-            RunEvent::RunStarted { .. } => false,
-            RunEvent::TargetQueued { .. } => false,
             RunEvent::TargetStarted { target_id, .. } => {
                 self.totals.started += 1;
                 self.on_target_started(&target_id);
@@ -252,10 +263,6 @@ impl RenderState {
                 self.refresh_summary();
                 false
             }
-            RunEvent::TestSuiteStarted { .. }
-            | RunEvent::TestSuiteCompleted { .. }
-            | RunEvent::TestCaseStarted { .. }
-            | RunEvent::TestCaseCompleted { .. } => false,
             RunEvent::RunCompleted { .. } => true,
             _ => false,
         }
@@ -284,7 +291,9 @@ impl RenderState {
         if let Some(entry) = self.active.get_mut(target_id) {
             entry.phase = phase;
             let elapsed = entry.started_at.elapsed();
-            entry.bar.set_message(active_line(target_id, phase, elapsed));
+            entry
+                .bar
+                .set_message(active_line(target_id, phase, elapsed));
         }
     }
 
@@ -321,19 +330,18 @@ impl RenderState {
         }
 
         let duration = format_duration_ms(duration_ms);
-        let (icon, tag, style_fn): (&str, &str, fn(String) -> console::StyledObject<String>) =
-            match (result, was_cached) {
-                (TargetResult::Succeeded, true) => ("✓", "cached", |s| style(s).green()),
-                (TargetResult::Succeeded, false) => ("✓", "built", |s| style(s).green()),
-                (TargetResult::Failed, _) => ("✗", "failed", |s| style(s).red().bold()),
-                (TargetResult::Skipped, _) => ("○", "skipped", |s| style(s).dim()),
-                (TargetResult::Cancelled, _) => ("⊘", "cancelled", |s| style(s).yellow()),
-            };
+        let (icon, tag, style_fn): (&str, &str, StyleFn) = match (result, was_cached) {
+            (TargetResult::Succeeded, true) => ("✓", "cached", |s| style(s).green()),
+            (TargetResult::Succeeded, false) => ("✓", "built", |s| style(s).green()),
+            (TargetResult::Failed, _) => ("✗", "failed", |s| style(s).red().bold()),
+            (TargetResult::Skipped, _) => ("○", "skipped", |s| style(s).dim()),
+            (TargetResult::Cancelled, _) => ("⊘", "cancelled", |s| style(s).yellow()),
+        };
 
         match (result, was_cached) {
             (TargetResult::Succeeded, true) => self.totals.cached += 1,
             (TargetResult::Succeeded, false) => self.totals.built += 1,
-            (TargetResult::Failed, _) | (TargetResult::Cancelled, _) => self.totals.failed += 1,
+            (TargetResult::Failed | TargetResult::Cancelled, _) => self.totals.failed += 1,
             (TargetResult::Skipped, _) => self.totals.skipped += 1,
         }
 
@@ -407,7 +415,8 @@ impl RenderState {
 
     fn summary_message(&self) -> String {
         let running = self.active.len();
-        let done = self.totals.built + self.totals.cached + self.totals.failed + self.totals.skipped;
+        let done =
+            self.totals.built + self.totals.cached + self.totals.failed + self.totals.skipped;
         let cache_pct = if self.totals.built + self.totals.cached > 0 {
             let denom = self.totals.built + self.totals.cached;
             (self.totals.cached * 100) / denom
@@ -423,11 +432,9 @@ impl RenderState {
     }
 
     fn warn_lagged(&self, missed: u64) {
-        let msg = style(format!(
-            "(reporter fell behind; {missed} events dropped)"
-        ))
-        .yellow()
-        .dim();
+        let msg = style(format!("(reporter fell behind; {missed} events dropped)"))
+            .yellow()
+            .dim();
         self.emit(format!("  {msg}"));
     }
 

--- a/crates/once-cli/src/reporter.rs
+++ b/crates/once-cli/src/reporter.rs
@@ -1,0 +1,602 @@
+//! Beautiful terminal renderer for build and test runs.
+//!
+//! Subscribes to the [`RunEventBus`] and draws a layered dashboard on
+//! stderr: completed targets scroll upward as short one-line summaries,
+//! and a sticky panel at the bottom shows the summary line plus one
+//! spinner per in-flight target with its current phase.
+//!
+//! On a non-TTY stderr (CI, piped, agent), the sticky panel is hidden
+//! and only the per-completion lines are emitted, one per line, so the
+//! output is grep-friendly and doesn't fight with the harness. Color
+//! honors `--color=auto|always|never` and the standard `NO_COLOR`,
+//! `CLICOLOR_FORCE`, and `TERM=dumb` environment variables via `console`.
+//!
+//! The reporter never blocks a producer: it consumes events on a
+//! `broadcast` receiver and drops with a warning when it falls behind
+//! the bus's ring. Producers only ever `send`.
+//!
+//! Verbosity has three levels that affect what captured child output
+//! surfaces:
+//!
+//! - `Normal` prints captured stderr only for failed targets.
+//! - `Verbose` also prints a short tail of captured output for every
+//!   completed target.
+//! - `ExtraVerbose` prints the full captured stdout+stderr for every
+//!   target, prefixed by target id.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use console::{style, Style};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use once_core::{LogStream, Phase, RunEvent, RunEventBus, TargetResult};
+use tokio::sync::broadcast::error::RecvError;
+use tokio::task::JoinHandle;
+
+/// How color should be applied to the reporter's output.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum ColorMode {
+    /// Colored output when stderr is a TTY and no override forbids it.
+    #[default]
+    Auto,
+    /// Force colored output.
+    Always,
+    /// Suppress all color escape sequences.
+    Never,
+}
+
+/// How much captured child output to surface for successful targets.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum Verbosity {
+    /// Only print captured output for failed targets. The default.
+    #[default]
+    Normal,
+    /// Also print the last few lines of captured output for every target.
+    Verbose,
+    /// Print all captured output for every target, live-prefixed.
+    ExtraVerbose,
+}
+
+/// Options controlling how the reporter renders a run.
+#[derive(Clone, Debug)]
+pub struct ReporterOptions {
+    /// A short label naming the run, e.g. `"build ripgrep-cli"`.
+    pub command_label: String,
+    pub color: ColorMode,
+    pub verbosity: Verbosity,
+    /// When true, do not draw the sticky bottom panel; only render
+    /// per-completion lines and the final summary. Set by `--quiet`.
+    pub suppress_panel: bool,
+}
+
+/// A running terminal reporter subscribed to a [`RunEventBus`].
+///
+/// Drop or [`finish`](Self::finish) to tear down cleanly.
+pub struct TerminalReporter {
+    handle: JoinHandle<()>,
+    multi: Arc<MultiProgress>,
+}
+
+impl TerminalReporter {
+    /// Subscribe to the bus and spawn a background task that renders
+    /// events as they arrive. Returns immediately.
+    #[must_use]
+    pub fn spawn(bus: &RunEventBus, options: ReporterOptions) -> Self {
+        apply_color_mode(options.color);
+
+        let draw_target = if options.suppress_panel {
+            ProgressDrawTarget::hidden()
+        } else {
+            ProgressDrawTarget::stderr()
+        };
+        let multi = Arc::new(MultiProgress::with_draw_target(draw_target));
+
+        let mut receiver = bus.subscribe();
+        let render_multi = Arc::clone(&multi);
+        let handle = tokio::spawn(async move {
+            let mut state = RenderState::new(render_multi, options);
+            state.render_header();
+            loop {
+                match receiver.recv().await {
+                    Ok(event) => {
+                        if state.handle_event(event) {
+                            break;
+                        }
+                    }
+                    Err(RecvError::Closed) => break,
+                    Err(RecvError::Lagged(missed)) => {
+                        state.warn_lagged(missed);
+                    }
+                }
+            }
+            state.finalize();
+        });
+
+        Self { handle, multi }
+    }
+
+    /// Wait for the reporter to finish rendering. This does not on its
+    /// own tell the reporter to stop; it returns when the bus closes
+    /// (all `RunEventBus` clones dropped) or a `RunCompleted` event has
+    /// been consumed.
+    pub async fn finish(self) {
+        let _ = self.handle.await;
+        let _ = self.multi.clear();
+    }
+}
+
+fn apply_color_mode(mode: ColorMode) {
+    match mode {
+        ColorMode::Auto => {}
+        ColorMode::Always => {
+            console::set_colors_enabled_stderr(true);
+            console::set_colors_enabled(true);
+        }
+        ColorMode::Never => {
+            console::set_colors_enabled_stderr(false);
+            console::set_colors_enabled(false);
+        }
+    }
+}
+
+struct RenderState {
+    multi: Arc<MultiProgress>,
+    options: ReporterOptions,
+    started_at: Instant,
+    summary: Option<ProgressBar>,
+    active: HashMap<String, ActiveTarget>,
+    captured: HashMap<String, CapturedOutput>,
+    totals: Totals,
+}
+
+struct ActiveTarget {
+    bar: ProgressBar,
+    started_at: Instant,
+    phase: Phase,
+}
+
+#[derive(Default)]
+struct CapturedOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+#[derive(Default, Clone, Copy)]
+struct Totals {
+    started: usize,
+    cached: usize,
+    built: usize,
+    failed: usize,
+    skipped: usize,
+}
+
+impl RenderState {
+    fn new(multi: Arc<MultiProgress>, options: ReporterOptions) -> Self {
+        Self {
+            multi,
+            options,
+            started_at: Instant::now(),
+            summary: None,
+            active: HashMap::new(),
+            captured: HashMap::new(),
+            totals: Totals::default(),
+        }
+    }
+
+    fn render_header(&mut self) {
+        let label = &self.options.command_label;
+        let header = style(format!("once  {label}")).bold();
+        let divider = style("─".repeat(40)).dim();
+        self.emit(format!("\n  {header}\n  {divider}"));
+
+        if !self.options.suppress_panel {
+            let summary = self.multi.add(ProgressBar::new_spinner());
+            summary.set_style(spinner_style_bold());
+            summary.set_message(self.summary_message());
+            summary.enable_steady_tick(Duration::from_millis(80));
+            self.summary = Some(summary);
+        }
+    }
+
+    /// Print a stand-alone line. When the sticky panel is active
+    /// (`MultiProgress` on a TTY), route through `println` so it lands
+    /// above the bars. Otherwise write straight to stderr so lines
+    /// still appear when indicatif's draw target is hidden.
+    fn emit(&self, text: impl AsRef<str>) {
+        use std::io::Write as _;
+        if console::user_attended_stderr() {
+            let _ = self.multi.println(text.as_ref());
+            return;
+        }
+        let stderr = std::io::stderr();
+        let mut handle = stderr.lock();
+        let _ = handle.write_all(text.as_ref().as_bytes());
+        let _ = handle.write_all(b"\n");
+    }
+
+    /// Returns `true` when the run is complete and the reporter can stop.
+    fn handle_event(&mut self, event: RunEvent) -> bool {
+        match event {
+            RunEvent::RunStarted { .. } => false,
+            RunEvent::TargetQueued { .. } => false,
+            RunEvent::TargetStarted { target_id, .. } => {
+                self.totals.started += 1;
+                self.on_target_started(&target_id);
+                self.refresh_summary();
+                false
+            }
+            RunEvent::TargetPhase {
+                target_id, phase, ..
+            } => {
+                self.on_target_phase(&target_id, phase);
+                false
+            }
+            RunEvent::LogChunk {
+                target_id,
+                stream,
+                bytes,
+                ..
+            } => {
+                self.on_log_chunk(&target_id, stream, &bytes);
+                false
+            }
+            RunEvent::TargetCompleted {
+                target_id,
+                result,
+                was_cached,
+                duration_ms,
+                ..
+            } => {
+                self.on_target_completed(&target_id, result, was_cached, duration_ms);
+                self.refresh_summary();
+                false
+            }
+            RunEvent::TestSuiteStarted { .. }
+            | RunEvent::TestSuiteCompleted { .. }
+            | RunEvent::TestCaseStarted { .. }
+            | RunEvent::TestCaseCompleted { .. } => false,
+            RunEvent::RunCompleted { .. } => true,
+            _ => false,
+        }
+    }
+
+    fn on_target_started(&mut self, target_id: &str) {
+        if self.options.suppress_panel {
+            return;
+        }
+        if self.active.contains_key(target_id) {
+            return;
+        }
+        let bar = self.multi.add(ProgressBar::new_spinner());
+        bar.set_style(spinner_style_child());
+        bar.set_message(active_line(target_id, Phase::Executing, Duration::ZERO));
+        bar.enable_steady_tick(Duration::from_millis(80));
+        let entry = ActiveTarget {
+            bar,
+            started_at: Instant::now(),
+            phase: Phase::Executing,
+        };
+        self.active.insert(target_id.to_string(), entry);
+    }
+
+    fn on_target_phase(&mut self, target_id: &str, phase: Phase) {
+        if let Some(entry) = self.active.get_mut(target_id) {
+            entry.phase = phase;
+            let elapsed = entry.started_at.elapsed();
+            entry.bar.set_message(active_line(target_id, phase, elapsed));
+        }
+    }
+
+    fn on_log_chunk(&mut self, target_id: &str, stream: LogStream, bytes: &[u8]) {
+        let entry = self.captured.entry(target_id.to_string()).or_default();
+        let buf = match stream {
+            LogStream::Stdout => &mut entry.stdout,
+            LogStream::Stderr => &mut entry.stderr,
+        };
+        buf.extend_from_slice(bytes);
+
+        if matches!(self.options.verbosity, Verbosity::ExtraVerbose) {
+            for line in split_lines(bytes) {
+                let prefix = style(format!("{target_id}: ")).dim();
+                let text = String::from_utf8_lossy(line);
+                let styled = match stream {
+                    LogStream::Stdout => style(text.to_string()),
+                    LogStream::Stderr => style(text.to_string()).yellow(),
+                };
+                self.emit(format!("  {prefix}{styled}"));
+            }
+        }
+    }
+
+    fn on_target_completed(
+        &mut self,
+        target_id: &str,
+        result: TargetResult,
+        was_cached: bool,
+        duration_ms: i64,
+    ) {
+        if let Some(entry) = self.active.remove(target_id) {
+            entry.bar.finish_and_clear();
+        }
+
+        let duration = format_duration_ms(duration_ms);
+        let (icon, tag, style_fn): (&str, &str, fn(String) -> console::StyledObject<String>) =
+            match (result, was_cached) {
+                (TargetResult::Succeeded, true) => ("✓", "cached", |s| style(s).green()),
+                (TargetResult::Succeeded, false) => ("✓", "built", |s| style(s).green()),
+                (TargetResult::Failed, _) => ("✗", "failed", |s| style(s).red().bold()),
+                (TargetResult::Skipped, _) => ("○", "skipped", |s| style(s).dim()),
+                (TargetResult::Cancelled, _) => ("⊘", "cancelled", |s| style(s).yellow()),
+            };
+
+        match (result, was_cached) {
+            (TargetResult::Succeeded, true) => self.totals.cached += 1,
+            (TargetResult::Succeeded, false) => self.totals.built += 1,
+            (TargetResult::Failed, _) | (TargetResult::Cancelled, _) => self.totals.failed += 1,
+            (TargetResult::Skipped, _) => self.totals.skipped += 1,
+        }
+
+        let icon = style_fn(icon.to_string());
+        let name = style(target_id.to_string()).bold();
+        let name = pad_right(&name.to_string(), 32);
+        let tag_col = style_fn(pad_right(tag, 10));
+        let dur = style(duration).dim();
+        self.emit(format!("  {icon} {name} {tag_col} {dur}"));
+
+        let captured = self.captured.remove(target_id).unwrap_or_default();
+        if matches!(result, TargetResult::Failed) {
+            self.print_captured(target_id, &captured, /*failure=*/ true);
+        } else if matches!(self.options.verbosity, Verbosity::Verbose) {
+            self.print_captured_tail(&captured);
+        } else if matches!(self.options.verbosity, Verbosity::ExtraVerbose) {
+            // Already streamed live via on_log_chunk.
+        }
+    }
+
+    fn print_captured(&self, _target_id: &str, captured: &CapturedOutput, failure: bool) {
+        let mut lines: Vec<Vec<u8>> = Vec::new();
+        for line in split_lines(&captured.stderr) {
+            lines.push(line.to_vec());
+        }
+        if lines.is_empty() {
+            for line in split_lines(&captured.stdout) {
+                lines.push(line.to_vec());
+            }
+        }
+        if lines.is_empty() {
+            return;
+        }
+        let bar_style: Box<dyn Fn(String) -> console::StyledObject<String>> = if failure {
+            Box::new(|s| style(s).red())
+        } else {
+            Box::new(|s| style(s).dim())
+        };
+        self.emit("");
+        for line in lines {
+            let text = String::from_utf8_lossy(&line);
+            let prefix = bar_style("│".to_string());
+            self.emit(format!("    {prefix} {text}"));
+        }
+        self.emit("");
+    }
+
+    fn print_captured_tail(&self, captured: &CapturedOutput) {
+        const TAIL_LINES: usize = 3;
+        let mut all: Vec<Vec<u8>> = split_lines(&captured.stdout)
+            .into_iter()
+            .chain(split_lines(&captured.stderr))
+            .map(<[u8]>::to_vec)
+            .collect();
+        if all.is_empty() {
+            return;
+        }
+        let start = all.len().saturating_sub(TAIL_LINES);
+        for line in all.drain(start..) {
+            let text = String::from_utf8_lossy(&line);
+            let prefix = style("│".to_string()).dim();
+            self.emit(format!("    {prefix} {text}"));
+        }
+    }
+
+    fn refresh_summary(&mut self) {
+        if let Some(summary) = &self.summary {
+            summary.set_message(self.summary_message());
+        }
+    }
+
+    fn summary_message(&self) -> String {
+        let running = self.active.len();
+        let done = self.totals.built + self.totals.cached + self.totals.failed + self.totals.skipped;
+        let cache_pct = if self.totals.built + self.totals.cached > 0 {
+            let denom = self.totals.built + self.totals.cached;
+            (self.totals.cached * 100) / denom
+        } else {
+            0
+        };
+        let label = &self.options.command_label;
+        let stats = style(format!(
+            "{done} done · {running} running · cache {cache_pct}%"
+        ))
+        .dim();
+        format!("{} · {stats}", style(label).bold())
+    }
+
+    fn warn_lagged(&self, missed: u64) {
+        let msg = style(format!(
+            "(reporter fell behind; {missed} events dropped)"
+        ))
+        .yellow()
+        .dim();
+        self.emit(format!("  {msg}"));
+    }
+
+    fn finalize(&mut self) {
+        for (_, entry) in self.active.drain() {
+            entry.bar.finish_and_clear();
+        }
+        if let Some(summary) = self.summary.take() {
+            summary.finish_and_clear();
+        }
+        let elapsed = self.started_at.elapsed();
+        let t = self.totals;
+        let mut segments: Vec<console::StyledObject<String>> = Vec::new();
+        if t.failed > 0 {
+            segments.push(style(format!("{} failed", t.failed)).red().bold());
+        }
+        if t.built > 0 {
+            segments.push(style(format!("{} built", t.built)).green());
+        }
+        if t.cached > 0 {
+            segments.push(style(format!("{} cached", t.cached)).dim());
+        }
+        if t.skipped > 0 {
+            segments.push(style(format!("{} skipped", t.skipped)).dim());
+        }
+        if segments.is_empty() {
+            segments.push(style("no targets".to_string()).dim());
+        }
+        let joined = segments
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let done_word = if t.failed > 0 {
+            style("Failed".to_string()).red().bold()
+        } else {
+            style("Done".to_string()).green().bold()
+        };
+        let dur = style(format!("in {}", format_duration(elapsed))).dim();
+        self.emit(format!("\n  {done_word}  {joined}  {dur}\n"));
+    }
+}
+
+fn spinner_style_bold() -> ProgressStyle {
+    ProgressStyle::with_template("  {spinner:.cyan.bold} {msg}")
+        .expect("valid spinner template")
+        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ")
+}
+
+fn spinner_style_child() -> ProgressStyle {
+    ProgressStyle::with_template("    {spinner:.cyan} {msg}")
+        .expect("valid spinner template")
+        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ")
+}
+
+fn active_line(target_id: &str, phase: Phase, elapsed: Duration) -> String {
+    let name = pad_right(target_id, 32);
+    let phase_label = phase_label(phase);
+    let phase_col = pad_right(phase_label, 10);
+    let phase_styled = phase_style(phase).apply_to(phase_col).to_string();
+    let dur = style(format_duration(elapsed)).dim();
+    format!("{name} {phase_styled} {dur}")
+}
+
+fn phase_label(phase: Phase) -> &'static str {
+    match phase {
+        Phase::Queued => "queued",
+        Phase::CacheChecking => "cache-lookup",
+        Phase::Preparing => "preparing",
+        Phase::Executing => "executing",
+        Phase::Capturing => "capturing",
+        Phase::Publishing => "publishing",
+    }
+}
+
+fn phase_style(phase: Phase) -> Style {
+    match phase {
+        Phase::Queued | Phase::CacheChecking | Phase::Preparing => Style::new().dim(),
+        Phase::Executing => Style::new().cyan(),
+        Phase::Capturing | Phase::Publishing => Style::new().magenta(),
+    }
+}
+
+fn format_duration(duration: Duration) -> String {
+    let secs = duration.as_secs_f64();
+    if secs < 1.0 {
+        format!("{}ms", duration.as_millis())
+    } else if secs < 60.0 {
+        format!("{secs:.1}s")
+    } else {
+        let mins = duration.as_secs() / 60;
+        let s = duration.as_secs() % 60;
+        format!("{mins}m{s:02}s")
+    }
+}
+
+fn format_duration_ms(duration_ms: i64) -> String {
+    if duration_ms < 0 {
+        return "?".to_string();
+    }
+    let ms = u64::try_from(duration_ms).unwrap_or(0);
+    format_duration(Duration::from_millis(ms))
+}
+
+fn pad_right(text: &str, width: usize) -> String {
+    let display_width = console::measure_text_width(text);
+    if display_width >= width {
+        text.to_string()
+    } else {
+        let pad = width - display_width;
+        format!("{text}{}", " ".repeat(pad))
+    }
+}
+
+fn split_lines(bytes: &[u8]) -> Vec<&[u8]> {
+    let mut out = Vec::new();
+    for line in bytes.split(|&b| b == b'\n') {
+        if !line.is_empty() {
+            out.push(line);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_duration_switches_units() {
+        assert_eq!(format_duration(Duration::from_millis(120)), "120ms");
+        assert_eq!(format_duration(Duration::from_millis(1200)), "1.2s");
+        assert_eq!(format_duration(Duration::from_secs(75)), "1m15s");
+    }
+
+    #[test]
+    fn split_lines_drops_trailing_newline_and_empty_frames() {
+        let lines = split_lines(b"a\nb\n\nc");
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], b"a");
+        assert_eq!(lines[1], b"b");
+        assert_eq!(lines[2], b"c");
+    }
+
+    #[test]
+    fn pad_right_measures_display_width() {
+        let padded = pad_right("hi", 6);
+        assert_eq!(console::measure_text_width(&padded), 6);
+    }
+
+    #[tokio::test]
+    async fn reporter_finishes_when_run_completed_seen() {
+        let bus = RunEventBus::new(8);
+        let reporter = TerminalReporter::spawn(
+            &bus,
+            ReporterOptions {
+                command_label: "build test".into(),
+                color: ColorMode::Never,
+                verbosity: Verbosity::Normal,
+                suppress_panel: true,
+            },
+        );
+        bus.publish(RunEvent::RunStarted { at_epoch_ms: 0 });
+        bus.publish(RunEvent::RunCompleted {
+            at_epoch_ms: 1,
+            exit_status: 0,
+        });
+        drop(bus);
+        // finish awaits the render task and clears the multi progress.
+        reporter.finish().await;
+    }
+}


### PR DESCRIPTION
## What changed

- New terminal reporter that subscribes to the run event bus and renders a layered dashboard on stderr: header, per-target completion lines with colored icons and durations, sticky spinner panel while work is in flight, final `Done`/`Failed` summary, and captured stderr surfaced in a red block on failure.
- `RunEventBus` moved from an opt-in `--ui` component to an always-on producer: `bus_events` helpers publish every lifecycle event (`RunStarted`, `TargetPhase(CacheChecking|Preparing|Executing|Capturing|Publishing)`, `TargetCompleted`, `RunCompleted`) whether or not the local HTTP dashboard is running.
- `BusOutputObserver` attaches to the session when the UI dashboard is not, so child stdout and stderr flow onto the bus as `LogChunk` events in every run.
- New global flags on the `once` command:
  - `--color=auto|always|never` (default `auto`, honors the standard [NO_COLOR](https://no-color.org/), `CLICOLOR_FORCE`, and `TERM=dumb` env variables through `console`/`indicatif`)
  - `-v` prints a short tail of captured child output per target, `-vv` streams captured output live with a target-prefixed line-per-chunk
  - `--quiet` suppresses the reporter entirely; failures still surface through the existing top-level error path
- `Output` gains `color` and `verbose` fields threaded through every command handler.
- `crate::commands::ui::Publisher` keeps only its UI snapshot-store responsibility; bus emission moves to `crate::bus_events` so a run without the dashboard still fires it.
- New workspace dependency: `indicatif = "0.17"` for the sticky panel and TTY-aware degradation.

## Why

Running `once build` or `once test` today prints nothing during the compile and a terse block at the end. On a large workspace like [jdx/mise](https://github.com/jdx/mise) that means zero output for the entire run, so there is no way to tell whether Once is working or hung. Agents parsing structured output are fine, but a human at a terminal has no signal.

The event vocabulary needed for a beautiful reporter already exists (`RunEventBus`, defined for [RFC 0008](https://github.com/tuist/once/blob/main/rfcs/0008-live-run-event-protocol.md)), but nothing on the terminal side subscribed to it and the producer only fired events when `--ui` was on. Moving the bus to always-on and adding a subscriber that draws with `indicatif` turns silence into a legible, colored, layered dashboard without changing the machine-parseable stdout envelope.

## Approach

Kept the change surgical:

- `RunEventBus` lifecycle is unchanged; only its wire-up moved so a bus is always created at the top of `graph::build` / `graph::test_with_filters`.
- Publisher stops publishing to the bus and only updates its UI snapshot store. Every previous phase call from Publisher was replaced with a corresponding `bus_events::` helper call on the always-on bus. A `BusOutputObserver` provides the `LogChunk` events that `LiveOutput` used to provide only under `--ui`.
- The reporter is a Tokio task with a `broadcast::Receiver`. On a TTY it draws through `indicatif::MultiProgress`; on a non-TTY it writes plain lines to stderr through a fallback `emit` helper. It tears down when it sees `RunCompleted`; the caller awaits its `finish` before returning so the summary lands before the CLI exits.
- Considered plumbing per-action events through `once-core`'s action runner so that a full workspace compile would show every dependency crate ticking. Not shipped in this pass because the runner does not carry a bus today and threading one through would be a cross-crate refactor. Called out in Follow-ups.

## Impact

- Human users: `once build <target>` and `once test <target>` now produce readable, colored progress and completion output. Cache hits, cache misses, and failures are visually distinct.
- Agents and scripts: unchanged. The stdout envelope for `--format=human`, `--format=json`, and `--format=toon` is byte-identical to before; the reporter writes only to stderr, and only when `--format=human` and not `--quiet`.
- CI: non-TTY stderr degrades to line-oriented output with no cursor escapes; `NO_COLOR` and `TERM=dumb` continue to suppress color.
- No configuration migration. New flags are opt-in with sensible defaults.

## Validation

Ran locally:

- `cargo test -p once-cli --bin once` → 403 passed, 0 failed (adds 4 reporter and 3 `bus_events` tests).
- `cargo build --release -p once-cli` clean.
- Against a fresh clone of [jdx/mise](https://github.com/jdx/mise):
  - `once build adler2-2.0.1` (cache hit, non-TTY): header + `✓ adler2-2.0.1 cached Xms` + `Done  1 cached  in Xms` on stderr; classic trailer unchanged on stdout.
  - `once build adler2-2.0.1 --color=always`: colored output with ANSI escapes even when piped.
  - `once build adler2-2.0.1 --quiet`: stderr empty, stdout unchanged.
  - `once build no-such-target --color=always`: red `✗ no-such-target failed` line + `Failed 1 failed` summary; captured error still surfaced through the existing top-level error path.
  - `once build adler2-2.0.1 --format=json`: reporter silent, single JSON envelope on stdout.

## Follow-ups (not in this pull request)

- Publish per-action events from `once-core`'s action runner so a large Cargo workspace compile shows every dependency crate ticking. That is the "hundreds of crates live" experience; today the reporter only sees the top-level target's phase events.
- Wire `crates/once-cli/src/commands/test_schedule/worker.rs` to publish per-batch bus events so `once test --all` gets the same reporter treatment (today the worker logs only through `tracing::info!`).
- Interactive verbosity keys (up/down to raise or lower during a run). Requires raw-mode plus a keystroke loop.
- Optional: suppress the classic stdout capability trailer when the reporter is drawing, to avoid visual interleaving on non-TTY captured output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhmAvjPpqfMu4F51A6yVdZ
