### PR TITLE
fix(apple,xcode): build and test Swift packages the way Swift Package Manager does

### DIFF
--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -407,6 +407,262 @@ def _apple_swift_testing_link_flags(testing_library_dir):
         return ["-framework", "Testing"]
     return ["-L", testing_library_dir, "-lTesting", "-Xlinker", "-rpath", "-Xlinker", testing_library_dir]
 
+def _apple_swift_testing_entry_point_source():
+    # A loadable test bundle has no entry point of its own, so the only way to
+    # reach the testing library is through whatever host loads the bundle, and
+    # that host decides what gets reported. Swift Package Manager answers this
+    # by compiling an entry point into the bundle: it stays loadable by
+    # `xctest`, which finds XCTest cases through the Objective-C runtime and
+    # ignores `main`, while a caller that wants the testing library's own
+    # structured output loads the bundle and calls `main` instead.
+    #
+    # Once goes one step further and normalizes that output here, in the
+    # process that produced it, rather than re-deriving outcomes from console
+    # text. The testing library writes its event stream to the path Once names,
+    # and this turns those records into normalized results.
+    return """#if canImport(Testing)
+import Testing
+#endif
+import Foundation
+
+enum OnceTestReport {
+    struct Case {
+        var name: String
+        var suite: String
+        var file: String
+        var status: String
+    }
+
+    static let quote = String(UnicodeScalar(34))
+    static let backslash = String(UnicodeScalar(92))
+
+    static func environmentPath(_ name: String) -> String? {
+        guard let value = ProcessInfo.processInfo.environment[name], !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    static func records(at path: String) -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return []
+        }
+        return contents.components(separatedBy: .newlines).compactMap { line in
+            guard let data = line.data(using: .utf8) else { return nil }
+            return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        }
+    }
+
+    /// A test function's identifier is its suite's identifier followed by the
+    /// function, so the enclosing suite is the longest suite identifier that
+    /// prefixes it. A free function has no such suite and falls back to the
+    /// name of the file that declares it.
+    static func suiteName(forTest id: String, suites: [String: String], file: String) -> String {
+        var best = ""
+        for (suiteID, suiteName) in suites where id.hasPrefix(suiteID + "/") && !suiteName.isEmpty {
+            if suiteID.count > best.count {
+                best = suiteID
+            }
+        }
+        if let name = suites[best], !name.isEmpty {
+            return name
+        }
+        var stem = (file as NSString).lastPathComponent
+        if stem.hasSuffix(".swift") {
+            stem = String(stem.dropLast(6))
+        }
+        return stem
+    }
+
+    static func relativePath(_ path: String) -> String {
+        let root = FileManager.default.currentDirectoryPath
+        if !root.isEmpty, path.hasPrefix(root + "/") {
+            return String(path.dropFirst(root.count + 1))
+        }
+        return path
+    }
+
+    static func quoted(_ value: String) -> String {
+        var out = quote
+        for scalar in value.unicodeScalars {
+            if scalar.value == 34 {
+                out += backslash + quote
+            } else if scalar.value == 92 {
+                out += backslash + backslash
+            } else if scalar.value < 0x20 {
+                out += backslash + "u" + String(format: "%04x", scalar.value)
+            } else {
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        return out + quote
+    }
+
+    static func jsonArray(_ value: String?) -> String {
+        guard let value else { return "[]" }
+        return "[" + quoted(value) + "]"
+    }
+
+    static func write(exitCode: CInt) {
+        guard let resultsPath = environmentPath("ONCE_TEST_RESULTS"),
+              let streamPath = environmentPath("ONCE_TEST_EVENT_STREAM") else {
+            return
+        }
+        let target = environmentPath("ONCE_TEST_TARGET") ?? ""
+        var suites: [String: String] = [:]
+        var order: [String] = []
+        var cases: [String: Case] = [:]
+
+        for record in records(at: streamPath) {
+            guard let payload = record["payload"] as? [String: Any],
+                  let kind = payload["kind"] as? String else { continue }
+            switch record["kind"] as? String {
+            case "test":
+                guard let id = payload["id"] as? String else { continue }
+                if kind == "suite" {
+                    suites[id] = payload["name"] as? String ?? ""
+                } else if kind == "function" {
+                    let location = payload["sourceLocation"] as? [String: Any] ?? [:]
+                    let declared = location["_filePath"] as? String ?? location["filePath"] as? String ?? ""
+                    var name = payload["name"] as? String ?? id
+                    if name.hasSuffix("()") {
+                        name = String(name.dropLast(2))
+                    }
+                    order.append(id)
+                    // Nothing confirms a test ran until the stream says so. A
+                    // test the run never reached stays without a verdict rather
+                    // than being credited with an outcome it never produced.
+                    cases[id] = Case(name: name, suite: "", file: relativePath(declared), status: "skipped")
+                }
+            case "event":
+                guard let id = payload["testID"] as? String, var entry = cases[id] else { continue }
+                switch kind {
+                case "testStarted":
+                    entry.status = "unknown"
+                case "testSkipped":
+                    entry.status = "skipped"
+                case "testCancelled", "testCaseCancelled":
+                    entry.status = "unknown"
+                case "issueRecorded":
+                    let issue = payload["issue"] as? [String: Any] ?? [:]
+                    let isFailure = issue["isFailure"] as? Bool ?? true
+                    let isKnown = issue["isKnown"] as? Bool ?? false
+                    if isFailure && !isKnown {
+                        entry.status = "failed"
+                    }
+                case "testEnded":
+                    if entry.status == "unknown" {
+                        entry.status = "passed"
+                    }
+                default:
+                    break
+                }
+                cases[id] = entry
+            default:
+                break
+            }
+        }
+
+        var encodedCases: [String] = []
+        var passed = 0
+        var failed = 0
+        var skipped = 0
+        for id in order {
+            guard var entry = cases[id] else { continue }
+            entry.suite = suiteName(forTest: id, suites: suites, file: entry.file)
+            switch entry.status {
+            case "passed": passed += 1
+            case "failed": failed += 1
+            case "skipped": skipped += 1
+            default: break
+            }
+            var encoded = "{"
+            encoded += quoted("id") + ":" + quoted(target + "::" + entry.suite + "/" + entry.name) + ","
+            encoded += quoted("name") + ":" + quoted(entry.name) + ","
+            encoded += quoted("suite") + ":" + quoted(entry.suite) + ","
+            encoded += quoted("file") + ":" + quoted(entry.file) + ","
+            encoded += quoted("status") + ":" + quoted(entry.status) + ","
+            encoded += quoted("attempts") + ":[{" + quoted("status") + ":" + quoted(entry.status) + "}],"
+            encoded += quoted("runner_metadata") + ":{" + quoted("runner") + ":" + quoted("swift_testing") + "}}"
+            encodedCases.append(encoded)
+        }
+
+        // The key order is spelled out rather than left to a dictionary so the
+        // same run always writes the same bytes.
+        var report = "{"
+        report += quoted("schema") + ":" + quoted("once.test_results.v1") + ","
+        report += quoted("target") + ":" + quoted(target) + ","
+        report += quoted("runner") + ":{" + quoted("type") + ":" + quoted("swift_testing") + "," + quoted("metadata") + ":{}},"
+        report += quoted("status") + ":" + quoted((exitCode == 0 && failed == 0) ? "passed" : "failed") + ","
+        report += quoted("summary") + ":{"
+        report += quoted("total") + ":" + String(encodedCases.count) + ","
+        report += quoted("passed") + ":" + String(passed) + ","
+        report += quoted("failed") + ":" + String(failed) + ","
+        report += quoted("skipped") + ":" + String(skipped) + ","
+        report += quoted("flaky") + ":0},"
+        report += quoted("cases") + ":[" + encodedCases.joined(separator: ",") + "],"
+        report += quoted("artifacts") + ":{"
+        report += quoted("logs") + ":" + jsonArray(environmentPath("ONCE_TEST_LOG")) + ","
+        report += quoted("native_results") + ":" + jsonArray(environmentPath("ONCE_TEST_NATIVE_RESULTS")) + "}}"
+        try? report.write(toFile: resultsPath, atomically: true, encoding: .utf8)
+    }
+}
+
+@main
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(*, deprecated, message: "Not deprecated. Marked so that tests covering deprecated functionality do not warn.")
+struct OnceTestEntryPoint {
+    private static func requestedTestingLibrary() -> String {
+        var arguments = CommandLine.arguments.makeIterator()
+        while let argument = arguments.next() {
+            if argument == "--testing-library", let name = arguments.next() {
+                return name.lowercased()
+            }
+        }
+        return "xctest"
+    }
+
+    static func main() async {
+#if canImport(Testing)
+        if Self.requestedTestingLibrary() == "swift-testing" {
+            let exitCode: CInt = await Testing.__swiftPMEntryPoint()
+            OnceTestReport.write(exitCode: exitCode)
+            exit(exitCode)
+        }
+#endif
+    }
+}
+"""
+
+def _apple_swift_testing_helper(swiftc_path):
+    # Running the testing library directly means loading the bundle and calling
+    # its entry point, which a loadable bundle cannot do for itself. Every
+    # Swift toolchain ships the small host that does it.
+    path = _swift_toolchain_dir(swiftc_path) + "/usr/libexec/swift/pm/swiftpm-testing-helper"
+    return path if host_file_exists(path) else ""
+
+def _apple_sources_import_xctest(sources):
+    for source in sources:
+        path = source if source.startswith("/") else workspace_root() + "/" + source
+        if not host_file_exists(path):
+            continue
+        contents = host_file_read(path)
+        if "import XCTest" in contents or "<XCTest/XCTest.h>" in contents:
+            return True
+    return False
+
+def _apple_swift_testing_filter(selector):
+    # Once names a case `Suite/method`; the testing library matches a regular
+    # expression against its own identifiers, which carry the module name in
+    # front and the argument list behind.
+    escaped = ""
+    for index in range(len(selector)):
+        character = selector[index]
+        if character in ".^$*+?()[]{}|\\":
+            escaped += "\\"
+        escaped += character
+    return escaped + "\\("
+
 def _swift_testing_library_dir(swiftc_path, sdk_name):
     # Xcode publishes Swift Testing as a platform framework. A Swift toolchain
     # installed beside Xcode instead ships its own copy next to the compiler,
