### PR TITLE
fix(ci): keep the shellspec suite green with the live run reporter

### DIFF
--- a/.github/workflows/once.yml
+++ b/.github/workflows/once.yml
@@ -266,7 +266,10 @@ jobs:
     needs: [changes, release-build]
     if: needs.changes.outputs.rust_ci == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # The macOS suite drives real Swift, Xcode, and toolchain installs and
+    # lands between 20 and 30 minutes depending on runner and network speed,
+    # so the cap only needs to catch a genuine hang.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/spec/swift_compatibility_spec.sh
+++ b/spec/swift_compatibility_spec.sh
@@ -72,18 +72,18 @@ SH
   restore_swift_artifacts_from_cache() {
     copy_native_package
 
-    once swift -- build >/dev/null
+    once swift -- build >/dev/null 2>&1
     find "$WORKSPACE/.once/out" -type f -print | sort > "$WORKSPACE/first-artifacts"
     swift_library_evidence > "$WORKSPACE/first-evidence.json"
     clear_swift_build_outputs
 
-    once swift -- build >/dev/null
+    once swift -- build >/dev/null 2>&1
     find "$WORKSPACE/.once/out" -type f -print | sort > "$WORKSPACE/second-artifacts"
     swift_library_evidence > "$WORKSPACE/second-evidence.json"
 
     printf '\npublic func cacheProbe() {}\n' >> "$WORKSPACE/Sources/OnceNativeSwiftPackage/Greeting.swift"
     clear_swift_build_outputs
-    once swift -- build >/dev/null
+    once swift -- build >/dev/null 2>&1
     swift_library_evidence > "$WORKSPACE/third-evidence.json"
 
     verify_swift_cache_evidence
@@ -92,11 +92,11 @@ SH
   reuse_consumer_when_module_is_unchanged() {
     copy_native_package
 
-    once swift -- build >/dev/null
+    once swift -- build >/dev/null 2>&1
     swift_dependency_evidence > "$WORKSPACE/dependency-before-evidence.json"
     perl -0pi -e 's/"one"/"two"/' "$WORKSPACE/Sources/OnceNativeDependency/Dependency.swift"
     clear_swift_build_outputs
-    once swift -- build >/dev/null
+    once swift -- build >/dev/null 2>&1
     swift_dependency_evidence > "$WORKSPACE/dependency-after-evidence.json"
     swift_consumer_evidence > "$WORKSPACE/consumer-evidence.json"
 
@@ -128,6 +128,8 @@ SH
     When call once swift -- build
     The status should be success
     The stdout should include 'once: build swift_package (swift_package_workspace)'
+    The stderr should include 'once  build swift_package'
+    The stderr should include 'Done'
   End
 
   It 'routes a compatible debug test through Once'
@@ -137,6 +139,8 @@ SH
     When call once swift -- test
     The status should be success
     The stdout should include 'once: test SwiftPackage_OnceNativeSwiftPackage_OnceNativeSwiftPackageTests (apple_test_bundle)'
+    The stderr should include 'once  test SwiftPackage_OnceNativeSwiftPackage_OnceNativeSwiftPackageTests'
+    The stderr should include 'Done'
     The path "$WORKSPACE/.once/out/SwiftPackage_OnceNativeSwiftPackage_OnceNativeSwiftPackageTests/test/test_results.json" should be file
   End
 


### PR DESCRIPTION
## What was failing

Two things went red on `main` after #267 landed.

**1. The macOS shellspec job exits 101 even though every example passes.**

The run on #267 finished all 288 examples with 0 failures and still failed the job:

```
Finished in 1263.59 seconds (user 689.30 seconds, sys 205.87 seconds)
288 examples, 0 failures, 4 warnings, 3 skips
...
##[error]Process completed with exit code 101.
```

shellspec treats warnings as failures by default and reports them with exit code 101. The four warnings were all the same shape:

```
WARNING: There was output to stderr but not found expectation

  stderr:
    once  test SwiftPackage_OnceNativeSwiftPackage_OnceNativeSwiftPackageTests
    ────────────────────────────────────────
    ✓ SwiftPackage_OnceNativeSwiftPackage_OnceNativeSwiftPackage built      432ms

      Done  1 built  in 2.8s
```

That is the new live run reporter doing exactly what it was built to do. It renders every human-format build and test run on stderr, and on a non-TTY it degrades to plain per-completion lines. The four swift compatibility examples only asserted on stdout, so shellspec saw unclaimed stderr and warned. Nothing was actually broken in the product.

**2. The same job then hit its 30 minute cap on `main`.**

The macOS suite drives real Swift, Xcode, and toolchain installs. It took 21 minutes on the PR run and did not finish inside 30 on `main`. The single slowest example, `portable starter examples`, alone swung from 296s to 526s between the two runs. The cap was tight enough that ordinary runner and network variance tripped it rather than catching a hang.

## What this changes

For the warnings, updating the specs is the right move rather than silencing the reporter: the stderr rendering is the feature, and CI should assert it. The two examples that invoke `once swift -- build` and `once swift -- test` directly now assert the rendered run alongside the existing stdout trailer, which also gives the reporter its first real coverage in the suite. The two helpers that already discarded stdout now discard the rendered run too, since they verify through evidence JSON rather than output.

For the timeout, 30 goes to 50. The alternative, making the macOS suite meaningfully faster, is worth doing but is its own piece of work and should not gate `main` being green.

## Verification

Reproduced the failure locally on macOS against a release build, confirming the same four warnings and the 101 exit. After the change, `shellspec spec/swift_compatibility_spec.sh` reports `7 examples, 0 failures` and exits 0. The full macOS suite runs here in CI.

Separately, the `web` workflow on `main` had also failed, on the `helm` job with "The self-hosted runner lost communication with the server". That was runner infrastructure, not code. I re-ran it and it passed in 16 seconds, so `web` on `main` is green again and needs nothing from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpWVDWTcDV1NaWhvWuK3eR