### PR TITLE
fix(release): publish the npm SDK through trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,14 @@ jobs:
       - build-sdk-libs
     if: needs.detect.outputs.should-release == 'true' && needs.publish.result == 'success' && needs.build-sdk-libs.result == 'success'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      # npm authenticates through trusted publishing: it trades this workflow's
+      # OIDC identity for a short-lived publish credential, so there is no npm
+      # token to store or rotate. The trusted publisher registered on npmjs.com
+      # pins the org, the repository and this workflow's filename, which means
+      # renaming this file revokes npm publishing until it is re-registered.
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
@@ -255,14 +263,12 @@ jobs:
           export-env: true
         env:
           RUBYGEMS_API_KEY: op://once/RubyGems API Key/api_key
-          NPM_TOKEN: op://once/npm Automation Token/token
-      - name: Configure package registries
-        run: |
-          echo "::add-mask::${RUBYGEMS_API_KEY}"
-          echo "::add-mask::${NPM_TOKEN}"
-          printf '%s\n' "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          chmod 0600 ~/.npmrc
+      # No ~/.npmrc is written on purpose. npm only starts the OIDC exchange
+      # when it finds no configured credential, so an _authToken line here
+      # would make it publish anonymously and fail with a 404 that says the
+      # package does not exist rather than that the credential was refused.
       - name: Publish SDK packages
         run: |
+          echo "::add-mask::${RUBYGEMS_API_KEY}"
           export GEM_HOST_API_KEY="${RUBYGEMS_API_KEY}"
           mise run release:publish-sdks --version "${{ needs.detect.outputs.next-version }}"

--- a/mise/tasks/release/publish-sdks.sh
+++ b/mise/tasks/release/publish-sdks.sh
@@ -36,6 +36,18 @@ for tool in gem npm; do
   fi
 done
 
+# npm publishes through OIDC trusted publishing in CI. Clients older than
+# 11.5.1 do not know how to make that exchange, quietly fall back to an
+# anonymous request, and the registry rejects it with a 404 claiming the
+# package does not exist. Checking the version up front turns that into an
+# error that names the real problem.
+npm_min_version="11.5.1"
+npm_version="$(npm --version)"
+if [[ "$(printf '%s\n%s\n' "${npm_min_version}" "${npm_version}" | sort -V | head -n1)" != "${npm_min_version}" ]]; then
+  echo "npm ${npm_min_version} or newer is required to publish; found ${npm_version}" >&2
+  exit 1
+fi
+
 if [[ ! -d packages/js/prebuilds || ! -d packages/ruby/prebuilds ]]; then
   echo "SDK prebuilds are missing; run release:package-sdk-libs first" >&2
   exit 1
@@ -49,16 +61,58 @@ cp -R packages/js/. "${stage_dir}/js/"
 cp -R packages/ruby/. "${stage_dir}/ruby/"
 rm -rf "${stage_dir}/js/node_modules" "${stage_dir}/ruby/"*.gem
 
-(
-  cd "${stage_dir}/js"
-  npm version "${version}" \
-    --no-git-tag-version \
-    --allow-same-version
-  npm publish --access public
-)
+npm_has_version() {
+  npm view "buildonce@${version}" version >/dev/null 2>&1
+}
 