@@ -1171,6 +1427,12 @@ def _apple_test_cases_script(swift_srcs, cases_file, target, runner_type, select
     # their enclosing `XCTestCase` subclass as the suite; Swift Testing
     # functions (`@Test func x`) take their enclosing type, defaulting to the
     # file name for free functions.
+    #
+    # Reading a declaration says a case exists, never that it ran or how it
+    # ended: source can compile away behind a condition, and a runner can
+    # filter, skip, or never reach it. Every case listed here is therefore
+    # `unknown`, and the run's own exit status carries the outcome. A runner
+    # that reports per-case results does not come through here at all.
     specs = _shell_words(swift_srcs)
     selected_cases = _shell_words(selectors)
     return """total=0
@@ -1191,7 +1453,7 @@ emit_case() {{
     done
     [ "$selected" = true ] || return 0
   fi
-  if [ "$status" -eq 0 ]; then case_status=passed; else case_status=unknown; fi
+  case_status=unknown
   total=$((total + 1))
   if [ "$total" -gt 1 ]; then printf ',\n' >> "$cases_file"; fi
   printf '{{"id":"%s::%s/%s","name":"%s","suite":"%s","file":"%s","status":"%s","attempts":[{{"status":"%s"}}],"runner_metadata":{{"runner":"%s"}}}}' "{target}" "$case_suite" "$case_name" "$case_name" "$case_suite" "$case_file" "$case_status" "$case_status" "{runner_type}" >> "$cases_file"
@@ -1241,6 +1503,23 @@ done
         specs = specs,
         selector_count = len(selectors),
         selected_cases = selected_cases,
+        target = target,
+        runner_type = runner_type,
+    )
+
+def _apple_test_report_script(swift_srcs, cases_file, target, runner_type, selectors = []):
+    # The run's exit status is the one outcome this path can state. The cases it
+    # lists come from the sources, so they are reported without a verdict.
+    return """{cases_script}
+if [ "$status" -eq 0 ]; then run_status=passed; else run_status=failed; fi
+{{
+  printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"%s","metadata":{{}}}},"status":"%s","summary":{{"total":%s,"passed":0,"failed":0,"skipped":0,"flaky":0}},"cases":[' "{target}" "{runner_type}" "$run_status" "$total"
+  cat "$cases_file"
+  printf '],"artifacts":{{"logs":["%s"],"native_results":["%s"]}}}}\n' "$log" "$native_results"
+}} > "$results"
+""".format(
+        cases_script = _apple_test_cases_script(swift_srcs, cases_file, target, runner_type, selectors),
+        cases_file = _shell_literal(cases_file),
         target = target,
         runner_type = runner_type,
     )
@@ -4916,6 +5195,11 @@ def _apple_test_bundle_impl(ctx):
     assembly_srcs = _filter_assembly_sources(all_srcs)
     if len(swift_srcs) == 0 and len(objc_srcs) == 0 and len(c_srcs) == 0 and len(cxx_srcs) == 0 and len(assembly_srcs) == 0:
         fail("apple_test_bundle " + ctx["label"]["id"] + " has no compilable sources")
+    declared_swift_srcs = list(swift_srcs)
+    if swift_testing:
+        entry_point_source = declare_output("OnceTestEntryPoint.swift")
+        write_path(entry_point_source, _apple_swift_testing_entry_point_source())
+        swift_srcs = swift_srcs + [entry_point_source]
 
     test_dir = ctx["build_dir"] + "/test"
     results = test_dir + "/test_results.json"
@@ -5452,13 +5736,46 @@ def _apple_test_bundle_impl(ctx):
             else:
                 selectors.append(case_filter)
         xctest_spec = ",".join(selectors) if selectors else "All"
+        # The XCTest host reports what it chooses to; the testing library's own
+        # entry point reports through the event stream, which names every test
+        # and what became of it. Take the second path when nothing else in the
+        # bundle needs the XCTest host, since only that host runs XCTest cases.
+        event_stream = test_dir + "/events.jsonl"
+        structured_swift_testing = (
+            swift_testing and
+            (platform == "macos" or platform == "macosx") and
+            not _apple_sources_import_xctest(declared_swift_srcs + objc_srcs) and
+            _apple_swift_testing_helper(swiftc["swiftc_path"]) != ""
+        )
+        if structured_swift_testing:
+            action_env["ONCE_TEST_RESULTS"] = results
+            action_env["ONCE_TEST_EVENT_STREAM"] = event_stream
+            action_env["ONCE_TEST_TARGET"] = ctx["label"]["id"]
+            action_env["ONCE_TEST_LOG"] = log
+            action_env["ONCE_TEST_NATIVE_RESULTS"] = native_results
         if platform == "macos" or platform == "macosx":
+            if structured_swift_testing:
+                runner_argv = [
+                    _apple_swift_testing_helper(swiftc["swiftc_path"]),
+                    "--test-bundle-path",
+                    test_binary,
+                    "--testing-library",
+                    "swift-testing",
+                    "--event-stream-output-path",
+                    event_stream,
+                    "--event-stream-version",
+                    "0",
+                ]
+                for selector in selectors:
+                    runner_argv.extend(["--filter", _apple_swift_testing_filter(selector)])
+            else:
+                runner_argv = [runner_xcrun, "xctest", "-XCTest", xctest_spec, test_bundle_path]
             runner_command = """cd {workspace}
 DYLD_LIBRARY_PATH={usr_lib}${{DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}} DYLD_FALLBACK_FRAMEWORK_PATH={frameworks}${{DYLD_FALLBACK_FRAMEWORK_PATH:+:$DYLD_FALLBACK_FRAMEWORK_PATH}} {command}""".format(
                 workspace = _shell_literal(workspace_root()),
                 usr_lib = _shell_literal(xctest_usr_lib_dir),
                 frameworks = _shell_literal(xctest_framework_dir),
-                command = _shell_words([runner_xcrun, "xctest", "-XCTest", xctest_spec, test_bundle_path]),
+                command = _shell_words(runner_argv),
             )
         elif sdk_variant == "simulator":
             simulator_setup = _ios_simulator_selection_script(runner_xcrun) + """
@@ -5514,13 +5831,7 @@ status_file={status_file}
 ) 2>&1 | tee "$log" >/dev/null
 status=$(cat "$status_file")
 cp "$log" "$native_results"
-{cases_script}
-if [ "$status" -eq 0 ]; then run_status=passed; failed=0; passed=$total; else run_status=failed; failed=1; passed=0; fi
-{{
-  printf '{{"schema":"once.test_results.v1","target":"%s","runner":{{"type":"%s","metadata":{{}}}},"status":"%s","summary":{{"total":%s,"passed":%s,"failed":%s,"skipped":0,"flaky":0}},"cases":[' "{target}" "{runner_type}" "$run_status" "$total" "$passed" "$failed"
-  cat "$cases_file"
-  printf '],"artifacts":{{"logs":["%s"],"native_results":["%s"]}}}}\n' "$log" "$native_results"
-}} > "$results"
+{report_script}
 exit "$status"
 """.format(
             test_dir = _shell_literal(test_dir),
@@ -5529,9 +5840,13 @@ exit "$status"
             native_results = _shell_literal(native_results),
             status_file = _shell_literal(test_dir + "/runner-status"),
             runner_command = runner_command,
-            cases_script = _apple_test_cases_script(swift_srcs, cases_file, ctx["label"]["id"], runner_type, selectors),
-            target = ctx["label"]["id"],
-            runner_type = runner_type,
+            report_script = "" if structured_swift_testing else _apple_test_report_script(
+                declared_swift_srcs,
+                cases_file,
+                ctx["label"]["id"],
+                runner_type,
+                selectors,
+            ),
         )
         test_inputs = [test_binary, info_plist, test_cs_stamp]
         test_inputs.extend(resource_files)

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -2476,6 +2476,33 @@ def _swift_macro_impl(ctx):
     ) = _collect_dep_compile_inputs(deps, ctx["build_dir"])
     dep_swiftmodule_inputs = _apple_collect_swiftmodule_inputs(deps)
 
+    # The sources compile twice: once into the plugin executable the compiler
+    # loads, and once into an archive a test target can link. Everything that
+    # describes how to compile them is shared.
+    compile_argv = []
+    for d in dep_swiftmodule_dirs:
+        compile_argv.extend(["-I", d])
+    for hdir in dep_header_dirs:
+        compile_argv.extend(["-Xcc", "-I", "-Xcc", hdir])
+    for modulemap in dep_modulemaps:
+        compile_argv.extend(["-Xcc", "-fmodule-map-file=" + modulemap])
+    for hmap in dep_hmaps:
+        compile_argv.extend(["-Xcc", "-I", "-Xcc", hmap])
+    for overlay in dep_vfs_overlays:
+        compile_argv.extend(["-Xcc", "-ivfsoverlay", "-Xcc", overlay])
+    for framework_dir in dep_framework_search_dirs:
+        compile_argv.extend(["-F", framework_dir])
+    _apple_disable_static_framework_autolinking(compile_argv, _apple_collect_link_framework_bundles(deps))
+    for framework in dep_framework_module_names:
+        compile_argv.extend(["-framework", framework])
+    for fw in dep_sdk_frameworks:
+        compile_argv.extend(["-framework", fw])
+    for dylib in dep_sdk_dylibs:
+        compile_argv.extend(["-l" + dylib])
+    _apple_add_swift_plugin_args(compile_argv, plugin_dylibs, plugin_executables)
+    for flag in _apple_swift_link_flags(swift_flags):
+        compile_argv.append(flag)
+
     swift_argv = list(swiftc["argv"]) + [
         "-emit-executable",
         "-emit-module",
@@ -2489,29 +2516,7 @@ def _swift_macro_impl(ctx):
         "-parse-as-library",
         "-o",
         plugin_executable,
-    ]
-    for d in dep_swiftmodule_dirs:
-        swift_argv.extend(["-I", d])
-    for hdir in dep_header_dirs:
-        swift_argv.extend(["-Xcc", "-I", "-Xcc", hdir])
-    for modulemap in dep_modulemaps:
-        swift_argv.extend(["-Xcc", "-fmodule-map-file=" + modulemap])
-    for hmap in dep_hmaps:
-        swift_argv.extend(["-Xcc", "-I", "-Xcc", hmap])
-    for overlay in dep_vfs_overlays:
-        swift_argv.extend(["-Xcc", "-ivfsoverlay", "-Xcc", overlay])
-    for framework_dir in dep_framework_search_dirs:
-        swift_argv.extend(["-F", framework_dir])
-    _apple_disable_static_framework_autolinking(swift_argv, _apple_collect_link_framework_bundles(deps))
-    for framework in dep_framework_module_names:
-        swift_argv.extend(["-framework", framework])
-    for fw in dep_sdk_frameworks:
-        swift_argv.extend(["-framework", fw])
-    for dylib in dep_sdk_dylibs:
-        swift_argv.extend(["-l" + dylib])
-    _apple_add_swift_plugin_args(swift_argv, plugin_dylibs, plugin_executables)
-    for flag in _apple_swift_link_flags(swift_flags):
-        swift_argv.append(flag)
+    ] + compile_argv
     for src in swift_srcs:
         swift_argv.append(src)
     # Dep archives appear as positional inputs; swiftc forwards
@@ -2556,11 +2561,45 @@ def _swift_macro_impl(ctx):
         identifier = "swift_macro_compile_" + module_name,
     )
 
+    # A macro is a tool for the targets that expand it, so its code stays out
+    # of what they link. A test target is the exception: it imports the module
+    # to exercise the implementation types, which needs them as an archive.
+    plugin_archive = declare_output(module_name + ".a")
+    archive_argv = list(swiftc["argv"]) + [
+        "-emit-library",
+        "-static",
+        "-module-name",
+        module_name,
+        "-target",
+        triple,
+        "-parse-as-library",
+        "-o",
+        plugin_archive,
+    ] + compile_argv + swift_srcs
+    run_action(
+        argv = archive_argv,
+        inputs = swift_inputs,
+        outputs = [plugin_archive],
+        env = swiftc["env"],
+        toolchain_identity = swiftc["identity"],
+        identifier = "swift_macro_archive_" + module_name,
+    )
+
     return {
         "label_id": ctx["label"]["id"],
         "plugin_executable": plugin_executable,
         "plugin_module_name": module_name,
         "transitive_plugin_executables": [plugin_executable + "#" + module_name],
+        "transitive_plugin_module_dirs": _unique([ctx["build_dir"]] + dep_swiftmodule_dirs),
+        "transitive_plugin_modulemaps": list(dep_modulemaps),
+        "transitive_plugin_header_dirs": list(dep_header_dirs),
+        "transitive_plugin_hmaps": list(dep_hmaps),
+        "transitive_plugin_vfs_overlays": list(dep_vfs_overlays),
+        "transitive_plugin_archives": _unique([plugin_archive] + dep_archives),
+        "transitive_plugin_module_inputs": _unique(
+            [plugin_swiftmodule] + plugin_module_sidecars +
+            _apple_swiftmodule_inputs_for_arch(dep_swiftmodule_inputs, host_arch()),
+        ),
     }
 
 # --- Bundle helpers ----------------------------------------------------
@@ -3026,6 +3065,32 @@ def _apple_swiftmodule_inputs_for_arch(inputs, arch):
                 continue
         selected.append(input)
     return selected
+
+_APPLE_MACRO_MODULE_KEYS = [
+    "module_dirs",
+    "modulemaps",
+    "header_dirs",
+    "hmaps",
+    "vfs_overlays",
+    "archives",
+    "module_inputs",
+]
+
+def _apple_collect_macro_module_inputs(deps):
+    """Aggregate what a test target needs to import the macros it depends on.
+
+    A macro is a tool everywhere else, so its module, its code, and what it was
+    built against reach only the targets that exercise the implementation
+    rather than every consumer that expands it.
+    """
+    collected = {key: [] for key in _APPLE_MACRO_MODULE_KEYS}
+    for dep in deps:
+        for key in _APPLE_MACRO_MODULE_KEYS:
+            values = collected[key]
+            for value in dep.get("transitive_plugin_" + key) or []:
+                if value and value not in values:
+                    values.append(value)
+    return collected
 
 def _collect_dep_compile_inputs(deps, build_dir):
     """Aggregate compile-visible inputs from dep providers.
