### PR TITLE
fix(graph): improve reproducible build execution

### DIFF
--- a/crates/once-cli/src/commands/graph/analysis/actions.rs
+++ b/crates/once-cli/src/commands/graph/analysis/actions.rs
@@ -161,7 +161,7 @@ impl DeclaredActionsState {
         deduplicate_outputs(&mut self.outputs);
         let cache_state = self
             .aggregate_cache_state
-            .unwrap_or(EvidenceCacheState::Miss);
+            .unwrap_or(EvidenceCacheState::Hit);
         let input_digest = compose_target_input_digest(&self.input_digests);
         let input_fingerprint =
             compose_target_input_fingerprint(input_digest, self.input_fingerprints);
@@ -848,12 +848,25 @@ async fn resolve_cacheable_declared_action(
     // a hit could delete an unrelated path with no command left to recreate it.
     let action_digest = action.digest();
     let mut action_lock = cacheable_action_lock(context.workspace, action_digest)?;
-    let _action_guard = action_lock.write().with_context(|| {
-        format!(
-            "locking action {} for {} ({})",
-            context.index, context.target_id, context.identifier
-        )
-    })?;
+    let _action_guard = loop {
+        match action_lock.try_write() {
+            Ok(guard) => break guard,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock
+                    || error.kind() == std::io::ErrorKind::Interrupted =>
+            {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "locking action {} for {} ({})",
+                        context.index, context.target_id, context.identifier
+                    )
+                });
+            }
+        }
+    };
     let cached = context
         .cache
         .get_action_result(&action_digest)
@@ -2043,7 +2056,7 @@ fn effective_network(declared: Option<&str>) -> Result<NetworkPolicy> {
             .parse::<NetworkPolicy>()
             .map_err(anyhow::Error::msg)
             .with_context(|| format!("parsing network policy `{raw}`")),
-        None => Ok(NetworkPolicy::default()),
+        None => Ok(NetworkPolicy::Deny),
     }
 }
 
