### PR TITLE
feat(cli): fan targetless build and lint over workspace-owned targets

### DIFF
--- a/crates/once-cli/src/cli.rs
+++ b/crates/once-cli/src/cli.rs
@@ -233,9 +233,11 @@ pub enum Cmd {
     /// match a cached action key reuse the prior outputs; everything
     /// else runs and lands its declared outputs in
     /// `<workspace>/.once/out/<target>/`. Use `once query targets` to
-    /// list available ids. When no target is supplied, Once builds the
-    /// single discovered workspace root. An ambiguous or explicitly authored
-    /// graph still requires a target.
+    /// list available ids. With no target and no `--all`, Once builds
+    /// every workspace-owned target that exposes `build`, in id order,
+    /// and fails fast when one build fails. Pass `--all` to include
+    /// every build-capable target in the loaded graph, including targets
+    /// reached through vendored dependencies.
     Build {
         /// Local filesystem sandbox policy for command actions.
         #[usage(long, default = "off")]
@@ -254,11 +256,19 @@ pub enum Cmd {
         /// Once serves the client interface from this process. The page
         /// receives the build target, dependency graph, cache decision,
         /// duration, action digest, and output as the build progresses.
+        /// The Runs interface currently supports a single target; combine
+        /// it with an explicit target id rather than a targetless build.
         #[usage(long)]
         ui: bool,
 
-        /// Target id, such as `services/api/Api` or `./Api`. Omit it to build
-        /// the single automatically discovered workspace root.
+        /// Build every build-capable target in the loaded graph, including
+        /// targets reached through vendored dependencies. Without it the
+        /// targetless default builds only workspace-owned targets.
+        #[usage(long, conflicts = "target")]
+        all: bool,
+
+        /// Target id, such as `services/api/Api` or `./Api`. Omit it to
+        /// build every workspace-owned build target discovered in the graph.
         target: Option<String>,
     },
 
@@ -266,6 +276,11 @@ pub enum Cmd {
     ///
     /// Executes the target's `lint` capability, normalizes its report,
     /// and returns a failing status when a finding meets `--fail-on`.
+    /// With no target and no `--all`, Once lints every workspace-owned
+    /// target that exposes `lint`, runs each one to completion, and
+    /// returns a failing status when any finding meets `--fail-on`.
+    /// Pass `--all` to include every lint-capable target in the loaded
+    /// graph, including targets reached through vendored dependencies.
     Lint {
         /// Local filesystem sandbox policy for command actions.
         #[usage(long, default = "off")]
@@ -279,7 +294,14 @@ pub enum Cmd {
         #[usage(long, default = "warning")]
         fail_on: LintSeverity,
 
-        /// Target id, such as `quality/python` or `./python`.
+        /// Lint every lint-capable target in the loaded graph, including
+        /// targets reached through vendored dependencies. Without it the
+        /// targetless default lints only workspace-owned targets.
+        #[usage(long, conflicts = "target")]
+        all: bool,
+
+        /// Target id, such as `quality/python` or `./python`. Omit it to
+        /// lint every workspace-owned lint target discovered in the graph.
         target: Option<String>,
     },
 
@@ -685,7 +707,6 @@ impl Cli {
         }
 
         match self.command.as_ref()? {
-            Cmd::Lint { target: None, .. } => Some(&["lint"]),
             Cmd::Run { target: None, .. } => Some(&["run"]),
             Cmd::Exec { argv, .. } if argv.is_empty() => Some(&["exec"]),
             Cmd::Cache { cmd: None } => Some(&["cache"]),

--- a/crates/once-cli/src/commands/graph/mod.rs
+++ b/crates/once-cli/src/commands/graph/mod.rs
@@ -487,8 +487,12 @@ async fn write_runs_report(workspace: &Path, ui_server: Option<&crate::commands:
     }
 }
 
+/// Run static analysis for one target and report whether findings met
+/// `fail_on` as a plain bool, so a caller that lints several targets in one
+/// invocation can OR the outcomes together and translate the result into a
+/// process exit code once.
 #[allow(clippy::too_many_arguments)]
-pub async fn lint(
+pub async fn lint_returning_fails(
     workspace: &Path,
     cache: &CacheProvider,
     output: Output,
@@ -497,7 +501,7 @@ pub async fn lint(
     fail_on: LintSeverity,
     resource_limits: ResourceLimits,
     resolved: &configuration::ResolvedConfiguration,
-) -> Result<ExitCode> {
+) -> Result<bool> {
     let graph =
         once_frontend::load_graph_workspace_with_configuration(workspace, &resolved.configuration)
             .context("loading graph")?;
@@ -553,11 +557,7 @@ pub async fn lint(
     } else {
         crate::sound::Event::Finished
     });
-    Ok(if fails {
-        ExitCode::from(1)
-    } else {
-        ExitCode::SUCCESS
-    })
+    Ok(fails)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -1065,40 +1065,7 @@ fn select_workspace_owned(workspace: &Path, capability: &str) -> Result<Workspac
             .filter(|target| resolver_kinds.contains(&target.kind))
             .flat_map(|root| root.dependency_ids().map(String::as_str))
             .collect::<std::collections::BTreeSet<_>>();
-        // Also seed with anything a resolver root explicitly named as one of
-        // its workspace-owned test targets, provided the target itself exposes
-        // the `test` capability. Those targets are owned by the resolver's
-        // project even when their dep chain does not otherwise reach a primary
-        // product (macro test bundles, for example); the capability filter is a
-        // soft guard against a resolver accidentally seeding a vendored id.
-        for root in graph
-            .iter()
-            .filter(|target| resolver_kinds.contains(&target.kind))
-        {
-            if let Some(once_frontend::AttrValue::List(values)) =
-                root.attrs.get("_default_test_roots")
-            {
-                for value in values {
-                    let Some(name) = value.as_str() else {
-                        continue;
-                    };
-                    let qualified = if root.label.package.is_empty() {
-                        name.to_string()
-                    } else {
-                        format!("{}/{}", root.label.package, name)
-                    };
-                    if let Some(target) = by_id.get(qualified.as_str()) {
-                        if target
-                            .capabilities
-                            .iter()
-                            .any(|declared| declared.name == "test")
-                        {
-                            root_seed.insert(target.label.id.as_str());
-                        }
-                    }
-                }
-            }
-        }
+        enrich_seed_with_declared_test_roots(graph, &resolver_kinds, &by_id, &mut root_seed);
         let mut selected = graph
             .iter()
             .filter(|target| has_capability(target))
@@ -1145,6 +1112,53 @@ fn select_workspace_owned(workspace: &Path, capability: &str) -> Result<Workspac
         targets: Vec::new(),
         resolver_candidates,
     })
+}
+
+/// Extend `root_seed` with resolver-declared workspace test targets.
+///
+/// A resolver root may publish its workspace test targets under the
+/// `_default_test_roots` attribute (the same signal `once test` consumes). Add
+/// each such target to the seed so a downstream reachability walk classifies
+/// it and its dep chain as workspace-owned, even when the chain does not
+/// otherwise reach a primary product (macro test bundles, for example). The
+/// `test` capability check is a soft guard against a resolver accidentally
+/// seeding a vendored id.
+fn enrich_seed_with_declared_test_roots<'graph>(
+    graph: &'graph [once_frontend::GraphTarget],
+    resolver_kinds: &std::collections::BTreeSet<String>,
+    by_id: &std::collections::BTreeMap<&'graph str, &'graph once_frontend::GraphTarget>,
+    root_seed: &mut std::collections::BTreeSet<&'graph str>,
+) {
+    for root in graph
+        .iter()
+        .filter(|target| resolver_kinds.contains(&target.kind))
+    {
+        let Some(once_frontend::AttrValue::List(values)) =
+            root.attrs.get("_default_test_roots")
+        else {
+            continue;
+        };
+        for value in values {
+            let Some(name) = value.as_str() else {
+                continue;
+            };
+            let qualified = if root.label.package.is_empty() {
+                name.to_string()
+            } else {
+                format!("{}/{}", root.label.package, name)
+            };
+            let Some(target) = by_id.get(qualified.as_str()) else {
+                continue;
+            };
+            if target
+                .capabilities
+                .iter()
+                .any(|declared| declared.name == "test")
+            {
+                root_seed.insert(target.label.id.as_str());
+            }
+        }
+    }
 }
 
 /// True when `target`'s transitive dependency chain reaches any id in `roots`.

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -117,6 +117,7 @@ async fn run_command(
             sandbox,
             config,
             ui,
+            all,
         } => {
             let resolved = commands::graph::resolve_invocation_configuration(workspace, &config)?;
             dispatch_build(
@@ -124,6 +125,7 @@ async fn run_command(
                 xdg,
                 output,
                 target,
+                all,
                 sandbox,
                 resource_limits,
                 resolved,
@@ -136,6 +138,7 @@ async fn run_command(
             sandbox,
             config,
             fail_on,
+            all,
         } => {
             let resolved = commands::graph::resolve_invocation_configuration(workspace, &config)?;
             dispatch_lint(
@@ -143,6 +146,7 @@ async fn run_command(
                 xdg,
                 output,
                 target,
+                all,
                 sandbox,
                 fail_on,
                 resource_limits,
@@ -304,24 +308,38 @@ async fn dispatch_build(
     xdg: &Xdg,
     output: Output,
     target: Option<String>,
+    all: bool,
     sandbox: SandboxMode,
     resource_limits: &ResourceLimits,
     resolved: commands::graph::ResolvedConfiguration,
     ui: bool,
 ) -> Result<ExitCode> {
-    let target = resolve_build_target(workspace, target)?;
+    let targets = resolve_build_targets(workspace, target, all)?;
+    if ui && targets.len() > 1 {
+        anyhow::bail!(
+            "the Runs interface currently supports a single build target; \
+             pass one explicitly or omit --ui to fan out"
+        );
+    }
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
-    Box::pin(commands::graph::build(
-        workspace,
-        &cache,
-        output,
-        &target,
-        sandbox,
-        resource_limits.clone(),
-        &resolved,
-        ui,
-    ))
-    .await
+    // `commands::graph::build` currently signals failure exclusively through
+    // `Err`; a `?` here fails the fan-out fast. If that contract ever weakens
+    // to "may return Ok(ExitCode::from(nonzero))", the loop needs to inspect
+    // the exit code and short-circuit on the first non-success value.
+    for target in &targets {
+        Box::pin(commands::graph::build(
+            workspace,
+            &cache,
+            output,
+            target,
+            sandbox,
+            resource_limits.clone(),
+            &resolved,
+            ui,
+        ))
+        .await?;
+    }
+    Ok(ExitCode::SUCCESS)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -330,24 +348,36 @@ async fn dispatch_lint(
     xdg: &Xdg,
     output: Output,
     target: Option<String>,
+    all: bool,
     sandbox: SandboxMode,
     fail_on: once_core::LintSeverity,
     resource_limits: &ResourceLimits,
     resolved: commands::graph::ResolvedConfiguration,
 ) -> Result<ExitCode> {
-    let target = resolve_required_target(workspace, target)?;
+    let targets = resolve_lint_targets(workspace, target, all)?;
     let cache = crate::cache_provider::resolve(workspace, xdg)?;
-    Box::pin(commands::graph::lint(
-        workspace,
-        &cache,
-        output,
-        &target,
-        sandbox,
-        fail_on,
-        resource_limits.clone(),
-        &resolved,
-    ))
-    .await
+    let mut any_failed = false;
+    for target in &targets {
+        let fails = Box::pin(commands::graph::lint_returning_fails(
+            workspace,
+            &cache,
+            output,
+            target,
+            sandbox,
+            fail_on,
+            resource_limits.clone(),
+            &resolved,
+        ))
+        .await?;
+        if fails {
+            any_failed = true;
+        }
+    }
+    Ok(if any_failed {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    })
 }
 
 struct TestDispatchArgs {
@@ -912,36 +942,256 @@ fn resolve_required_target(workspace: &Path, target: Option<String>) -> Result<S
     resolve_target_arg(workspace, &raw)
 }
 
-fn resolve_build_target(workspace: &Path, target: Option<String>) -> Result<String> {
+fn resolve_build_targets(
+    workspace: &Path,
+    target: Option<String>,
+    all: bool,
+) -> Result<Vec<String>> {
+    resolve_capability_targets(workspace, target, all, "build")
+}
+
+fn resolve_lint_targets(
+    workspace: &Path,
+    target: Option<String>,
+    all: bool,
+) -> Result<Vec<String>> {
+    resolve_capability_targets(workspace, target, all, "lint")
+}
+
+fn resolve_capability_targets(
+    workspace: &Path,
+    target: Option<String>,
+    all: bool,
+    capability: &str,
+) -> Result<Vec<String>> {
     if let Some(target) = target {
-        return resolve_target_arg(workspace, &target);
+        return Ok(vec![resolve_target_arg(workspace, &target)?]);
     }
-    let resolver_kinds = once_frontend::target_kind_schemas_for_workspace(workspace)?
-        .into_iter()
+    if all {
+        let targets = all_targets_with_capability(workspace, capability)?;
+        if targets.is_empty() {
+            anyhow::bail!(
+                "no {capability}-capable target was found in the graph; \
+                 pass `once {capability} <target>` using an id from `once query targets`",
+            );
+        }
+        return Ok(targets);
+    }
+    let selection = select_workspace_owned(workspace, capability)?;
+    if !selection.targets.is_empty() {
+        return Ok(selection.targets);
+    }
+    match selection.resolver_candidates.as_slice() {
+        [] => anyhow::bail!(
+            "no workspace-owned {capability} target was discovered; \
+             pass `once {capability} <target>` using an id from `once query targets`, \
+             or `once {capability} --all` to include every {capability}-capable target in the graph",
+        ),
+        candidates => anyhow::bail!(
+            "multiple workspace-owned {capability} candidates were discovered; \
+             pass `once {capability} <target>` using one of: {list}, \
+             or `once {capability} --all` to build every {capability}-capable target in the graph",
+            list = candidates.join(", "),
+        ),
+    }
+}
+
+/// Selection produced for a capability's targetless fan-out.
+struct WorkspaceOwnedSelection {
+    /// Targets to fan out over. Empty when the heuristic anchored nothing.
+    targets: Vec<String>,
+    /// Resolver-kind targets that expose the capability at the kind level.
+    /// The caller uses this to build an actionable error when `targets` is
+    /// empty and more than one candidate exists (single-candidate graphs are
+    /// promoted into `targets` here).
+    resolver_candidates: Vec<String>,
+}
+
+/// Targets that count as workspace-owned for the given capability, plus any
+/// resolver-kind candidates the caller can surface in an error.
+///
+/// Owned means declared by a manifest Once loaded from the project root, not
+/// synthesized by transitive dependency resolution. Once does not yet carry an
+/// explicit origin marker on `GraphTarget`, so the primary rule is heuristic:
+/// "any target whose dependency chain reaches one of the resolver-declared
+/// anchor points". Anchor points are the direct dependencies of every
+/// resolver-kind root plus the entries the resolver lists under its
+/// `_default_test_roots` attribute (filtered to ones that actually expose the
+/// `test` capability, to reduce the risk of a vendored id sneaking through
+/// the seed). Vendored packages typically do not depend on the workspace that
+/// consumes them, so the walk terminates without a hit and they stay out. The
+/// heuristic still leaks when an anchor id itself points at vendored code;
+/// replacing it with a modeled origin marker is tracked as a follow-up.
+///
+/// The single-resolver fallback kicks in when the primary rule finds nothing,
+/// or when the resolver itself refuses to load: if exactly one
+/// manifest-declared target is of a resolver kind whose schema exposes the
+/// capability, that target is returned as the sole selection. This preserves
+/// the bare-native-project shape where the resolver itself is the buildable
+/// thing. Multi-candidate graphs are returned via `resolver_candidates` for
+/// the caller to render as an actionable error.
+fn select_workspace_owned(workspace: &Path, capability: &str) -> Result<WorkspaceOwnedSelection> {
+    let schemas = once_frontend::target_kind_schemas_for_workspace(workspace)?;
+    let resolver_kinds = schemas
+        .iter()
+        .filter(|schema| schema.has_resolver())
+        .map(|schema| schema.kind.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    let capable_resolver_kinds = schemas
+        .iter()
         .filter(|schema| {
             schema.has_resolver()
                 && schema
                     .capabilities
                     .iter()
-                    .any(|capability| capability.name == "build")
+                    .any(|declared| declared.name == capability)
         })
-        .map(|schema| schema.kind)
+        .map(|schema| schema.kind.clone())
         .collect::<std::collections::BTreeSet<_>>();
-    let candidates = once_frontend::load_workspace(workspace)?
-        .iter()
-        .filter(|target| resolver_kinds.contains(&target.kind))
-        .map(once_frontend::Target::id)
-        .collect::<Vec<_>>();
-    match candidates.as_slice() {
-        [target] => Ok(target.clone()),
-        [] => anyhow::bail!(
-            "no default build target was discovered; pass `once build <target>` using an id from `once query targets`"
-        ),
-        _ => anyhow::bail!(
-            "multiple default build targets were discovered; pass `once build <target>` using one of: {}",
-            candidates.join(", ")
-        ),
+    let graph_result = once_frontend::load_graph_workspace(workspace);
+    if let Ok(graph) = graph_result.as_ref() {
+        let has_capability = |target: &once_frontend::GraphTarget| {
+            target
+                .capabilities
+                .iter()
+                .any(|declared| declared.name == capability)
+        };
+        let by_id = graph
+            .iter()
+            .map(|target| (target.label.id.as_str(), target))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let mut root_seed = graph
+            .iter()
+            .filter(|target| resolver_kinds.contains(&target.kind))
+            .flat_map(|root| root.dependency_ids().map(String::as_str))
+            .collect::<std::collections::BTreeSet<_>>();
+        // Also seed with anything a resolver root explicitly named as one of
+        // its workspace-owned test targets, provided the target itself exposes
+        // the `test` capability. Those targets are owned by the resolver's
+        // project even when their dep chain does not otherwise reach a primary
+        // product (macro test bundles, for example); the capability filter is a
+        // soft guard against a resolver accidentally seeding a vendored id.
+        for root in graph
+            .iter()
+            .filter(|target| resolver_kinds.contains(&target.kind))
+        {
+            if let Some(once_frontend::AttrValue::List(values)) =
+                root.attrs.get("_default_test_roots")
+            {
+                for value in values {
+                    let Some(name) = value.as_str() else {
+                        continue;
+                    };
+                    let qualified = if root.label.package.is_empty() {
+                        name.to_string()
+                    } else {
+                        format!("{}/{}", root.label.package, name)
+                    };
+                    if let Some(target) = by_id.get(qualified.as_str()) {
+                        if target
+                            .capabilities
+                            .iter()
+                            .any(|declared| declared.name == "test")
+                        {
+                            root_seed.insert(target.label.id.as_str());
+                        }
+                    }
+                }
+            }
+        }
+        let mut selected = graph
+            .iter()
+            .filter(|target| has_capability(target))
+            .filter(|target| reaches_any_root(target, &by_id, &root_seed))
+            .map(|target| target.label.id.clone())
+            .collect::<Vec<_>>();
+        selected.sort();
+        selected.dedup();
+        if !selected.is_empty() {
+            return Ok(WorkspaceOwnedSelection {
+                targets: selected,
+                resolver_candidates: Vec::new(),
+            });
+        }
     }
+    let mut resolver_candidates = match graph_result.as_ref() {
+        Ok(graph) => graph
+            .iter()
+            .filter(|target| capable_resolver_kinds.contains(&target.kind))
+            .map(|target| target.label.id.clone())
+            .collect::<Vec<_>>(),
+        Err(_) => once_frontend::load_workspace(workspace)?
+            .iter()
+            .filter(|target| capable_resolver_kinds.contains(&target.kind))
+            .map(once_frontend::Target::id)
+            .collect::<Vec<_>>(),
+    };
+    resolver_candidates.sort();
+    resolver_candidates.dedup();
+    if resolver_candidates.len() == 1 {
+        return Ok(WorkspaceOwnedSelection {
+            targets: resolver_candidates,
+            resolver_candidates: Vec::new(),
+        });
+    }
+    if resolver_candidates.is_empty() {
+        // Nothing usable. If the graph itself failed to load, surface the
+        // original error so the targetless invocation does not disappear.
+        if let Err(error) = graph_result {
+            return Err(anyhow::Error::new(error).context("loading graph"));
+        }
+    }
+    Ok(WorkspaceOwnedSelection {
+        targets: Vec::new(),
+        resolver_candidates,
+    })
+}
+
+/// True when `target`'s transitive dependency chain reaches any id in `roots`.
+///
+/// `roots` is the set of direct dependencies of any resolver-kind target -- the
+/// resolver's declared primary products for a native integration project. Test
+/// bundles, macro plugins, and example executables sit alongside those products
+/// in the same workspace and pull them in as deps, so a BFS from such a target
+/// through its own `dependency_ids` hits a root and the target counts as owned.
+/// Vendored packages never depend on the workspace that consumes them, so the
+/// walk terminates without a hit and they stay out.
+fn reaches_any_root(
+    target: &once_frontend::GraphTarget,
+    by_id: &std::collections::BTreeMap<&str, &once_frontend::GraphTarget>,
+    roots: &std::collections::BTreeSet<&str>,
+) -> bool {
+    let mut pending = std::collections::VecDeque::from([target.label.id.as_str()]);
+    let mut visited = std::collections::BTreeSet::new();
+    while let Some(id) = pending.pop_front() {
+        if roots.contains(id) {
+            return true;
+        }
+        if !visited.insert(id) {
+            continue;
+        }
+        if let Some(node) = by_id.get(id) {
+            pending.extend(node.dependency_ids().map(String::as_str));
+        }
+    }
+    false
+}
+
+fn all_targets_with_capability(workspace: &Path, capability: &str) -> Result<Vec<String>> {
+    let graph = once_frontend::load_graph_workspace(workspace).context("loading graph")?;
+    let mut selected = graph
+        .iter()
+        .filter(|target| {
+            target
+                .capabilities
+                .iter()
+                .any(|declared| declared.name == capability)
+        })
+        .map(|target| target.label.id.clone())
+        .collect::<Vec<_>>();
+    selected.sort();
+    selected.dedup();
+    Ok(selected)
 }
 
 fn resolve_target_arg(workspace: &Path, raw: &str) -> Result<String> {
@@ -968,15 +1218,47 @@ mod tests {
     }
 
     #[test]
-    fn default_build_target_does_not_expand_native_project_resolvers() {
+    fn default_build_target_falls_back_to_the_lone_native_project_resolver() {
         let temporary = tempfile::tempdir().unwrap();
         let project = temporary.path().join("App.xcodeproj");
         std::fs::create_dir(&project).unwrap();
         std::fs::write(project.join("project.pbxproj"), "not a project").unwrap();
 
         assert_eq!(
-            resolve_build_target(temporary.path(), None).unwrap(),
-            "xcode"
+            resolve_build_targets(temporary.path(), None, false).unwrap(),
+            vec!["xcode".to_string()]
         );
+    }
+
+    #[test]
+    fn explicit_target_bypasses_default_selection_for_build_and_lint() {
+        let temporary = tempfile::tempdir().unwrap();
+        let project = temporary.path().join("App.xcodeproj");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::write(project.join("project.pbxproj"), "not a project").unwrap();
+
+        assert_eq!(
+            resolve_build_targets(temporary.path(), Some("xcode".to_string()), false).unwrap(),
+            vec!["xcode".to_string()]
+        );
+        assert_eq!(
+            resolve_lint_targets(temporary.path(), Some("xcode".to_string()), false).unwrap(),
+            vec!["xcode".to_string()]
+        );
+    }
+
+    #[test]
+    fn targetless_lint_errors_when_no_lint_target_is_declared() {
+        let temporary = tempfile::tempdir().unwrap();
+        let project = temporary.path().join("App.xcodeproj");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::write(project.join("project.pbxproj"), "not a project").unwrap();
+
+        // The bare xcode fixture exposes build at the kind level but not lint,
+        // so targetless lint has nothing to fall back to and errors either
+        // with the workspace-owned message or by surfacing the graph load
+        // failure. What matters is that it fails cleanly instead of panicking.
+        resolve_lint_targets(temporary.path(), None, false)
+            .expect_err("bare xcode fixture has no lint-capable target");
     }
 }

--- a/crates/once-cli/src/dispatch.rs
+++ b/crates/once-cli/src/dispatch.rs
@@ -1133,8 +1133,7 @@ fn enrich_seed_with_declared_test_roots<'graph>(
         .iter()
         .filter(|target| resolver_kinds.contains(&target.kind))
     {
-        let Some(once_frontend::AttrValue::List(values)) =
-            root.attrs.get("_default_test_roots")
+        let Some(once_frontend::AttrValue::List(values)) = root.attrs.get("_default_test_roots")
         else {
             continue;
         };

--- a/web/priv/docs/guide/getting-started.md
+++ b/web/priv/docs/guide/getting-started.md
@@ -26,15 +26,24 @@ try it before writing Once configuration:
 ```sh
 cd path/to/project
 once query targets
-once build --ui
+once build
 once test
+once lint
 ```
 
-Once recognizes the native workspace from its existing files. The build opens
-the Runs interface so you can follow the live graph and see which actions are
-running or reused. The test command selects first-party tests by default. No
-`once.toml` is created. Add `--ui` to `once test` when you also want to follow
-test batches and results in the Runs interface.
+Once recognizes the native workspace from its existing files. `once build`,
+`once test`, and `once lint` each default to the workspace's own targets: the
+build fans out over every workspace-owned target that exposes `build`, the
+test run selects first-party tests, and lint runs every workspace-owned
+target that exposes `lint`. No `once.toml` is created.
+
+Pass `--all` to any of the three to include targets reached through resolved
+dependencies; `once lint --all` in particular will lint vendored third-party
+code, so pair it with `--fail-on error` when you want to keep the noise
+manageable. Pass `--ui` to `once build` or `once test` on one explicit
+target to follow the live graph in the Runs interface. See
+[Graph guide](/guide/graph/) for the full workspace-owned rule (and its
+current heuristic limitations) and the per-ecosystem behavior.
 
 Continue with the matching guide for [Rust](/guide/graph/rust), [Swift
 Packages](/guide/graph/swift-packages), [Xcode

--- a/web/priv/docs/guide/graph/index.md
+++ b/web/priv/docs/guide/graph/index.md
@@ -11,15 +11,42 @@ start in its root without creating a file:
 
 ```sh
 once query targets
-once build --ui
+once build
 once test
+once lint
 ```
 
-The first command shows what Once recognized. The second opens the Runs
-interface and streams the live build graph while the native workspace builds.
-The third runs first-party tests. Resolved dependency test suites are excluded
-unless you explicitly request `once test --all`. Use `once test --ui` to keep
-the Runs interface open through test scheduling and results.
+The first command shows what Once recognized. The remaining three act on the
+workspace's own targets by default: `once build` builds every workspace-owned
+target that exposes `build` (failing fast on the first bad build), `once test`
+runs first-party tests, and `once lint` lints every workspace-owned target
+that exposes `lint` (running each one to completion so you see every finding).
+
+Workspace-owned means the target is one of the pieces the repository's own
+manifest declares, not one pulled in through a resolved dependency. A test
+run on a Cargo project builds and tests the workspace's crates without
+running the test suites of the crates they depend on; the same rule applies
+to `once build` and `once lint`.
+
+The current definition of workspace-owned is heuristic: Once traces every
+target whose dependency chain reaches one of the resolver's declared primary
+products. Sibling targets that live in the same manifest but do not depend
+on one of those products (a standalone macro plugin, for example) can slip
+past the default. Pass the target id explicitly, or use `--all`, to pick
+those up. A future release will replace the heuristic with an explicit
+origin marker on each target so the default catches every workspace-owned
+target without exception.
+
+Pass `--all` (available on all three) to reach past the workspace boundary
+and act on every capable target in the loaded graph, resolved dependencies
+included. Use it with care on `once lint --all`: it will run every
+lint-capable target in the graph, including vendored third-party code, and
+the invocation fails when any finding meets `--fail-on`. `once lint --all
+--fail-on error` is a reasonable starting point when you want to sweep the
+whole graph.
+
+Pass `once build --ui` or `once test --ui` on a single explicit target to
+follow the live graph in the Runs interface.
 
 Continue with the guide for [Rust](/guide/graph/rust), [Swift
 Packages](/guide/graph/swift-packages), [Xcode


### PR DESCRIPTION
## What changed

- `once build` and `once lint` now default to fanning out over
  workspace-owned targets when no target is passed, matching what
  `once test` already does. Build fails fast on the first failing target;
  lint runs every target to completion so all findings surface and returns
  a failing status when any finding meets `--fail-on`.
- A `--all` flag on both commands expands the default set to every
  build- or lint-capable target in the loaded graph, including targets
  reached through vendored dependencies.
- The default set is chosen by a heuristic: it seeds from every direct
  dependency of a resolver-kind root and from the resolver's own declared
  workspace test targets (filtered to entries that actually expose the
  `test` capability), then extends via a dependency-chain walk so any
  target that reaches an anchor comes along. Resolver-kind targets that
  expose the capability are kept in the fan-out so mixed graphs (an Xcode
  project alongside Once-declared targets, for example) do not silently
  narrow.
- When the heuristic anchors nothing but several resolver-kind roots
  expose the capability, the error lists them so a targeted retry is one
  paste away.
- `commands::graph::lint_returning_fails` is extracted so the lint
  fan-out can OR per-target findings into one exit code without
  inspecting `ExitCode`.
- Guide pages (`getting-started`, `graph`) describe the shared default,
  call out the current heuristic's known gap (sibling targets that do
  not depend on a workspace product), and warn that `once lint --all`
  will lint vendored code (pair with `--fail-on error`).

## Why

Before this change the three verbs disagreed on the "no target" case:
`once test` fanned out over first-party tests, `once build` required an
unambiguous single resolver root or errored, `once lint` printed help.
Users trying an existing Cargo/Swift Package Manager/Xcode/Bazel project
kept hitting that inconsistency, and the natural
["build/test everything at once"](https://doc.rust-lang.org/cargo/commands/cargo-build.html)
mental model from other build tools did not carry over. Making the three
verbs share one default (workspace-owned by default, `--all` to reach
past the boundary) removes the surprise and matches what people already
type on day one.

## Approach

Ownership is not yet modeled directly on `GraphTarget`, so this change
uses a heuristic seeded from the resolver-declared products plus the
resolver's `_default_test_roots` attribute (the same attribute
`once test` already consumes), and expanded through the graph via a
dependency-chain walk. Vendored packages typically do not depend on the
workspace that consumes them, so the walk terminates without them; the
`_default_test_roots` seed entries are filtered to targets that actually
expose the `test` capability as a soft guard against a resolver
accidentally seeding a vendored id.

The heuristic still misses siblings that live in the same manifest but
do not depend on any workspace product (Vapor's `VaporMacrosPlugin`
against the swift-syntax macro host chain is the reference case). That
gap is documented in the guide and users can name the id explicitly or
reach for `--all`. A follow-up will replace the heuristic with an
explicit origin marker on `GraphTarget` so the default catches every
workspace-owned target without exception.

## Impact

Behavior change for `once build` and `once lint` with no argument. Old
`once build` on a graph with a single resolver root would build that
resolver alone; now it builds the resolver's workspace-owned targets
(and the resolver itself when it exposes `build`). Old `once lint`
printed help; now it lints every workspace-owned lint target and returns
non-zero on any finding at or above `--fail-on`. Neither shape breaks
any documented invocation, and both commands accept the same explicit
target ids they did before.

## Validation

- `cargo test -p once-cli` → 408 passed, 0 failed, plus 2 doc/architecture tests.
- Vapor reference project (`/tmp/once-vapor-repro`, Swift toolchain pinned to `org.swift.64202609041a`):
  - `once build` → 7 workspace-owned targets plus the `swift_package` resolver root, exit 0. `VaporMacrosPlugin` is skipped as documented.
  - `once build --all` → fans into vendored packages (AsyncHTTPClient, swift-syntax, swift-nio, …), exit 0.
  - `once lint` → clean actionable error (no lint-capable target on Vapor), exit 2.
- Docs pages loaded from a local Phoenix docs server (`/docs/guide`, `/docs/guide/getting-started`, `/docs/reference/cli/build`, `/docs/reference/cli/lint`), all HTTP 200, all four contain the new workspace-owned and `--all` guidance.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTNqYh8sCWaLoFUAXHPRuM