@@ -4936,6 +5001,21 @@ def _apple_test_bundle_impl(ctx):
     ) = _collect_dep_compile_inputs(deps, ctx["build_dir"])
     compile_swiftmodule_inputs = _apple_collect_swiftmodule_inputs(deps)
     dep_archives = [archive for archive in dep_archives if archive not in host_link_archives]
+    macro_modules = _apple_collect_macro_module_inputs(deps)
+    for target_list, key in [
+        (compile_swiftmodule_dirs, "module_dirs"),
+        (dep_modulemaps, "modulemaps"),
+        (compile_header_dirs, "header_dirs"),
+        (dep_hmaps, "hmaps"),
+        (dep_vfs_overlays, "vfs_overlays"),
+        (compile_swiftmodule_inputs, "module_inputs"),
+    ]:
+        for value in macro_modules[key]:
+            if value not in target_list:
+                target_list.append(value)
+    for archive in macro_modules["archives"]:
+        if archive not in dep_archives and archive not in host_link_archives:
+            dep_archives.append(archive)
     alwayslink_archives = _apple_collect_alwayslink_archives(deps)
     runtime_framework_bundles = _apple_collect_runtime_framework_bundles(deps)
     runner_xcodebuild = ""

--- a/crates/once-frontend/prelude/apple.star
+++ b/crates/once-frontend/prelude/apple.star
@@ -106,6 +106,20 @@ def _developer_env(xcode_developer_dir):
         env["DEVELOPER_DIR"] = xcode_developer_dir
     return env
 
+def _apple_linker_dir(xcode_developer_dir, env):
+    # A Swift toolchain installed next to Xcode rather than inside it ships a
+    # compiler but no linker, and the compiler locates `ld` by searching the
+    # environment. Actions run with an environment Once controls, so the
+    # directory holding the linker has to be resolved and passed explicitly.
+    if xcode_developer_dir:
+        return xcode_developer_dir + "/" + _XCTOOLCHAIN_BIN_REL
+    return _parent_dir(host_command([host_which("xcrun"), "--find", "ld"], env = env).strip())
+
+def _apple_compiler_env(xcode_developer_dir, env):
+    action_env = dict(env)
+    action_env["PATH"] = _apple_linker_dir(xcode_developer_dir, env) + ":/usr/bin:/bin"
+    return action_env
+
 # When a target sets `xcode_developer_dir`, the build resolves tools and
 # SDK paths directly from the layout under that directory rather than
 # shelling out to `xcrun`. The xcrun fallback still applies when no
@@ -168,9 +182,10 @@ def _resolve_swiftc(platform, sdk_variant, xcode_developer_dir):
         swiftc_path = host_command([xcrun, "--sdk", sdk, "--find", "swiftc"], env = env).strip()
         sdk_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-path"], env = env).strip()
     version = host_command([swiftc_path, "--version"], env = env).strip()
+    action_env = _apple_compiler_env(xcode_developer_dir, env)
     # Identity folds in the developer dir override so different Xcode
     # installations partition the action cache cleanly.
-    identity = "once.apple.swiftc.v1\x00" + swiftc_path + "\x00" + version + "\x00" + (xcode_developer_dir or "")
+    identity = "once.apple.swiftc.v1\x00" + swiftc_path + "\x00" + version + "\x00" + (xcode_developer_dir or "") + "\x00" + action_env["PATH"]
     return {
         # Once supplies the outer action sandbox. Disabling Swift's nested
         # subprocess sandbox lets compiler plugins run inside that same policy
@@ -180,7 +195,7 @@ def _resolve_swiftc(platform, sdk_variant, xcode_developer_dir):
         "sdk_name": sdk,
         "sdk_path": sdk_path,
         "identity": identity,
-        "env": env,
+        "env": action_env,
     }
 
 def _filter_swift_sources(paths):
@@ -211,14 +226,15 @@ def _resolve_clang(platform, sdk_variant, xcode_developer_dir):
         clangxx_path = host_command([xcrun, "--sdk", sdk, "--find", "clang++"], env = env).strip()
         sdk_path = host_command([xcrun, "--sdk", sdk, "--show-sdk-path"], env = env).strip()
     version = host_command([clang_path, "--version"], env = env).strip()
-    identity = "once.apple.clang.v1\x00" + clang_path + "\x00" + version + "\x00" + (xcode_developer_dir or "")
+    action_env = _apple_compiler_env(xcode_developer_dir, env)
+    identity = "once.apple.clang.v1\x00" + clang_path + "\x00" + version + "\x00" + (xcode_developer_dir or "") + "\x00" + action_env["PATH"]
     return {
         "clang_path": clang_path,
         "clangxx_path": clangxx_path,
         "sdk_name": sdk,
         "sdk_path": sdk_path,
         "identity": identity,
-        "env": env,
+        "env": action_env,
     }
 
 def _resolve_libtool(platform, sdk_variant, xcode_developer_dir):
@@ -370,12 +386,36 @@ def _resolve_apple_thinning_tools(xcode_developer_dir):
         "env": action_env,
     }
 
-def _swift_testing_macros_plugin(swiftc_path):
+def _swift_toolchain_dir(swiftc_path):
     suffix = "/usr/bin/swiftc"
     if not _ends_with(swiftc_path, suffix):
         fail("unable to derive Swift toolchain path from swiftc at " + swiftc_path)
-    toolchain_dir = swiftc_path[:len(swiftc_path) - len(suffix)]
-    return toolchain_dir + "/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib"
+    return swiftc_path[:len(swiftc_path) - len(suffix)]
+
+def _swift_testing_macros_plugin(swiftc_path):
+    return _swift_toolchain_dir(swiftc_path) + "/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib"
+
+def _apple_swift_testing_compile_flags(testing_library_dir, testing_framework_dir, testing_macros_plugin):
+    if testing_library_dir:
+        return ["-I", testing_library_dir, "-load-plugin-library", testing_macros_plugin]
+    return ["-F", testing_framework_dir, "-framework", "Testing", "-load-plugin-library", testing_macros_plugin]
+
+def _apple_swift_testing_link_flags(testing_library_dir):
+    # The compiler's own Swift Testing library is a dynamic library resolved
+    # through an rpath rather than a framework the platform already exposes.
+    if not testing_library_dir:
+        return ["-framework", "Testing"]
+    return ["-L", testing_library_dir, "-lTesting", "-Xlinker", "-rpath", "-Xlinker", testing_library_dir]
+
+def _swift_testing_library_dir(swiftc_path, sdk_name):
+    # Xcode publishes Swift Testing as a platform framework. A Swift toolchain
+    # installed beside Xcode instead ships its own copy next to the compiler,
+    # and its macro plugin expands to code only that copy declares. The two
+    # move independently, so the compiler's own library wins when it has one.
+    directory = _swift_toolchain_dir(swiftc_path) + "/usr/lib/swift/" + sdk_name + "/testing"
+    if host_file_exists(directory + "/libTesting.dylib"):
+        return directory
+    return ""
 
 def _unique_dirs(paths):
     seen = {}
@@ -1316,6 +1356,7 @@ def _apple_library_impl(ctx):
     testing_framework_dir = ""
     testing_usr_lib_dir = ""
     testing_macros_plugin = ""
+    testing_library_dir = ""
     if swift_testing or xctest_support:
         if xcode_developer_dir:
             testing_platform_path = _developer_platform_path(xcode_developer_dir, swiftc["sdk_name"])
@@ -1325,6 +1366,7 @@ def _apple_library_impl(ctx):
         testing_usr_lib_dir = testing_platform_path + "/Developer/usr/lib"
     if swift_testing:
         testing_macros_plugin = _swift_testing_macros_plugin(swiftc["swiftc_path"])
+        testing_library_dir = _swift_testing_library_dir(swiftc["swiftc_path"], swiftc["sdk_name"])
     archive = declare_output(module_name + ".a")
 
     deps = _apple_native_deps(ctx)
@@ -1729,7 +1771,7 @@ def _apple_library_impl(ctx):
             if generated_framework_module:
                 swift_base_argv.extend(["-F", generated_framework_search_dir])
             if swift_testing:
-                swift_base_argv.extend(["-F", testing_framework_dir, "-framework", "Testing", "-load-plugin-library", testing_macros_plugin])
+                swift_base_argv.extend(_apple_swift_testing_compile_flags(testing_library_dir, testing_framework_dir, testing_macros_plugin))
             if xctest_support:
                 swift_base_argv.extend(["-F", testing_framework_dir, "-I", testing_usr_lib_dir, "-L", testing_usr_lib_dir, "-framework", "XCTest", "-lXCTestSwiftSupport"])
             # Header search paths flow through `-Xcc -I` so swiftc's
@@ -4837,6 +4879,7 @@ def _apple_test_bundle_impl(ctx):
     xctest_framework_dir = platform_path + "/Developer/Library/Frameworks"
     xctest_usr_lib_dir = platform_path + "/Developer/usr/lib"
     testing_macros_plugin = _swift_testing_macros_plugin(swiftc["swiftc_path"])
+    testing_library_dir = _swift_testing_library_dir(swiftc["swiftc_path"], swiftc["sdk_name"]) if swift_testing else ""
 
     runner_name = product_name + "-Runner"
     runner_bundle_dir = runner_name + ".app"
@@ -4966,12 +5009,10 @@ def _apple_test_bundle_impl(ctx):
         test_binary,
     ]
     if swift_testing:
-        swift_argv.extend([
-            "-framework",
-            "Testing",
-            "-load-plugin-library",
-            testing_macros_plugin,
-        ])
+        if testing_library_dir:
+            swift_argv.extend(["-I", testing_library_dir])
+        swift_argv.extend(_apple_swift_testing_link_flags(testing_library_dir))
+        swift_argv.extend(["-load-plugin-library", testing_macros_plugin])
     if host_executable:
         swift_argv.extend([
             "-Xlinker",
@@ -5845,7 +5886,7 @@ def _swift_package_dependencies_impl(ctx):
     swift = _swiftpm_swift_executable(attrs.get("swift") or "swift", xcode_developer_dir, swiftc["swiftc_path"])
     version = host_command([swift, "--version"], env = swiftc["env"]).strip()
     action_env = dict(swiftc["env"])
-    action_path = _parent_dir(swiftc["swiftc_path"]) + ":" + _parent_dir(swift) + ":/usr/bin:/bin"
+    action_path = _parent_dir(swiftc["swiftc_path"]) + ":" + _parent_dir(swift) + ":" + swiftc["env"]["PATH"]
     action_env["PATH"] = action_path
     triple = _apple_triple(platform, minimum_os, sdk_variant, arch, False)
     build_triple_dir = _swiftpm_build_triple_dir(platform, sdk_variant, arch)

--- a/crates/once-frontend/prelude/swift_package.star
+++ b/crates/once-frontend/prelude/swift_package.star
@@ -20,7 +20,7 @@ def _swift_package_workspace_resolver(ctx):
     swift_info_cache[absolute_package_path] = {"info": info}
     package = {"identity": _basename(package_path) or info.get("name") or ctx["label"]["name"], "path": package_path, "info": info}
     packages = [package] + _swift_package_remote_infos(ctx, info, swift, swiftc["env"], absolute_package_path, package_path, cache = swift_info_cache)
-    graph = _xcode_local_swift_package_specs(ctx, packages, attrs.get("platform") or "macos", attrs.get("minimum_os") or "13.0", attrs.get("sdk_variant") or "simulator")
+    graph = _xcode_local_swift_package_specs(ctx, packages, attrs.get("platform") or "macos", attrs.get("minimum_os") or "13.0", attrs.get("sdk_variant") or "simulator", root_identities = [package["identity"]])
     roots = []
     test_roots = []
     for product in info.get("products") or []:

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -2030,6 +2030,12 @@ def _xcode_swift_package_dependencies(target, identity, target_ids, product_ids,
                 deps.append("./" + lazy_dependency)
     return deps
 
+def _xcode_swift_package_depends_on_macro(target, identity, target_ids, product_ids, platform, macro_target_ids, enabled_traits = [], lazy_products = {}, lazy_dependency = ""):
+    for dependency in _xcode_swift_package_dependencies(target, identity, target_ids, product_ids, platform, enabled_traits, lazy_products, lazy_dependency):
+        if macro_target_ids.get(dependency[2:]):
+            return True
+    return False
+
 def _xcode_swift_imports(sources):
     modules = []
     for source in sources:
@@ -2171,6 +2177,7 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
     host_target_ids = {}
     host_product_ids = {}
     module_ids = {}
+    macro_target_ids = {}
     resolved_traits = _xcode_swift_package_resolved_traits(package_infos, root_identities)
     for package in package_infos:
         identity = package["identity"]
@@ -2179,6 +2186,8 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
             if name:
                 target_id = _xcode_swift_package_target_id(identity, name, target_prefix)
                 host_target_id = target_id if (target.get("type") or "") in ["binary", "macro", "test"] else _xcode_swift_package_host_target_id(identity, name, target_prefix)
+                if (target.get("type") or "") == "macro":
+                    macro_target_ids[target_id] = True
                 target_ids[identity + "\x1f" + name] = target_id
                 target_ids[identity.lower() + "\x1f" + name] = target_id
                 host_target_ids[identity + "\x1f" + name] = host_target_id
@@ -2290,13 +2299,30 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
                     },
                 })
                 continue
