### PR TITLE
chore(infra): retire the cluster CR in favour of Flux in tuist/tuist

### DIFF
--- a/infra/k8s/cluster-production.yaml
+++ b/infra/k8s/cluster-production.yaml
@@ -1,47 +1,21 @@
-# Once production workload Cluster, topology mode against `tuist-hcloud`.
+# MOVED — this cluster is now reconciled by Flux from tuist/tuist.
 #
-# Reconciled by the self-hosted CAPI + caph management cluster maintained
-# in tuist/tuist. Once currently serves only the static Phoenix marketing
-# site, so the cluster is collapsed to the minimum that stays operational:
-# a single control-plane node and a single worker. HA is intentionally
-# given up here to keep the Hetzner bill down until the registry backend
-# lands and warrants a larger shape again.
-apiVersion: cluster.x-k8s.io/v1beta2
-kind: Cluster
-metadata:
-  name: once-production
-  namespace: org-tuist
-spec:
-  clusterNetwork:
-    services:
-      cidrBlocks:
-        - 10.128.0.0/12
-    pods:
-      cidrBlocks:
-        - 192.168.0.0/16
-    serviceDomain: cluster.local
-  topology:
-    classRef:
-      name: tuist-hcloud
-    version: v1.34.6
-    controlPlane:
-      replicas: 1
-    variables:
-      - name: region
-        value: fsn1
-      - name: hcloudControlPlaneMachineType
-        value: cpx22
-      - name: hcloudWorkerMachineType
-        value: cpx22
-      - name: hcloudSSHKeyName
-        value:
-          - name: tuist-ops
-    workers:
-      machineDeployments:
-        - class: hcloud-worker
-          name: md-0
-          replicas: 1
-          failureDomain: fsn1
-          metadata:
-            labels:
-              node.cluster.x-k8s.io/pool: general
+# The once-production Cluster CR lives at:
+#
+#   tuist/tuist  infra/k8s/clusters/workloads/once/cluster.yaml
+#
+# Change the cluster's shape (replicas, machine types, k8s version, pools)
+# by opening a PR there. Flux on the management cluster reconciles it on an
+# interval; a PR touching that path also gets a server-side `flux diff`
+# posted showing the live-vs-desired delta before merge.
+#
+# Why this file is a stub rather than a manifest: nothing ever applied it to
+# the management cluster, so it had silently drifted from the live object
+# (it was missing `disableControlPlaneKubeletLocalMode` and
+# `statefulRaidLevel`, both of which the live cluster carries). Leaving a
+# real manifest here would be a second, wrong source of truth that looks
+# authoritative and does nothing — exactly the drift-blindness the move to
+# Flux exists to remove. Kept as a pointer rather than deleted so this path
+# still answers "where is my cluster defined?".
+#
+# See tuist/tuist  infra/flux/mgmt/README.md and hive/specs/72.


### PR DESCRIPTION
**Do not merge until [tuist/tuist#11652](https://github.com/tuist/tuist/pull/11652) has landed and Flux is bootstrapped and verified reconciling.** Draft until then.

## What

Replaces `infra/k8s/cluster-production.yaml` with a pointer to its new home:

    tuist/tuist  infra/k8s/clusters/workloads/once/cluster.yaml

## Why

tuist/tuist#11652 moves the workload `Cluster` CRs under Flux on the management cluster, implementing [hive/specs/72](https://hive.tuist.dev/specs/72). Its migration step retires each tenant repo's copy.

Leaving the manifest here would create a second source of truth that *looks* authoritative and does nothing — someone edits it, nothing happens. That is precisely the drift-blindness the spec exists to remove, just relocated.

It is also **already wrong**. Nothing has ever applied this file to the management cluster, so it has silently diverged from the live object: it declares neither `disableControlPlaneKubeletLocalMode` nor `statefulRaidLevel`, both of which the live cluster carries. That drift was found by the pre-enable `kubectl diff` gate in #11652 and fixed there by syncing the imported copy to live.

Kept as a stub rather than deleted so this path still answers "where is my cluster defined?".

## Not changed

`ci-service-account.yaml` and the other in-cluster config stay — they are app-deploy and add-on concerns, not cluster topology. Only the `Cluster` CR moves.

## After this

Cluster shape changes (replicas, machine types, k8s version, pools) go through a PR in tuist/tuist. Flux reconciles on an interval, and such PRs get a server-side `flux diff` posted showing the live-vs-desired delta before merge.