### PR TITLE
fix(xcode): resolve reachable package targets for native builds

### DIFF
--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -52,6 +52,7 @@ fn spawn_reporter(
     }
     let options = ReporterOptions {
         command_label: command_label.to_string(),
+        initial_status: Some("loading graph".to_string()),
         color: match output.color {
             ColorChoice::Auto => ColorMode::Auto,
             ColorChoice::Always => ColorMode::Always,

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -315,6 +315,19 @@ mod tests {
             std::fs::canonicalize(workspace).unwrap()
         );
     }
+
+    #[test]
+    fn default_build_target_does_not_expand_native_project_resolvers() {
+        let temporary = tempfile::tempdir().unwrap();
+        let project = temporary.path().join("App.xcodeproj");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::write(project.join("project.pbxproj"), "not a project").unwrap();
+
+        assert_eq!(
+            resolve_build_target(temporary.path(), None).unwrap(),
+            "xcode"
+        );
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -935,25 +948,24 @@ fn resolve_build_target(workspace: &Path, target: Option<String>) -> Result<Stri
     if let Some(target) = target {
         return resolve_target_arg(workspace, &target);
     }
-    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
     let resolver_kinds = once_frontend::target_kind_schemas_for_workspace(workspace)?
         .into_iter()
-        .filter(once_frontend::TargetKindSchema::has_resolver)
-        .map(|schema| schema.kind)
-        .collect::<std::collections::BTreeSet<_>>();
-    let candidates = graph
-        .iter()
-        .filter(|target| {
-            resolver_kinds.contains(&target.kind)
-                && target
+        .filter(|schema| {
+            schema.has_resolver()
+                && schema
                     .capabilities
                     .iter()
                     .any(|capability| capability.name == "build")
         })
-        .map(|target| target.label.id.as_str())
+        .map(|schema| schema.kind)
+        .collect::<std::collections::BTreeSet<_>>();
+    let candidates = once_frontend::load_workspace(workspace)?
+        .iter()
+        .filter(|target| resolver_kinds.contains(&target.kind))
+        .map(once_frontend::Target::id)
         .collect::<Vec<_>>();
     match candidates.as_slice() {
-        [target] => Ok((*target).to_string()),
+        [target] => Ok(target.clone()),
         [] => anyhow::bail!(
             "no default build target was discovered; pass `once build <target>` using an id from `once query targets`"
         ),

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -298,39 +298,6 @@ fn resolve_mcp_workspace(workspace: &Path, workspace_override: Option<PathBuf>) 
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[cfg(unix)]
-    #[test]
-    fn mcp_workspace_override_is_canonicalized() {
-        let temporary = tempfile::tempdir().unwrap();
-        let workspace = temporary.path().join("workspace");
-        let alias = temporary.path().join("alias");
-        std::fs::create_dir(&workspace).unwrap();
-        std::os::unix::fs::symlink(&workspace, &alias).unwrap();
-
-        assert_eq!(
-            resolve_mcp_workspace(temporary.path(), Some(alias)).unwrap(),
-            std::fs::canonicalize(workspace).unwrap()
-        );
-    }
-
-    #[test]
-    fn default_build_target_does_not_expand_native_project_resolvers() {
-        let temporary = tempfile::tempdir().unwrap();
-        let project = temporary.path().join("App.xcodeproj");
-        std::fs::create_dir(&project).unwrap();
-        std::fs::write(project.join("project.pbxproj"), "not a project").unwrap();
-
-        assert_eq!(
-            resolve_build_target(temporary.path(), None).unwrap(),
-            "xcode"
-        );
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_build(
     workspace: &Path,
@@ -979,4 +946,37 @@ fn resolve_build_target(workspace: &Path, target: Option<String>) -> Result<Stri
 
 fn resolve_target_arg(workspace: &Path, raw: &str) -> Result<String> {
     once_frontend::normalize_cli_target(workspace, raw).context("resolving target argument")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn mcp_workspace_override_is_canonicalized() {
+        let temporary = tempfile::tempdir().unwrap();
+        let workspace = temporary.path().join("workspace");
+        let alias = temporary.path().join("alias");
+        std::fs::create_dir(&workspace).unwrap();
+        std::os::unix::fs::symlink(&workspace, &alias).unwrap();
+
+        assert_eq!(
+            resolve_mcp_workspace(temporary.path(), Some(alias)).unwrap(),
+            std::fs::canonicalize(workspace).unwrap()
+        );
+    }
+
+    #[test]
+    fn default_build_target_does_not_expand_native_project_resolvers() {
+        let temporary = tempfile::tempdir().unwrap();
+        let project = temporary.path().join("App.xcodeproj");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::write(project.join("project.pbxproj"), "not a project").unwrap();
+
+        assert_eq!(
+            resolve_build_target(temporary.path(), None).unwrap(),
+            "xcode"
+        );
+    }
 }

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -298,10 +298,11 @@ fn resolve_mcp_workspace(workspace: &Path, workspace_override: Option<PathBuf>) 
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn mcp_workspace_override_is_canonicalized() {
         let temporary = tempfile::tempdir().unwrap();

--- a/crates/once-cli/src/reporter.rs
+++ b/crates/once-cli/src/reporter.rs
@@ -63,6 +63,8 @@ pub enum Verbosity {
 pub struct ReporterOptions {
     /// A short label naming the run, e.g. `"build ripgrep-cli"`.
     pub command_label: String,
+    /// Status shown until the first target starts executing.
+    pub initial_status: Option<String>,
     pub color: ColorMode,
     pub verbosity: Verbosity,
     /// When true, do not draw the sticky bottom panel; only render
@@ -94,9 +96,9 @@ impl TerminalReporter {
 
         let mut receiver = bus.subscribe();
         let render_multi = Arc::clone(&multi);
+        let mut state = RenderState::new(render_multi, options);
+        state.render_header();
         let handle = tokio::spawn(async move {
-            let mut state = RenderState::new(render_multi, options);
-            state.render_header();
             loop {
                 match receiver.recv().await {
                     Ok(event) => {
@@ -145,6 +147,7 @@ struct RenderState {
     options: ReporterOptions,
     started_at: Instant,
     summary: Option<ProgressBar>,
+    status: Option<String>,
     active: HashMap<String, ActiveTarget>,
     captured: HashMap<String, CapturedOutput>,
     totals: Totals,
@@ -179,11 +182,13 @@ struct Totals {
 
 impl RenderState {
     fn new(multi: Arc<MultiProgress>, options: ReporterOptions) -> Self {
+        let status = options.initial_status.clone();
         Self {
             multi,
             options,
             started_at: Instant::now(),
             summary: None,
+            status,
             active: HashMap::new(),
             captured: HashMap::new(),
             totals: Totals::default(),
@@ -232,6 +237,7 @@ impl RenderState {
     fn handle_event(&mut self, event: RunEvent) -> bool {
         match event {
             RunEvent::TargetStarted { target_id, .. } => {
+                self.status = None;
                 self.totals.started += 1;
                 self.on_target_started(&target_id);
                 self.refresh_summary();
@@ -414,6 +420,10 @@ impl RenderState {
     }
 
     fn summary_message(&self) -> String {
+        let label = &self.options.command_label;
+        if let Some(status) = &self.status {
+            return format!("{} · {}", style(label).bold(), style(status).dim());
+        }
         let running = self.active.len();
         let done =
             self.totals.built + self.totals.cached + self.totals.failed + self.totals.skipped;
@@ -423,7 +433,6 @@ impl RenderState {
         } else {
             0
         };
-        let label = &self.options.command_label;
         let stats = style(format!(
             "{done} done · {running} running · cache {cache_pct}%"
         ))
@@ -592,6 +601,7 @@ mod tests {
             &bus,
             ReporterOptions {
                 command_label: "build test".into(),
+                initial_status: Some("loading graph".into()),
                 color: ColorMode::Never,
                 verbosity: Verbosity::Normal,
                 suppress_panel: true,
@@ -605,5 +615,28 @@ mod tests {
         drop(bus);
         // finish awaits the render task and clears the multi progress.
         reporter.finish().await;
+    }
+
+    #[test]
+    fn initial_status_is_replaced_when_a_target_starts() {
+        let multi = Arc::new(MultiProgress::with_draw_target(ProgressDrawTarget::hidden()));
+        let mut state = RenderState::new(
+            multi,
+            ReporterOptions {
+                command_label: "build xcode".into(),
+                initial_status: Some("loading graph".into()),
+                color: ColorMode::Never,
+                verbosity: Verbosity::Normal,
+                suppress_panel: false,
+            },
+        );
+
+        assert!(state.summary_message().contains("loading graph"));
+        state.handle_event(RunEvent::TargetStarted {
+            at_epoch_ms: 0,
+            target_id: "xcode".into(),
+        });
+        assert!(!state.summary_message().contains("loading graph"));
+        assert!(state.summary_message().contains("1 running"));
     }
 }

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -1449,7 +1449,7 @@ def _xcode_local_package_products(ctx, wanted):
         for product in info.get("products") or []:
             product_name = product.get("name") or ""
             if product_name in remaining:
-                resolved[product_name] = {"identity": package_identity, "path": absolute, "platforms": platforms}
+                resolved[product_name] = {"identity": package_identity, "path": package_dir, "platforms": platforms, "info": info}
                 remaining.pop(product_name)
     return resolved
 
@@ -1616,6 +1616,17 @@ def _xcode_expand_swift_package_infos(ctx, initial_infos):
     for _ in range(32):
         discovered = []
         for package in pending:
+            for dependency in package["info"].get("dependencies") or []:
+                for local in dependency.get("fileSystem") or []:
+                    path = _xcode_workspace_input_path(local.get("path") or "")
+                    identity = local.get("nameForTargetDependencyResolutionOnly") or local.get("identity") or _basename(path)
+                    key = identity.lower()
+                    if not path or key in known or not host_file_exists(_xcode_abs(path + "/Package.swift")):
+                        continue
+                    info = _xcode_swift_package_info(ctx, path, identity)
+                    discovered.append(info)
+                    infos.append(info)
+                    known[key] = True
             pins = _xcode_package_resolved_pins_at(package.get("path") or "")
             for identity, pin in pins.items():
                 if pin.get("kind") != "remoteSourceControl" or identity in known:
@@ -3442,6 +3453,7 @@ def _xcode_workspace_resolver(ctx):
     # Pass two: lower every project's native targets, resolving dependencies and
     # test hosts against the workspace-wide name map.
     all_specs = []
+    native_spec_names = {}
     all_xcframework_modules = {}
     test_plan_settings = _xcode_test_plan_settings(ctx)
     for project in projects:
@@ -3465,15 +3477,31 @@ def _xcode_workspace_resolver(ctx):
         # package manifest supplies graph metadata only; Once compiles every
         # source target directly rather than delegating package builds.
         package_refs = _xcode_spm_package_refs(objects)
+        per_target_products = {}
+        unresolved_product_names = {}
+        for target in native_targets:
+            products = _xcode_target_spm_products(objects, target, package_refs)
+            per_target_products[target.get("name") or ""] = products
+            for product in products:
+                if not product.get("package_identity"):
+                    unresolved_product_names[product["name"]] = True
+        local_products = _xcode_local_package_products(ctx, unresolved_product_names.keys())
+        for products in per_target_products.values():
+            for product in products:
+                local = local_products.get(product["name"])
+                if local and not product.get("package_identity"):
+                    product["package_identity"] = local["identity"]
         local_package_infos = _xcode_local_swift_package_infos(ctx, project_dir, package_refs)
+        known_local_package_paths = {info["path"]: True for info in local_package_infos}
+        for name in sorted(local_products.keys()):
+            local = local_products[name]
+            if local["path"] not in known_local_package_paths:
+                local_package_infos.append({"identity": local["identity"], "path": local["path"], "info": local["info"]})
+                known_local_package_paths[local["path"]] = True
         package_infos = _xcode_expand_swift_package_infos(
             ctx,
             local_package_infos + _xcode_remote_swift_package_infos(ctx, entry_path, project_path, package_refs),
         )
-        per_target_products = {}
-        for target in native_targets:
-            products = _xcode_target_spm_products(objects, target, package_refs)
-            per_target_products[target.get("name") or ""] = products
         package_platform = _xcode_spm_platform(ctx, objects, native_targets, project_settings, configuration, path_maps)
         package_minimum_os = _xcode_spm_min_os(ctx, objects, native_targets, package_platform, configuration, project_settings, path_maps)
         package_graph = _xcode_local_swift_package_specs(
@@ -3517,6 +3545,7 @@ def _xcode_workspace_resolver(ctx):
             if spec["kind"] == "apple_library":
                 spec["attrs"]["exported_deps"] = list(spec["deps"])
             all_specs.append(spec)
+            native_spec_names[spec["name"]] = True
         all_specs.extend(package_graph["specs"])
         all_specs.extend(xcframework_specs)
 
@@ -3538,9 +3567,11 @@ def _xcode_workspace_resolver(ctx):
     for spec in specs:
         spec["deps"] = [dep for dep in spec["deps"] if dep[2:] in emitted]
 
-    # Applications are the natural build roots. Library-only projects build
-    # their non-test products, while the resolver metadata selects test bundles.
-    return {"targets": specs, "roots": _xcode_roots(specs), "attrs": {"_default_test_roots": [spec["name"] for spec in specs if spec["kind"] == "apple_test_bundle"]}}
+    # Native applications are the natural build roots. Library-only projects
+    # build their non-test products, while resolver metadata selects native test
+    # bundles. Package targets remain reachable only through native dependencies.
+    native_specs = [spec for spec in specs if spec["name"] in native_spec_names]
+    return {"targets": specs, "roots": _xcode_roots(native_specs), "attrs": {"_default_test_roots": [spec["name"] for spec in native_specs if spec["kind"] == "apple_test_bundle"]}}
 
 def _xcode_spm_platform(ctx, objects, native_targets, project_settings, configuration, path_maps):
     # The synthesized package builds for one platform. Prefer the project's

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -14679,6 +14679,74 @@ result = repr([[info["identity"], info["path"]] for info in infos])
 }
 
 #[test]
+fn prelude_xcode_discovers_products_from_unreferenced_local_swift_packages() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+def glob(patterns):
+    return ["WMFComponents/Package.swift"]
+
+def host_which(name):
+    return name
+
+def host_command(argv, env = None, cwd = None, merge_stderr = None):
+    if argv == ["xcrun", "--find", "swift"]:
+        return "swift"
+    return '{{"name":"WMFComponents","platforms":[],"products":[{{"name":"WMFComponents","targets":["WMFComponents"]}}],"targets":[]}}'
+
+products = _xcode_local_package_products({{}}, ["WMFComponents"])
+result = repr(products["WMFComponents"])
+"#,
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"{"identity": "WMFComponents", "path": "WMFComponents", "platforms": {}, "info": {"name": "WMFComponents", "platforms": [], "products": [{"name": "WMFComponents", "targets": ["WMFComponents"]}], "targets": []}}"#
+    );
+}
+
+#[test]
+fn prelude_xcode_expands_local_swift_package_dependencies() {
+    let prelude = xcode_prelude_source();
+    let source = format!(
+        r#"{prelude}
+def workspace_root():
+    return "/workspace"
+
+def host_file_exists(path):
+    return path == "/workspace/WMFData/Package.swift"
+
+def host_which(name):
+    return name
+
+def host_command(argv, env = None, cwd = None, merge_stderr = None):
+    if argv == ["xcrun", "--find", "swift"]:
+        return "swift"
+    return '{{"name":"WMFData","dependencies":[],"products":[],"targets":[]}}'
+
+infos = _xcode_expand_swift_package_infos({{}}, [{{
+    "identity": "WMFComponents",
+    "path": "WMFComponents",
+    "info": {{
+        "dependencies": [{{"fileSystem": [{{
+            "identity": "wmfdata",
+            "nameForTargetDependencyResolutionOnly": "WMFData",
+            "path": "/workspace/WMFData",
+        }}]}}],
+    }},
+}}])
+result = repr([[info["identity"], info["path"]] for info in infos])
+"#,
+    );
+    assert_eq!(
+        eval_prelude_source_to_repr(source).unwrap(),
+        r#"[["WMFComponents", "WMFComponents"], ["WMFData", "WMFData"]]"#
+    );
+}
+
+#[test]
 fn prelude_xcode_reconciles_local_package_products_into_native_targets() {
     let prelude = xcode_prelude_source();
     let source = format!(
@@ -17409,6 +17477,25 @@ def host_file_exists(path):
 def host_file_read(path):
     return ""
 
+def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant, configuration = "Debug", lazy_products = {{}}, lazy_dependency = "", target_prefix = "SwiftPackage"):
+    return {{
+        "specs": [{{
+            "name": "XcodePackage_swift-argument-parser_changelog-authors",
+            "kind": "apple_application",
+            "deps": [],
+            "srcs": ["Tools/changelog-authors/ChangelogAuthors.swift"],
+            "attrs": {{}},
+        }}, {{
+            "name": "XcodePackage_swift-argument-parser_ArgumentParserTests",
+            "kind": "apple_test_bundle",
+            "deps": [],
+            "srcs": ["Tests/ArgumentParserTests.swift"],
+            "attrs": {{}},
+        }}],
+        "products": {{}},
+        "modules": {{}},
+    }}
+
 ctx = {{
     "label": {{"package": "app", "name": "hello", "id": "app/hello"}},
     "attr": {{"project": "App.xcodeproj"}},
@@ -17417,6 +17504,7 @@ graph = _xcode_workspace_resolver(ctx)
 specs = {{spec["name"]: spec for spec in graph["targets"]}}
 result = repr([
     graph["roots"],
+    graph["attrs"]["_default_test_roots"],
     [specs["Feature"]["kind"], specs["App"]["kind"], specs["AppTests"]["kind"]],
     specs["App"]["deps"],
     specs["AppTests"]["deps"],
@@ -17435,6 +17523,6 @@ result = repr([
     let out = eval_prelude_source_to_repr(source).unwrap();
     assert_eq!(
         out,
-        r#"[["App"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["Source/Core/Feature.swift"], {"Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["App.swift"], "dev.once.App", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
+        r#"[["App"], ["AppTests"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["Source/Core/Feature.swift"], {"Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["App.swift"], "dev.once.App", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
     );
 }


### PR DESCRIPTION
## What changed

The Xcode resolver now keeps native Xcode products as the default build and test roots. Package applications, tests, and libraries remain available when a native target depends on them, but they are no longer selected as independent roots.

Workspace-local Swift packages are now discovered when Xcode product dependencies omit an explicit local package reference. Their local file-system dependencies are followed recursively so the complete reachable package graph is lowered.

Default build target selection now reads unexpanded workspace declarations, avoiding a duplicate graph expansion before the build begins. The existing terminal reporter now renders synchronously and starts with a **loading graph** state that remains visible until target execution starts.

## Why

Building the Wikipedia application appeared idle during initial graph loading, then attempted to build the Swift Argument Parser maintenance executable named **changelog-authors** for an Apple mobile simulator. That executable only defines its entry point for macOS, so the linker reported a missing main symbol.

After excluding that unrelated executable, the build exposed a second resolver gap: several workspace-local package modules used by Wikipedia were absent from the compilation graph.

The resolver pass can take long enough that a blank terminal looks like a stalled command. The startup work should use the same live reporting language as target execution.

## Root cause

The Xcode resolver selected roots from every lowered target. That included application and test targets belonging to dependency packages, not just native products declared by the Xcode workspace.

The resolver also relied on explicit local package reference objects when loading Swift packages. Some Xcode product dependencies name a local package product without carrying that reference, so existing product discovery was not used and transitive local file-system dependencies were missed.

Separately, automatic target selection expanded the full native project graph before creating the reporter. Even after removing that duplicate work, the reporter created its header inside a spawned asynchronous task. Once uses a single-threaded asynchronous runtime, so synchronous graph evaluation could prevent that task from rendering until the graph was ready.

## Approach

Native target names are tracked independently and used to derive default build and test roots. Package targets remain connected through normal dependency edges.

Unresolved product names are matched against workspace-local package manifests. The discovered manifest metadata is reused during package lowering, and local file-system package dependencies are added recursively.

Automatic build target selection now filters unexpanded workspace targets by resolver kinds that expose a build capability.

The reporter creates its header and initial spinner before spawning its event loop. Build and test commands use **loading graph** as the initial state, then replace it with the normal target counters as soon as execution begins.

## Impact

Wikipedia builds no longer select dependency package maintenance executables or dependency test bundles as roots. Its reachable local data, localization, component, and test-support packages are included in the graph.

People running a build now get an animated graph-loading indication before resolver work completes. No manifest or configuration migration is required.

## Example terminal output

~~~text
  once  build xcode
  ────────────────────────────────────────
  ⠋ build xcode · loading graph
~~~

## Validation

- mise exec -- cargo test -p once-frontend prelude_xcode: 86 passed, 0 failed.
- mise exec -- cargo test -p once-cli reporter::tests: 5 passed, 0 failed.
- mise exec -- cargo test -p once-cli default_build_target_does_not_expand_native_project_resolvers: 1 passed, 0 failed.
- mise exec -- cargo clippy -p once-cli --all-targets -- -D warnings
- mise exec -- cargo fmt --all -- --check
- mise exec -- cargo build -p once-cli
- git diff --check
- Ran target/debug/once build in an interactive terminal against the Wikipedia application checkout. The standard Once header and animated **build xcode · loading graph** state remained visible throughout graph evaluation.
- The complete command test suite passed 404 of 405 tests. The unrelated file-system watcher barrier test timed out on this host, and its isolated retry remained blocked in the same watcher barrier.
- The Wikipedia build passed the original missing main symbol and missing local module failures, compiling the reachable local packages and native extension targets.