+            # A test target that depends on a macro links the macro's code, and
+            # a macro is only ever built for the host. Swift Package Manager
+            # answers that by building such a test target for the host too,
+            # which carries every one of its dependencies to the host as well.
+            # Anything less mixes host and destination builds of the same
+            # module in one link.
+            tests_a_macro = target_type == "test" and _xcode_swift_package_depends_on_macro(
+                target,
+                identity,
+                target_ids,
+                product_ids,
+                platform,
+                macro_target_ids,
+                package_traits,
+                lazy_products,
+                lazy_dependency,
+            )
             variants = [{
                 "id": target_id,
-                "platform": platform,
-                "minimum_os": package_minimum_os,
-                "sdk_variant": sdk_variant,
-                "target_ids": target_ids,
-                "product_ids": product_ids,
+                "platform": "macos" if tests_a_macro else platform,
+                "minimum_os": package_host_minimum_os if tests_a_macro else package_minimum_os,
+                "sdk_variant": "simulator" if tests_a_macro else sdk_variant,
+                "target_ids": host_target_ids if tests_a_macro else target_ids,
+                "product_ids": host_product_ids if tests_a_macro else product_ids,
             }]
             if target_type != "test":
                 variants.append({

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -2358,6 +2358,12 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
                     attrs["module_name"] = name
                     attrs["exported_deps"] = dependencies
                     attrs["swift_flags"] = attrs["swift_flags"] + ["-enable-testing"]
+                    # Swift Package Manager hands the linker every object file a
+                    # target produced. Reaching the same result through an
+                    # archive means force-loading it, otherwise a file whose only
+                    # contribution is a protocol conformance is dropped and the
+                    # conformance goes missing at runtime.
+                    attrs["alwayslink"] = True
                     attrs["exported_headers"] = _unique(_xcode_swift_package_target_headers(package_path, target))
                     attrs["modulemap"] = _xcode_swift_package_target_modulemap(package_path, target)
                     attrs["enable_modules"] = True

--- a/crates/once-frontend/prelude/xcode.star
+++ b/crates/once-frontend/prelude/xcode.star
@@ -1999,10 +1999,8 @@ def _xcode_package_condition_allows(condition, platform, enabled_traits = []):
         wanted = "macos" if platform == "macosx" else platform
         if wanted.lower() not in [name.lower() for name in names]:
             return False
-    for trait in (condition or {}).get("traits") or []:
-        if trait not in enabled_traits:
-            return False
-    return True
+    traits = (condition or {}).get("traits") or []
+    return not traits or any([trait in enabled_traits for trait in traits])
 
 def _xcode_swift_package_dependencies(target, identity, target_ids, product_ids, platform, enabled_traits = [], lazy_products = {}, lazy_dependency = ""):
     deps = []
@@ -2013,7 +2011,7 @@ def _xcode_swift_package_dependencies(target, identity, target_ids, product_ids,
                 continue
             condition = {}
             for value in values[1:]:
-                if type(value) == "dict" and value.get("platformNames"):
+                if type(value) == "dict" and (value.get("platformNames") or value.get("traits")):
                     condition = value
             if not _xcode_package_condition_allows(condition, platform, enabled_traits):
                 continue
@@ -2111,11 +2109,53 @@ def _xcode_swift_package_target_flags(target, platform, default_language_mode, e
         "language_mode": swift_language_mode,
     }
 
-def _xcode_swift_package_default_traits(package):
-    for trait in package["info"].get("traits") or []:
-        if (trait.get("name") or "") == "default":
-            return sorted(_unique(trait.get("enabledTraits") or []))
-    return []
+def _xcode_swift_package_resolved_traits(package_infos, root_identities = None):
+    packages = {package["identity"].lower(): package for package in package_infos}
+    dependencies = {}
+    referenced = {}
+    budget = len(packages) + 1
+    for identity, package in packages.items():
+        entries = []
+        budget += len(package["info"].get("traits") or [])
+        for dependency in package["info"].get("dependencies") or []:
+            for kind in ["sourceControl", "fileSystem", "registry"]:
+                for entry in dependency.get(kind) or []:
+                    dependency_identity = (entry.get("identity") or "").lower()
+                    if dependency_identity not in packages:
+                        continue
+                    requests = entry.get("traits")
+                    if requests == None:
+                        requests = [{"name": "default"}]
+                    entries.append((dependency_identity, requests))
+                    referenced[dependency_identity] = True
+                    budget += len(requests)
+        dependencies[identity] = entries
+    roots = [identity.lower() for identity in root_identities] if root_identities != None else [identity for identity in packages if identity not in referenced]
+    enabled = {identity: {"default": True} if identity in roots else {} for identity in packages}
+    # Each pass adds a trait or stops, including traits enabled across packages.
+    for _ in range(budget):
+        changed = False
+        for identity, package in packages.items():
+            active = enabled[identity]
+            for declaration in package["info"].get("traits") or []:
+                if declaration.get("name") not in active:
+                    continue
+                for trait in declaration.get("enabledTraits") or []:
+                    if trait not in active:
+                        active[trait] = True
+                        changed = True
+            for dependency_identity, requests in dependencies[identity]:
+                for request in requests:
+                    conditions = (request.get("condition") or {}).get("traits") or []
+                    if conditions and not any([trait in active for trait in conditions]):
+                        continue
+                    trait = request.get("name") or ""
+                    if trait and trait not in enabled[dependency_identity]:
+                        enabled[dependency_identity][trait] = True
+                        changed = True
+        if not changed:
+            return {identity: sorted([trait for trait in traits if trait != "default"]) for identity, traits in enabled.items()}
+    fail("Swift package trait resolution did not converge")
 
 def _xcode_swift_package_trait_flags(traits):
     flags = []
@@ -2123,7 +2163,7 @@ def _xcode_swift_package_trait_flags(traits):
         flags.extend(["-D", trait])
     return flags
 
-def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant, configuration = "Debug", lazy_products = {}, lazy_dependency = "", target_prefix = "SwiftPackage"):
+def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant, configuration = "Debug", lazy_products = {}, lazy_dependency = "", target_prefix = "SwiftPackage", root_identities = None):
     # Lower source package targets as ordinary Apple libraries. Products group
     # one or more targets, so consumers receive the complete product closure.
     target_ids = {}
@@ -2131,6 +2171,7 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
     host_target_ids = {}
     host_product_ids = {}
     module_ids = {}
+    resolved_traits = _xcode_swift_package_resolved_traits(package_infos, root_identities)
     for package in package_infos:
         identity = package["identity"]
         for target in package["info"].get("targets") or []:
@@ -2170,7 +2211,7 @@ def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, s
     for package in package_infos:
         identity = package["identity"]
         package_path = package["path"]
-        package_traits = _xcode_swift_package_default_traits(package)
+        package_traits = resolved_traits[identity.lower()]
         package_minimum_os = _xcode_swift_package_minimum_os(package, platform, minimum_os)
         package_host_minimum_os = _xcode_swift_package_minimum_os(package, "macos", "13.0")
         for target in package["info"].get("targets") or []:
@@ -3655,6 +3696,7 @@ def _xcode_workspace_resolver(ctx):
             ctx["attr"].get("sdk_variant") or "simulator",
             configuration,
             target_prefix = "XcodePackage_" + _xcode_sanitized_target_name(ctx["label"]["id"]),
+            root_identities = _unique([ref["identity"] for ref in package_refs.values()] + [package["identity"] for package in local_package_infos]),
         )
         xcframework_specs = _xcode_workspace_xcframework_specs(ctx, package_platform, ctx["attr"].get("sdk_variant") or "simulator")
         xcframework_names = _xcode_xcframework_name_map(xcframework_specs)

