### PR TITLE
fix(graph): report the host tool that refused to run, not the traceback

### DIFF
--- a/crates/once-frontend/src/analysis/engine.rs
+++ b/crates/once-frontend/src/analysis/engine.rs
@@ -16,8 +16,8 @@ use sha2::Digest as _;
 
 use super::globals::{globals_for_prelude, UnchangedWorkspace};
 use super::store::{
-    with_active_store, AnalysisObservations, AnalysisStore, CachedToolCommand, CommandPolicy,
-    DeclaredAction, HostCache,
+    with_active_store, with_store, AnalysisObservations, AnalysisStore, CachedToolCommand,
+    CommandPolicy, DeclaredAction, HostCache, HostToolFailure,
 };
 use super::values::{attr_value_to_starlark, json_to_value, value_to_json};
 use crate::graph::{Diagnostic, GraphTarget, TargetKindSchema};
@@ -751,7 +751,57 @@ fn resolve_targets_in_starlark<T>(
     result
 }
 
+/// The host tool failure behind `message`, when one explains it.
+///
+/// A resolver stops at its first failure, so the last recorded one is the
+/// candidate. Requiring the executable to appear in `message` is what ties the
+/// two together: without it a stale record from an earlier target could
+/// describe a failure it had nothing to do with.
+fn causing_tool_failure(message: &str) -> Option<HostToolFailure> {
+    let failure = with_store(|store| store.and_then(|store| store.host_cache.last_tool_failure()))?;
+    message.contains(&failure.program).then_some(failure)
+}
+
+/// Report a host tool that ran and refused, leading with the executable and
+/// the reason rather than the Starlark traceback that wraps them.
+///
+/// The traceback names the prelude function that reached for the tool, which
+/// reads as a fault in Once. The fault is in the tool: Once ran whatever the
+/// host resolves for that name, so the repair is to fix that executable, and
+/// the way to see it plainly is to run it outside Once.
+fn tool_failure_diagnostic(
+    target: &GraphTarget,
+    stage: &str,
+    failure: &HostToolFailure,
+) -> anyhow::Error {
+    let name = failure.name();
+    let mut message = format!(
+        "target kind {stage} failed for `{target}`: `{name}` is not usable\n\n  resolved to  {program}\n  exited with  {status}",
+        target = target.label.id,
+        program = failure.program,
+        status = failure.status,
+    );
+    if !failure.stderr.is_empty() {
+        message.push_str("\n  stderr       ");
+        message.push_str(&failure.stderr.replace('\n', "\n               "));
+    }
+    // Carried in the message, not only in the repair: the repair reaches
+    // structured consumers, and this is the line a person needs to read.
+    let repair = format!(
+        "Once runs the `{name}` the host resolves, not one of its own. Run `{name}` yourself from the workspace root to see the same failure, then repair that installation."
+    );
+    message.push_str("\n\n");
+    message.push_str(&repair);
+    let diagnostic = Diagnostic::new("host_tool_not_usable", message)
+        .with_target(&target.label.id)
+        .with_repair(repair);
+    anyhow!(AnalysisFailure { diagnostic })
+}
+
 fn analysis_failure(target: &GraphTarget, stage: &str, message: &str) -> anyhow::Error {
+    if let Some(failure) = causing_tool_failure(message) {
+        return tool_failure_diagnostic(target, stage, &failure);
+    }
     let (code, repair) = if message.contains("select()") && message.contains("no") {
         (
             "select_no_matching_branch",

--- a/crates/once-frontend/src/analysis/store.rs
+++ b/crates/once-frontend/src/analysis/store.rs
@@ -533,8 +533,38 @@ impl<K: Ord + Clone, V: Clone> SingleFlight<K, V> {
     }
 }
 
+/// What a host tool did when it refused to run.
+///
+/// A resolver's toolchain probe reaches the host through Starlark, and a
+/// Starlark error flattens to a traceback string on the way back out. Keeping
+/// the parts here lets the analysis boundary say which executable failed and
+/// why, instead of leaving the reason buried at the bottom of a traceback.
+#[derive(Debug, Clone)]
+pub(super) struct HostToolFailure {
+    /// Executable that ran, as resolved (usually an absolute path).
+    pub(super) program: String,
+    /// How the process ended, rendered.
+    pub(super) status: String,
+    /// What it wrote to stderr, trimmed.
+    pub(super) stderr: String,
+}
+
+impl HostToolFailure {
+    /// The name a person would call this tool: the file name of the
+    /// executable that actually ran.
+    pub(super) fn name(&self) -> &str {
+        Path::new(&self.program)
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(&self.program)
+    }
+}
+
 pub(super) struct HostCache {
     which: Arc<SingleFlight<String, Option<String>>>,
+    /// The most recent command that exited non-zero. Read only on the error
+    /// path, to describe a failure the traceback would otherwise obscure.
+    last_tool_failure: Arc<Mutex<Option<HostToolFailure>>>,
     commands: Arc<SingleFlight<CommandKey, String>>,
     environment: Arc<Mutex<BTreeMap<String, Option<String>>>>,
     paths: Arc<Mutex<BTreeSet<PathBuf>>>,
@@ -554,6 +584,7 @@ impl Clone for HostCache {
     fn clone(&self) -> Self {
         Self {
             which: Arc::clone(&self.which),
+            last_tool_failure: Arc::clone(&self.last_tool_failure),
             commands: Arc::clone(&self.commands),
             environment: Arc::clone(&self.environment),
             paths: Arc::clone(&self.paths),
@@ -575,6 +606,7 @@ impl HostCache {
     fn with_env_lookup(host_env: impl Fn(&str) -> Option<String> + Send + Sync + 'static) -> Self {
         Self {
             which: Arc::new(SingleFlight::new()),
+            last_tool_failure: Arc::new(Mutex::new(None)),
             commands: Arc::new(SingleFlight::new()),
             environment: Arc::new(Mutex::new(BTreeMap::new())),
             paths: Arc::new(Mutex::new(BTreeSet::new())),
@@ -723,6 +755,24 @@ impl HostCache {
         Ok(resolved)
     }
 
+    /// Remember the most recent non-zero exit so the analysis boundary can
+    /// describe it. Only the last one is kept: a resolver stops at its first
+    /// failure, so that is the one being reported.
+    fn record_tool_failure(&self, failure: HostToolFailure) {
+        *self
+            .last_tool_failure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(failure);
+    }
+
+    /// The most recent host tool failure, if one has been recorded.
+    pub(super) fn last_tool_failure(&self) -> Option<HostToolFailure> {
+        self.last_tool_failure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
     /// Run `argv` (optionally with extra env vars) and cache its
     /// stdout.
     ///
@@ -759,11 +809,11 @@ impl HostCache {
             .next()
             .ok_or_else(|| anyhow!("host_command requires a non-empty argv"))?;
         let command_args: Vec<&String> = iter.collect();
-        let resolved_program = self.tool_paths.get(program).unwrap_or(program);
-        if Path::new(resolved_program).components().count() > 1 {
-            self.observe_path(Path::new(resolved_program));
+        let resolved_program = self.tool_paths.get(program).unwrap_or(program).clone();
+        if Path::new(&resolved_program).components().count() > 1 {
+            self.observe_path(Path::new(&resolved_program));
         }
-        let mut command = Command::new(resolved_program);
+        let mut command = Command::new(&resolved_program);
         command.args(&command_args);
         if let Some(cwd) = cwd {
             command.current_dir(cwd);
@@ -779,11 +829,14 @@ impl HostCache {
                 .map(|arg| arg.as_str())
                 .collect::<Vec<_>>()
                 .join(" ");
+            let stderr = String::from_utf8_lossy(&stderr).trim().to_string();
+            self.record_tool_failure(HostToolFailure {
+                program: resolved_program.clone(),
+                status: status.to_string(),
+                stderr: stderr.clone(),
+            });
             return Err(anyhow!(
-                "`{program} {}` exited with {}: {}",
-                rendered_args,
-                status,
-                String::from_utf8_lossy(&stderr).trim()
+                "`{program} {rendered_args}` exited with {status}: {stderr}"
             ));
         }
         // Some tools (kotlinc, older javac) print their version banner to

--- a/crates/once-frontend/src/analysis/tests.rs
+++ b/crates/once-frontend/src/analysis/tests.rs
@@ -1610,6 +1610,61 @@ custom = {
     assert!(!failure.diagnostic.repairs.is_empty());
 }
 
+#[cfg(unix)]
+#[test]
+fn a_host_tool_that_refuses_to_run_is_reported_instead_of_the_traceback() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let tool = tmp.path().join("cargo");
+    std::fs::write(
+        &tool,
+        "#!/bin/sh\necho 'no version is set for shim: cargo' >&2\nexit 1\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let engine = AnalysisEngine::from_source(format!(
+        r#"
+def _impl(ctx):
+    host_command(["{tool}", "metadata"])
+
+custom = {{
+    "_once_target_kind": True,
+    "kind": "custom",
+    "impl": _impl,
+}}
+"#,
+        tool = tool.display()
+    ))
+    .unwrap();
+
+    let error = engine
+        .analyze_target(&target("custom"), tmp.path(), &[])
+        .unwrap_err();
+    let failure = error
+        .downcast_ref::<AnalysisFailure>()
+        .expect("structured analysis failure");
+
+    assert_eq!(failure.diagnostic.code, "host_tool_not_usable");
+    assert_eq!(
+        failure.diagnostic.target.as_deref(),
+        Some("apps/ios/Sample")
+    );
+    // The executable, why it failed, and what to do, without the Starlark
+    // traceback that used to bury all three.
+    let message = &failure.diagnostic.message;
+    assert!(message.contains("`cargo` is not usable"), "{message}");
+    assert!(message.contains(&tool.display().to_string()), "{message}");
+    assert!(
+        message.contains("no version is set for shim: cargo"),
+        "{message}"
+    );
+    assert!(message.contains("Run `cargo` yourself"), "{message}");
+    assert!(!message.contains("Traceback"), "{message}");
+    assert!(!failure.diagnostic.repairs.is_empty());
+}
+
 #[test]
 fn workspace_configuration_drives_common_select_resolution() {
     let workspace = TempDir::new().unwrap();


### PR DESCRIPTION
## The problem

Building the `mise` repository failed twice in a row with output like this:

```
once: evaluation error in cargo:
target kind resolver failed for `cargo`: Traceback (most recent call last):
  File <builtin>, in <module>
  * once//modules/all.star:14874, in _cargo_workspace_resolver
      resolved = _cargo_resolved_metadata(ctx, vendor_dir, not vendor_dir)
  * once//modules/all.star:13827, in _cargo_resolved_metadata
      metadata = _cargo_metadata_for_platform(ctx, cargo, manifest, filter_platform)
  * once//modules/all.star:14102, in _cargo_metadata_for_platform
      metadata_content = host_command(
error: `/Users/.../mise/command-wrappers/bin/cargo --config ... metadata ...` exited with exit status: 1: mise ERROR "mbx" couldn't exec process: No such file or directory
     --> once//modules/all.star:14102:24
  ... 10 more lines of source span ...
```

Both times the reasonable read was "Once is broken." It wasn't. `jdx/mise` sets `[wrappers.cargo] command = "mbx"`, `mbx` comes from `mr-boxington`, and that tool was not installed, so the repository's own `cargo` could not exec. Running it with nothing of ours involved gave the identical error:

```
$ cd /path/to/mise && ~/.local/share/mise/command-wrappers/bin/cargo --version
mise ERROR "mbx" couldn't exec process: No such file or directory
```

Once ran the `cargo` the host resolved, and that executable was broken. The information needed to see that was in the output, sitting under thirty lines of traceback that pointed at `once//modules/all.star`.

## What this changes

A resolver probes the host toolchain through Starlark, and a Starlark error flattens to a traceback string on the way back out, which is how the reason ended up last and the prelude ended up first. So the parts are captured where they still exist: `HostCache::run_command` records the program, exit status, and stderr when a command exits non-zero, and the analysis boundary uses that record to report the executable and the reason directly.

```
target kind resolver failed for `cargo`: `cargo` is not usable

  resolved to  /Users/.../mise/command-wrappers/bin/cargo
  exited with  exit status: 1
  stderr       mise ERROR "mbx" couldn't exec process: No such file or directory

Once runs the `cargo` the host resolves, not one of its own. Run `cargo` yourself
from the workspace root to see the same failure, then repair that installation.
```

Three details worth calling out.

The record is tied to the failure being reported by requiring the resolved executable to appear in the error message. Without that check, a stale record from an earlier target could describe a failure it had nothing to do with. Failures with no host command behind them are untouched and keep their traceback, which is the useful thing for those.

The guidance rides in the message rather than only in the diagnostic's `repair` field. Structured diagnostics do not currently reach the error envelope on this path (`"diagnostics": []`, which was already true before this change), so a repair-only version would never be read. The repair is still set for consumers, for when that plumbing improves.

## What was considered and rejected

The tempting fix is to have Once skip a broken tool and try the next match on `PATH`, which would have found rustup's `cargo` further down and made this build work. That was rejected deliberately. Once's observation ledger exists to guarantee a build used the tools the host actually provides; silently compiling against a different toolchain than `command -v cargo` reports trades a loud failure for an unreproducible one that surfaces much later as a confusing cache hit. Once picked the tool the shell would have picked. That is correct, and worth keeping. What was wrong was how it said so.

It would also have needed new recorded Starlark globals with observation-ledger and replay support, for a worse outcome.

## Verification

Reproduced the reported failure with a stub `cargo` on `PATH` that exits non-zero, confirming the old output matches what was reported, then confirmed the new output against the same reproduction. A test covers the executable, the reason, the guidance, and the absence of the traceback. `cargo test --package once-frontend` passes 656 tests; clippy and fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpWVDWTcDV1NaWhvWuK3eR