-(
-  cd "${stage_dir}/ruby"
-  ONCE_VERSION="${version}" gem build once.gemspec
-  gem push "buildonce-${version}.gem"
-)
+gem_has_version() {
+  # `gem list --remote` prints `buildonce (0.53.1, 0.53.0, ...)`, so the
+  # version list is unwrapped and matched whole to avoid 0.5.4 matching
+  # 0.54.0. grep runs without -q so that it drains the pipeline instead of
+  # closing it early and tripping pipefail on a SIGPIPE from tr.
+  gem list --remote --exact --all buildonce 2>/dev/null |
+    sed -n 's/^buildonce (\(.*\))$/\1/p' |
+    tr ',' '\n' |
+    sed 's/[[:space:]]//g' |
+    grep -Fx "${version}" >/dev/null
+}
+
+publish_npm() {
+  if npm_has_version; then
+    echo "buildonce@${version} is already on npm; skipping"
+    return 0
+  fi
+
+  (
+    cd "${stage_dir}/js" &&
+      npm version "${version}" --no-git-tag-version --allow-same-version &&
+      npm publish --access public
+  )
+}
+
+publish_gem() {
+  if gem_has_version; then
+    echo "buildonce ${version} is already on RubyGems; skipping"
+    return 0
+  fi
+
+  (
+    cd "${stage_dir}/ruby" &&
+      ONCE_VERSION="${version}" gem build once.gemspec &&
+      gem push "buildonce-${version}.gem"
+  )
+}
+
+# The registries are published independently so an outage or an expired
+# credential on one does not leave the other silently unreleased. Each step is
+# a no-op once the version is on the registry, which makes re-running the job
+# the way to recover from a partial release.
+failures=()
+
+publish_npm || failures+=("npm")
+publish_gem || failures+=("RubyGems")
+
+if ((${#failures[@]} > 0)); then
+  echo "failed to publish buildonce ${version} to: ${failures[*]}" >&2
+  exit 1
+fi

--- a/mise/tasks/release/publish-sdks.sh
+++ b/mise/tasks/release/publish-sdks.sh
@@ -36,18 +36,6 @@ for tool in gem npm; do
   fi
 done
 
-# npm publishes through OIDC trusted publishing in CI. Clients older than
-# 11.5.1 do not know how to make that exchange, quietly fall back to an
-# anonymous request, and the registry rejects it with a 404 claiming the
-# package does not exist. Checking the version up front turns that into an
-# error that names the real problem.
-npm_min_version="11.5.1"
-npm_version="$(npm --version)"
-if [[ "$(printf '%s\n%s\n' "${npm_min_version}" "${npm_version}" | sort -V | head -n1)" != "${npm_min_version}" ]]; then
-  echo "npm ${npm_min_version} or newer is required to publish; found ${npm_version}" >&2
-  exit 1
-fi
-
 if [[ ! -d packages/js/prebuilds || ! -d packages/ruby/prebuilds ]]; then
   echo "SDK prebuilds are missing; run release:package-sdk-libs first" >&2
   exit 1
@@ -81,6 +69,19 @@ publish_npm() {
   if npm_has_version; then
     echo "buildonce@${version} is already on npm; skipping"
     return 0
+  fi
+
+  # npm authenticates through OIDC trusted publishing. Clients older than
+  # 11.5.1 do not know how to make that exchange, quietly fall back to an
+  # anonymous request, and the registry answers it with a 404 claiming the
+  # package does not exist. Checking here turns that into an error that
+  # names the real problem.
+  local npm_min_version="11.5.1"
+  local npm_version
+  npm_version="$(npm --version)"
+  if [[ "$(printf '%s\n%s\n' "${npm_min_version}" "${npm_version}" | sort -V | head -n1)" != "${npm_min_version}" ]]; then
+    echo "npm ${npm_min_version} or newer is required to publish; found ${npm_version}" >&2
+    return 1
   fi
 
   (

--- a/spec/release_sdk_spec.sh
+++ b/spec/release_sdk_spec.sh
@@ -152,4 +152,101 @@ Describe 'release SDK packaging scripts'
     The status should be failure
     The stderr should include 'SDK prebuilds are missing'
   End
+
+  # Staging a package tree that the publish path will actually walk, so the
+  # registry stubs below are reached instead of the prebuilds guard.
+  setup_publishable_packages() {
+    mkdir -p \
+      "$WORKSPACE/packages/js/prebuilds" \
+      "$WORKSPACE/packages/ruby/prebuilds"
+    printf '{"name":"buildonce","version":"0.0.0"}\n' > "$WORKSPACE/packages/js/package.json"
+    printf 'Gem::Specification.new\n' > "$WORKSPACE/packages/ruby/once.gemspec"
+  }
+
+  It 'skips registries that already carry the version'
+    setup_release_path
+    setup_publishable_packages
+    # `npm view <pkg>@<version>` succeeding is how npm reports that the
+    # version is published; `gem list --remote` prints its own listing.
+    write_stub npm \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = view ]; then exit 0; fi' \
+      'echo "npm $* should not have run" >&2' \
+      'exit 1'
+    write_stub gem \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = list ]; then echo "buildonce (0.9.0, 0.1.0)"; exit 0; fi' \
+      'echo "gem $* should not have run" >&2' \
+      'exit 1'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 0.9.0
+    The status should be success
+    The stdout should include 'already on npm; skipping'
+    The stdout should include 'already on RubyGems; skipping'
+  End
+
+  It 'matches published versions exactly rather than as substrings'
+    setup_release_path
+    setup_publishable_packages
+    write_stub npm \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = --version ]; then echo 11.17.0; exit 0; fi' \
+      'if [ "$1" = view ]; then exit 1; fi' \
+      'exit 0'
+    # 0.54.0 must not be read as published just because 0.5.4 is.
+    write_stub gem \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = list ]; then echo "buildonce (0.5.4, 0.1.0)"; exit 0; fi' \
+      'if [ "$1" = push ]; then echo "pushed $2"; exit 0; fi' \
+      'exit 0'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 0.54.0
+    The status should be success
+    The stdout should not include 'already on RubyGems'
+    The stdout should include 'pushed buildonce-0.54.0.gem'
+  End
+
+  It 'publishes to RubyGems even when npm publishing fails'
+    setup_release_path
+    setup_publishable_packages
+    write_stub npm \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = --version ]; then echo 11.17.0; exit 0; fi' \
+      'if [ "$1" = view ]; then exit 1; fi' \
+      'if [ "$1" = publish ]; then echo "npm refused the credential" >&2; exit 1; fi' \
+      'exit 0'
+    write_stub gem \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = list ]; then echo "buildonce (0.1.0)"; exit 0; fi' \
+      'if [ "$1" = push ]; then echo "pushed $2"; exit 0; fi' \
+      'exit 0'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 0.9.0
+    The status should be failure
+    The stdout should include 'pushed buildonce-0.9.0.gem'
+    The stderr should include 'failed to publish buildonce 0.9.0 to: npm'
+  End
+
+  It 'rejects npm clients too old for trusted publishing'
+    setup_release_path
+    setup_publishable_packages
+    write_stub npm \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = view ]; then exit 1; fi' \
+      'if [ "$1" = --version ]; then echo 10.9.2; exit 0; fi' \
+      'exit 0'
+    write_stub gem \
+      '#!/usr/bin/env bash' \
+      'if [ "$1" = list ]; then echo "buildonce (0.9.0)"; exit 0; fi' \
+      'exit 0'
+    cd "$WORKSPACE"
+
+    When call "$REPO_ROOT/mise/tasks/release/publish-sdks.sh" --version 0.9.0
+    The status should be failure
+    The stdout should include 'already on RubyGems; skipping'
+    The stderr should include 'npm 11.5.1 or newer is required to publish; found 10.9.2'
+  End
 End