--- a/crates/once-frontend/tests/examples.rs
+++ b/crates/once-frontend/tests/examples.rs
@@ -579,12 +579,13 @@ fn local_swift_package(root: &Path) -> (String, String) {
     fs::create_dir_all(remote.join("Sources/RemoteSupport")).expect("remote source directory");
     fs::write(
         remote.join("Package.swift"),
-        r#"// swift-tools-version: 6.0
+        r#"// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(
     name: "RemoteSupport",
     products: [.library(name: "RemoteSupport", targets: ["RemoteSupport"])],
+    traits: [.trait(name: "RemoteFeature")],
     targets: [.target(name: "RemoteSupport")]
 )
 "#,
@@ -592,7 +593,7 @@ let package = Package(
     .expect("remote package manifest");
     fs::write(
         remote.join("Sources/RemoteSupport/RemoteSupport.swift"),
-        "public func remoteValue() -> Int { 42 }\n",
+        "#if RemoteFeature\npublic func remoteValue() -> Int { 42 }\n#endif\n",
     )
     .expect("remote source");
     for args in [
@@ -629,13 +630,13 @@ fn swift_package_native_project_lowers_remote_packages_directly() {
     fs::write(
         tmp.path().join("Package.swift"),
         format!(
-            r#"// swift-tools-version: 6.0
+            r#"// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(
     name: "LazyRemote",
     dependencies: [
-        .package(url: "{remote_url}", exact: "1.0.0"),
+        .package(url: "{remote_url}", exact: "1.0.0", traits: ["RemoteFeature"]),
     ],
     targets: [
         .target(name: "App", dependencies: [
@@ -650,23 +651,16 @@ let package = Package(
     .expect("package manifest");
     fs::write(
         tmp.path().join("Package.resolved"),
-        format!(
-            r#"{{
-  "version": 3,
-  "pins": [
-    {{
-      "identity": "remote-support",
-      "kind": "remoteSourceControl",
-      "location": "{remote_url}",
-      "state": {{
-        "revision": "{revision}",
-        "version": "1.0.0"
-      }}
-    }}
-  ]
-}}
-"#
-        ),
+        serde_json::to_vec(&serde_json::json!({
+            "version": 3,
+            "pins": [{
+                "identity": "remote-support",
+                "kind": "remoteSourceControl",
+                "location": remote_url,
+                "state": {"revision": revision, "version": "1.0.0"},
+            }],
+        }))
+        .expect("package lock encoding"),
     )
     .expect("package lock");
     fs::write(
@@ -706,6 +700,11 @@ let package = Package(
                     == Some(&AttrValue::String("RemoteSupport".to_string()))
         })
         .expect("directly lowered remote library");
+    assert!(matches!(
+        remote.attrs.get("defines"),
+        Some(AttrValue::List(defines))
+            if defines.contains(&AttrValue::String("RemoteFeature".to_string()))
+    ));
     let app = graph
         .iter()
         .find(|target| target.label.id == "SwiftPackage_LazyRemote_App")

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -26,6 +26,9 @@ mod swift_package_linking;
 #[path = "prelude/swift_testing_library.rs"]
 mod swift_testing_library;
 
+#[path = "prelude/swift_testing_results.rs"]
+mod swift_testing_results;
+
 fn store_for(workspace: &Path, package: &str) -> AnalysisStore {
     AnalysisStore::new(
         workspace.to_path_buf(),

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -17,6 +17,9 @@ use tempfile::TempDir;
 #[path = "prelude/swift_package_traits.rs"]
 mod swift_package_traits;
 
+#[path = "prelude/swift_macro_testing.rs"]
+mod swift_macro_testing;
+
 #[path = "prelude/swift_package_linking.rs"]
 mod swift_package_linking;
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -14,6 +14,9 @@ use starlark::syntax::{AstModule, Dialect};
 use starlark::values::list::ListRef;
 use tempfile::TempDir;
 
+#[path = "prelude/swift_package_traits.rs"]
+mod swift_package_traits;
+
 fn store_for(workspace: &Path, package: &str) -> AnalysisStore {
     AnalysisStore::new(
         workspace.to_path_buf(),
@@ -15673,27 +15676,6 @@ result = repr([
 }
 
 #[test]
-fn prelude_xcode_orders_swift_package_default_traits() {
-    let prelude = xcode_prelude_source();
-    let source = format!(
-        r#"{prelude}
-package = {{
-    "info": {{
-        "traits": [
-            {{"name": "default", "enabledTraits": ["FoundationNetworking", "Clocks", "Foundation", "Clocks"]}},
-        ],
-    }},
-}}
-result = repr(_xcode_swift_package_default_traits(package))
-"#
-    );
-    assert_eq!(
-        eval_prelude_source_to_repr(source).unwrap(),
-        r#"["Clocks", "Foundation", "FoundationNetworking"]"#
-    );
-}
-
-#[test]
 fn prelude_xcode_translates_swift_feature_settings_generically() {
     let prelude = xcode_prelude_source();
     let source = format!(
@@ -17490,7 +17472,7 @@ def host_file_exists(path):
 def host_file_read(path):
     return ""
 
-def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant, configuration = "Debug", lazy_products = {{}}, lazy_dependency = "", target_prefix = "SwiftPackage"):
+def _xcode_local_swift_package_specs(ctx, package_infos, platform, minimum_os, sdk_variant, configuration = "Debug", lazy_products = {{}}, lazy_dependency = "", target_prefix = "SwiftPackage", root_identities = None):
     return {{
         "specs": [{{
             "name": "XcodePackage_swift-argument-parser_changelog-authors",

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -17,6 +17,9 @@ use tempfile::TempDir;
 #[path = "prelude/swift_package_traits.rs"]
 mod swift_package_traits;
 
+#[path = "prelude/swift_testing_library.rs"]
+mod swift_testing_library;
+
 fn store_for(workspace: &Path, package: &str) -> AnalysisStore {
     AnalysisStore::new(
         workspace.to_path_buf(),
@@ -13143,6 +13146,10 @@ result = repr([codesign["codesign_path"], codesign["env"]])
 /// not contain xcrun even when discovery went through it. This
 /// keeps cache keys identical whether or not the user pins a
 /// developer dir.
+///
+/// A Swift toolchain installed outside Xcode contributes the compiler
+/// but not the linker, so the resolved environment has to carry the
+/// directory where the linker actually lives.
 #[test]
 fn prelude_resolve_swiftc_fallback_returns_direct_invocation() {
     let prelude = apple_prelude_source();
@@ -13155,7 +13162,9 @@ def host_which(name):
 
 def host_command(argv, env = None, merge_stderr = None):
     if "--find" in argv and argv[len(argv) - 1] == "swiftc":
-        return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc\n"
+        return "/Toolchains/swift-snapshot.xctoolchain/usr/bin/swiftc\n"
+    if "--find" in argv and argv[len(argv) - 1] == "ld":
+        return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld\n"
     if "--show-sdk-path" in argv:
         return "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk\n"
     if "--version" in argv:
@@ -13168,6 +13177,7 @@ result = repr([
     swiftc["swiftc_path"],
     swiftc["sdk_path"],
     swiftc["env"],
+    swiftc["identity"],
 ])
 "#
     );
@@ -13177,13 +13187,25 @@ result = repr([
         "fallback argv must not include xcrun: {out}"
     );
     assert!(
-        out.contains("XcodeDefault.xctoolchain/usr/bin/swiftc"),
+        out.contains("swift-snapshot.xctoolchain/usr/bin/swiftc"),
         "{out}"
     );
     assert!(out.contains("iPhoneSimulator.sdk"), "{out}");
     assert!(
         out.contains("\"SWIFT_DETERMINISTIC_HASHING\": \"1\""),
         "{out}"
+    );
+    assert!(
+        out.contains(
+            "\"PATH\": \"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:/usr/bin:/bin\""
+        ),
+        "the linker directory must reach actions through PATH: {out}"
+    );
+    assert_eq!(
+        out.matches("XcodeDefault.xctoolchain/usr/bin:/usr/bin:/bin")
+            .count(),
+        2,
+        "the tool search path must also partition the action cache: {out}"
     );
 }
 

--- a/crates/once-frontend/tests/prelude.rs
+++ b/crates/once-frontend/tests/prelude.rs
@@ -17,6 +17,9 @@ use tempfile::TempDir;
 #[path = "prelude/swift_package_traits.rs"]
 mod swift_package_traits;
 
+#[path = "prelude/swift_package_linking.rs"]
+mod swift_package_linking;
+
 #[path = "prelude/swift_testing_library.rs"]
 mod swift_testing_library;
 

--- a/crates/once-frontend/tests/prelude/swift_macro_testing.rs
+++ b/crates/once-frontend/tests/prelude/swift_macro_testing.rs
@@ -1,0 +1,81 @@
+use super::{apple_prelude_source, eval_prelude_source_to_repr, xcode_prelude_source};
+
+/// A macro is a tool for the targets that expand it, so its code must not
+/// reach what they link. A target that unit-tests the macro is the exception:
+/// it imports the module to reach the implementation types, so the macro
+/// exposes its module and an archive under keys only that path reads.
+#[test]
+fn a_macro_offers_its_module_only_to_the_targets_that_test_it() {
+    let result = eval_prelude_source_to_repr(format!(
+        "{}\n{}",
+        apple_prelude_source(),
+        r#"
+plugin = {
+    "transitive_plugin_executables": ["/out/Plugin-tool#Plugin"],
+    "transitive_plugin_module_dirs": ["/out/Plugin", "/out/Syntax"],
+    "transitive_plugin_archives": ["/out/Plugin/Plugin.a", "/out/Syntax/Syntax.a"],
+    "transitive_plugin_module_inputs": ["/out/Plugin/Plugin.swiftmodule"],
+}
+library = {"transitive_archives": ["/out/Lib/Lib.a"]}
+collected = _apple_collect_macro_module_inputs([plugin, library])
+(swiftmodule_dirs, header_dirs, modulemaps, hmaps, archives, framework_search_dirs, framework_module_names, framework_files, sdk_frameworks, sdk_dylibs, linkopts, vfs_overlays, plugin_dylibs, plugin_executables) = _collect_dep_compile_inputs([plugin, library], "/out/Consumer")
+result = repr([
+    collected["module_dirs"],
+    collected["archives"],
+    collected["module_inputs"],
+    archives,
+    plugin_executables,
+])
+"#
+    ))
+    .unwrap();
+    assert_eq!(
+        result,
+        r#"[["/out/Plugin", "/out/Syntax"], ["/out/Plugin/Plugin.a", "/out/Syntax/Syntax.a"], ["/out/Plugin/Plugin.swiftmodule"], ["/out/Lib/Lib.a"], ["/out/Plugin-tool#Plugin"]]"#
+    );
+}
+
+/// A macro only ever builds for the host, so a test target that links one has
+/// to build for the host as well, and that carries every dependency of that
+/// test target to the host too. Mixing a host build and a destination build of
+/// the same module in one link redefines it.
+#[test]
+fn a_test_target_that_links_a_macro_builds_for_the_host() {
+    let result = eval_prelude_source_to_repr(format!(
+        "{}\n{}",
+        xcode_prelude_source(),
+        r#"
+def workspace_root():
+    return "/workspace"
+def host_file_exists(path):
+    return False
+def host_file_read(path):
+    return ""
+def _xcode_swift_package_target_sources(package_path, target):
+    return ["Sources/" + target["name"] + ".swift"]
+packages = [{"identity": "kit", "path": "", "info": {
+    "platforms": [{"platformName": "ios", "version": "17.0"}],
+    "targets": [
+        {"name": "Support", "type": "regular"},
+        {"name": "KitMacros", "type": "macro", "dependencies": [{"target": ["Support"]}]},
+        {"name": "MacroTests", "type": "test", "dependencies": [
+            {"target": ["KitMacros"]},
+            {"target": ["Support"]},
+        ]},
+        {"name": "PlainTests", "type": "test", "dependencies": [{"target": ["Support"]}]},
+    ],
+}}]
+graph = _xcode_local_swift_package_specs({"label": {"package": ""}, "attr": {}}, packages, "ios", "17.0", "simulator")
+specs = {spec["name"]: spec for spec in graph["specs"]}
+result = repr([
+    [specs[name]["attrs"]["platform"], specs[name]["deps"]]
+    for name in ["SwiftPackage_kit_MacroTests", "SwiftPackage_kit_PlainTests"]
+])
+"#
+    ))
+    .unwrap();
+    assert_eq!(
+        result,
+        r#"[["macos", ["./SwiftPackage_kit_KitMacros", "./SwiftPackage_kit_Support_MacroHost"]], ["ios", ["./SwiftPackage_kit_Support"]]]"#
+    );
+}

--- a/crates/once-frontend/tests/prelude/swift_package_linking.rs
+++ b/crates/once-frontend/tests/prelude/swift_package_linking.rs
@@ -1,0 +1,41 @@
+use super::{eval_prelude_source_to_repr, xcode_prelude_source};
+
+/// Swift Package Manager hands the linker every object file a target
+/// produced, so a file whose only contribution is a protocol conformance
+/// still reaches the binary. Once collects a target into an archive instead,
+/// and an archive member nothing references is dropped, which loses the
+/// conformance at runtime. Library targets therefore force-load; a test
+/// bundle and an executable are linked directly and do not.
+#[test]
+fn library_targets_force_load_so_conformances_survive() {
+    let result = eval_prelude_source_to_repr(format!(
+        "{}\n{}",
+        xcode_prelude_source(),
+        r#"
+def workspace_root():
+    return "/workspace"
+def host_file_exists(path):
+    return False
+def host_file_read(path):
+    return ""
+def _xcode_swift_package_target_sources(package_path, target):
+    return ["Sources/" + target["name"] + ".swift"]
+packages = [{"identity": "kit", "path": "", "info": {"targets": [
+    {"name": "Kit", "type": "regular"},
+    {"name": "KitTests", "type": "test"},
+    {"name": "kit-cli", "type": "executable"},
+]}}]
+graph = _xcode_local_swift_package_specs({"label": {"package": ""}, "attr": {}}, packages, "macos", "13.0", "simulator")
+specs = {spec["name"]: spec for spec in graph["specs"]}
+result = repr([
+    [specs[name]["kind"], specs[name]["attrs"].get("alwayslink")]
+    for name in ["SwiftPackage_kit_Kit", "SwiftPackage_kit_KitTests", "SwiftPackage_kit_kit-cli"]
+])
+"#
+    ))
+    .unwrap();
+    assert_eq!(
+        result,
+        r#"[["apple_library", True], ["apple_test_bundle", None], ["apple_application", None]]"#
+    );
+}

--- a/crates/once-frontend/tests/prelude/swift_package_traits.rs
+++ b/crates/once-frontend/tests/prelude/swift_package_traits.rs
@@ -1,0 +1,124 @@
+use super::{eval_prelude_source_to_repr, xcode_prelude_source};
+
+fn evaluate(body: &str) -> String {
+    eval_prelude_source_to_repr(format!("{}\n{body}", xcode_prelude_source())).unwrap()
+}
+
+#[test]
+fn unifies_dependency_traits_and_expands_nested_traits_until_stable() {
+    let result = evaluate(
+        r#"
+packages = [
+    {"identity": "streaming", "info": {"traits": [
+        {"name": "Streaming", "enabledTraits": ["Storage"]},
+        {"name": "Storage", "enabledTraits": ["Streaming"]},
+    ]}},
+    {"identity": "transport", "info": {
+        "traits": [{"name": "Client"}, {"name": "Server"}],
+        "dependencies": [{"registry": [{"identity": "streaming", "traits": [
+            {"name": "Streaming", "condition": {"traits": ["Client", "Unused"]}},
+            {"name": "Disabled", "condition": {"traits": ["Unused"]}},
+        ]}]}],
+    }},
+    {"identity": "client", "info": {"dependencies": [{"sourceControl": [
+        {"identity": "TRANSPORT", "traits": [{"name": "Client"}]},
+    ]}]}},
+    {"identity": "server", "info": {"dependencies": [{"fileSystem": [
+        {"identity": "transport", "traits": [{"name": "Server"}]},
+    ]}]}},
+]
+traits = _xcode_swift_package_resolved_traits(packages)
+reordered = _xcode_swift_package_resolved_traits(list(reversed(packages)))
+result = repr([traits["transport"], traits["streaming"], traits == reordered])
+"#,
+    );
+    assert_eq!(
+        result,
+        r#"[["Client", "Server"], ["Storage", "Streaming"], True]"#
+    );
+}
+
+#[test]
+fn preserves_omitted_defaults_and_respects_explicit_trait_selection() {
+    let result = evaluate(
+        r#"
+def package(identity):
+    return {"identity": identity, "info": {"traits": [
+        {"name": "default", "enabledTraits": ["DefaultFeature"]},
+        {"name": "DefaultFeature", "enabledTraits": ["Nested"]},
+        {"name": "Nested"},
+        {"name": "OptIn"},
+    ]}}
+root = package("root")
+root["info"]["dependencies"] = [{"sourceControl": [
+    {"identity": "omitted"},
+    {"identity": "disabled", "traits": []},
+    {"identity": "selected", "traits": [{"name": "OptIn"}]},
+    {"identity": "defaults", "traits": [{"name": "default"}, {"name": "OptIn"}]},
+]}]
+packages = [root] + [package(name) for name in ["omitted", "disabled", "selected", "defaults"]]
+traits = _xcode_swift_package_resolved_traits(packages, ["ROOT"])
+direct_roots = _xcode_swift_package_resolved_traits(packages, ["root", "disabled"])
+result = repr([
+    [traits[name] for name in ["root", "omitted", "disabled", "selected", "defaults"]],
+    direct_roots["disabled"],
+])
+"#,
+    );
+    assert_eq!(
+        result,
+        r#"[[["DefaultFeature", "Nested"], ["DefaultFeature", "Nested"], [], ["OptIn"], ["DefaultFeature", "Nested", "OptIn"]], ["DefaultFeature", "Nested"]]"#
+    );
+}
+
+#[test]
+fn applies_resolved_traits_to_compilation_and_conditional_dependencies() {
+    let result = evaluate(
+        r#"
+def workspace_root():
+    return "/workspace"
+def host_file_exists(path):
+    return False
+def host_file_read(path):
+    return ""
+def _xcode_swift_package_target_sources(package_path, target):
+    return ["Sources/" + target["name"] + ".swift"]
+packages = [
+    {"identity": "app", "path": "", "info": {"dependencies": [{"sourceControl": [
+        {"identity": "streaming", "traits": [{"name": "Streaming"}]},
+    ]}]}},
+    {"identity": "streaming", "path": "Vendor/Streaming", "info": {
+        "traits": [{"name": "Streaming"}],
+        "targets": [
+            {"name": "Storage", "type": "regular"},
+            {"name": "Streaming", "type": "regular", "settings": [
+                {"tool": "swift", "kind": {"define": {"_0": "HAS_STORAGE"}}, "condition": {"traits": ["Streaming", "Other"]}},
+            ], "dependencies": [
+                {"target": ["Storage", {"traits": ["Streaming", "Other"]}]},
+                {"target": ["Disabled", {"traits": ["Other"]}]},
+            ]},
+            {"name": "Disabled", "type": "regular"},
+            {"name": "Plugin", "type": "macro"},
+        ],
+    }},
+]
+graph = _xcode_local_swift_package_specs({"label": {"package": ""}, "attr": {}}, packages, "macos", "13.0", "simulator")
+specs = {spec["name"]: spec for spec in graph["specs"]}
+target = specs["SwiftPackage_streaming_Streaming"]
+host = specs["SwiftPackage_streaming_Streaming_MacroHost"]
+macro = specs["SwiftPackage_streaming_Plugin"]
+result = repr([
+    target["attrs"]["defines"],
+    target["deps"],
+    "HAS_STORAGE" in target["attrs"]["swift_flags"],
+    "Streaming" in host["attrs"]["defines"],
+    "Streaming" in macro["attrs"]["swift_flags"],
+    _xcode_package_condition_allows({"platformNames": ["ios"], "traits": ["Streaming"]}, "macos", ["Streaming"]),
+])
+"#,
+    );
+    assert_eq!(
+        result,
+        r#"[["SWIFT_PACKAGE", "DEBUG", "Streaming"], ["./SwiftPackage_streaming_Storage"], True, True, True, False]"#
+    );
+}

--- a/crates/once-frontend/tests/prelude/swift_testing_library.rs
+++ b/crates/once-frontend/tests/prelude/swift_testing_library.rs
@@ -1,0 +1,50 @@
+use super::{apple_prelude_source, eval_prelude_source_to_repr};
+
+fn evaluate(body: &str) -> String {
+    eval_prelude_source_to_repr(format!("{}\n{body}", apple_prelude_source())).unwrap()
+}
+
+/// Xcode publishes Swift Testing as a platform framework, and a Swift
+/// toolchain installed beside Xcode ships its own copy next to the
+/// compiler. Only the copy that belongs to the compiler matches the macro
+/// plugin that same compiler loads, so it has to win when it is present.
+#[test]
+fn prefers_the_testing_library_that_ships_with_the_compiler() {
+    let result = evaluate(
+        r#"
+def host_file_exists(path):
+    return path.startswith("/Toolchains/snapshot.xctoolchain/")
+
+result = repr([
+    _swift_testing_library_dir("/Toolchains/snapshot.xctoolchain/usr/bin/swiftc", "macosx"),
+    _swift_testing_library_dir("/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc", "iphonesimulator"),
+])
+"#,
+    );
+    assert_eq!(
+        result,
+        r#"["/Toolchains/snapshot.xctoolchain/usr/lib/swift/macosx/testing", ""]"#
+    );
+}
+
+/// Compiling against the compiler's own copy is a module search path, and
+/// linking it is a dynamic library reached through an rpath rather than a
+/// framework the platform already exposes. Without a toolchain copy both
+/// fall back to the platform framework.
+#[test]
+fn compiles_and_links_against_whichever_testing_library_applies() {
+    let result = evaluate(
+        r#"
+result = repr([
+    _apple_swift_testing_compile_flags("/toolchain/testing", "/platform/Frameworks", "/plugin.dylib"),
+    _apple_swift_testing_link_flags("/toolchain/testing"),
+    _apple_swift_testing_compile_flags("", "/platform/Frameworks", "/plugin.dylib"),
+    _apple_swift_testing_link_flags(""),
+])
+"#,
+    );
+    assert_eq!(
+        result,
+        r#"[["-I", "/toolchain/testing", "-load-plugin-library", "/plugin.dylib"], ["-L", "/toolchain/testing", "-lTesting", "-Xlinker", "-rpath", "-Xlinker", "/toolchain/testing"], ["-F", "/platform/Frameworks", "-framework", "Testing", "-load-plugin-library", "/plugin.dylib"], ["-framework", "Testing"]]"#
+    );
+}

--- a/crates/once-frontend/tests/prelude/swift_testing_results.rs
+++ b/crates/once-frontend/tests/prelude/swift_testing_results.rs
@@ -1,0 +1,204 @@
+use super::{apple_prelude_source, eval_prelude_source_to_repr, eval_prelude_string_function};
+
+/// Reading a declaration proves a case exists, never that it ran or how it
+/// ended. Source can compile away behind a condition and a runner can filter
+/// or never reach a case, so a listing derived from sources reports no
+/// verdict, and the counts it summarizes stay at zero.
+#[cfg(unix)]
+#[test]
+fn a_listing_taken_from_sources_reports_no_verdict() {
+    let script = eval_prelude_string_function(
+        "_apple_test_report_script",
+        r#"(["Suite.swift"], "cases.jsonl", "tests/Bundle", "swift_testing")"#,
+    )
+    .unwrap();
+
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join("Suite.swift"),
+        "import Testing\nstruct MathSuite {\n  @Test func addsNumbers() {}\n}\n",
+    )
+    .unwrap();
+    let output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "status=0\nlog=run.log\nnative_results=native.txt\nresults=results.json\n{script}"
+        ))
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+
+    let results = std::fs::read_to_string(dir.path().join("results.json")).unwrap();
+    assert!(
+        results.contains(r#""id":"tests/Bundle::MathSuite/addsNumbers""#),
+        "{results}"
+    );
+    assert!(results.contains(r#""status":"unknown""#), "{results}");
+    assert!(
+        results.contains(r#""summary":{"total":1,"passed":0,"failed":0,"skipped":0,"flaky":0}"#),
+        "a listing must not credit itself with outcomes: {results}"
+    );
+    assert!(
+        results.contains(r#""status":"passed""#),
+        "the run's own outcome is known: {results}"
+    );
+}
+
+/// Only the XCTest host runs XCTest cases, so a bundle that has any is left to
+/// it. A bundle without them is free to run through the testing library's own
+/// entry point, which reports every test and what became of it.
+#[test]
+fn a_bundle_holding_xctest_cases_stays_with_the_xctest_host() {
+    let result = eval_prelude_source_to_repr(format!(
+        "{}\n{}",
+        apple_prelude_source(),
+        r##"
+sources = {
+    "/ws/Suite.swift": "import Testing\n@Test func a() {}\n",
+    "/ws/Legacy.swift": "import XCTest\nclass Legacy: XCTestCase {}\n",
+    "/ws/Bridge.m": "#import <XCTest/XCTest.h>\n",
+}
+def workspace_root():
+    return "/ws"
+def host_file_exists(path):
+    return path in sources
+def host_file_read(path):
+    return sources[path]
+result = repr([
+    _apple_sources_import_xctest(["Suite.swift"]),
+    _apple_sources_import_xctest(["Suite.swift", "Legacy.swift"]),
+    _apple_sources_import_xctest(["Bridge.m"]),
+    _apple_sources_import_xctest(["Missing.swift"]),
+    _apple_swift_testing_filter("MathSuite/addsNumbers"),
+    _apple_swift_testing_helper("/Toolchains/absent.xctoolchain/usr/bin/swiftc"),
+])
+"##
+    ))
+    .unwrap();
+
+    assert_eq!(
+        result,
+        r#"[False, True, True, False, "MathSuite/addsNumbers\\(", ""]"#
+    );
+}
+
+/// The testing library's event stream is the record of what ran. Compile the
+/// reporting half of the generated entry point on its own and feed it a stream
+/// to confirm the normalized results follow the stream rather than the exit
+/// status: a known issue is not a failure, an unreached test claims no pass,
+/// and a recorded failure is reported as one.
+#[cfg(target_os = "macos")]
+#[test]
+fn normalized_results_follow_the_event_stream() {
+    let source =
+        eval_prelude_string_function("_apple_swift_testing_entry_point_source", "()").unwrap();
+    let reporting = source
+        .split_once("@main")
+        .expect("the generated source declares an entry point")
+        .0
+        .to_string();
+
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(dir.path().join("Report.swift"), &reporting).unwrap();
+    std::fs::write(
+        dir.path().join("main.swift"),
+        "OnceTestReport.write(exitCode: 0)\n",
+    )
+    .unwrap();
+
+    let suite = r#"{"kind":"test","payload":{"kind":"suite","id":"M.Suite","name":"Suite","sourceLocation":{"_filePath":"Tests/Suite.swift","line":1,"column":1}},"version":0}"#;
+    let test = |name: &str| {
+        format!(
+            r#"{{"kind":"test","payload":{{"kind":"function","id":"M.Suite/{name}()/Tests/Suite.swift:2:3","name":"{name}()","isParameterized":false,"sourceLocation":{{"_filePath":"Tests/Suite.swift","line":2,"column":3}}}},"version":0}}"#
+        )
+    };
+    let event = |kind: &str, name: &str, extra: &str| {
+        format!(
+            r#"{{"kind":"event","payload":{{"kind":"{kind}","testID":"M.Suite/{name}()/Tests/Suite.swift:2:3","messages":[]{extra}}},"version":0}}"#
+        )
+    };
+    let stream = [
+        suite.to_string(),
+        test("passes"),
+        test("failsForReal"),
+        test("hasKnownIssue"),
+        test("neverRuns"),
+        event("testStarted", "passes", ""),
+        event("testEnded", "passes", ""),
+        event("testStarted", "failsForReal", ""),
+        event(
+            "issueRecorded",
+            "failsForReal",
+            r#","issue":{"isKnown":false,"isFailure":true,"severity":"error"}"#,
+        ),
+        event("testEnded", "failsForReal", ""),
+        event("testStarted", "hasKnownIssue", ""),
+        event(
+            "issueRecorded",
+            "hasKnownIssue",
+            r#","issue":{"isKnown":true,"isFailure":true,"severity":"error"}"#,
+        ),
+        event("testEnded", "hasKnownIssue", ""),
+    ]
+    .join("\n");
+    std::fs::write(dir.path().join("events.jsonl"), stream).unwrap();
+
+    let compiled = std::process::Command::new("xcrun")
+        .args([
+            "swiftc",
+            "-Onone",
+            "-o",
+            "report",
+            "Report.swift",
+            "main.swift",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        compiled.status.success(),
+        "{}",
+        String::from_utf8_lossy(&compiled.stderr)
+    );
+
+    let run = std::process::Command::new("./report")
+        .current_dir(dir.path())
+        .env("ONCE_TEST_RESULTS", "results.json")
+        .env("ONCE_TEST_EVENT_STREAM", "events.jsonl")
+        .env("ONCE_TEST_TARGET", "tests/Bundle")
+        .env("ONCE_TEST_LOG", "run.log")
+        .env("ONCE_TEST_NATIVE_RESULTS", "native.txt")
+        .output()
+        .unwrap();
+    assert!(run.status.success(), "{run:?}");
+
+    let results = std::fs::read_to_string(dir.path().join("results.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&results).unwrap();
+    assert_eq!(parsed["status"], "failed", "{results}");
+    assert_eq!(parsed["summary"]["total"], 4, "{results}");
+    assert_eq!(
+        parsed["summary"]["passed"], 2,
+        "a known issue is not a failure: {results}"
+    );
+    assert_eq!(parsed["summary"]["failed"], 1, "{results}");
+    assert_eq!(
+        parsed["summary"]["skipped"], 1,
+        "a test the run never reached claims no pass: {results}"
+    );
+    let by_name = |name: &str| {
+        parsed["cases"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|case| case["name"] == name)
+            .unwrap_or_else(|| panic!("{name} missing from {results}"))
+            .clone()
+    };
+    assert_eq!(by_name("passes")["status"], "passed");
+    assert_eq!(by_name("failsForReal")["status"], "failed");
+    assert_eq!(by_name("hasKnownIssue")["status"], "passed");
+    assert_eq!(by_name("neverRuns")["status"], "skipped");
+    assert_eq!(by_name("passes")["id"], "tests/Bundle::Suite/passes");
+    assert_eq!(by_name("passes")["suite"], "Suite");
+}

--- a/crates/once-frontend/tests/prelude/swift_testing_results.rs
+++ b/crates/once-frontend/tests/prelude/swift_testing_results.rs
@@ -45,8 +45,8 @@ fn a_listing_taken_from_sources_reports_no_verdict() {
     );
 }
 
-/// Only the XCTest host runs XCTest cases, so a bundle that has any is left to
-/// it. A bundle without them is free to run through the testing library's own
+/// Only the `XCTest` host runs `XCTest` cases, so a bundle that has any is left
+/// to it. A bundle without them is free to run through the testing library's own
 /// entry point, which reports every test and what became of it.
 #[test]
 fn a_bundle_holding_xctest_cases_stays_with_the_xctest_host() {
@@ -107,42 +107,7 @@ fn normalized_results_follow_the_event_stream() {
     )
     .unwrap();
 
-    let suite = r#"{"kind":"test","payload":{"kind":"suite","id":"M.Suite","name":"Suite","sourceLocation":{"_filePath":"Tests/Suite.swift","line":1,"column":1}},"version":0}"#;
-    let test = |name: &str| {
-        format!(
-            r#"{{"kind":"test","payload":{{"kind":"function","id":"M.Suite/{name}()/Tests/Suite.swift:2:3","name":"{name}()","isParameterized":false,"sourceLocation":{{"_filePath":"Tests/Suite.swift","line":2,"column":3}}}},"version":0}}"#
-        )
-    };
-    let event = |kind: &str, name: &str, extra: &str| {
-        format!(
-            r#"{{"kind":"event","payload":{{"kind":"{kind}","testID":"M.Suite/{name}()/Tests/Suite.swift:2:3","messages":[]{extra}}},"version":0}}"#
-        )
-    };
-    let stream = [
-        suite.to_string(),
-        test("passes"),
-        test("failsForReal"),
-        test("hasKnownIssue"),
-        test("neverRuns"),
-        event("testStarted", "passes", ""),
-        event("testEnded", "passes", ""),
-        event("testStarted", "failsForReal", ""),
-        event(
-            "issueRecorded",
-            "failsForReal",
-            r#","issue":{"isKnown":false,"isFailure":true,"severity":"error"}"#,
-        ),
-        event("testEnded", "failsForReal", ""),
-        event("testStarted", "hasKnownIssue", ""),
-        event(
-            "issueRecorded",
-            "hasKnownIssue",
-            r#","issue":{"isKnown":true,"isFailure":true,"severity":"error"}"#,
-        ),
-        event("testEnded", "hasKnownIssue", ""),
-    ]
-    .join("\n");
-    std::fs::write(dir.path().join("events.jsonl"), stream).unwrap();
+    std::fs::write(dir.path().join("events.jsonl"), event_stream()).unwrap();
 
     let compiled = std::process::Command::new("xcrun")
         .args([
@@ -201,4 +166,46 @@ fn normalized_results_follow_the_event_stream() {
     assert_eq!(by_name("neverRuns")["status"], "skipped");
     assert_eq!(by_name("passes")["id"], "tests/Bundle::Suite/passes");
     assert_eq!(by_name("passes")["suite"], "Suite");
+}
+
+/// One run's worth of records, in the shape the testing library writes them:
+/// a test that passes, one that records a real failure, one whose only issue
+/// the test itself marks as known, and one the run never reaches.
+#[cfg(target_os = "macos")]
+fn event_stream() -> String {
+    let suite = r#"{"kind":"test","payload":{"kind":"suite","id":"M.Suite","name":"Suite","sourceLocation":{"_filePath":"Tests/Suite.swift","line":1,"column":1}},"version":0}"#;
+    let test = |name: &str| {
+        format!(
+            r#"{{"kind":"test","payload":{{"kind":"function","id":"M.Suite/{name}()/Tests/Suite.swift:2:3","name":"{name}()","isParameterized":false,"sourceLocation":{{"_filePath":"Tests/Suite.swift","line":2,"column":3}}}},"version":0}}"#
+        )
+    };
+    let event = |kind: &str, name: &str, extra: &str| {
+        format!(
+            r#"{{"kind":"event","payload":{{"kind":"{kind}","testID":"M.Suite/{name}()/Tests/Suite.swift:2:3","messages":[]{extra}}},"version":0}}"#
+        )
+    };
+    [
+        suite.to_string(),
+        test("passes"),
+        test("failsForReal"),
+        test("hasKnownIssue"),
+        test("neverRuns"),
+        event("testStarted", "passes", ""),
+        event("testEnded", "passes", ""),
+        event("testStarted", "failsForReal", ""),
+        event(
+            "issueRecorded",
+            "failsForReal",
+            r#","issue":{"isKnown":false,"isFailure":true,"severity":"error"}"#,
+        ),
+        event("testEnded", "failsForReal", ""),
+        event("testStarted", "hasKnownIssue", ""),
+        event(
+            "issueRecorded",
+            "hasKnownIssue",
+            r#","issue":{"isKnown":true,"isFailure":true,"severity":"error"}"#,
+        ),
+        event("testEnded", "hasKnownIssue", ""),
+    ]
+    .join("\n")
 }

--- a/web/priv/changelog/2026-09-09-swift-package-traits.md
+++ b/web/priv/changelog/2026-09-09-swift-package-traits.md
@@ -1,0 +1,13 @@
+---
+title: Preserve Swift dependency traits
+date: 2026-09-09
+---
+
+Native Swift package builds now preserve traits requested by dependencies.
+Once combines requests across the package graph and expands traits that enable
+other traits before compiling libraries and macros. This fixes missing types
+when a dependency exposes functionality behind an opt-in trait.
+
+Explicit trait lists, disabled defaults, and conditional trait requests follow
+the package declarations. The same resolved traits control compiler settings
+and optional target dependencies.

--- a/web/priv/changelog/2026-09-09-swift-toolchain-selection.md
+++ b/web/priv/changelog/2026-09-09-swift-toolchain-selection.md
@@ -16,3 +16,8 @@ test targets now compile and link against the copy the selected compiler
 provides when it has one, and against the version Xcode publishes otherwise.
 Test bundles that previously failed to expand `@Test` and `@Suite` build
 again.
+
+Swift package libraries are also force-loaded into what depends on them, the
+way Swift Package Manager links every object file a target produced. A source
+file whose only contribution is a protocol conformance is no longer dropped,
+so conformances declared in an extension are found at runtime.

--- a/web/priv/changelog/2026-09-09-swift-toolchain-selection.md
+++ b/web/priv/changelog/2026-09-09-swift-toolchain-selection.md
@@ -1,0 +1,18 @@
+---
+title: Builds with a Swift toolchain outside Xcode
+date: 2026-09-09
+---
+
+A Swift toolchain installed beside Xcode contributes the compiler, but the
+linker and the software development kit still come from Xcode. Apple builds
+now resolve those separately and pass the linker's location to every compile
+and link, so a package that needs a newer compiler than the one Xcode ships
+builds without falling back to whatever the surrounding shell happened to
+expose.
+
+Swift Testing follows the same rule. A macro plugin only matches the testing
+library from its own toolchain, and the two ship on different schedules, so
+test targets now compile and link against the copy the selected compiler
+provides when it has one, and against the version Xcode publishes otherwise.
+Test bundles that previously failed to expand `@Test` and `@Suite` build
+again.

--- a/web/priv/changelog/2026-09-10-swift-test-reporting.md
+++ b/web/priv/changelog/2026-09-10-swift-test-reporting.md
@@ -1,0 +1,21 @@
+---
+title: Test results that follow the run
+date: 2026-09-10
+---
+
+Swift Testing bundles now report every test and what actually became of it.
+The testing library keeps a record of the run, and Once turns that record into
+its normalized results instead of listing what the sources declare and
+crediting each one with the run's exit status. A test that was filtered out,
+skipped, or never reached is reported as such rather than as a pass, and an
+issue a test marks as known no longer counts as a failure.
+
+Where results still have to come from the XCTest host, that host reports the
+run's outcome rather than each test's. Once lists the cases it finds so a shard
+can address them, but lists them without a verdict, so a green run never
+carries verdicts nothing produced.
+
+Test bundles that depend on a Swift macro can now import it. Code behind
+`canImport` of a macro module used to compile away, which quietly emptied the
+test targets that exercise macro implementations. Such a bundle builds for the
+host along with its dependencies, matching how a macro itself is built.

--- a/web/priv/docs/guide/graph/swift-packages.md
+++ b/web/priv/docs/guide/graph/swift-packages.md
@@ -91,6 +91,25 @@ xcrun --find swift
 xcrun swift --version
 ```
 
+Once selects the Swift compiler through `xcrun`. A Swiftly `.swift-version`
+file does not change that selection. If a package requires a separately
+installed Swift toolchain, select its bundle identifier for the build:
+
+```sh
+TOOLCHAINS=your.toolchain.bundle.identifier once build
+```
+
+Check the selection with `TOOLCHAINS=your.toolchain.bundle.identifier xcrun
+swift --version`. The selected compiler must support the package's
+`swift-tools-version`.
+
+A Swift toolchain installed beside Xcode contributes the compiler and the
+macros it loads, while Xcode still contributes the linker and the software
+development kit. Once resolves each of those separately, so builds that mix
+them link and expand macros against matching tools. Swift Testing follows the
+same rule: when the selected compiler ships its own copy, tests compile and
+link against that one rather than the version Xcode publishes.
+
 Start with the [Apple guide](/guide/graph/apple) if a first-party Apple target
 does not build yet. Package integration is easier to diagnose after the local
 compiler, software development kit, linker, and code-signing path work.

--- a/web/priv/docs/guide/graph/swift-packages.md
+++ b/web/priv/docs/guide/graph/swift-packages.md
@@ -115,3 +115,9 @@ once build SwiftPackage_MyPackage_MyLibrary
 There is no Once initialization step. A first build can access the network when
 Swift Package Manager must create `Package.resolved` or Once must materialize a
 pinned source dependency.
+
+Once preserves package traits requested by dependencies, including traits that
+enable other traits and conditional requests. Code guarded by a dependency's
+opt-in trait is compiled with that trait enabled. Explicit empty trait lists
+disable defaults for that dependency declaration; requests from other packages
+are still combined according to Swift Package Manager's rules.

--- a/web/priv/docs/reference/prelude/apple_test_bundle.md
+++ b/web/priv/docs/reference/prelude/apple_test_bundle.md
@@ -42,6 +42,19 @@ so code guarded by `canImport` of the macro module compiles. A macro only ever
 builds for the host, so a test bundle that depends on one builds for the host
 as well, along with everything it depends on.
 
+## Reported Results
+
+A Swift Testing bundle reports every test and what became of it. The testing
+library records the run and Once turns that record into normalized results, so
+a test that was filtered out, skipped, or never reached is reported as such
+rather than as a pass, and an issue the test marked as known is not a failure.
+
+Where results have to come from the XCTest host instead, that host reports the
+run's outcome and not each test's. Once still lists the cases it finds in the
+sources so a shard can address them, but lists them without a verdict. A
+bundle stays with the XCTest host when it holds XCTest cases, which only that
+host runs, and when it runs anywhere other than macOS.
+
 ## Attributes
 
 | Attribute | Type | Required | Default | Description |

--- a/web/priv/docs/reference/prelude/apple_test_bundle.md
+++ b/web/priv/docs/reference/prelude/apple_test_bundle.md
@@ -37,6 +37,11 @@ directory, stages the required testing frameworks, and launches the declared
 application under test. Compilation, linking, packaging, and signing remain
 Once build actions.
 
+A bundle that depends on a Swift macro links the macro and imports its module,
+so code guarded by `canImport` of the macro module compiles. A macro only ever
+builds for the host, so a test bundle that depends on one builds for the host
+as well, along with everything it depends on.
+
 ## Attributes
 
 | Attribute | Type | Required | Default | Description |

--- a/web/priv/docs/reference/prelude/swift_macro.md
+++ b/web/priv/docs/reference/prelude/swift_macro.md
@@ -11,6 +11,14 @@ swift-syntax checkout supplied through `deps`. Any
 reaches a `swift_macro` target picks up the executable and declaring module
 automatically.
 
+A macro is a tool for the targets that expand it, so its code stays out of what
+they link. A target that unit-tests the macro is the exception: it imports the
+module to reach the implementation types, so an
+[`apple_test_bundle`](/reference/prelude/apple_test_bundle) that depends on a
+macro compiles and links against it. A macro only ever builds for the host, so
+such a test target builds for the host too, and so does everything it depends
+on.
+
 ## Attributes
 
 | Attribute | Type | Required | Default | Description |

--- a/web/priv/docs/reference/prelude/swift_package_workspace.md
+++ b/web/priv/docs/reference/prelude/swift_package_workspace.md
@@ -26,6 +26,14 @@ Swift Package Manager supplies manifest and lockfile metadata, but does not
 build the dependency products. Registry dependencies are not supported by
 native package lowering yet.
 
+Package traits follow the declarations in `Package.swift`. Once enables the
+root package's defaults, combines traits requested by all packages that use a
+dependency, and expands traits that enable other traits. Explicit dependency
+trait lists replace that dependency declaration's defaults; an empty list
+enables none. Conditional trait requests activate when any of their required
+traits is enabled. The resolved traits control compilation conditions,
+compiler settings, and optional target dependencies, including macro builds.
+
 ## Attributes
 
 | Attribute | Type | Required | Default | Description |

--- a/web/priv/docs/reference/prelude/swift_package_workspace.md
+++ b/web/priv/docs/reference/prelude/swift_package_workspace.md
@@ -26,6 +26,11 @@ Swift Package Manager supplies manifest and lockfile metadata, but does not
 build the dependency products. Registry dependencies are not supported by
 native package lowering yet.
 
+Library targets are force-loaded into whatever links them, matching how Swift
+Package Manager hands the linker every object file a target produced. A source
+file whose only contribution is a protocol conformance would otherwise be
+dropped, and the conformance would be missing at runtime.
+
 Package traits follow the declarations in `Package.swift`. Once enables the
 root package's defaults, combines traits requested by all packages that use a
 dependency, and expands traits that enable other traits. Explicit dependency

--- a/web/priv/docs/reference/prelude/xcode_workspace.md
+++ b/web/priv/docs/reference/prelude/xcode_workspace.md
@@ -30,6 +30,12 @@ matching pinned revisions while lowering remote Swift packages. Checksum-pinned
 binary package archives download as normal cacheable dependencies instead of
 being fetched while the graph loads.
 
+Swift package traits requested by dependencies are combined across the package
+graph and applied to compilation, compiler settings, and optional target
+dependencies. Packages referenced directly by the Xcode project enable their
+default traits. Package library targets are force-loaded into whatever links
+them so conformances declared in an extension survive.
+
 See [Xcode Projects](/guide/graph/apple/xcode) for a walkthrough.
 
 ## Attributes


### PR DESCRIPTION
## What changed

Five focused changes that together let Once build and test [Vapor](https://github.com/vapor/vapor), a large Swift package that exercises corners of Swift Package Manager that Once had not met yet.

- **Swift package traits are resolved across the graph.** Traits used to be read only from a package's own default declaration, so a dependency's opt-in trait stayed off. Resolution now unifies the trait requests every package makes of a dependency, expands traits that enable other traits until the set is stable, and honours explicit lists, disabled defaults, and conditional requests.
- **Builds work with a Swift toolchain installed outside Xcode.** The linker's directory is resolved separately from the compiler and passed to every compile and link. Swift Testing follows the same rule, so the testing library and the macro plugin always come from the same toolchain.
- **Swift package libraries are force-loaded.** A source file whose only contribution is a protocol conformance is no longer dropped at link time.
- **Test targets can import the macros they exercise.** A macro target now also emits a static archive, exposed only to test bundles, and a test target with a direct macro dependency builds for the host along with its dependencies.
- **Test results come from the run rather than from the sources.** Swift Testing bundles get a generated entry point so they can be driven through the toolchain's testing helper with its structured event stream.

## Why

Vapor is worth supporting on its own, but each failure it surfaced is a general gap rather than something specific to that package. It pins a Swift 6.4 snapshot toolchain installed next to Xcode, declares traits and consumes dependencies that declare their own, ships macros with their own test targets, and relies on conformances declared in extensions. Any Swift package with those shapes hit the same problems.

The last item is the one worth calling out beyond Swift: `once test` was reporting passing tests for runs that executed nothing. That is a correctness problem in how Once reports results, and it is what kept the macro gap invisible for as long as it was.

## Root cause

Each failure had a distinct cause, found by comparing Once against Swift Package Manager on the same sources.

- **Traits.** Only the root package's `default` trait was read. A conditional request was also treated as requiring every listed trait; Swift Package Manager satisfies it when any one of them is enabled, which was confirmed against it directly in both directions.
- **Linker.** A Swift toolchain installed beside Xcode ships a compiler but no `ld`, and the compiler locates one by searching the environment. Once's actions run with an environment it controls, so every link failed with a bare `posix_spawn failed: No such file or directory`.
- **Swift Testing.** Once loaded the macro plugin from the selected compiler but linked Xcode's `Testing.framework`. The two ship on different schedules, so `@Test` and `@Suite` expanded to code the linked library did not declare.
- **Conformances.** Swift Package Manager hands the linker every object file a target produced. Once collects a target into an archive, and the linker never pulls in an archive member nothing references. Vapor's `File: MultipartPartConvertible` conformance was present in `Vapor.a` and absent from the linked test binary, which failed five multipart tests that pass under Swift Package Manager.
- **Macro imports.** A macro target built only a plugin executable, so `#if canImport(VaporMacrosPlugin)` was false and all three macro test files compiled away to nothing.
- **Reporting.** Cases were listed by parsing sources for test declarations, then every one was stamped `passed` whenever the runner exited zero. Nothing reconciled that list against what actually ran.

## Approach

Where Once had a choice to make, the answer was taken from Apple's own sources rather than guessed. Two of them settled decisions that earlier attempts had got wrong.

`BuildPlan.swift` in Swift Package Manager holds the rule for macro dependencies: a macro is only traversed when the depending module is a test, and such a test module builds for the host, which carries its whole dependency closure to the host with it. An earlier attempt forwarded the macro's host closure into a test built for the destination and produced duplicate module definitions; flipping the test target to the host is what avoids that. This was also checked empirically: an executable that depends on a macro links none of its objects, while a test target links all of them.

For results, `Documentation/ABI/JSON.md` in swift-testing describes the [application binary interface](https://en.wikipedia.org/wiki/Application_binary_interface) event stream, which names every test and what became of it. Passing `--event-stream-output-path` through `xctest` does nothing, because the XCTest host supplies its own configuration. Swift Package Manager reaches the stream by compiling an entry point into the bundle and then loading the bundle and calling that entry point through a small helper the toolchain ships. Once now does the same and normalizes the records in the process that produced them. The bundle stays loadable by `xctest`, which ignores `main`.

That path is used only when a bundle holds no XCTest cases, since only the XCTest host runs those, and when the platform is macOS. Everywhere else the run's exit status is the one outcome Once can state, so discovered cases are listed without a verdict instead of being credited with a pass. Reporting `unknown` is a deliberate choice over guessing: a green run that carries verdicts nothing produced is worse than one that admits what it does not know.

## Impact

Swift package builds that previously failed now work, and results that were previously wrong are now right.

- Test result records change shape for Swift Testing bundles on macOS: `cases` now reflects the run, including tests that were skipped or filtered out, and an issue a test marks as known is no longer counted as a failure. Anything reading `summary.passed` will see real numbers rather than a count of declarations.
- On the XCTest host path, per-case status becomes `unknown` and the summary counts become zero. The run-level status is unchanged and still accurate. Case identifiers are still listed so sharding can address them.
- Swift Testing bundles gain a generated entry point source and therefore export `main`. This does not change how `xctest` runs them.
- Adding the linker directory to the compiler environment changes the toolchain identity, so the first build after this change rebuilds Apple targets.
- The structured path depends on the testing helper the toolchain ships. When it is absent, Once falls back to the XCTest host rather than failing.

## Validation

Vapor at `Sources` head, built with the Swift 6.4 snapshot toolchain it pins:

- All eight targets build: `Vapor`, `VaporTesting`, `VaporMacros`, `VaporMacrosPlugin`, `Development`, and the three test bundles.
- `once test SwiftPackage_vapor_VaporTests` reports 504 tests: 495 passed, 8 skipped, 1 failed. The failure is `testPortOverride`, which binds a fixed port that is occupied on the machine used here, and it fails identically outside Once.
- `once test SwiftPackage_vapor_VaporMacroTests` reports 38 tests and `SwiftPackage_vapor_VaporMacroIntegrationTests` reports 16. Both previously produced no tests while reporting success.
- The same multipart tests were run under Swift Package Manager to confirm the failures were Once's and not upstream.

In this repository:

- `cargo test -p once-frontend` passes: 288 unit, 4 cmake, 18 examples, 363 prelude. Five new prelude test files cover trait resolution, toolchain selection, force-loading, macro imports, and result reporting. One of them compiles the generated reporting code on its own and drives it with an event stream to confirm a known issue is not a failure and an unreached test claims no pass.
- `shellspec spec/apple_spec.sh spec/test_capability_spec.sh spec/swift_compatibility_spec.sh` passes: 79 examples, 0 failures. This includes the existing end-to-end assertions on normalized results for the Swift Testing fixture, which the new writer matches exactly, key order included.
- `cargo fmt --check -p once-frontend` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VN6wzF2Lu7r3hytNfFUAsA