@@ -2193,7 +2206,7 @@ fn compose_input_fingerprint_with_available(
     source_digest_cache: Option<&SourceDigestCache>,
 ) -> Result<InputFingerprintManifest> {
     let mut builder = InputDigestBuilder::new(b"once.declared_action.input.v4\0");
-    push_declared_action_metadata(&mut builder, declared)?;
+    push_declared_action_metadata(&mut builder, declared, workspace)?;
 
     let mut sorted_inputs = declared
         .inputs
@@ -2234,6 +2247,7 @@ fn compose_input_fingerprint_with_available(
 fn push_declared_action_metadata(
     builder: &mut InputDigestBuilder,
     declared: &DeclaredAction,
+    workspace: &Path,
 ) -> Result<()> {
     if let Some(identity) = &declared.toolchain_identity {
         builder.push_bytes_component("toolchain", "identity", identity.as_bytes());
@@ -2246,12 +2260,17 @@ fn push_declared_action_metadata(
             serde_json::to_vec(operation).context("serializing declared action operation")?;
         builder.push_bytes_component("command", "operation", &encoded);
     }
-    for arg in &declared.argv {
+    let canonical_argv = declared
+        .argv
+        .iter()
+        .map(|arg| canonical_action_value(arg, workspace))
+        .collect::<Vec<_>>();
+    for arg in &canonical_argv {
         builder.push_bytes(arg.as_bytes());
     }
-    if !declared.argv.is_empty() {
+    if !canonical_argv.is_empty() {
         let encoded =
-            serde_json::to_vec(&declared.argv).context("serializing declared action arguments")?;
+            serde_json::to_vec(&canonical_argv).context("serializing declared action arguments")?;
         builder.record_bytes("command", "arguments", &encoded);
     }
     if let Some(stdout) = &declared.stdout {
@@ -2276,13 +2295,18 @@ fn push_declared_action_metadata(
     if !declared.arg_files.is_empty() {
         builder.record_bytes("command", "argument-files", &encoded_arg_files);
     }
-    for (key, value) in &declared.env {
+    let canonical_env = declared
+        .env
+        .iter()
+        .map(|(key, value)| (key, canonical_action_value(value, workspace)))
+        .collect::<BTreeMap<_, _>>();
+    for (key, value) in &canonical_env {
         builder.push_bytes(key.as_bytes());
         builder.push_bytes(value.as_bytes());
     }
-    if !declared.env.is_empty() {
+    if !canonical_env.is_empty() {
         let encoded =
-            serde_json::to_vec(&declared.env).context("serializing declared environment")?;
+            serde_json::to_vec(&canonical_env).context("serializing declared environment")?;
         builder.record_bytes("environment", "declared", &encoded);
     }
     for path in &declared.clean_paths {
@@ -2303,6 +2327,14 @@ fn push_declared_action_metadata(
         builder.record_bytes("command", "working-directory", cwd.as_bytes());
     }
     Ok(())
+}
+
+fn canonical_action_value(value: &str, workspace: &Path) -> String {
+    let workspace = workspace.to_string_lossy();
+    if workspace.is_empty() {
+        return value.to_owned();
+    }
+    value.replace(workspace.as_ref(), "{{once.execution_root}}")
 }
 
 #[cfg(test)]

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -282,7 +282,6 @@ pub async fn build(
             .await;
     }
     bus_events::target_preparing(&bus, target_id);
-    bus_events::target_executing(&bus, target_id);
     session.with_known_changes(changes);
     let session = session;
     let target = match session.target(target_id) {

--- a/crates/once-cli/src/reporter.rs
+++ b/crates/once-cli/src/reporter.rs
@@ -155,7 +155,6 @@ struct RenderState {
 
 struct ActiveTarget {
     bar: ProgressBar,
-    started_at: Instant,
     phase: Phase,
 }
 
@@ -170,6 +169,8 @@ struct CapturedOutput {
 /// to keep the completion match arm readable and satisfy
 /// clippy's `type_complexity` lint.
 type StyleFn = fn(String) -> console::StyledObject<String>;
+
+const TARGET_COLUMN_WIDTH: usize = 56;
 
 #[derive(Default, Clone, Copy)]
 struct Totals {
@@ -283,11 +284,10 @@ impl RenderState {
         }
         let bar = self.multi.add(ProgressBar::new_spinner());
         bar.set_style(spinner_style_child());
-        bar.set_message(active_line(target_id, Phase::Executing, Duration::ZERO));
+        bar.set_message(active_line(target_id, Phase::Executing));
         bar.enable_steady_tick(Duration::from_millis(80));
         let entry = ActiveTarget {
             bar,
-            started_at: Instant::now(),
             phase: Phase::Executing,
         };
         self.active.insert(target_id.to_string(), entry);
@@ -296,10 +296,7 @@ impl RenderState {
     fn on_target_phase(&mut self, target_id: &str, phase: Phase) {
         if let Some(entry) = self.active.get_mut(target_id) {
             entry.phase = phase;
-            let elapsed = entry.started_at.elapsed();
-            entry
-                .bar
-                .set_message(active_line(target_id, phase, elapsed));
+            entry.bar.set_message(active_line(target_id, phase));
         }
     }
 
@@ -352,8 +349,8 @@ impl RenderState {
         }
 
         let icon = style_fn(icon.to_string());
-        let name = style(target_id.to_string()).bold();
-        let name = pad_right(&name.to_string(), 32);
+        let name = style(fit_column(target_id, TARGET_COLUMN_WIDTH)).bold();
+        let name = pad_right(&name.to_string(), TARGET_COLUMN_WIDTH);
         let tag_col = style_fn(pad_right(tag, 10));
         let dur = style(duration).dim();
         self.emit(format!("  {icon} {name} {tag_col} {dur}"));
@@ -494,18 +491,20 @@ fn spinner_style_bold() -> ProgressStyle {
 }
 
 fn spinner_style_child() -> ProgressStyle {
-    ProgressStyle::with_template("    {spinner:.cyan} {msg}")
+    ProgressStyle::with_template("    {spinner:.cyan} {msg} {elapsed_precise:.dim}")
         .expect("valid spinner template")
         .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ")
 }
 
-fn active_line(target_id: &str, phase: Phase, elapsed: Duration) -> String {
-    let name = pad_right(target_id, 32);
+fn active_line(target_id: &str, phase: Phase) -> String {
+    let name = pad_right(
+        &fit_column(target_id, TARGET_COLUMN_WIDTH),
+        TARGET_COLUMN_WIDTH,
+    );
     let phase_label = phase_label(phase);
     let phase_col = pad_right(phase_label, 10);
     let phase_styled = phase_style(phase).apply_to(phase_col).to_string();
-    let dur = style(format_duration(elapsed)).dim();
-    format!("{name} {phase_styled} {dur}")
+    format!("{name} {phase_styled}")
 }
 
 fn phase_label(phase: Phase) -> &'static str {
@@ -558,6 +557,26 @@ fn pad_right(text: &str, width: usize) -> String {
     }
 }
 
+fn fit_column(text: &str, width: usize) -> String {
+    if console::measure_text_width(text) <= width {
+        return text.to_string();
+    }
+    if width <= 1 {
+        return "…".chars().take(width).collect();
+    }
+
+    let mut fitted = String::new();
+    for ch in text.chars() {
+        let candidate = format!("{fitted}{ch}");
+        if console::measure_text_width(&candidate) >= width {
+            break;
+        }
+        fitted.push(ch);
+    }
+    fitted.push('…');
+    fitted
+}
+
 fn split_lines(bytes: &[u8]) -> Vec<&[u8]> {
     let mut out = Vec::new();
     for line in bytes.split(|&b| b == b'\n') {
@@ -592,6 +611,16 @@ mod tests {
     fn pad_right_measures_display_width() {
         let padded = pad_right("hi", 6);
         assert_eq!(console::measure_text_width(&padded), 6);
+    }
+
+    #[test]
+    fn fit_column_truncates_long_target_names() {
+        assert_eq!(fit_column("short", 8), "short");
+        assert_eq!(fit_column("long-target", 8), "long-ta…");
+        assert_eq!(
+            console::measure_text_width(&fit_column("long-target", 8)),
+            8
+        );
     }
 
     #[tokio::test]

--- a/crates/once-core/src/local.rs
+++ b/crates/once-core/src/local.rs
@@ -259,8 +259,28 @@ async fn spawn_and_capture(
     let (program, rest) = argv.split_first().ok_or(Error::EmptyArgv)?;
     tracing::Span::current().record("program", tracing::field::display(program));
 
-    let mut command = Command::new(program);
-    command.args(rest);
+    #[cfg(target_os = "macos")]
+    let mut command = if network.is_denied() {
+        let mut command = Command::new("/usr/bin/sandbox-exec");
+        command.args([
+            "-p",
+            "(version 1) (allow default) (deny network*) (allow network-inbound (local ip \"localhost:*\")) (allow network-outbound (remote ip \"localhost:*\")) (allow network-outbound (path-regex #\"^/private/var/tmp/com\\.apple\\.launchd\\..*\"))",
+            "--",
+            program,
+        ]);
+        command.args(rest);
+        command
+    } else {
+        let mut command = Command::new(program);
+        command.args(rest);
+        command
+    };
+    #[cfg(not(target_os = "macos"))]
+    let mut command = {
+        let mut command = Command::new(program);
+        command.args(rest);
+        command
+    };
     command.env_clear();
     for (k, v) in &env {
         command.env(k, v);
@@ -275,13 +295,12 @@ async fn spawn_and_capture(
     command.kill_on_drop(true);
     // Isolate the child from the network when the action declared `deny`.
     // On Linux a seccomp filter installed between fork and exec turns every
-    // network syscall into `EACCES`. Other platforms accept the declaration
-    // but cannot enforce it; warn so the gap is visible rather than silent.
+    // network syscall into `EACCES`. macOS uses sandbox-exec above.
     #[cfg(target_os = "linux")]
     if network.is_denied() {
         crate::network::arm(&mut command);
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     if network.is_denied() {
         tracing::warn!(
             program = %program,

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -172,7 +172,10 @@ def _resolve_swiftc(platform, sdk_variant, xcode_developer_dir):
     # installations partition the action cache cleanly.
     identity = "once.apple.swiftc.v1\x00" + swiftc_path + "\x00" + version + "\x00" + (xcode_developer_dir or "")
     return {
-        "argv": [swiftc_path, "-sdk", sdk_path],
+        # Once supplies the outer action sandbox. Disabling Swift's nested
+        # subprocess sandbox lets compiler plugins run inside that same policy
+        # instead of failing when Seatbelt rejects a second sandbox profile.
+        "argv": [swiftc_path, "-disable-sandbox", "-sdk", sdk_path],
         "swiftc_path": swiftc_path,
         "sdk_name": sdk,
         "sdk_path": sdk_path,
@@ -1423,7 +1426,7 @@ def _apple_library_impl(ctx):
         resolved_header_dir = _package_relative(ctx, header_dir)
         if resolved_header_dir and resolved_header_dir not in own_private_header_dirs:
             own_private_header_dirs.append(resolved_header_dir)
-    own_private_header_files = _apple_header_inputs(ctx, own_private_header_dirs)
+    own_private_header_files = _unique((ctx["attr"].get("private_headers") or []) + _apple_header_inputs(ctx, own_private_header_dirs))
 
     staged_headers = []
     staged_headers_dir = ""
@@ -3372,7 +3375,7 @@ def _apple_framework_impl(ctx):
         absolute_header_dir = resolved_header_dir if resolved_header_dir.startswith("/") else workspace_root() + "/" + resolved_header_dir
         if resolved_header_dir and host_path_exists(absolute_header_dir) and resolved_header_dir not in private_header_dirs:
             private_header_dirs.append(resolved_header_dir)
-    private_header_files = _apple_header_inputs(ctx, private_header_dirs)
+    private_header_files = _unique((ctx["attr"].get("private_headers") or []) + _apple_header_inputs(ctx, private_header_dirs))
 
     all_srcs = glob(ctx["srcs"])
     swift_srcs = _filter_swift_sources(all_srcs)
@@ -3793,7 +3796,7 @@ def _apple_run_prebuild_actions(ctx, attrs):
             env = action_env,
             cacheable = cacheable,
             inherit_parent_env = not cacheable,
-            sandbox = "off",
+            sandbox = "copied-inputs" if cacheable else "off",
             create_dirs = output_dirs,
             toolchain_identity = identity or "",
             identifier = "prebuild_action:" + ctx["label"]["id"] + ":" + (action.get("name") or "script"),
@@ -3870,7 +3873,7 @@ def _apple_application_impl(ctx):
         absolute_header_dir = resolved_header_dir if resolved_header_dir.startswith("/") else workspace_root() + "/" + resolved_header_dir
         if resolved_header_dir and host_path_exists(absolute_header_dir) and resolved_header_dir not in private_header_dirs:
             private_header_dirs.append(resolved_header_dir)
-    private_header_files = _apple_header_inputs(ctx, private_header_dirs)
+    private_header_files = _unique((ctx["attr"].get("private_headers") or []) + _apple_header_inputs(ctx, private_header_dirs))
     application_extension = attrs.get("application_extension") or False
     enable_testing = attrs.get("enable_testing") or False
     if enable_testing:
@@ -5419,9 +5422,8 @@ exit "$status"
         run_action(
             argv = [host_which("sh"), "-c", script],
             inputs = test_inputs,
-            outputs = [test_dir, results, log, native_results],
+            outputs = [test_dir],
             env = action_env,
-            cacheable = False,
             toolchain_identity = "once.apple." + runner_type + ".runner.v2\x00" + swiftc["identity"],
             identifier = "apple_" + runner_type + ":" + ctx["label"]["id"],
         )
@@ -6060,6 +6062,7 @@ apple_library = target_kind(
         attr("exported_headers", "list<string>", default = "[]", docs = "Headers made available to dependent targets"),
         attr("exported_header_dirs", "list<string>", default = "[]", docs = "Header search directories made available to dependent targets"),
         attr("private_header_dirs", "list<string>", default = "[]", docs = "Header search directories used only while compiling this target"),
+        attr("private_headers", "list<string>", default = "[]", docs = "Private header files required while compiling this target"),
         attr("resources", "list<string>", default = "[]", docs = "Files and directory roots placed in this library's propagated resource bundle"),
         attr("structured_resources", "list<string>", default = "[]", docs = "Resource directory roots whose own basename is preserved inside the propagated bundle"),
         attr("resource_bundle_name", "string", docs = "Name of the propagated resource bundle. The `.bundle` suffix is added when omitted", configurable = False),
@@ -6175,6 +6178,7 @@ apple_framework = target_kind(
         attr("exported_headers", "list<string>", default = "[]", docs = "Headers exported to downstream consumers"),
         attr("exported_header_dirs", "list<string>", default = "[]", docs = "Header search directories made available to dependent targets"),
         attr("private_header_dirs", "list<string>", default = "[]", docs = "Header search directories used only while compiling this target"),
+        attr("private_headers", "list<string>", default = "[]", docs = "Private header files required while compiling this target"),
         attr("resources", "list<string>", default = "[]", docs = "Resource glob patterns bundled into the framework"),
         attr("structured_resources", "list<string>", default = "[]", docs = "Resource directory roots whose own basename is preserved inside the framework"),
         attr("asset_catalogs", "list<string>", default = "[]", docs = "Asset catalog paths compiled into the framework bundle"),
@@ -6235,6 +6239,7 @@ apple_application = target_kind(
         attr("xcode_developer_dir", "string", docs = "Pin a specific Xcode by overriding `DEVELOPER_DIR`. Folded into the action cache key"),
         attr("families", "list<string>", default = "[]", docs = "Supported device families, such as iphone or ipad"),
         attr("product_name", "string", docs = "Application product name. Defaults to the target name", configurable = False),
+        attr("module_name", "string", docs = "Swift module name. Defaults to the product name", configurable = False),
         attr("resources", "list<string>", default = "[]", docs = "Resource and asset catalog glob patterns"),
         attr("structured_resources", "list<string>", default = "[]", docs = "Resource directory roots whose own basename is preserved inside the application bundle"),
         attr("asset_catalogs", "list<string>", default = "[]", docs = "Asset catalog paths compiled into the application bundle"),
@@ -6258,6 +6263,7 @@ apple_application = target_kind(
         attr("clang_defines", "list<string>", default = "[]", docs = "C-family preprocessor definitions"),
         attr("exported_header_dirs", "list<string>", default = "[]", docs = "Header search directories exported by the application target"),
         attr("private_header_dirs", "list<string>", default = "[]", docs = "Private header search directories used while compiling the application"),
+        attr("private_headers", "list<string>", default = "[]", docs = "Private header files required while compiling the application"),
         attr("bridging_header", "string", docs = "ObjC bridging header imported into every Swift source (`-import-objc-header`), letting them see ObjC symbols and any frameworks the header imports"),
         attr("prefix_header", "string", docs = "Prefix header included before every C-family source"),
         attr("entitlements_substitutions", "map<string,string>", default = "{}", docs = "Build-setting values substituted into `$(NAME)` or `${NAME}` placeholders before signing", configurable = False),
@@ -6374,6 +6380,7 @@ apple_test_bundle = target_kind(
         attr("clang_defines", "list<string>", default = "[]", docs = "C-family preprocessor definitions"),
         attr("exported_header_dirs", "list<string>", default = "[]", docs = "Header search directories exported by the test target"),
         attr("private_header_dirs", "list<string>", default = "[]", docs = "Private header search directories used while compiling tests"),
+        attr("private_headers", "list<string>", default = "[]", docs = "Private header files required while compiling tests"),
         attr("bridging_header", "string", docs = "Objective-C bridging header imported into Swift test sources"),
         attr("prefix_header", "string", docs = "Prefix header included before every C-family test source"),
         attr("prebuild_actions", "list<string>", default = "[]", docs = "Ordered serialized build preparation actions that run before compilation.", configurable = False),

--- a/crates/once-frontend/prelude/rust.star
+++ b/crates/once-frontend/prelude/rust.star
@@ -378,10 +378,10 @@ def _rust_response_file_args(ctx, args, name):
 
 def _rust_materialized_cwd_arg(arg):
     if arg.startswith(".once/"):
-        return _workspace_absolute(arg)
+        return execution_path(arg)
     parts = _split_once(arg, "=")
     if len(parts) == 2 and parts[1].startswith(".once/"):
-        return parts[0] + "=" + _workspace_absolute(parts[1])
+        return parts[0] + "=" + execution_path(parts[1])
     return arg
 
 def _rust_user_flags(ctx):
@@ -543,6 +543,8 @@ def _workspace_absolute(path):
     root = workspace_root()
     if not root:
         return path
+    if path == ".":
+        return root
     return root + "/" + path
 
 def _rust_bin_exe_deps(ctx):
@@ -1026,11 +1028,11 @@ def _rust_proc_macro_dirs(deps):
         if proc_macro:
             directory = _parent_dir(proc_macro)
             if directory:
-                dirs.append(_workspace_absolute(directory))
+                dirs.append(execution_path(directory))
         for transitive in dep.get("transitive_proc_macros") or []:
             directory = _parent_dir(transitive)
             if directory:
-                dirs.append(_workspace_absolute(directory))
+                dirs.append(execution_path(directory))
     return _unique(dirs)
 
 def _rust_add_windows_proc_macro_path(env, deps):
@@ -1091,7 +1093,7 @@ def _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path
         env["NUM_JOBS"] = "1"
     if "OPT_LEVEL" not in env:
         env["OPT_LEVEL"] = "0"
-    env["OUT_DIR"] = _workspace_absolute(out_dir)
+    env["OUT_DIR"] = execution_path(out_dir)
     if "PROFILE" not in env:
         env["PROFILE"] = "debug"
     env["RUSTC"] = rustc
@@ -1146,15 +1148,15 @@ def _rust_dep_metadata_exports(deps):
       ;;
   esac
 done < {stdout}
-""".format(metadata = _rust_dep_metadata_key_shell(prefix), stdout = _shell_quote(_workspace_absolute(stdout))))
+""".format(metadata = _rust_dep_metadata_key_shell(prefix), stdout = _shell_quote(execution_path(stdout))))
     return ("\n".join(snippets), _unique(inputs))
 
 def _rust_build_script_output_pipeline(runner, status, stdout):
-    runner_exec = _shell_quote(_workspace_absolute(runner))
+    runner_exec = _shell_quote(execution_path(runner))
     printf = _shell_quote(host_which("printf"))
     tee = _shell_quote(host_which("tee"))
     status_abs = _shell_quote(status)
-    stdout_abs = _shell_quote(_workspace_absolute(stdout))
+    stdout_abs = _shell_quote(execution_path(stdout))
     status_capture = "{ " + runner_exec + " 2>&1; " + printf + " '%s' \"$?\" > " + status_abs + "; }"
     return status_capture + " | " + tee + " " + stdout_abs
 
@@ -1208,7 +1210,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     _rust_add_windows_proc_macro_path(build_script_compile_env, deps)
     run_action(
         argv = compile_argv,
-        inputs = _unique([script_path] + dep_inputs + dependency_build_outputs + dependency_build_inputs + wrapped[1] + _rust_extra_inputs(ctx)),
+        inputs = _unique([script_path] + source_inputs + build_script_inputs + dep_inputs + dependency_build_outputs + dependency_build_inputs + wrapped[1] + _rust_extra_inputs(ctx)),
         outputs = [runner],
         env = build_script_compile_env,
         toolchain_identity = identity + linker_identity + "\x00build-script",
@@ -1216,6 +1218,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     )
     tool_paths = _rust_build_script_tool_paths(ctx)
     run_env = _rust_build_script_env(ctx, rustc, target, host_triple, out_dir, script_path, tool_paths)
+    status = out_dir + "/.once-build-script-status"
     metadata_exports, metadata_inputs = _rust_dep_metadata_exports(metadata_deps)
     run_script = _rust_build_script_run_shell(runner, stdout, run_env, metadata_exports)
     # Cargo's default: a build script that prints no `rerun-if` directive
@@ -1230,7 +1233,7 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
     run_action(
         argv = [host_which("sh"), "-c", run_script],
         inputs = _unique([runner] + metadata_inputs + source_inputs + build_script_inputs + _rust_extra_inputs(ctx)),
-        outputs = [out_dir, stdout],
+        outputs = [out_dir, stdout, status],
         # Emptying the output directory belongs to the script's own setup, not
         # to a step before it. Declared as separate actions, the wipe ran even
         # when the script's result was already cached, and the cache hit then
@@ -1245,8 +1248,8 @@ def _rust_build_script(ctx, rustc, identity, target, host_triple, edition, dep_a
         identifier = _rust_action_identifier(ctx, "build-script"),
     )
     compile_env = _rust_compile_action_env(ctx, target, host_triple)
-    compile_env["OUT_DIR"] = _workspace_absolute(out_dir)
-    return (out_dir, [script_path, stdout], compile_env, stdout)
+    compile_env["OUT_DIR"] = execution_path(out_dir)
+    return (out_dir, [script_path, out_dir, stdout], compile_env, stdout)
 
 def _rustc_unix_read_dependency_link_searches(stdout):
     return """while IFS= read -r line; do
@@ -1254,11 +1257,14 @@ def _rustc_unix_read_dependency_link_searches(stdout):
     cargo:rustc-link-search=*|cargo::rustc-link-search=*)
       value=${{line#cargo:rustc-link-search=}}
       value=${{value#cargo::rustc-link-search=}}
+      case "$value" in
+        */.once/out/*) value={out_root}"/${{value#*/.once/out/}}" ;;
+      esac
       set -- "$@" -L "$value"
       ;;
   esac
 done < {stdout}
-""".format(stdout = _shell_quote(_workspace_absolute(stdout)))
+""".format(stdout = _shell_quote(execution_path(stdout)), out_root = _shell_quote(execution_path(".once/out")))
 
 def _rustc_unix_read_own_build_script_args(stdout):
     return """while IFS= read -r line; do
@@ -1291,11 +1297,14 @@ def _rustc_unix_read_own_build_script_args(stdout):
     cargo:rustc-link-search=*|cargo::rustc-link-search=*)
       value=${{line#cargo:rustc-link-search=}}
       value=${{value#cargo::rustc-link-search=}}
+      case "$value" in
+        */.once/out/*) value={out_root}"/${{value#*/.once/out/}}" ;;
+      esac
       set -- "$@" -L "$value"
       ;;
   esac
 done < {stdout}
-""".format(stdout = _shell_quote(_workspace_absolute(stdout)))
+""".format(stdout = _shell_quote(execution_path(stdout)), out_root = _shell_quote(execution_path(".once/out")))
 
 def _rustc_unix_build_script_args(argv, own_stdout, dependency_stdouts):
     snippets = []
@@ -1915,7 +1924,7 @@ def _rust_cargo_runtime_env(ctx):
     }
 
 def _rust_test_env(ctx, test_dir):
-    env = {"HOME": execution_path(test_dir + "/home")}
+    env = {"HOME": execution_path(_rust_scratch_dir(ctx) + "/test-home")}
     process_path = _rust_process_path()
     if process_path:
         env["PATH"] = process_path
@@ -1945,7 +1954,7 @@ def _rust_test_info(ctx, test_binary, results, log, native_results, test_dir):
         "command": {
             "argv": [test_binary] + args,
             "env": _rust_test_env(ctx, test_dir),
-            "cwd": ".",
+            "cwd": _rust_test_cwd(ctx) or ".",
         },
         "outputs": {
             "results": results,
@@ -1993,8 +2002,8 @@ use std::process::{self, Command, Output};
 
 fn main() {
     let args = env::args().collect::<Vec<_>>();
-    if args.len() < 6 {
-        eprintln!("usage: once-rust-test-runner <binary> <results> <log> <native-results> <target> [args...]");
+    if args.len() < 7 {
+        eprintln!("usage: once-rust-test-runner <binary> <results> <log> <native-results> <target> <cwd> [args...]");
         process::exit(2);
     }
     let binary = &args[1];
@@ -2002,20 +2011,21 @@ fn main() {
     let log = &args[3];
     let native_results = &args[4];
     let target = &args[5];
-    let runner_args = &args[6..];
+    let cwd = &args[6];
+    let runner_args = &args[7..];
 
     create_parent(results);
     create_parent(log);
     create_parent(native_results);
 
-    let list_output = Command::new(binary).args(runner_args).arg("--list").output();
+    let list_output = test_command(binary, cwd, runner_args).arg("--list").output();
     let list_text = match &list_output {
         Ok(output) => output_text(output),
         Err(error) => format!("failed to list tests: {error}\\n"),
     };
     let cases = parse_list(&list_text);
 
-    let run_output = Command::new(binary).args(runner_args).output();
+    let run_output = test_command(binary, cwd, runner_args).output();
     let (run_text, exit_code, passed) = match run_output {
         Ok(output) => {
             let code = output.status.code().unwrap_or(1);
@@ -2029,7 +2039,17 @@ fn main() {
     fs::write(log, &run_text).expect("write log");
     fs::write(native_results, format!("$ {binary} --list\\n{list_text}\\n$ {binary}\\n{run_text}")).expect("write native results");
     fs::write(results, report).expect("write results");
+    if !passed {
+        eprint!("{run_text}");
+    }
     process::exit(exit_code);
+}
+
+fn test_command(binary: &str, cwd: &str, runner_args: &[String]) -> Command {
+    let mut command = Command::new(binary);
+    command.args(runner_args);
+    command.current_dir(cwd);
+    command
 }
 
 fn create_parent(path: &str) {
@@ -2156,13 +2176,13 @@ def _rust_test_impl(ctx):
     results = test_dir + "/test_results.json"
     log = test_dir + "/rust-libtest.log"
     native_results = test_dir + "/native_results.txt"
+    _, _, host_triple = _rustc_toolchain(_rust_target(ctx))
     provider["test_info"] = _rust_test_info(ctx, provider["test_binary"], results, log, native_results, test_dir)
 
     if ctx["capability"] != "test":
         return provider
 
     target = _rust_target(ctx)
-    _, _, host_triple = _rustc_toolchain(target)
     if target and target != host_triple:
         fail(ctx["label"]["id"] + ": rust_test execution supports the host target only; remove `target` or run the cross-compiled test binary with a platform runner")
 
@@ -2217,6 +2237,7 @@ def _rust_test_impl(ctx):
             execution_path(log),
             execution_path(native_results),
             ctx["label"]["id"],
+            ".",
         ] + _rust_attr(ctx, "args", []) + _rust_test_filter_args(ctx),
         inputs = _unique(
             [runner, staged_test_binary] +
@@ -2225,7 +2246,9 @@ def _rust_test_impl(ctx):
             _rust_test_package_inputs(ctx) +
             (provider.get("transitive_data") or [])
         ),
-        outputs = [test_dir, results, log, native_results],
+        outputs = [test_dir],
+        clean_paths = [_rust_scratch_dir(ctx) + "/test-home"],
+        create_dirs = [_rust_scratch_dir(ctx) + "/test-home"],
         cwd = _rust_test_cwd(ctx),
         env = _rust_test_env(ctx, test_dir),
         toolchain_identity = runner_identity + "\x00once.rust_test.run.v1",
@@ -3236,6 +3259,7 @@ def _cargo_workspace_target_enabled(target, node):
     return True
 
 def _cargo_workspace_attrs(package, target, node, source_root, aliases):
+    package_inputs = _cargo_package_source_globs(source_root)
     attrs = {
         "crate_name": _cargo_crate_name(package, target),
         "crate_root": source_root + "/" + _cargo_source_rel(package, target),
@@ -3243,6 +3267,8 @@ def _cargo_workspace_attrs(package, target, node, source_root, aliases):
         "features": node.get("features") or [],
         "rustc_env": _cargo_rustc_env(package, target, source_root),
         "cargo_package": package["name"],
+        "compile_data": package_inputs,
+        "_build_script_inputs": package_inputs,
     }
     if aliases:
         attrs["crate_aliases"] = aliases

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -1790,6 +1790,17 @@ def _xcode_swift_package_target_header_dirs(package_path, target):
         headers = glob([root + target_path + "/**/*.h"])
     return _unique([_parent_dir(header) for header in headers if _parent_dir(header) and not _xcode_swift_package_target_path_is_excluded(root, target_path, excluded, header)])
 
+def _xcode_swift_package_target_private_headers(package_path, target):
+    target_path = _xcode_swift_package_target_path(target)
+    root = package_path + "/" if package_path else ""
+    excluded = target.get("exclude") or []
+    absolute = _xcode_abs(root + target_path)
+    if package_path.startswith(".once/"):
+        headers = [_xcode_workspace_relative(path) for path in host_command([host_which("find"), absolute, "-name", "*.h", "-type", "f"]).split("\n") if path]
+    else:
+        headers = glob([root + target_path + "/**/*.h"])
+    return _unique([header for header in headers if not _xcode_swift_package_target_path_is_excluded(root, target_path, excluded, header)])
+
 def _xcode_swift_package_target_datamodels(package_path, target):
     target_path = _xcode_swift_package_target_path(target)
     root = package_path + "/" + target_path
@@ -2186,6 +2197,7 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
                     "clang_flags": ["-std=c++17"] + flags["clang"],
                     "exported_header_dirs": _xcode_swift_package_include_dirs(package_path, target),
                     "private_header_dirs": _xcode_swift_package_target_header_dirs(package_path, target),
+                    "private_headers": _xcode_swift_package_target_private_headers(package_path, target),
                     "prebuild_actions": prebuild_actions,
                     "resources": resource_paths,
                     "structured_resources": structured_resource_paths,
@@ -3213,6 +3225,9 @@ def _xcode_application_attrs(ctx, target, settings, subs, platform, files):
     product_name = _xcode_product_name(settings, target, subs)
     if product_name:
         attrs["product_name"] = product_name
+    module_name = _xcode_resolve_vars(_xcode_scalar(settings.get("PRODUCT_MODULE_NAME")), subs)
+    if module_name and not module_name.startswith("$(") and not module_name.startswith("${"):
+        attrs["module_name"] = module_name
     bundle_id = _xcode_bundle_id(settings, subs, product_name)
     attrs["bundle_id"] = bundle_id
     _xcode_add_info_plist_attrs(attrs, settings, subs, product_name, bundle_id)

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -17415,6 +17415,7 @@ fn prelude_xcode_workspace_resolver_lowers_native_targets() {
                 "name": "Debug",
                 "buildSettings": {
                     "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "PRODUCT_MODULE_NAME": "CustomAppModule",
                     "PRODUCT_BUNDLE_IDENTIFIER": "dev.once.App",
                     "DEVELOPMENT_TEAM": "TEAM123",
                     "TARGETED_DEVICE_FAMILY": "1,2",
@@ -17512,6 +17513,7 @@ result = repr([
     specs["Feature"]["attrs"].get("per_source_clang_flags"),
     specs["App"]["srcs"],
     specs["App"]["attrs"].get("bundle_id"),
+    specs["App"]["attrs"].get("module_name"),
     specs["App"]["attrs"].get("development_team"),
     specs["App"]["attrs"].get("families"),
     specs["App"]["attrs"].get("minimum_os"),
@@ -17523,6 +17525,6 @@ result = repr([
     let out = eval_prelude_source_to_repr(source).unwrap();
     assert_eq!(
         out,
-        r#"[["App"], ["AppTests"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["Source/Core/Feature.swift"], {"Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["App.swift"], "dev.once.App", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
+        r#"[["App"], ["AppTests"], ["apple_framework", "apple_application", "apple_test_bundle"], ["./Feature"], ["./App"], ["Source/Core/Feature.swift"], {"Source/Core/Feature.swift": "[\"-DNDEBUG\",\"-fno-objc-arc\"]"}, ["App.swift"], "dev.once.App", "CustomAppModule", "TEAM123", ["iphone", "ipad"], "16.0", True]"#
     );
 }

--- a/web/priv/docs/reference/prelude/apple_application.md
+++ b/web/priv/docs/reference/prelude/apple_application.md
@@ -28,6 +28,7 @@ framework, and then signs the application.
 | `xcode_developer_dir` | string | no | active Xcode | Xcode developer directory used to resolve build tools |
 | `families` | list&lt;string&gt; | no | `[]` | Supported device families (`iphone`, `ipad`); an empty list uses `iphone` |
 | `product_name` | string | no | target name | Application product name (not configurable) |
+| `module_name` | string | no | product name | Swift module name (not configurable) |
 | `resources` | list&lt;string&gt; | no | `[]` | Resource files and directory roots placed in the application bundle |
 | `structured_resources` | list&lt;string&gt; | no | `[]` | Resource directory roots whose own basename is preserved inside the application bundle |
 | `asset_catalogs` | list&lt;string&gt; | no | `[]` | Asset catalog paths compiled into the application bundle |
@@ -51,6 +52,7 @@ framework, and then signs the application.
 | `clang_defines` | list&lt;string&gt; | no | `[]` | C-family preprocessor definitions |
 | `exported_header_dirs` | list&lt;string&gt; | no | `[]` | Header search directories exported by the application target |
 | `private_header_dirs` | list&lt;string&gt; | no | `[]` | Private header search directories used while compiling the application |
+| `private_headers` | list&lt;string&gt; | no | `[]` | Private header files required while compiling the application |
 | `bridging_header` | string | no |  | Objective-C bridging header imported into Swift sources |
 | `prefix_header` | string | no |  | Prefix header included before every C-family source |
 | `prebuild_actions` | list&lt;string&gt; | no | `[]` | Adapter-owned serialized build preparation actions that run before compilation. Records may opt into caching when they declare complete inputs and outputs; always-run records remain uncached |

--- a/web/priv/docs/reference/prelude/apple_framework.md
+++ b/web/priv/docs/reference/prelude/apple_framework.md
@@ -27,6 +27,7 @@ used for the build.
 | `exported_headers` | list&lt;string&gt; | no | `[]` | Headers exported to downstream consumers |
 | `exported_header_dirs` | list&lt;string&gt; | no | `[]` | Header search directories exported to downstream consumers |
 | `private_header_dirs` | list&lt;string&gt; | no | `[]` | Header search directories used only while compiling the framework |
+| `private_headers` | list&lt;string&gt; | no | `[]` | Private header files required while compiling the framework |
 | `resources` | list&lt;string&gt; | no | `[]` | Resource glob patterns bundled into the framework |
 | `structured_resources` | list&lt;string&gt; | no | `[]` | Resource directory roots whose own basename is preserved in the framework |
 | `asset_catalogs` | list&lt;string&gt; | no | `[]` | Asset catalog paths compiled into the framework bundle |

--- a/web/priv/docs/reference/prelude/apple_library.md
+++ b/web/priv/docs/reference/prelude/apple_library.md
@@ -26,6 +26,7 @@ merge them with `lipo`.
 | `exported_headers` | list&lt;string&gt; | no | `[]` | Headers made available to dependent targets |
 | `exported_header_dirs` | list&lt;string&gt; | no | `[]` | Header search directories made available to dependent targets |
 | `private_header_dirs` | list&lt;string&gt; | no | `[]` | Header search directories used only while compiling this target |
+| `private_headers` | list&lt;string&gt; | no | `[]` | Private header files required while compiling this target |
 | `resources` | list&lt;string&gt; | no | `[]` | Files and directory roots placed in this library's propagated resource bundle |
 | `structured_resources` | list&lt;string&gt; | no | `[]` | Resource directory roots whose own basename is preserved inside the propagated bundle |
 | `resource_bundle_name` | string | no |  | Name of the propagated resource bundle. The `.bundle` suffix is added when omitted |

--- a/web/priv/docs/reference/prelude/apple_test_bundle.md
+++ b/web/priv/docs/reference/prelude/apple_test_bundle.md
@@ -72,6 +72,7 @@ Once build actions.
 | `clang_defines` | list&lt;string&gt; | no | `[]` | C-family preprocessor definitions |
 | `exported_header_dirs` | list&lt;string&gt; | no | `[]` | Header search directories exported by the test target |
 | `private_header_dirs` | list&lt;string&gt; | no | `[]` | Private header search directories used while compiling tests |
+| `private_headers` | list&lt;string&gt; | no | `[]` | Private header files required while compiling tests |
 | `bridging_header` | string | no |  | Objective-C bridging header imported into Swift test sources |
 | `prefix_header` | string | no |  | Prefix header included before every C-family test source |
 | `prebuild_actions` | list&lt;string&gt; | no | `[]` | Adapter-owned serialized build preparation actions that run before compilation. Records may opt into caching when they declare complete inputs and outputs; always-run records remain uncached |


### PR DESCRIPTION
## What changed

This makes build and test actions more reproducible while improving the live terminal output for large build graphs.

- Align and truncate target names consistently, and show live elapsed time without duplicate execution transitions.
- Deny action network access by default and enforce that policy on macOS while retaining local Apple test-manager communication.
- Canonicalize workspace paths in action fingerprints and avoid blocking the asynchronous executor while waiting for action locks.
- Declare Rust build-script sources, generated directories, test inputs, working directories, and scratch homes explicitly.
- Make Apple test results cacheable, run cacheable prebuild actions with copied inputs, and support private package headers and product module names from Xcode projects.
- Document the new Apple target attributes.

## Why

Large real-world projects such as Wikipedia for iOS and Mise exposed misleading terminal alignment, undeclared inputs, workspace-specific action hashes, and test actions that could never be restored from cache. These gaps made otherwise identical work difficult to reuse and hid important isolation assumptions.

## Root cause

Action metadata retained absolute workspace paths, unspecified network policies inherited unrestricted access, and several Rust and Apple target actions did not fully describe the source or generated files they consumed. Aggregate targets without their own actions were also reported as cache misses even when every dependency was restored.

## Approach

The implementation keeps the shared graph machinery ecosystem-neutral. Generic execution code now supplies stricter defaults and stable fingerprint values, while Rust and Apple behavior remains in their respective Starlark target kinds. The target kinds declare the additional inputs, outputs, execution paths, and schema attributes needed by their tools.

## Impact

Repeated Wikipedia and Mise builds can restore all previously completed build targets from cache. Action fingerprints no longer vary solely because a checkout moved. Network access must now be requested explicitly by actions that require it.

This remains a draft because strict copied-input validation identified follow-up work for a stable virtual Rust source root, configuration-aware Xcode test graphs, and dependency acquisition during graph analysis.

## Validation

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo check -p once-core -p once-frontend -p once-cli --tests`
- `mise exec -- cargo test -p once-frontend prelude_xcode_workspace_resolver_lowers_native_targets`
- `mise exec -- cargo test -p once-cli input_digest_ignores_unrelated_module_source_changes`
- Wikipedia cold build: 18 targets built in 12 minutes 41 seconds.
- Wikipedia repeated build: all 19 targets restored from cache in 1 minute 17 seconds.
- Mise `cargo_vfox` cold build: 337 targets built in 1 minute 23 seconds.
- Mise `cargo_vfox` repeated build: all 337 targets restored from cache in 6.8 seconds.
- Mise `cargo_vfox_unit_tests`: 113 passed and 4 snapshot tests exposed the remaining virtual-source-root mismatch.