### PR DESCRIPTION
## What is broken

The `Release` workflow on `main` has been red since 0.54.0. The GitHub release itself published fine, but `Publish RubyGems and npm packages` failed and neither `buildonce` on npm nor `buildonce` on RubyGems ever got 0.54.0. Both registries are still sitting on 0.53.1, so anyone installing the JS or Ruby SDK is two releases behind the CLI.

The failure ([run 34285727822](https://github.com/tuist/once/actions/runs/34285727822)) is:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/buildonce - Not found
npm error 404  The requested resource 'buildonce@0.54.0' could not be found
```

That 404 is misleading. `buildonce` obviously exists, we own it, and it has 51 published versions. npm answers an unauthenticated `PUT` with a 404 rather than a 401 so that it does not leak which private packages exist, so what this actually says is that the credential was refused.

Nothing in the release path changed between 0.53.1 publishing successfully on September 5 and 0.54.0 failing on September 8. `git log 0.53.1..HEAD -- .github/workflows/release.yml mise/tasks/release packages/` is empty. The 1Password step loaded the secret without error, so the token was present, just no longer valid. The npm credential expired.

## Why not just rotate the token

That was my first instinct, but it only buys us about three months. npm revoked all classic tokens in December 2025 and capped granular tokens at 90 days, which is almost exactly the gap between the token last working and it failing here. On top of that, [npm is removing direct publishing from 2FA-bypass tokens in January 2027](https://github.blog/changelog/2026-07-31-restricting-npm-bypass-2fa-granular-access-tokens/). A rotation now means doing this again in 90 days, and then migrating anyway before January.

So we go straight to OIDC trusted publishing. The workflow trades its GitHub identity for a short-lived publish credential, there is no secret to store or rotate, and we get provenance attestations for free.

I considered keeping the token in place as a fallback alongside OIDC. That does not work: npm only starts the OIDC exchange when it finds no configured credential, so an `_authToken` line in `.npmrc` makes it publish anonymously and produces exactly the 404 above. It has to be one or the other, so the `.npmrc` write is gone and there is a comment on the step explaining why nothing should put it back.

I left RubyGems on its stored API key. It works today and rubygems.org trusted publishing is a separate registry-side setup, so it did not belong in a change meant to get releases moving again. Worth doing as a follow-up.

## The second bug this exposed

`publish-sdks.sh` ran npm and then RubyGems as one fail-fast sequence. npm failing meant the gem push never ran, which is why 0.54.0 is missing from both registries rather than just npm. And re-running the job could not fix it, because whichever registry had already accepted the version would reject the second attempt.

Each registry is now published independently and each step is a no-op when the version is already there, so re-running the job is the way to recover from a partial release. Version matching is exact, so 0.5.4 does not match 0.54.0.

I also added an npm version guard. Trusted publishing needs npm 11.5.1 or newer, and an older client silently skips the OIDC exchange and fails with the same misleading 404. Given how long that 404 took to read correctly the first time, it is worth failing with a message that names the real problem. We are on 11.17.0 via node 26.5.0, so this is a guard rather than a fix.

## Before this merges

The trusted publisher has to be registered on npmjs.com first, or the release after this lands fails the same way. On the `buildonce` package settings: organization `tuist`, repository `once`, workflow filename `release.yml`, environment blank.

Note that this pins the workflow filename. Renaming `release.yml` revokes npm publishing until it is re-registered, which is called out in a comment on the job.

## Verification

I ran the rewritten script end to end against 0.53.1, which is already on both registries, and it correctly skipped both and exited 0. I checked the version matching against 0.53.1, 0.54.0, 0.5.4, 0.1.0 and 0.14.5 and each resolved correctly on both registries. shellcheck is clean, and the workflow YAML parses with the job resolving as intended.

The auth path itself cannot be verified before merge, since OIDC only works from the default branch's workflow. The first release after this merges is the real test. If it fails, the fallback is to register the publisher and re-run the failed job, which now works because publishing is idempotent.

0.54.0 will stay missing from npm and RubyGems. Nothing depends on it, since it was never published, and the next release will carry those commits forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQMKwHTYWnjo5Z7Mjna4SW
